### PR TITLE
feat: init asset and pool for other chains

### DIFF
--- a/.github/scripts/__test__/data/sorter/expected/asset_01.json
+++ b/.github/scripts/__test__/data/sorter/expected/asset_01.json
@@ -5,7 +5,9 @@
     "symbol": "WETH",
     "decimals": "8",
     "entity": "Wormhole",
-    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs/logo.png"
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs/logo.png",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/weth/",
+    "coingecko": "https://www.coingecko.com/en/coins/weth"
   },
   {
     "id": "terra1plhefzma59lh6rjk5gfkq45pz2chfq35nm9xgdz4pcuhp3nnwekq8sthua",

--- a/.github/scripts/__test__/data/sorter/expected/entity_01.json
+++ b/.github/scripts/__test__/data/sorter/expected/entity_01.json
@@ -9,19 +9,13 @@
     "name": "Cosmos",
     "website": "https://cosmos.network/",
     "telegram": "https://t.me/cosmosproject",
-    "twitter": "https://twitter.com/cosmos",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/cosmos/",
-    "coingecko": "https://www.coingecko.com/en/coins/cosmos-hub"
+    "twitter": "https://twitter.com/cosmos"
   },
   {
     "name": "Secret Network",
     "website": "scrt.network",
     "telegram": "https://t.me/scrtCommunity",
-    "twitter": "https://twitter.com/SecretNetwork",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/secret/",
-    "coingecko": "https://www.coingecko.com/en/coins/secret"
+    "twitter": "https://twitter.com/SecretNetwork"
   },
-  {
-    "name": "Test"
-  }
+  { "name": "Test" }
 ]

--- a/.github/scripts/__test__/data/sorter/raw/asset_01.json
+++ b/.github/scripts/__test__/data/sorter/raw/asset_01.json
@@ -5,7 +5,7 @@
     "symbol": "WETH",
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs/logo.png",
     "id": "terra15hhqg8gyz04zapynqtk7uvlsp7lzay7etrt9ann0276v94yae63sxygeat",
-    "discord": "https://coinmarketcap.com/currencies/weth/",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/weth/",
     "website": "https://wormholenetwork.com/",
     "decimals": "8",
     "coingecko": "https://www.coingecko.com/en/coins/weth",

--- a/.github/scripts/src/shared/enums.ts
+++ b/.github/scripts/src/shared/enums.ts
@@ -3,6 +3,7 @@ export enum ChainDirectories {
   JUNO = "juno",
   KUIJIRA = "kujira",
   TERRA = "terra",
+  TERRACLASSIC = "terraclassic",
 }
 
 export enum JsonFiles {

--- a/.github/scripts/src/shared/enums.ts
+++ b/.github/scripts/src/shared/enums.ts
@@ -1,6 +1,7 @@
 export enum ChainDirectories {
   OSMOSIS = "osmosis",
   JUNO = "juno",
+  KUIJIRA = "kujira",
   TERRA = "terra",
 }
 

--- a/.github/scripts/src/shared/enums.ts
+++ b/.github/scripts/src/shared/enums.ts
@@ -1,5 +1,6 @@
 export enum ChainDirectories {
   OSMOSIS = "osmosis",
+  JUNO = "juno",
   TERRA = "terra",
 }
 

--- a/.github/scripts/src/shared/schema.ts
+++ b/.github/scripts/src/shared/schema.ts
@@ -46,7 +46,7 @@ const EntityType = Type.Object({
 
 const PoolType = Type.Object({
   id: Type.String(stringOptions),
-  lp_token_id: Type.String(stringOptions),
+  lp_token_id: Type.Optional(Type.String(stringOptions)),
   asset_ids: Type.Tuple([
     Type.String(stringOptions),
     Type.String(stringOptions),

--- a/.github/scripts/src/shared/schema.ts
+++ b/.github/scripts/src/shared/schema.ts
@@ -20,6 +20,8 @@ const AssetType = Type.Object({
   decimals: Type.RegEx(integerRegEx),
   circ_supply_api: Type.Optional(Type.String()),
   icon: Type.Optional(Type.String()),
+  coinmarketcap: Type.Optional(Type.String()),
+  coingecko: Type.Optional(Type.String()),
 });
 
 const BinaryType = Type.Object({
@@ -40,8 +42,6 @@ const EntityType = Type.Object({
   telegram: Type.Optional(Type.String()),
   twitter: Type.Optional(Type.String()),
   discord: Type.Optional(Type.String()),
-  coinmarketcap: Type.Optional(Type.String()),
-  coingecko: Type.Optional(Type.String()),
 });
 
 const PoolType = Type.Object({

--- a/.github/scripts/src/sorter/order.ts
+++ b/.github/scripts/src/sorter/order.ts
@@ -76,8 +76,8 @@ export function orderEntityKeys(entityData: Entity[]): Entity[] {
 
 export function orderPoolKeys(poolData: Pool[]): Pool[] {
   return poolData.map((v) => {
-    const { id, lp_token_id, asset_ids, dex, type } = v;
-    return { id, lp_token_id, asset_ids, dex, type };
+    const { id, asset_ids, dex, type, lp_token_id } = v;
+    return { id, asset_ids, dex, type, lp_token_id };
   });
 }
 

--- a/.github/scripts/src/sorter/order.ts
+++ b/.github/scripts/src/sorter/order.ts
@@ -22,7 +22,17 @@ export function orderLabelledKeys(
 
 export function orderAssetKeys(assetData: Asset[]): Asset[] {
   return assetData.map((v) => {
-    const { id, entity, name, symbol, decimals, circ_supply_api, icon } = v;
+    const {
+      id,
+      entity,
+      name,
+      symbol,
+      decimals,
+      circ_supply_api,
+      icon,
+      coingecko,
+      coinmarketcap,
+    } = v;
 
     const sortedAsset: Asset = {
       id,
@@ -32,6 +42,8 @@ export function orderAssetKeys(assetData: Asset[]): Asset[] {
       decimals,
       circ_supply_api,
       icon,
+      coingecko,
+      coinmarketcap,
     };
 
     const filteredAsset = Object.fromEntries(
@@ -44,15 +56,7 @@ export function orderAssetKeys(assetData: Asset[]): Asset[] {
 
 export function orderEntityKeys(entityData: Entity[]): Entity[] {
   return entityData.map((v) => {
-    const {
-      name,
-      website,
-      telegram,
-      twitter,
-      discord,
-      coinmarketcap,
-      coingecko,
-    } = v;
+    const { name, website, telegram, twitter, discord } = v;
 
     const sortedEntity = {
       name,
@@ -60,8 +64,6 @@ export function orderEntityKeys(entityData: Entity[]): Entity[] {
       telegram,
       twitter,
       discord,
-      coinmarketcap,
-      coingecko,
     };
 
     const filteredEntity = Object.fromEntries(

--- a/.github/scripts/src/sorter/order.ts
+++ b/.github/scripts/src/sorter/order.ts
@@ -30,8 +30,8 @@ export function orderAssetKeys(assetData: Asset[]): Asset[] {
       decimals,
       circ_supply_api,
       icon,
-      coingecko,
       coinmarketcap,
+      coingecko,
     } = v;
 
     const sortedAsset: Asset = {
@@ -42,8 +42,8 @@ export function orderAssetKeys(assetData: Asset[]): Asset[] {
       decimals,
       circ_supply_api,
       icon,
-      coingecko,
       coinmarketcap,
+      coingecko,
     };
 
     const filteredAsset = Object.fromEntries(

--- a/README.md
+++ b/README.md
@@ -107,12 +107,12 @@ Contains **dexes' liquidity pools**. This file will update automatically if all 
 type Pool = {
   // The contract address of the liquidity pool
   id: string;
-  // The contract address of the LP token
-  lp_token_id: string;
   asset_ids: string[];
   dex: string;
-  // The liquidity pool type; typically "xyk" or "stable"
+  // The liquidity pool type: "xyk" | "stable" | "orderbook" | "balancerV1"
   type: string;
+  // The contract address of the LP token (if it exists)
+  lp_token_id?: string | undefined;
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ type Asset = {
   // Following optional fields are all URL links
   circ_supply_api?: string | undefined;
   icon?: string | undefined;
-  coingecko?: string | undefined;
   coinmarketcap?: string | undefined;
+  coingecko?: string | undefined;
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ type Asset = {
   // Following optional fields are all URL links
   circ_supply_api?: string | undefined;
   icon?: string | undefined;
-  coinmarketcap?: string | undefined;
   coingecko?: string | undefined;
+  coinmarketcap?: string | undefined;
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ type Asset = {
   // Following optional fields are all URL links
   circ_supply_api?: string | undefined;
   icon?: string | undefined;
+  coinmarketcap?: string | undefined;
+  coingecko?: string | undefined;
 };
 ```
 
@@ -94,8 +96,6 @@ type Entity = {
   telegram?: string | undefined;
   twitter?: string | undefined;
   discord?: string | undefined;
-  coinmarketcap?: string | undefined;
-  coingecko?: string | undefined;
 }
 ```
 

--- a/juno/asset.json
+++ b/juno/asset.json
@@ -5,12 +5,7 @@
     "name": "Akash Network",
     "symbol": "AKT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/akt.png",
-    "website": "https://akash.network/",
-    "telegram": "https://t.me/AkashNW",
-    "twitter": "https://twitter.com/akashnet_",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/akash-network/",
-    "coingecko": "https://www.coingecko.com/en/coins/akash-network"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/akt.png"
   },
   {
     "id": "ibc/0CB5D60E57FD521FA39D11E3E410144389010AC5EF5F292BC9BDD832FA2FDBF9",
@@ -18,12 +13,7 @@
     "name": "BitCanna",
     "symbol": "BCNA",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/bcna.png",
-    "website": "https://www.bitcanna.io/",
-    "telegram": "https://t.me/BitcannaGlobal",
-    "twitter": "https://twitter.com/BitcannaGlobal",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/bitcanna/",
-    "coingecko": "https://www.coingecko.com/en/coins/bitcanna"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/bcna.png"
   },
   {
     "id": "ibc/008BFD000A10BCE5F0D4DD819AE1C1EC2942396062DABDD6AE64A655ABC7085B",
@@ -31,12 +21,7 @@
     "name": "BitSong",
     "symbol": "BTSG",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/btsg.png",
-    "website": "https://bitsong.io/",
-    "telegram": "https://t.me/BitSongOfficial",
-    "twitter": "https://twitter.com/BitSongOfficial",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/bitsong/",
-    "coingecko": "https://www.coingecko.com/en/coins/bitsong"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/btsg.png"
   },
   {
     "id": "ibc/D836B191CDAE8EDACDEBE7B64B504C5E06CC17C6A072DAF278F9A96DF66F6241",
@@ -44,12 +29,7 @@
     "name": "Chihuahua",
     "symbol": "HUAHUA",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/huahua.png",
-    "website": "https://www.chihuahua.wtf/",
-    "telegram": "https://t.me/chihuahua_cosmos",
-    "twitter": "https://twitter.com/ChihuahuaChain",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/chihuahua-wtf/",
-    "coingecko": "https://www.coingecko.com/en/coins/chihuahua-chain"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/huahua.png"
   },
   {
     "id": "ibc/946AD96F278770521526D7283F58268DA2F6ACDDE40324A9D1C86811D78C86A0",
@@ -57,12 +37,7 @@
     "name": "Comdex",
     "symbol": "CMDX",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/cmdx.png",
-    "website": "https://comdex.one/",
-    "telegram": "https://t.me/ComdexChat",
-    "twitter": "https://twitter.com/ComdexOfficial",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/comdex/",
-    "coingecko": "https://www.coingecko.com/en/coins/comdex"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/cmdx.png"
   },
   {
     "id": "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
@@ -70,12 +45,7 @@
     "name": "Atom",
     "symbol": "ATOM",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/atom.png",
-    "website": "https://cosmos.network/",
-    "telegram": "https://t.me/cosmosproject",
-    "twitter": "https://twitter.com/cosmos",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/cosmos/",
-    "coingecko": "https://www.coingecko.com/en/coins/cosmos-hub"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/atom.png"
   },
   {
     "id": "juno1x02k67asfmjawgc96dj8nxq6se3fmx36gedgs5hvkjegdhfy97rs3jgj2h",
@@ -83,11 +53,7 @@
     "name": "CZAR",
     "symbol": "CZAR",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/czar.png",
-    "website": "https://forecast.deliverdao.org/",
-    "telegram": "https://t.me/czardao",
-    "twitter": "https://twitter.com/czar_dao",
-    "discord": "https://discord.com/invite/AdRfaeEc4A"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/czar.png"
   },
   {
     "id": "ibc/6842C591DC4588411A565C9FF650FB15A17DFE3F0A43201E8141E4D14B8D171A",
@@ -95,12 +61,7 @@
     "name": "Dig Chain",
     "symbol": "DIG",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/dig.png",
-    "website": "https://digchain.org/",
-    "telegram": "https://t.me/digchain_official",
-    "twitter": "https://twitter.com/Dig_Chain",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/dig-chain/",
-    "coingecko": "https://www.coingecko.com/en/coins/dig-chain"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/dig.png"
   },
   {
     "id": "juno1vaeuky9hqacenay9nmuualugvv54tdhyt2wsvhnjasx9s946hhmqaq3kh7",
@@ -108,10 +69,7 @@
     "name": "Burned Fortis Oeconomia Token",
     "symbol": "BFOT",
     "decimals": "10",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/bFOT.png",
-    "website": "https://www.fortisoeconomia.com/",
-    "telegram": "https://t.me/fortisoeconomia",
-    "twitter": "https://twitter.com/Fortisoeconomia"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/bFOT.png"
   },
   {
     "id": "juno10ynpq4wchr4ruu6mhrfh29495ep4cja5vjnkhz3j5lrgcsap9vtssyeekl",
@@ -133,10 +91,7 @@
     "name": "HOPE Galaxy",
     "symbol": "HOPE",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/hopelogo.png",
-    "website": "https://www.hopegalaxy.io/",
-    "twitter": "https://twitter.com/HopeGalaxyNFT",
-    "coingecko": "https://www.coingecko.com/en/coins/hope-galaxy"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/hopelogo.png"
   },
   {
     "id": "ujuno",
@@ -144,12 +99,7 @@
     "name": "Juno",
     "symbol": "JUNO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/juno.png",
-    "website": "https://www.junonetwork.io/",
-    "telegram": "https://t.me/JunoNetwork",
-    "twitter": "https://twitter.com/JunoNetwork",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/juno/",
-    "coingecko": "https://www.coingecko.com/en/coins/juno-network"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/juno.png"
   },
   {
     "id": "juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr",
@@ -157,10 +107,7 @@
     "name": "NETA",
     "symbol": "NETA",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/neta.png",
-    "website": "https://www.neta.money/",
-    "twitter": "https://twitter.com/NetaMoney",
-    "coingecko": "https://www.coingecko.com/en/coins/neta"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/neta.png"
   },
   {
     "id": "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g",
@@ -168,9 +115,7 @@
     "name": "Raw",
     "symbol": "RAW",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/Raw.png",
-    "website": "https://www.rawdao.zone/",
-    "twitter": "https://twitter.com/raw_dao"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/Raw.png"
   },
   {
     "id": "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup",
@@ -178,12 +123,7 @@
     "name": "Loop",
     "symbol": "Loop",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/a46f3a10b8e67105233f358aa1de114fc34df221/images/loop.png",
-    "website": "https://juno.loop.markets/",
-    "telegram": "https://t.me/loopfinance",
-    "twitter": "https://twitter.com/loop_finance",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/loop-finance/",
-    "coingecko": "https://www.coingecko.com/en/coins/loop"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/a46f3a10b8e67105233f358aa1de114fc34df221/images/loop.png"
   },
   {
     "id": "juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
@@ -199,11 +139,7 @@
     "name": "MARBLE",
     "symbol": "MARBLE",
     "decimals": "3",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/marble.png",
-    "website": "https://www.marbledao.finance/",
-    "telegram": "https://t.me/MarbleDao",
-    "twitter": "https://twitter.com/marbledaocosmos/",
-    "coingecko": "https://www.coingecko.com/en/coins/marble-dao"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/marble.png"
   },
   {
     "id": "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518",
@@ -211,12 +147,7 @@
     "name": "Osmosis",
     "symbol": "OSMO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/osmo.png",
-    "website": "https://osmosis.zone/",
-    "telegram": "https://t.me/osmosis_chat",
-    "twitter": "https://twitter.com/osmosiszone",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/osmosis/",
-    "coingecko": "https://www.coingecko.com/en/coins/osmosis"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/osmo.png"
   },
   {
     "id": "ibc/7455B3F2F2737906BACF4AE980069A4CAB7C7F9FDAABAEFBA439DF037AEC5898",
@@ -224,12 +155,7 @@
     "name": "Persistence",
     "symbol": "XPRT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/xprt.png",
-    "website": "https://persistence.one/",
-    "telegram": "https://t.me/PersistenceOne",
-    "twitter": "https://twitter.com/PersistenceOne",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/persistence/",
-    "coingecko": "https://www.coingecko.com/en/coins/persistence"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/xprt.png"
   },
   {
     "id": "juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l",
@@ -237,10 +163,7 @@
     "name": "POSTHUMAN",
     "symbol": "PHMN",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/PHMN.png",
-    "website": "https://posthuman.digital/",
-    "telegram": "https://t.me/posthumanchat",
-    "twitter": "https://twitter.com/POSTHUMAN_DVS"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/PHMN.png"
   },
   {
     "id": "ibc/B55B08EF3667B0C6F029C2CC9CAA6B00788CF639EBB84B34818C85CBABA33ABD",
@@ -248,12 +171,7 @@
     "name": "Secret",
     "symbol": "SCRT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/scrt.png",
-    "website": "https://scrt.network/",
-    "telegram": "https://t.me/SCRTcommunity",
-    "twitter": "https://twitter.com/SecretNetwork",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/secret/",
-    "coingecko": "https://www.coingecko.com/en/coins/secret"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/scrt.png"
   },
   {
     "id": "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
@@ -261,11 +179,7 @@
     "name": "StakeEasy bJUNO",
     "symbol": "bJUNO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/bjuno.png",
-    "website": "https://juno.stakeeasy.finance/",
-    "telegram": "https://t.me/StakeEasyProtocol",
-    "twitter": "https://twitter.com/StakeEasy",
-    "coingecko": "https://www.coingecko.com/en/coins/stakeeasy-bjuno/"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/bjuno.png"
   },
   {
     "id": "juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf",
@@ -273,12 +187,7 @@
     "name": "StakeEasy governance token",
     "symbol": "SEASY",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/seasy.png",
-    "website": "https://stakeeasy.finance/",
-    "telegram": "https://t.me/StakeEasyProtocol",
-    "twitter": "https://twitter.com/StakeEasy",
-    "discord": "https://discord.gg/gKjzApDstD",
-    "coingecko": "https://www.coingecko.com/en/coins/seasy"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/seasy.png"
   },
   {
     "id": "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
@@ -286,12 +195,7 @@
     "name": "StakeEasy seJUNO",
     "symbol": "seJUNO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/sejuno.png",
-    "website": "https://stakeeasy.finance/",
-    "telegram": "https://t.me/StakeEasyProtocol",
-    "twitter": "https://twitter.com/StakeEasy",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/loop-finance/",
-    "coingecko": "https://www.coingecko.com/en/coins/stakeeasy-juno-derivative/"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/sejuno.png"
   },
   {
     "id": "ibc/F6B367385300865F654E110976B838502504231705BAC0849B0651C226385885",
@@ -299,12 +203,7 @@
     "name": "Stargaze",
     "symbol": "STARS",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/stars.png",
-    "website": "https://www.stargaze.zone/",
-    "telegram": "https://t.me/joinchat/ZQ95YmIn3AI0ODFh",
-    "twitter": "https://twitter.com/stargazezone",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/stargaze/",
-    "coingecko": "https://www.coingecko.com/en/coins/stargaze"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/stars.png"
   },
   {
     "id": "ibc/107D152BB3176FAEBF4C2A84C5FFDEEA7C7CB4FE1BBDAB710F1FD25BCD055CBF",
@@ -320,12 +219,7 @@
     "name": "Terra Classic",
     "symbol": "LUNC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/lunc.png",
-    "website": "https://www.terra.money/",
-    "telegram": "https://t.me/TerraNetworkLobby",
-    "twitter": "https://twitter.com/terra_money",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-luna/",
-    "coingecko": "https://www.coingecko.com/en/coins/terra-luna-classic"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/lunc.png"
   },
   {
     "id": "juno1hy0ky3pe742phd4w55tdfej0ez55h4jx4g06rp4wsa0mne9wzudqy4hum2",
@@ -333,9 +227,7 @@
     "name": "Arto DAO",
     "symbol": "ARTO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/arto.png",
-    "telegram": "https://t.me/artodao",
-    "twitter": "https://twitter.com/ArtoDAO"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/arto.png"
   },
   {
     "id": "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
@@ -343,11 +235,7 @@
     "name": "WYND",
     "symbol": "WYND",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmorama/wynd-assets-list/main/images/WYND.svg",
-    "website": "httpshttps://www.wynddao.com/",
-    "telegram": "httpshttps://telegram.me/wynd_dao",
-    "twitter": "https://twitter.com/wynddao",
-    "coingecko": "httpshttps://www.coingecko.com/en/coins/wynd"
+    "icon": "https://raw.githubusercontent.com/cosmorama/wynd-assets-list/main/images/WYND.svg"
   },
   {
     "id": "juno1a0khag6cfzu5lrwazmyndjgvlsuk7g4vn9jd8ceym8f4jf6v2l9q6d348a",
@@ -388,9 +276,7 @@
     "name": "CANLAB",
     "symbol": "CANLAB",
     "decimals": "3",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/cannalabs.png",
-    "website": "https://www.cannalabs420.com/",
-    "twitter": "https://twitter.com/cannalabs420"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/cannalabs.png"
   },
   {
     "id": "juno1t8dnpktypue65q0hjz7tr3cvqypgj5vkxhd2twvng4a2ywa3j25spjuk6z",
@@ -404,9 +290,7 @@
     "name": "CoinDex",
     "symbol": "COIN",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/coindex.png",
-    "website": "https://coin-dex.io/",
-    "twitter": "https://twitter.com/coindex9"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/coindex.png"
   },
   {
     "id": "juno1p32te9zfhd99ehpxfd06hka6hc9p7tv5kyl5909mzedg5klze09qrg08ry",
@@ -420,24 +304,14 @@
     "name": "e-Money",
     "symbol": "NGM",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/ngm.png",
-    "website": "https://e-money.com/",
-    "telegram": "https://t.me/emoney_com",
-    "twitter": "https://twitter.com/emoney_com",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/e-money-coin/",
-    "coingecko": "https://www.coingecko.com/en/coins/e-money"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/ngm.png"
   },
   {
     "id": "ibc/B9F7C1E4CE9219B5AF06C47B18661DBD49CCD7A6C18FF789E2FB62BB365CFF9C",
     "name": "e-Money EUR",
     "symbol": "EEUR",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/eeur.png",
-    "website": "https://e-money.com/",
-    "telegram": "https://t.me/emoney_com",
-    "twitter": "https://twitter.com/emoney_com",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/e-money/",
-    "coingecko": "https://www.coingecko.com/en/coins/e-money-eur"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/eeur.png"
   },
   {
     "id": "juno1gzys54drag6753qq75mkt3yhjwyv4rp698kfvesh0wcy5737z4tsn0chtm",
@@ -458,18 +332,14 @@
     "name": "Hulcat",
     "symbol": "HULC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/hulcat.png",
-    "website": "https://hulcat.github.io/",
-    "twitter": "https://twitter.com/hulcatoshi"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/hulcat.png"
   },
   {
     "id": "juno1n7n7d5088qlzlj37e9mgmkhx6dfgtvt02hqxq66lcap4dxnzdhwqfmgng3",
     "name": "JoeDAO",
     "symbol": "JOE",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/joedao.png",
-    "website": "https://joedao.io/",
-    "twitter": "https://twitter.com/JoeDAOofficial"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/joedao.png"
   },
   {
     "id": "juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3",
@@ -483,9 +353,7 @@
     "name": "OpenNMN",
     "symbol": "NMN",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/nmn.png",
-    "website": "https://www.opennmn.com/",
-    "twitter": "https://twitter.com/OpenNMN"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/nmn.png"
   },
   {
     "id": "juno13926947pmrjly5p9hf5juey65c6rget0gqrnx3us3r6pvnpf4hwqm8mchy",
@@ -499,18 +367,14 @@
     "name": "RAC",
     "symbol": "RAC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/racoon.png",
-    "website": "https://www.racoon.supply/",
-    "twitter": "https://twitter.com/RacoonSupply"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/racoon.png"
   },
   {
     "id": "juno14lycavan8gvpjn97aapzvwmsj8kyrvf644p05r0hu79namyj3ens87650k",
     "name": "Signal",
     "symbol": "SGNL",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/sgnl.png",
-    "website": "https://www.signal.contact/",
-    "twitter": "https://twitter.com/SignalSGNL"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/sgnl.png"
   },
   {
     "id": "juno147t4fd3tny6hws6rha9xs5gah9qa6g7hrjv9tuvv6ce6m25sy39sq6yv52",
@@ -531,19 +395,14 @@
     "name": "Terra UST Classic",
     "symbol": "USTC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/ustc.png",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/terrausd/",
-    "coingecko": "https://www.coingecko.com/en/coins/terraclassicusd"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/ustc.png"
   },
   {
     "id": "juno1wurfx334prlceydmda3aecldn2xh4axhqtly05n8gptgl69ee7msrewg6y",
     "name": "Tuckermint",
     "symbol": "TUCK",
     "decimals": "3",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/tuckermint.png",
-    "website": "https://tuckermint.com/",
-    "telegram": "https://t.me/tuckermintchat",
-    "twitter": "https://twitter.com/TuckermintNet"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/tuckermint.png"
   },
   {
     "id": "juno1kqx9rhc8ksx52tukdx797k4rjrhkgfh4gljs04ql97hmnnkgyvxs5cqt7d",

--- a/juno/asset.json
+++ b/juno/asset.json
@@ -1,45 +1,5 @@
 [
   {
-    "id": "ibc/DFC6F33796D5D0075C5FB54A4D7B8E76915ACF434CB1EE2A1BA0BB8334E17C3A",
-    "entity": "Akash Network",
-    "name": "Akash Network",
-    "symbol": "AKT",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/akt.png"
-  },
-  {
-    "id": "ibc/0CB5D60E57FD521FA39D11E3E410144389010AC5EF5F292BC9BDD832FA2FDBF9",
-    "entity": "BitCanna",
-    "name": "BitCanna",
-    "symbol": "BCNA",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/bcna.png"
-  },
-  {
-    "id": "ibc/008BFD000A10BCE5F0D4DD819AE1C1EC2942396062DABDD6AE64A655ABC7085B",
-    "entity": "BitSong",
-    "name": "BitSong",
-    "symbol": "BTSG",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/btsg.png"
-  },
-  {
-    "id": "ibc/D836B191CDAE8EDACDEBE7B64B504C5E06CC17C6A072DAF278F9A96DF66F6241",
-    "entity": "Chihuahua",
-    "name": "Chihuahua",
-    "symbol": "HUAHUA",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/huahua.png"
-  },
-  {
-    "id": "ibc/946AD96F278770521526D7283F58268DA2F6ACDDE40324A9D1C86811D78C86A0",
-    "entity": "Comdex",
-    "name": "Comdex",
-    "symbol": "CMDX",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/cmdx.png"
-  },
-  {
     "id": "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
     "entity": "Cosmos",
     "name": "Atom",
@@ -48,20 +8,20 @@
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/atom.png"
   },
   {
-    "id": "juno1x02k67asfmjawgc96dj8nxq6se3fmx36gedgs5hvkjegdhfy97rs3jgj2h",
-    "entity": "CZAR",
-    "name": "CZAR",
-    "symbol": "CZAR",
+    "id": "ibc/52423136339C1CE8C91F6A586DFE41591BDDD4665AE526DFFA8421F9ACF95196",
+    "entity": "e-Money",
+    "name": "e-Money",
+    "symbol": "NGM",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/czar.png"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/ngm.png"
   },
   {
-    "id": "ibc/6842C591DC4588411A565C9FF650FB15A17DFE3F0A43201E8141E4D14B8D171A",
-    "entity": "Dig Chain",
-    "name": "Dig Chain",
-    "symbol": "DIG",
+    "id": "ibc/B9F7C1E4CE9219B5AF06C47B18661DBD49CCD7A6C18FF789E2FB62BB365CFF9C",
+    "entity": "e-Money",
+    "name": "e-Money EUR",
+    "symbol": "EEUR",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/dig.png"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/eeur.png"
   },
   {
     "id": "juno1vaeuky9hqacenay9nmuualugvv54tdhyt2wsvhnjasx9s946hhmqaq3kh7",
@@ -86,14 +46,6 @@
     "decimals": "10"
   },
   {
-    "id": "juno1re3x67ppxap48ygndmrc7har2cnc7tcxtm9nplcas4v0gc3wnmvs3s807z",
-    "entity": "Hope Galaxy",
-    "name": "HOPE Galaxy",
-    "symbol": "HOPE",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/hopelogo.png"
-  },
-  {
     "id": "ujuno",
     "entity": "Juno",
     "name": "Juno",
@@ -102,68 +54,12 @@
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/juno.png"
   },
   {
-    "id": "juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr",
-    "entity": "Juno",
-    "name": "NETA",
-    "symbol": "NETA",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/neta.png"
-  },
-  {
-    "id": "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g",
-    "entity": "Juno",
-    "name": "Raw",
-    "symbol": "RAW",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/Raw.png"
-  },
-  {
-    "id": "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup",
-    "entity": "Loop",
-    "name": "Loop",
-    "symbol": "Loop",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/a46f3a10b8e67105233f358aa1de114fc34df221/images/loop.png"
-  },
-  {
-    "id": "juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
-    "entity": "Marble",
-    "name": "Block",
-    "symbol": "BLOCK",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/MarbleDAO/brand-assets/main/block.png"
-  },
-  {
-    "id": "juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl",
-    "entity": "Marble",
-    "name": "MARBLE",
-    "symbol": "MARBLE",
-    "decimals": "3",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/marble.png"
-  },
-  {
     "id": "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518",
     "entity": "Osmosis",
     "name": "Osmosis",
     "symbol": "OSMO",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/osmo.png"
-  },
-  {
-    "id": "ibc/7455B3F2F2737906BACF4AE980069A4CAB7C7F9FDAABAEFBA439DF037AEC5898",
-    "entity": "Persistence",
-    "name": "Persistence",
-    "symbol": "XPRT",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/xprt.png"
-  },
-  {
-    "id": "juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l",
-    "entity": "POSTHUMAN",
-    "name": "POSTHUMAN",
-    "symbol": "PHMN",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/PHMN.png"
   },
   {
     "id": "ibc/B55B08EF3667B0C6F029C2CC9CAA6B00788CF639EBB84B34818C85CBABA33ABD",
@@ -198,12 +94,12 @@
     "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/sejuno.png"
   },
   {
-    "id": "ibc/F6B367385300865F654E110976B838502504231705BAC0849B0651C226385885",
-    "entity": "Stargaze",
-    "name": "Stargaze",
-    "symbol": "STARS",
+    "id": "juno173c59crjqeec28cpzs7n0y7hm4cd308zda8z6j4cnl6pct3stenseg2dxp",
+    "entity": "Steak",
+    "name": "Steak Token",
+    "symbol": "STEAK",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/stars.png"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/Steak.png"
   },
   {
     "id": "ibc/107D152BB3176FAEBF4C2A84C5FFDEEA7C7CB4FE1BBDAB710F1FD25BCD055CBF",
@@ -211,31 +107,14 @@
     "name": "Luna",
     "symbol": "LUNA",
     "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/Luna.svg"
+    "icon": "/logos/luna.svg"
   },
   {
-    "id": "ibc/8F865D9760B482FF6254EDFEC1FF2F1273B9AB6873A7DE484F89639795D73D75",
-    "entity": "Terra Money",
-    "name": "Terra Classic",
-    "symbol": "LUNC",
+    "id": "ibc/DFC6F33796D5D0075C5FB54A4D7B8E76915ACF434CB1EE2A1BA0BB8334E17C3A",
+    "name": "Akash Network",
+    "symbol": "AKT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/lunc.png"
-  },
-  {
-    "id": "juno1hy0ky3pe742phd4w55tdfej0ez55h4jx4g06rp4wsa0mne9wzudqy4hum2",
-    "entity": "TODO ENTITY",
-    "name": "Arto DAO",
-    "symbol": "ARTO",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/arto.png"
-  },
-  {
-    "id": "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
-    "entity": "Wynd",
-    "name": "WYND",
-    "symbol": "WYND",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmorama/wynd-assets-list/main/images/WYND.svg"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/akt.png"
   },
   {
     "id": "juno1a0khag6cfzu5lrwazmyndjgvlsuk7g4vn9jd8ceym8f4jf6v2l9q6d348a",
@@ -259,11 +138,39 @@
     "icon": "https://raw.githubusercontent.com/cosmorama/wynd-assets-list/main/images/AQUA.png"
   },
   {
+    "id": "juno1hy0ky3pe742phd4w55tdfej0ez55h4jx4g06rp4wsa0mne9wzudqy4hum2",
+    "name": "Arto DAO",
+    "symbol": "ARTO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/arto.png"
+  },
+  {
     "id": "ibc/5CB906E82B7A88E62644AD811361F5858B74BA9EBD75C84B6D24B20C01A4819F",
     "name": "Asset Mantle",
     "symbol": "MNTL",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/assetmantle.png"
+  },
+  {
+    "id": "ibc/0CB5D60E57FD521FA39D11E3E410144389010AC5EF5F292BC9BDD832FA2FDBF9",
+    "name": "BitCanna",
+    "symbol": "BCNA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/bcna.png"
+  },
+  {
+    "id": "ibc/008BFD000A10BCE5F0D4DD819AE1C1EC2942396062DABDD6AE64A655ABC7085B",
+    "name": "BitSong",
+    "symbol": "BTSG",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/btsg.png"
+  },
+  {
+    "id": "juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
+    "name": "Block",
+    "symbol": "BLOCK",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/MarbleDAO/brand-assets/main/block.png"
   },
   {
     "id": "juno17r2vpc5enkyfe2xle9sedxdq3msfpacwcfp9rnr6jc3e7v6av0jqmfyfzp",
@@ -286,11 +193,32 @@
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/primo.png"
   },
   {
+    "id": "ibc/D836B191CDAE8EDACDEBE7B64B504C5E06CC17C6A072DAF278F9A96DF66F6241",
+    "name": "Chihuahua",
+    "symbol": "HUAHUA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/huahua.png"
+  },
+  {
     "id": "juno1cl2ewl842wcnagz5psd68z4dpp4gfxrrm9atm807uvyyg235h85stg7awy",
     "name": "CoinDex",
     "symbol": "COIN",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/coindex.png"
+  },
+  {
+    "id": "ibc/946AD96F278770521526D7283F58268DA2F6ACDDE40324A9D1C86811D78C86A0",
+    "name": "Comdex",
+    "symbol": "CMDX",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/cmdx.png"
+  },
+  {
+    "id": "juno1x02k67asfmjawgc96dj8nxq6se3fmx36gedgs5hvkjegdhfy97rs3jgj2h",
+    "name": "CZAR",
+    "symbol": "CZAR",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/czar.png"
   },
   {
     "id": "juno1p32te9zfhd99ehpxfd06hka6hc9p7tv5kyl5909mzedg5klze09qrg08ry",
@@ -300,18 +228,11 @@
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/daisy.png"
   },
   {
-    "id": "ibc/52423136339C1CE8C91F6A586DFE41591BDDD4665AE526DFFA8421F9ACF95196",
-    "name": "e-Money",
-    "symbol": "NGM",
+    "id": "ibc/6842C591DC4588411A565C9FF650FB15A17DFE3F0A43201E8141E4D14B8D171A",
+    "name": "Dig Chain",
+    "symbol": "DIG",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/ngm.png"
-  },
-  {
-    "id": "ibc/B9F7C1E4CE9219B5AF06C47B18661DBD49CCD7A6C18FF789E2FB62BB365CFF9C",
-    "name": "e-Money EUR",
-    "symbol": "EEUR",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/eeur.png"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/dig.png"
   },
   {
     "id": "juno1gzys54drag6753qq75mkt3yhjwyv4rp698kfvesh0wcy5737z4tsn0chtm",
@@ -328,6 +249,13 @@
     "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/glto.png"
   },
   {
+    "id": "juno1re3x67ppxap48ygndmrc7har2cnc7tcxtm9nplcas4v0gc3wnmvs3s807z",
+    "name": "HOPE Galaxy",
+    "symbol": "HOPE",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/hopelogo.png"
+  },
+  {
     "id": "juno1pshrvuw5ng2q4nwcsuceypjkp48d95gmcgjdxlus2ytm4k5kvz2s7t9ldx",
     "name": "Hulcat",
     "symbol": "HULC",
@@ -342,6 +270,20 @@
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/joedao.png"
   },
   {
+    "id": "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup",
+    "name": "Loop",
+    "symbol": "Loop",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/a46f3a10b8e67105233f358aa1de114fc34df221/images/loop.png"
+  },
+  {
+    "id": "juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl",
+    "name": "MARBLE",
+    "symbol": "MARBLE",
+    "decimals": "3",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/marble.png"
+  },
+  {
     "id": "juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3",
     "name": "MUSE",
     "symbol": "MUSE",
@@ -349,11 +291,32 @@
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/MUSE.png"
   },
   {
+    "id": "juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr",
+    "name": "NETA",
+    "symbol": "NETA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/neta.png"
+  },
+  {
     "id": "juno17r8dyxuj25muaudhgqgx4xrg6gzr6tvzem6gwtpprnfld58yggcqjhhkjy",
     "name": "OpenNMN",
     "symbol": "NMN",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/nmn.png"
+  },
+  {
+    "id": "ibc/7455B3F2F2737906BACF4AE980069A4CAB7C7F9FDAABAEFBA439DF037AEC5898",
+    "name": "Persistence",
+    "symbol": "XPRT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/xprt.png"
+  },
+  {
+    "id": "juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l",
+    "name": "POSTHUMAN",
+    "symbol": "PHMN",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/PHMN.png"
   },
   {
     "id": "juno13926947pmrjly5p9hf5juey65c6rget0gqrnx3us3r6pvnpf4hwqm8mchy",
@@ -370,6 +333,13 @@
     "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/racoon.png"
   },
   {
+    "id": "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g",
+    "name": "Raw",
+    "symbol": "RAW",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/Raw.png"
+  },
+  {
     "id": "juno14lycavan8gvpjn97aapzvwmsj8kyrvf644p05r0hu79namyj3ens87650k",
     "name": "Signal",
     "symbol": "SGNL",
@@ -384,11 +354,18 @@
     "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/drgn.png"
   },
   {
-    "id": "juno173c59crjqeec28cpzs7n0y7hm4cd308zda8z6j4cnl6pct3stenseg2dxp",
-    "name": "Steak Token",
-    "symbol": "STEAK",
+    "id": "ibc/F6B367385300865F654E110976B838502504231705BAC0849B0651C226385885",
+    "name": "Stargaze",
+    "symbol": "STARS",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/Steak.png"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/stars.png"
+  },
+  {
+    "id": "ibc/8F865D9760B482FF6254EDFEC1FF2F1273B9AB6873A7DE484F89639795D73D75",
+    "name": "Terra Classic",
+    "symbol": "LUNC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/lunc.png"
   },
   {
     "id": "ibc/2DA4136457810BCB9DAAB620CA67BC342B17C3C70151CA70490A170DF7C9CB27",
@@ -417,5 +394,12 @@
     "symbol": "USDC",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/axlusdc.png"
+  },
+  {
+    "id": "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
+    "name": "WYND",
+    "symbol": "WYND",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmorama/wynd-assets-list/main/images/WYND.svg"
   }
 ]

--- a/juno/asset.json
+++ b/juno/asset.json
@@ -6,8 +6,8 @@
     "symbol": "ATOM",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/atom.png",
-    "coingecko": "https://www.coingecko.com/en/coins/cosmos-hub",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/cosmos/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/cosmos/",
+    "coingecko": "https://www.coingecko.com/en/coins/cosmos-hub"
   },
   {
     "id": "ujuno",
@@ -16,8 +16,8 @@
     "symbol": "JUNO",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/juno.png",
-    "coingecko": "https://www.coingecko.com/en/coins/juno-network",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/juno/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/juno/",
+    "coingecko": "https://www.coingecko.com/en/coins/juno-network"
   },
   {
     "id": "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518",
@@ -26,8 +26,8 @@
     "symbol": "OSMO",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/osmo.png",
-    "coingecko": "https://www.coingecko.com/en/coins/osmosis",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/osmosis/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/osmosis/",
+    "coingecko": "https://www.coingecko.com/en/coins/osmosis"
   },
   {
     "id": "ibc/B55B08EF3667B0C6F029C2CC9CAA6B00788CF639EBB84B34818C85CBABA33ABD",
@@ -36,8 +36,8 @@
     "symbol": "SCRT",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/scrt.png",
-    "coingecko": "https://www.coingecko.com/en/coins/secret",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/secret/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/secret/",
+    "coingecko": "https://www.coingecko.com/en/coins/secret"
   },
   {
     "id": "juno173c59crjqeec28cpzs7n0y7hm4cd308zda8z6j4cnl6pct3stenseg2dxp",
@@ -61,8 +61,8 @@
     "symbol": "AKT",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/akt.png",
-    "coingecko": "https://www.coingecko.com/en/coins/akash-network",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/akash-network/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/akash-network/",
+    "coingecko": "https://www.coingecko.com/en/coins/akash-network"
   },
   {
     "id": "juno1a0khag6cfzu5lrwazmyndjgvlsuk7g4vn9jd8ceym8f4jf6v2l9q6d348a",
@@ -105,8 +105,8 @@
     "symbol": "BCNA",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/bcna.png",
-    "coingecko": "https://www.coingecko.com/en/coins/bitcanna",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/bitcanna/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/bitcanna/",
+    "coingecko": "https://www.coingecko.com/en/coins/bitcanna"
   },
   {
     "id": "ibc/008BFD000A10BCE5F0D4DD819AE1C1EC2942396062DABDD6AE64A655ABC7085B",
@@ -114,8 +114,8 @@
     "symbol": "BTSG",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/btsg.png",
-    "coingecko": "https://www.coingecko.com/en/coins/bitsong",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/bitsong/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/bitsong/",
+    "coingecko": "https://www.coingecko.com/en/coins/bitsong"
   },
   {
     "id": "juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
@@ -157,8 +157,8 @@
     "symbol": "HUAHUA",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/huahua.png",
-    "coingecko": "https://www.coingecko.com/en/coins/chihuahua-chain",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/chihuahua-wtf/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/chihuahua-wtf/",
+    "coingecko": "https://www.coingecko.com/en/coins/chihuahua-chain"
   },
   {
     "id": "juno1cl2ewl842wcnagz5psd68z4dpp4gfxrrm9atm807uvyyg235h85stg7awy",
@@ -173,8 +173,8 @@
     "symbol": "CMDX",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/cmdx.png",
-    "coingecko": "https://www.coingecko.com/en/coins/comdex",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/comdex/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/comdex/",
+    "coingecko": "https://www.coingecko.com/en/coins/comdex"
   },
   {
     "id": "juno1x02k67asfmjawgc96dj8nxq6se3fmx36gedgs5hvkjegdhfy97rs3jgj2h",
@@ -196,8 +196,8 @@
     "symbol": "DIG",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/dig.png",
-    "coingecko": "https://www.coingecko.com/en/coins/dig-chain",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/dig-chain/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/dig-chain/",
+    "coingecko": "https://www.coingecko.com/en/coins/dig-chain"
   },
   {
     "id": "ibc/52423136339C1CE8C91F6A586DFE41591BDDD4665AE526DFFA8421F9ACF95196",
@@ -205,8 +205,8 @@
     "symbol": "NGM",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/ngm.png",
-    "coingecko": "https://www.coingecko.com/en/coins/e-money",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/e-money-coin/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/e-money-coin/",
+    "coingecko": "https://www.coingecko.com/en/coins/e-money"
   },
   {
     "id": "ibc/B9F7C1E4CE9219B5AF06C47B18661DBD49CCD7A6C18FF789E2FB62BB365CFF9C",
@@ -214,8 +214,8 @@
     "symbol": "EEUR",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/eeur.png",
-    "coingecko": "https://www.coingecko.com/en/coins/e-money-eur",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/e-money/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/e-money/",
+    "coingecko": "https://www.coingecko.com/en/coins/e-money-eur"
   },
   {
     "id": "juno1gzys54drag6753qq75mkt3yhjwyv4rp698kfvesh0wcy5737z4tsn0chtm",
@@ -265,8 +265,8 @@
     "symbol": "Loop",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/a46f3a10b8e67105233f358aa1de114fc34df221/images/loop.png",
-    "coingecko": "https://www.coingecko.com/en/coins/loop",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/loop-finance/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/loop-finance/",
+    "coingecko": "https://www.coingecko.com/en/coins/loop"
   },
   {
     "id": "juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl",
@@ -304,8 +304,8 @@
     "symbol": "XPRT",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/xprt.png",
-    "coingecko": "https://www.coingecko.com/en/coins/persistence",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/persistence/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/persistence/",
+    "coingecko": "https://www.coingecko.com/en/coins/persistence"
   },
   {
     "id": "juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l",
@@ -377,8 +377,8 @@
     "symbol": "seJUNO",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/sejuno.png",
-    "coingecko": "https://www.coingecko.com/en/coins/stakeeasy-juno-derivative/",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/loop-finance/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/loop-finance/",
+    "coingecko": "https://www.coingecko.com/en/coins/stakeeasy-juno-derivative/"
   },
   {
     "id": "ibc/F6B367385300865F654E110976B838502504231705BAC0849B0651C226385885",
@@ -386,8 +386,8 @@
     "symbol": "STARS",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/stars.png",
-    "coingecko": "https://www.coingecko.com/en/coins/stargaze",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/stargaze/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/stargaze/",
+    "coingecko": "https://www.coingecko.com/en/coins/stargaze"
   },
   {
     "id": "ibc/8F865D9760B482FF6254EDFEC1FF2F1273B9AB6873A7DE484F89639795D73D75",
@@ -395,8 +395,8 @@
     "symbol": "LUNC",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/lunc.png",
-    "coingecko": "https://www.coingecko.com/en/coins/terra-luna-classic",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-luna/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-luna/",
+    "coingecko": "https://www.coingecko.com/en/coins/terra-luna-classic"
   },
   {
     "id": "ibc/2DA4136457810BCB9DAAB620CA67BC342B17C3C70151CA70490A170DF7C9CB27",
@@ -404,8 +404,8 @@
     "symbol": "USTC",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/ustc.png",
-    "coingecko": "https://www.coingecko.com/en/coins/terraclassicusd",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/terrausd/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terrausd/",
+    "coingecko": "https://www.coingecko.com/en/coins/terraclassicusd"
   },
   {
     "id": "juno1wurfx334prlceydmda3aecldn2xh4axhqtly05n8gptgl69ee7msrewg6y",

--- a/juno/asset.json
+++ b/juno/asset.json
@@ -5,45 +5,9 @@
     "name": "Atom",
     "symbol": "ATOM",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/atom.png"
-  },
-  {
-    "id": "ibc/52423136339C1CE8C91F6A586DFE41591BDDD4665AE526DFFA8421F9ACF95196",
-    "entity": "e-Money",
-    "name": "e-Money",
-    "symbol": "NGM",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/ngm.png"
-  },
-  {
-    "id": "ibc/B9F7C1E4CE9219B5AF06C47B18661DBD49CCD7A6C18FF789E2FB62BB365CFF9C",
-    "entity": "e-Money",
-    "name": "e-Money EUR",
-    "symbol": "EEUR",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/eeur.png"
-  },
-  {
-    "id": "juno1vaeuky9hqacenay9nmuualugvv54tdhyt2wsvhnjasx9s946hhmqaq3kh7",
-    "entity": "Fortis Oeconomia",
-    "name": "Burned Fortis Oeconomia Token",
-    "symbol": "BFOT",
-    "decimals": "10",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/bFOT.png"
-  },
-  {
-    "id": "juno10ynpq4wchr4ruu6mhrfh29495ep4cja5vjnkhz3j5lrgcsap9vtssyeekl",
-    "entity": "Fortis Oeconomia",
-    "name": "Grand Fortis Oeconomia Token",
-    "symbol": "gFOT",
-    "decimals": "10"
-  },
-  {
-    "id": "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
-    "entity": "Fortis Oeconomia",
-    "name": "Stable Fortis Oeconomia Token",
-    "symbol": "sFOT",
-    "decimals": "10"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/atom.png",
+    "coingecko": "https://www.coingecko.com/en/coins/cosmos-hub",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/cosmos/"
   },
   {
     "id": "ujuno",
@@ -51,7 +15,9 @@
     "name": "Juno",
     "symbol": "JUNO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/juno.png"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/juno.png",
+    "coingecko": "https://www.coingecko.com/en/coins/juno-network",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/juno/"
   },
   {
     "id": "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518",
@@ -59,7 +25,9 @@
     "name": "Osmosis",
     "symbol": "OSMO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/osmo.png"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/osmo.png",
+    "coingecko": "https://www.coingecko.com/en/coins/osmosis",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/osmosis/"
   },
   {
     "id": "ibc/B55B08EF3667B0C6F029C2CC9CAA6B00788CF639EBB84B34818C85CBABA33ABD",
@@ -67,31 +35,9 @@
     "name": "Secret",
     "symbol": "SCRT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/scrt.png"
-  },
-  {
-    "id": "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
-    "entity": "StakeEasy",
-    "name": "StakeEasy bJUNO",
-    "symbol": "bJUNO",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/bjuno.png"
-  },
-  {
-    "id": "juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf",
-    "entity": "StakeEasy",
-    "name": "StakeEasy governance token",
-    "symbol": "SEASY",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/seasy.png"
-  },
-  {
-    "id": "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
-    "entity": "StakeEasy",
-    "name": "StakeEasy seJUNO",
-    "symbol": "seJUNO",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/sejuno.png"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/scrt.png",
+    "coingecko": "https://www.coingecko.com/en/coins/secret",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/secret/"
   },
   {
     "id": "juno173c59crjqeec28cpzs7n0y7hm4cd308zda8z6j4cnl6pct3stenseg2dxp",
@@ -114,7 +60,9 @@
     "name": "Akash Network",
     "symbol": "AKT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/akt.png"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/akt.png",
+    "coingecko": "https://www.coingecko.com/en/coins/akash-network",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/akash-network/"
   },
   {
     "id": "juno1a0khag6cfzu5lrwazmyndjgvlsuk7g4vn9jd8ceym8f4jf6v2l9q6d348a",
@@ -156,14 +104,18 @@
     "name": "BitCanna",
     "symbol": "BCNA",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/bcna.png"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/bcna.png",
+    "coingecko": "https://www.coingecko.com/en/coins/bitcanna",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/bitcanna/"
   },
   {
     "id": "ibc/008BFD000A10BCE5F0D4DD819AE1C1EC2942396062DABDD6AE64A655ABC7085B",
     "name": "BitSong",
     "symbol": "BTSG",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/btsg.png"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/btsg.png",
+    "coingecko": "https://www.coingecko.com/en/coins/bitsong",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/bitsong/"
   },
   {
     "id": "juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
@@ -177,6 +129,13 @@
     "name": "BOOBA",
     "symbol": "BOOB",
     "decimals": "6"
+  },
+  {
+    "id": "juno1vaeuky9hqacenay9nmuualugvv54tdhyt2wsvhnjasx9s946hhmqaq3kh7",
+    "name": "Burned Fortis Oeconomia Token",
+    "symbol": "BFOT",
+    "decimals": "10",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/bFOT.png"
   },
   {
     "id": "juno1vn38rzq0wc7zczp4dhy0h5y5kxh2jjzeahwe30c9cc6dw3lkyk5qn5rmfa",
@@ -197,7 +156,9 @@
     "name": "Chihuahua",
     "symbol": "HUAHUA",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/huahua.png"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/huahua.png",
+    "coingecko": "https://www.coingecko.com/en/coins/chihuahua-chain",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/chihuahua-wtf/"
   },
   {
     "id": "juno1cl2ewl842wcnagz5psd68z4dpp4gfxrrm9atm807uvyyg235h85stg7awy",
@@ -211,7 +172,9 @@
     "name": "Comdex",
     "symbol": "CMDX",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/cmdx.png"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/cmdx.png",
+    "coingecko": "https://www.coingecko.com/en/coins/comdex",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/comdex/"
   },
   {
     "id": "juno1x02k67asfmjawgc96dj8nxq6se3fmx36gedgs5hvkjegdhfy97rs3jgj2h",
@@ -232,7 +195,27 @@
     "name": "Dig Chain",
     "symbol": "DIG",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/dig.png"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/dig.png",
+    "coingecko": "https://www.coingecko.com/en/coins/dig-chain",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/dig-chain/"
+  },
+  {
+    "id": "ibc/52423136339C1CE8C91F6A586DFE41591BDDD4665AE526DFFA8421F9ACF95196",
+    "name": "e-Money",
+    "symbol": "NGM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/ngm.png",
+    "coingecko": "https://www.coingecko.com/en/coins/e-money",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/e-money-coin/"
+  },
+  {
+    "id": "ibc/B9F7C1E4CE9219B5AF06C47B18661DBD49CCD7A6C18FF789E2FB62BB365CFF9C",
+    "name": "e-Money EUR",
+    "symbol": "EEUR",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/eeur.png",
+    "coingecko": "https://www.coingecko.com/en/coins/e-money-eur",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/e-money/"
   },
   {
     "id": "juno1gzys54drag6753qq75mkt3yhjwyv4rp698kfvesh0wcy5737z4tsn0chtm",
@@ -249,11 +232,18 @@
     "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/glto.png"
   },
   {
+    "id": "juno10ynpq4wchr4ruu6mhrfh29495ep4cja5vjnkhz3j5lrgcsap9vtssyeekl",
+    "name": "Grand Fortis Oeconomia Token",
+    "symbol": "gFOT",
+    "decimals": "10"
+  },
+  {
     "id": "juno1re3x67ppxap48ygndmrc7har2cnc7tcxtm9nplcas4v0gc3wnmvs3s807z",
     "name": "HOPE Galaxy",
     "symbol": "HOPE",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/hopelogo.png"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/hopelogo.png",
+    "coingecko": "https://www.coingecko.com/en/coins/hope-galaxy"
   },
   {
     "id": "juno1pshrvuw5ng2q4nwcsuceypjkp48d95gmcgjdxlus2ytm4k5kvz2s7t9ldx",
@@ -274,14 +264,17 @@
     "name": "Loop",
     "symbol": "Loop",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/a46f3a10b8e67105233f358aa1de114fc34df221/images/loop.png"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/a46f3a10b8e67105233f358aa1de114fc34df221/images/loop.png",
+    "coingecko": "https://www.coingecko.com/en/coins/loop",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/loop-finance/"
   },
   {
     "id": "juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl",
     "name": "MARBLE",
     "symbol": "MARBLE",
     "decimals": "3",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/marble.png"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/marble.png",
+    "coingecko": "https://www.coingecko.com/en/coins/marble-dao"
   },
   {
     "id": "juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3",
@@ -295,7 +288,8 @@
     "name": "NETA",
     "symbol": "NETA",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/neta.png"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/neta.png",
+    "coingecko": "https://www.coingecko.com/en/coins/neta"
   },
   {
     "id": "juno17r8dyxuj25muaudhgqgx4xrg6gzr6tvzem6gwtpprnfld58yggcqjhhkjy",
@@ -309,7 +303,9 @@
     "name": "Persistence",
     "symbol": "XPRT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/xprt.png"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/xprt.png",
+    "coingecko": "https://www.coingecko.com/en/coins/persistence",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/persistence/"
   },
   {
     "id": "juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l",
@@ -347,6 +343,12 @@
     "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/sgnl.png"
   },
   {
+    "id": "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
+    "name": "Stable Fortis Oeconomia Token",
+    "symbol": "sFOT",
+    "decimals": "10"
+  },
+  {
     "id": "juno147t4fd3tny6hws6rha9xs5gah9qa6g7hrjv9tuvv6ce6m25sy39sq6yv52",
     "name": "Stake Dragons",
     "symbol": "DRGN",
@@ -354,25 +356,56 @@
     "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/drgn.png"
   },
   {
+    "id": "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
+    "name": "StakeEasy bJUNO",
+    "symbol": "bJUNO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/bjuno.png",
+    "coingecko": "https://www.coingecko.com/en/coins/stakeeasy-bjuno/"
+  },
+  {
+    "id": "juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf",
+    "name": "StakeEasy governance token",
+    "symbol": "SEASY",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/seasy.png",
+    "coingecko": "https://www.coingecko.com/en/coins/seasy"
+  },
+  {
+    "id": "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
+    "name": "StakeEasy seJUNO",
+    "symbol": "seJUNO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/sejuno.png",
+    "coingecko": "https://www.coingecko.com/en/coins/stakeeasy-juno-derivative/",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/loop-finance/"
+  },
+  {
     "id": "ibc/F6B367385300865F654E110976B838502504231705BAC0849B0651C226385885",
     "name": "Stargaze",
     "symbol": "STARS",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/stars.png"
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/stars.png",
+    "coingecko": "https://www.coingecko.com/en/coins/stargaze",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/stargaze/"
   },
   {
     "id": "ibc/8F865D9760B482FF6254EDFEC1FF2F1273B9AB6873A7DE484F89639795D73D75",
     "name": "Terra Classic",
     "symbol": "LUNC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/lunc.png"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/lunc.png",
+    "coingecko": "https://www.coingecko.com/en/coins/terra-luna-classic",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-luna/"
   },
   {
     "id": "ibc/2DA4136457810BCB9DAAB620CA67BC342B17C3C70151CA70490A170DF7C9CB27",
     "name": "Terra UST Classic",
     "symbol": "USTC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/ustc.png"
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/ustc.png",
+    "coingecko": "https://www.coingecko.com/en/coins/terraclassicusd",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terrausd/"
   },
   {
     "id": "juno1wurfx334prlceydmda3aecldn2xh4axhqtly05n8gptgl69ee7msrewg6y",
@@ -400,6 +433,7 @@
     "name": "WYND",
     "symbol": "WYND",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmorama/wynd-assets-list/main/images/WYND.svg"
+    "icon": "https://raw.githubusercontent.com/cosmorama/wynd-assets-list/main/images/WYND.svg",
+    "coingecko": "httpshttps://www.coingecko.com/en/coins/wynd"
   }
 ]

--- a/juno/asset.json
+++ b/juno/asset.json
@@ -1,0 +1,562 @@
+[
+  {
+    "id": "ibc/DFC6F33796D5D0075C5FB54A4D7B8E76915ACF434CB1EE2A1BA0BB8334E17C3A",
+    "entity": "Akash Network",
+    "name": "Akash Network",
+    "symbol": "AKT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/akt.png",
+    "website": "https://akash.network/",
+    "telegram": "https://t.me/AkashNW",
+    "twitter": "https://twitter.com/akashnet_",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/akash-network/",
+    "coingecko": "https://www.coingecko.com/en/coins/akash-network"
+  },
+  {
+    "id": "ibc/0CB5D60E57FD521FA39D11E3E410144389010AC5EF5F292BC9BDD832FA2FDBF9",
+    "entity": "BitCanna",
+    "name": "BitCanna",
+    "symbol": "BCNA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/bcna.png",
+    "website": "https://www.bitcanna.io/",
+    "telegram": "https://t.me/BitcannaGlobal",
+    "twitter": "https://twitter.com/BitcannaGlobal",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/bitcanna/",
+    "coingecko": "https://www.coingecko.com/en/coins/bitcanna"
+  },
+  {
+    "id": "ibc/008BFD000A10BCE5F0D4DD819AE1C1EC2942396062DABDD6AE64A655ABC7085B",
+    "entity": "BitSong",
+    "name": "BitSong",
+    "symbol": "BTSG",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/btsg.png",
+    "website": "https://bitsong.io/",
+    "telegram": "https://t.me/BitSongOfficial",
+    "twitter": "https://twitter.com/BitSongOfficial",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/bitsong/",
+    "coingecko": "https://www.coingecko.com/en/coins/bitsong"
+  },
+  {
+    "id": "ibc/D836B191CDAE8EDACDEBE7B64B504C5E06CC17C6A072DAF278F9A96DF66F6241",
+    "entity": "Chihuahua",
+    "name": "Chihuahua",
+    "symbol": "HUAHUA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/huahua.png",
+    "website": "https://www.chihuahua.wtf/",
+    "telegram": "https://t.me/chihuahua_cosmos",
+    "twitter": "https://twitter.com/ChihuahuaChain",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/chihuahua-wtf/",
+    "coingecko": "https://www.coingecko.com/en/coins/chihuahua-chain"
+  },
+  {
+    "id": "ibc/946AD96F278770521526D7283F58268DA2F6ACDDE40324A9D1C86811D78C86A0",
+    "entity": "Comdex",
+    "name": "Comdex",
+    "symbol": "CMDX",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/cmdx.png",
+    "website": "https://comdex.one/",
+    "telegram": "https://t.me/ComdexChat",
+    "twitter": "https://twitter.com/ComdexOfficial",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/comdex/",
+    "coingecko": "https://www.coingecko.com/en/coins/comdex"
+  },
+  {
+    "id": "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
+    "entity": "Cosmos",
+    "name": "Atom",
+    "symbol": "ATOM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/atom.png",
+    "website": "https://cosmos.network/",
+    "telegram": "https://t.me/cosmosproject",
+    "twitter": "https://twitter.com/cosmos",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/cosmos/",
+    "coingecko": "https://www.coingecko.com/en/coins/cosmos-hub"
+  },
+  {
+    "id": "juno1x02k67asfmjawgc96dj8nxq6se3fmx36gedgs5hvkjegdhfy97rs3jgj2h",
+    "entity": "CZAR",
+    "name": "CZAR",
+    "symbol": "CZAR",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/czar.png",
+    "website": "https://forecast.deliverdao.org/",
+    "telegram": "https://t.me/czardao",
+    "twitter": "https://twitter.com/czar_dao",
+    "discord": "https://discord.com/invite/AdRfaeEc4A"
+  },
+  {
+    "id": "ibc/6842C591DC4588411A565C9FF650FB15A17DFE3F0A43201E8141E4D14B8D171A",
+    "entity": "Dig Chain",
+    "name": "Dig Chain",
+    "symbol": "DIG",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/dig.png",
+    "website": "https://digchain.org/",
+    "telegram": "https://t.me/digchain_official",
+    "twitter": "https://twitter.com/Dig_Chain",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/dig-chain/",
+    "coingecko": "https://www.coingecko.com/en/coins/dig-chain"
+  },
+  {
+    "id": "juno1vaeuky9hqacenay9nmuualugvv54tdhyt2wsvhnjasx9s946hhmqaq3kh7",
+    "entity": "Fortis Oeconomia",
+    "name": "Burned Fortis Oeconomia Token",
+    "symbol": "BFOT",
+    "decimals": "10",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/bFOT.png",
+    "website": "https://www.fortisoeconomia.com/",
+    "telegram": "https://t.me/fortisoeconomia",
+    "twitter": "https://twitter.com/Fortisoeconomia"
+  },
+  {
+    "id": "juno10ynpq4wchr4ruu6mhrfh29495ep4cja5vjnkhz3j5lrgcsap9vtssyeekl",
+    "entity": "Fortis Oeconomia",
+    "name": "Grand Fortis Oeconomia Token",
+    "symbol": "gFOT",
+    "decimals": "10"
+  },
+  {
+    "id": "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
+    "entity": "Fortis Oeconomia",
+    "name": "Stable Fortis Oeconomia Token",
+    "symbol": "sFOT",
+    "decimals": "10"
+  },
+  {
+    "id": "juno1re3x67ppxap48ygndmrc7har2cnc7tcxtm9nplcas4v0gc3wnmvs3s807z",
+    "entity": "Hope Galaxy",
+    "name": "HOPE Galaxy",
+    "symbol": "HOPE",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/hopelogo.png",
+    "website": "https://www.hopegalaxy.io/",
+    "twitter": "https://twitter.com/HopeGalaxyNFT",
+    "coingecko": "https://www.coingecko.com/en/coins/hope-galaxy"
+  },
+  {
+    "id": "ujuno",
+    "entity": "Juno",
+    "name": "Juno",
+    "symbol": "JUNO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/juno.png",
+    "website": "https://www.junonetwork.io/",
+    "telegram": "https://t.me/JunoNetwork",
+    "twitter": "https://twitter.com/JunoNetwork",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/juno/",
+    "coingecko": "https://www.coingecko.com/en/coins/juno-network"
+  },
+  {
+    "id": "juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr",
+    "entity": "Juno",
+    "name": "NETA",
+    "symbol": "NETA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/neta.png",
+    "website": "https://www.neta.money/",
+    "twitter": "https://twitter.com/NetaMoney",
+    "coingecko": "https://www.coingecko.com/en/coins/neta"
+  },
+  {
+    "id": "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g",
+    "entity": "Juno",
+    "name": "Raw",
+    "symbol": "RAW",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/Raw.png",
+    "website": "https://www.rawdao.zone/",
+    "twitter": "https://twitter.com/raw_dao"
+  },
+  {
+    "id": "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup",
+    "entity": "Loop",
+    "name": "Loop",
+    "symbol": "Loop",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/a46f3a10b8e67105233f358aa1de114fc34df221/images/loop.png",
+    "website": "https://juno.loop.markets/",
+    "telegram": "https://t.me/loopfinance",
+    "twitter": "https://twitter.com/loop_finance",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/loop-finance/",
+    "coingecko": "https://www.coingecko.com/en/coins/loop"
+  },
+  {
+    "id": "juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
+    "entity": "Marble",
+    "name": "Block",
+    "symbol": "BLOCK",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/MarbleDAO/brand-assets/main/block.png"
+  },
+  {
+    "id": "juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl",
+    "entity": "Marble",
+    "name": "MARBLE",
+    "symbol": "MARBLE",
+    "decimals": "3",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/marble.png",
+    "website": "https://www.marbledao.finance/",
+    "telegram": "https://t.me/MarbleDao",
+    "twitter": "https://twitter.com/marbledaocosmos/",
+    "coingecko": "https://www.coingecko.com/en/coins/marble-dao"
+  },
+  {
+    "id": "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518",
+    "entity": "Osmosis",
+    "name": "Osmosis",
+    "symbol": "OSMO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/osmo.png",
+    "website": "https://osmosis.zone/",
+    "telegram": "https://t.me/osmosis_chat",
+    "twitter": "https://twitter.com/osmosiszone",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/osmosis/",
+    "coingecko": "https://www.coingecko.com/en/coins/osmosis"
+  },
+  {
+    "id": "ibc/7455B3F2F2737906BACF4AE980069A4CAB7C7F9FDAABAEFBA439DF037AEC5898",
+    "entity": "Persistence",
+    "name": "Persistence",
+    "symbol": "XPRT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/xprt.png",
+    "website": "https://persistence.one/",
+    "telegram": "https://t.me/PersistenceOne",
+    "twitter": "https://twitter.com/PersistenceOne",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/persistence/",
+    "coingecko": "https://www.coingecko.com/en/coins/persistence"
+  },
+  {
+    "id": "juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l",
+    "entity": "POSTHUMAN",
+    "name": "POSTHUMAN",
+    "symbol": "PHMN",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/PHMN.png",
+    "website": "https://posthuman.digital/",
+    "telegram": "https://t.me/posthumanchat",
+    "twitter": "https://twitter.com/POSTHUMAN_DVS"
+  },
+  {
+    "id": "ibc/B55B08EF3667B0C6F029C2CC9CAA6B00788CF639EBB84B34818C85CBABA33ABD",
+    "entity": "Secret Network",
+    "name": "Secret",
+    "symbol": "SCRT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/scrt.png",
+    "website": "https://scrt.network/",
+    "telegram": "https://t.me/SCRTcommunity",
+    "twitter": "https://twitter.com/SecretNetwork",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/secret/",
+    "coingecko": "https://www.coingecko.com/en/coins/secret"
+  },
+  {
+    "id": "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
+    "entity": "StakeEasy",
+    "name": "StakeEasy bJUNO",
+    "symbol": "bJUNO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/bjuno.png",
+    "website": "https://juno.stakeeasy.finance/",
+    "telegram": "https://t.me/StakeEasyProtocol",
+    "twitter": "https://twitter.com/StakeEasy",
+    "coingecko": "https://www.coingecko.com/en/coins/stakeeasy-bjuno/"
+  },
+  {
+    "id": "juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf",
+    "entity": "StakeEasy",
+    "name": "StakeEasy governance token",
+    "symbol": "SEASY",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/seasy.png",
+    "website": "https://stakeeasy.finance/",
+    "telegram": "https://t.me/StakeEasyProtocol",
+    "twitter": "https://twitter.com/StakeEasy",
+    "discord": "https://discord.gg/gKjzApDstD",
+    "coingecko": "https://www.coingecko.com/en/coins/seasy"
+  },
+  {
+    "id": "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
+    "entity": "StakeEasy",
+    "name": "StakeEasy seJUNO",
+    "symbol": "seJUNO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/sejuno.png",
+    "website": "https://stakeeasy.finance/",
+    "telegram": "https://t.me/StakeEasyProtocol",
+    "twitter": "https://twitter.com/StakeEasy",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/loop-finance/",
+    "coingecko": "https://www.coingecko.com/en/coins/stakeeasy-juno-derivative/"
+  },
+  {
+    "id": "ibc/F6B367385300865F654E110976B838502504231705BAC0849B0651C226385885",
+    "entity": "Stargaze",
+    "name": "Stargaze",
+    "symbol": "STARS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/stars.png",
+    "website": "https://www.stargaze.zone/",
+    "telegram": "https://t.me/joinchat/ZQ95YmIn3AI0ODFh",
+    "twitter": "https://twitter.com/stargazezone",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/stargaze/",
+    "coingecko": "https://www.coingecko.com/en/coins/stargaze"
+  },
+  {
+    "id": "ibc/107D152BB3176FAEBF4C2A84C5FFDEEA7C7CB4FE1BBDAB710F1FD25BCD055CBF",
+    "entity": "Terra Money",
+    "name": "Luna",
+    "symbol": "LUNA",
+    "decimals": "6",
+    "icon": "https://assets.terra.money/icon/svg/Luna.svg"
+  },
+  {
+    "id": "ibc/8F865D9760B482FF6254EDFEC1FF2F1273B9AB6873A7DE484F89639795D73D75",
+    "entity": "Terra Money",
+    "name": "Terra Classic",
+    "symbol": "LUNC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/lunc.png",
+    "website": "https://www.terra.money/",
+    "telegram": "https://t.me/TerraNetworkLobby",
+    "twitter": "https://twitter.com/terra_money",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-luna/",
+    "coingecko": "https://www.coingecko.com/en/coins/terra-luna-classic"
+  },
+  {
+    "id": "juno1hy0ky3pe742phd4w55tdfej0ez55h4jx4g06rp4wsa0mne9wzudqy4hum2",
+    "entity": "TODO ENTITY",
+    "name": "Arto DAO",
+    "symbol": "ARTO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/arto.png",
+    "telegram": "https://t.me/artodao",
+    "twitter": "https://twitter.com/ArtoDAO"
+  },
+  {
+    "id": "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
+    "entity": "Wynd",
+    "name": "WYND",
+    "symbol": "WYND",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmorama/wynd-assets-list/main/images/WYND.svg",
+    "website": "httpshttps://www.wynddao.com/",
+    "telegram": "httpshttps://telegram.me/wynd_dao",
+    "twitter": "https://twitter.com/wynddao",
+    "coingecko": "httpshttps://www.coingecko.com/en/coins/wynd"
+  },
+  {
+    "id": "juno1a0khag6cfzu5lrwazmyndjgvlsuk7g4vn9jd8ceym8f4jf6v2l9q6d348a",
+    "name": "Amplified JUNO",
+    "symbol": "ampJUNO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/ampjuno.png"
+  },
+  {
+    "id": "juno1hnftys64ectjfynm6qjk9my8jd3f6l9dq9utcd3dy8ehwrsx9q4q7n9uxt",
+    "name": "Aqua",
+    "symbol": "AQUA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmorama/wynd-assets-list/main/images/AQUA.png"
+  },
+  {
+    "id": "juno1w7kspnu3j4hmzvsltsk00xujfa84sf502vs2zjcawl03vgn7vj3sww9mh7",
+    "name": "Aqua",
+    "symbol": "AQUA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmorama/wynd-assets-list/main/images/AQUA.png"
+  },
+  {
+    "id": "ibc/5CB906E82B7A88E62644AD811361F5858B74BA9EBD75C84B6D24B20C01A4819F",
+    "name": "Asset Mantle",
+    "symbol": "MNTL",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/assetmantle.png"
+  },
+  {
+    "id": "juno17r2vpc5enkyfe2xle9sedxdq3msfpacwcfp9rnr6jc3e7v6av0jqmfyfzp",
+    "name": "BOOBA",
+    "symbol": "BOOB",
+    "decimals": "6"
+  },
+  {
+    "id": "juno1vn38rzq0wc7zczp4dhy0h5y5kxh2jjzeahwe30c9cc6dw3lkyk5qn5rmfa",
+    "name": "CANLAB",
+    "symbol": "CANLAB",
+    "decimals": "3",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/cannalabs.png",
+    "website": "https://www.cannalabs420.com/",
+    "twitter": "https://twitter.com/cannalabs420"
+  },
+  {
+    "id": "juno1t8dnpktypue65q0hjz7tr3cvqypgj5vkxhd2twvng4a2ywa3j25spjuk6z",
+    "name": "Cardinal Finance ",
+    "symbol": "PRIMO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/primo.png"
+  },
+  {
+    "id": "juno1cl2ewl842wcnagz5psd68z4dpp4gfxrrm9atm807uvyyg235h85stg7awy",
+    "name": "CoinDex",
+    "symbol": "COIN",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/coindex.png",
+    "website": "https://coin-dex.io/",
+    "twitter": "https://twitter.com/coindex9"
+  },
+  {
+    "id": "juno1p32te9zfhd99ehpxfd06hka6hc9p7tv5kyl5909mzedg5klze09qrg08ry",
+    "name": "Daisy Finance ",
+    "symbol": "DAISY",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/daisy.png"
+  },
+  {
+    "id": "ibc/52423136339C1CE8C91F6A586DFE41591BDDD4665AE526DFFA8421F9ACF95196",
+    "name": "e-Money",
+    "symbol": "NGM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/ngm.png",
+    "website": "https://e-money.com/",
+    "telegram": "https://t.me/emoney_com",
+    "twitter": "https://twitter.com/emoney_com",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/e-money-coin/",
+    "coingecko": "https://www.coingecko.com/en/coins/e-money"
+  },
+  {
+    "id": "ibc/B9F7C1E4CE9219B5AF06C47B18661DBD49CCD7A6C18FF789E2FB62BB365CFF9C",
+    "name": "e-Money EUR",
+    "symbol": "EEUR",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/eeur.png",
+    "website": "https://e-money.com/",
+    "telegram": "https://t.me/emoney_com",
+    "twitter": "https://twitter.com/emoney_com",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/e-money/",
+    "coingecko": "https://www.coingecko.com/en/coins/e-money-eur"
+  },
+  {
+    "id": "juno1gzys54drag6753qq75mkt3yhjwyv4rp698kfvesh0wcy5737z4tsn0chtm",
+    "name": "FUTURE OF",
+    "symbol": "FUTURE",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/futuretoken.png"
+  },
+  {
+    "id": "juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se",
+    "name": "Gelotto",
+    "symbol": "GLTO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/glto.png"
+  },
+  {
+    "id": "juno1pshrvuw5ng2q4nwcsuceypjkp48d95gmcgjdxlus2ytm4k5kvz2s7t9ldx",
+    "name": "Hulcat",
+    "symbol": "HULC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/hulcat.png",
+    "website": "https://hulcat.github.io/",
+    "twitter": "https://twitter.com/hulcatoshi"
+  },
+  {
+    "id": "juno1n7n7d5088qlzlj37e9mgmkhx6dfgtvt02hqxq66lcap4dxnzdhwqfmgng3",
+    "name": "JoeDAO",
+    "symbol": "JOE",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/joedao.png",
+    "website": "https://joedao.io/",
+    "twitter": "https://twitter.com/JoeDAOofficial"
+  },
+  {
+    "id": "juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3",
+    "name": "MUSE",
+    "symbol": "MUSE",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/MUSE.png"
+  },
+  {
+    "id": "juno17r8dyxuj25muaudhgqgx4xrg6gzr6tvzem6gwtpprnfld58yggcqjhhkjy",
+    "name": "OpenNMN",
+    "symbol": "NMN",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/nmn.png",
+    "website": "https://www.opennmn.com/",
+    "twitter": "https://twitter.com/OpenNMN"
+  },
+  {
+    "id": "juno13926947pmrjly5p9hf5juey65c6rget0gqrnx3us3r6pvnpf4hwqm8mchy",
+    "name": "PUNK",
+    "symbol": "PUNK",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/punk.png"
+  },
+  {
+    "id": "juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa",
+    "name": "RAC",
+    "symbol": "RAC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/racoon.png",
+    "website": "https://www.racoon.supply/",
+    "twitter": "https://twitter.com/RacoonSupply"
+  },
+  {
+    "id": "juno14lycavan8gvpjn97aapzvwmsj8kyrvf644p05r0hu79namyj3ens87650k",
+    "name": "Signal",
+    "symbol": "SGNL",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/sgnl.png",
+    "website": "https://www.signal.contact/",
+    "twitter": "https://twitter.com/SignalSGNL"
+  },
+  {
+    "id": "juno147t4fd3tny6hws6rha9xs5gah9qa6g7hrjv9tuvv6ce6m25sy39sq6yv52",
+    "name": "Stake Dragons",
+    "symbol": "DRGN",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/drgn.png"
+  },
+  {
+    "id": "juno173c59crjqeec28cpzs7n0y7hm4cd308zda8z6j4cnl6pct3stenseg2dxp",
+    "name": "Steak Token",
+    "symbol": "STEAK",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/Steak.png"
+  },
+  {
+    "id": "ibc/2DA4136457810BCB9DAAB620CA67BC342B17C3C70151CA70490A170DF7C9CB27",
+    "name": "Terra UST Classic",
+    "symbol": "USTC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/ustc.png",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terrausd/",
+    "coingecko": "https://www.coingecko.com/en/coins/terraclassicusd"
+  },
+  {
+    "id": "juno1wurfx334prlceydmda3aecldn2xh4axhqtly05n8gptgl69ee7msrewg6y",
+    "name": "Tuckermint",
+    "symbol": "TUCK",
+    "decimals": "3",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/tuckermint.png",
+    "website": "https://tuckermint.com/",
+    "telegram": "https://t.me/tuckermintchat",
+    "twitter": "https://twitter.com/TuckermintNet"
+  },
+  {
+    "id": "juno1kqx9rhc8ksx52tukdx797k4rjrhkgfh4gljs04ql97hmnnkgyvxs5cqt7d",
+    "name": "UniverseDAO",
+    "symbol": "VERSE",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/main/images/VERSE.png"
+  },
+  {
+    "id": "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034",
+    "name": "USDC",
+    "symbol": "USDC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/CosmosContracts/junoswap-asset-list/main/images/axlusdc.png"
+  }
+]

--- a/juno/entity.json
+++ b/juno/entity.json
@@ -1,0 +1,206 @@
+[
+  {
+    "name": "Akash Network",
+    "website": "https://akash.network/",
+    "telegram": "https://t.me/AkashNW",
+    "twitter": "https://twitter.com/akashnet_"
+  },
+  {
+    "name": "Arto DAO",
+    "telegram": "https://t.me/artodao",
+    "twitter": "https://twitter.com/ArtoDAO"
+  },
+  {
+    "name": "BitCanna",
+    "website": "https://www.bitcanna.io/",
+    "telegram": "https://t.me/BitcannaGlobal",
+    "twitter": "https://twitter.com/BitcannaGlobal"
+  },
+  {
+    "name": "BitSong",
+    "website": "https://bitsong.io/",
+    "telegram": "https://t.me/BitSongOfficial",
+    "twitter": "https://twitter.com/BitSongOfficial"
+  },
+  {
+    "name": "CANLAB",
+    "website": "https://www.cannalabs420.com/",
+    "twitter": "https://twitter.com/cannalabs420"
+  },
+  {
+    "name": "Cardinal Finance "
+  },
+  {
+    "name": "Chihuahua",
+    "website": "https://www.chihuahua.wtf/",
+    "telegram": "https://t.me/chihuahua_cosmos",
+    "twitter": "https://twitter.com/ChihuahuaChain"
+  },
+  {
+    "name": "CoinDex",
+    "website": "https://coin-dex.io/",
+    "twitter": "https://twitter.com/coindex9"
+  },
+  {
+    "name": "Comdex",
+    "website": "https://comdex.one/",
+    "telegram": "https://t.me/ComdexChat",
+    "twitter": "https://twitter.com/ComdexOfficial"
+  },
+  {
+    "name": "Cosmos",
+    "website": "https://cosmos.network/",
+    "telegram": "https://t.me/cosmosproject",
+    "twitter": "https://twitter.com/cosmos"
+  },
+  {
+    "name": "CZAR",
+    "website": "https://forecast.deliverdao.org/",
+    "telegram": "https://t.me/czardao",
+    "twitter": "https://twitter.com/czar_dao",
+    "discord": "https://discord.com/invite/AdRfaeEc4A"
+  },
+  {
+    "name": "Dig Chain",
+    "website": "https://digchain.org/",
+    "telegram": "https://t.me/digchain_official",
+    "twitter": "https://twitter.com/Dig_Chain"
+  },
+  {
+    "name": "e-Money",
+    "website": "https://e-money.com/",
+    "telegram": "https://t.me/emoney_com",
+    "twitter": "https://twitter.com/emoney_com"
+  },
+  {
+    "name": "Fortis Oeconomia"
+  },
+  {
+    "name": "FUTURE OF"
+  },
+  {
+    "name": "HOPE Galaxy",
+    "website": "https://www.hopegalaxy.io/",
+    "twitter": "https://twitter.com/HopeGalaxyNFT"
+  },
+  {
+    "name": "Hulcat",
+    "website": "https://hulcat.github.io/",
+    "twitter": "https://twitter.com/hulcatoshi"
+  },
+  {
+    "name": "JoeDAO",
+    "website": "https://joedao.io/",
+    "twitter": "https://twitter.com/JoeDAOofficial"
+  },
+  {
+    "name": "Juno",
+    "website": "https://www.junonetwork.io/",
+    "telegram": "https://t.me/JunoNetwork",
+    "twitter": "https://twitter.com/JunoNetwork"
+  },
+  {
+    "name": "Loop",
+    "website": "https://juno.loop.markets/",
+    "telegram": "https://t.me/loopfinance",
+    "twitter": "https://twitter.com/loop_finance"
+  },
+  {
+    "name": "MARBLE",
+    "website": "https://www.marbledao.finance/",
+    "telegram": "https://t.me/MarbleDao",
+    "twitter": "https://twitter.com/marbledaocosmos/"
+  },
+  {
+    "name": "NETA",
+    "website": "https://www.neta.money/",
+    "twitter": "https://twitter.com/NetaMoney"
+  },
+  {
+    "name": "OpenNMN",
+    "website": "https://www.opennmn.com/",
+    "twitter": "https://twitter.com/OpenNMN"
+  },
+  {
+    "name": "Osmosis",
+    "website": "https://osmosis.zone/",
+    "telegram": "https://t.me/osmosis_chat",
+    "twitter": "https://twitter.com/osmosiszone"
+  },
+  {
+    "name": "Persistence",
+    "website": "https://persistence.one/",
+    "telegram": "https://t.me/PersistenceOne",
+    "twitter": "https://twitter.com/PersistenceOne"
+  },
+  {
+    "name": "POSTHUMAN",
+    "website": "https://posthuman.digital/",
+    "telegram": "https://t.me/posthumanchat",
+    "twitter": "https://twitter.com/POSTHUMAN_DVS"
+  },
+  {
+    "name": "RAC",
+    "website": "https://www.racoon.supply/",
+    "twitter": "https://twitter.com/RacoonSupply"
+  },
+  {
+    "name": "Raw",
+    "website": "https://www.rawdao.zone/",
+    "twitter": "https://twitter.com/raw_dao"
+  },
+  {
+    "name": "Secret Network",
+    "website": "scrt.network",
+    "telegram": "https://t.me/scrtCommunity",
+    "twitter": "https://twitter.com/SecretNetwork"
+  },
+  {
+    "name": "Signal",
+    "website": "https://www.signal.contact/",
+    "twitter": "https://twitter.com/SignalSGNL"
+  },
+  {
+    "name": "StakeEasy",
+    "website": "https://stakeeasy.finance/",
+    "telegram": "https://t.me/StakeEasyProtocol",
+    "twitter": "https://twitter.com/StakeEasy",
+    "discord": "https://discord.gg/gKjzApDstD"
+  },
+  {
+    "name": "Stargaze",
+    "website": "https://www.stargaze.zone/",
+    "telegram": "https://t.me/joinchat/ZQ95YmIn3AI0ODFh",
+    "twitter": "https://twitter.com/stargazezone"
+  },
+  {
+    "name": "Steak",
+    "website": "https://app.steak.club/",
+    "telegram": "https://t.me/+PadO-WwMDxNjMGEx",
+    "twitter": "https://twitter.com/st4k3h0us3"
+  },
+  {
+    "name": "Terra Classic",
+    "website": "https://www.terra.money/",
+    "telegram": "https://t.me/TerraNetworkLobby",
+    "twitter": "https://twitter.com/terra_money"
+  },
+  {
+    "name": "Terra Money",
+    "website": "https://www.terra.money/",
+    "telegram": "https://t.me/TerraNetworkLobby",
+    "twitter": "https://twitter.com/terra_money"
+  },
+  {
+    "name": "Tuckermint",
+    "website": "https://tuckermint.com/",
+    "telegram": "https://t.me/tuckermintchat",
+    "twitter": "https://twitter.com/TuckermintNet"
+  },
+  {
+    "name": "WYND",
+    "website": "httpshttps://www.wynddao.com/",
+    "telegram": "httpshttps://telegram.me/wynd_dao",
+    "twitter": "https://twitter.com/wynddao"
+  }
+]

--- a/juno/pool.json
+++ b/juno/pool.json
@@ -1,0 +1,1102 @@
+[
+  {
+    "id": "juno1dug89d22vtu7v27ee9gg4xq5seu2tu705d6eh3kmvh0uvy7depaqg45qdj",
+    "lp_token_id": "UNABLE TO GET DATA FROM: Fortis",
+    "asset_ids": [
+      "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
+      "juno1vaeuky9hqacenay9nmuualugvv54tdhyt2wsvhnjasx9s946hhmqaq3kh7"
+    ],
+    "dex": "Fortis",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1qg9m2zdqaxx4udxxyun4cjq5myazlldymdmhkuy7fmvretyxz92q89zdvv",
+    "lp_token_id": "UNABLE TO GET DATA FROM: Fortis",
+    "asset_ids": [
+      "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
+      "ibc/2DA4136457810BCB9DAAB620CA67BC342B17C3C70151CA70490A170DF7C9CB27"
+    ],
+    "dex": "Fortis",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1r72th8l800djmhu8f0xhfkw046a4zlm0kcrela2vxwf0ehh3l68qumh53q",
+    "lp_token_id": "UNABLE TO GET DATA FROM: Fortis",
+    "asset_ids": [
+      "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
+      "juno10ynpq4wchr4ruu6mhrfh29495ep4cja5vjnkhz3j5lrgcsap9vtssyeekl"
+    ],
+    "dex": "Fortis",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1wjpdhpv7x5cusg028xglazr8ldxr7cnm0tss8sd9pg4r959rlgtqjkf70x",
+    "lp_token_id": "UNABLE TO GET DATA FROM: Fortis",
+    "asset_ids": [
+      "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
+      "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
+    ],
+    "dex": "Fortis",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1wuu8nwr37kmg0njg6p3ag7j4qcm08vs6z9e9j28aendnfnuxmd3sc4yrhm",
+    "lp_token_id": "UNABLE TO GET DATA FROM: Fortis",
+    "asset_ids": [
+      "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
+      "ujuno"
+    ],
+    "dex": "Fortis",
+    "type": "xyk"
+  },
+  {
+    "id": "juno107l74mj5q7d6zdzqzwpmdkk76628az2p9z08z9cj5pa7s5fpucws96f57e",
+    "lp_token_id": "juno1a7cyletk5w0v7w4v2h65w4qx6hfrjq6p054ymeldn57tta0pnrdqlh2enk",
+    "asset_ids": [
+      "ujuno",
+      "juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno10epwgtux4th7ka26lnd7x9r7de90lvurx65ealw5djdt6dyhzp3q4ghpnu",
+    "lp_token_id": "juno1w606gnjcvpswgltkj4qzs5avpgrrukjxv7wtsnsl3rund6s6v7zst3g06t",
+    "asset_ids": [
+      "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
+      "ujuno"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno10mrlcttkwt99wxnqfyk6327lq3ac9yhfle2fd0c5s4rp8dzqy9ps3sjzyf",
+    "lp_token_id": "juno1jpdjyc3c973frxkjkmvgr5ececzf9qslzrunxd2xkstem8zr338scnzt27",
+    "asset_ids": [
+      "ujuno",
+      "ibc/8F865D9760B482FF6254EDFEC1FF2F1273B9AB6873A7DE484F89639795D73D75"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno10yvrummu6ma72z9ne82k888acn5que7s8ef3xtadd3fkhtq9xkuq80dhjs",
+    "lp_token_id": "juno168cj6jad3s33gdgepresplqapn7vydqqxdx8jwy7nkqmhwc30gnqhd9e5u",
+    "asset_ids": [
+      "ujuno",
+      "juno1a0khag6cfzu5lrwazmyndjgvlsuk7g4vn9jd8ceym8f4jf6v2l9q6d348a"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno124d0zymrkdxv72ccyuqrquur8dkesmxmx2unfn7dej95yqx5yn8s70x3yj",
+    "lp_token_id": "juno1u57ju64c5qdmkrjgch2e3amutpjqrez6cq0jp7h2pytuthpfns7s4jln57",
+    "asset_ids": [
+      "ujuno",
+      "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno133xa84qnue3uy0mj9emvauddxzw554rfl9rr6eadhfau50ws7gvs4ynm79",
+    "lp_token_id": "juno1khupy0j42e4xlc6x6qp70gzrf80x90m9ff0067l2zyn3qdg6djlsw8h404",
+    "asset_ids": [
+      "ujuno",
+      "juno1wurfx334prlceydmda3aecldn2xh4axhqtly05n8gptgl69ee7msrewg6y"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno14hrt7htv42234xwpsxmxaxu7wywak7zflpk9jf5nze3w6e93czdsfwe0ly",
+    "lp_token_id": "juno1pca9ws39kps48dd0gmw7nxy5zgha2qhs8mxstswyyhcjd29jwpaq2uk9p8",
+    "asset_ids": [
+      "juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf",
+      "ujuno"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno14nak8v6xeawstrq7r7qmpa67qqfc9xzzymfdfpnp0luycv8knyuq5a6w2m",
+    "lp_token_id": "juno15jjyzdr4e9jc6ztnpdev4xzf5zzg0wm3tx96szn320r6q2nvgj9snyx0jc",
+    "asset_ids": [
+      "ujuno",
+      "juno1cl2ewl842wcnagz5psd68z4dpp4gfxrrm9atm807uvyyg235h85stg7awy"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno14p3wvpeezqueenfu9jy29s96xuk0hp38k5d5k4ysyzk789v032sqp8uvh3",
+    "lp_token_id": "juno1g62krgjk45ww5kle0nxugxfl5rskse5gd6zgh8hazn87uf8l942sfpxm8a",
+    "asset_ids": [
+      "ujuno",
+      "juno1p32te9zfhd99ehpxfd06hka6hc9p7tv5kyl5909mzedg5klze09qrg08ry"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno150vj5jusg4g8n82q40nd9cmq3unc255u3hf5qh6pud4dexkgyp0ss7yvwq",
+    "lp_token_id": "juno1luhat2afjej7m3aypxyn7hyk0c4w8y823f5qcuxkkljyvwwtwnrsq6qrvy",
+    "asset_ids": [
+      "ujuno",
+      "juno13926947pmrjly5p9hf5juey65c6rget0gqrnx3us3r6pvnpf4hwqm8mchy"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno152lfpmadpxh2xha5wmlh2np5rj8fuy06sk72j55v686wd4q4c9jsvwj0gm",
+    "lp_token_id": "juno1s82s62c3q5cnjfhcqmvthjd58t6jetxmf8rxp9xmqmyy05fu2qusp9fg97",
+    "asset_ids": [
+      "ujuno",
+      "ibc/946AD96F278770521526D7283F58268DA2F6ACDDE40324A9D1C86811D78C86A0"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1653nhx2330rnhmzk2qe9w74kwwa3jtxe4lrfs5cfq8szfms8pqzsra5fvq",
+    "lp_token_id": "juno1dtmjggsjx56ehpdjccqlzzls7u4wsnxejt4rj46x3g2jqayls87svgemgq",
+    "asset_ids": [
+      "ujuno",
+      "ibc/52423136339C1CE8C91F6A586DFE41591BDDD4665AE526DFFA8421F9ACF95196"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno16zn96yf3vnxengke3vcf6mg9x7qyppgsdh3dnnmvdd8hvtpw58wsrjuu56",
+    "lp_token_id": "juno1pe2umwzqea0hvstzug2mm2ntrcxm336374954p5f6e52s5gf2zusklhqqr",
+    "asset_ids": [
+      "ujuno",
+      "juno1pshrvuw5ng2q4nwcsuceypjkp48d95gmcgjdxlus2ytm4k5kvz2s7t9ldx"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1730cx75d8uevqvrkcwxpy9trhqqfksu5u9xwqss0qe4tn7x0tt3shakhk8",
+    "lp_token_id": "juno1lgprt38gkp4nvggjl0dm0e7k5lgd80e525f8rjg60tc6fk2xexcqhpp6sm",
+    "asset_ids": [
+      "ujuno",
+      "ibc/D836B191CDAE8EDACDEBE7B64B504C5E06CC17C6A072DAF278F9A96DF66F6241"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno17h4sgpaksygdnswpx74szv98hggddc08ny4zv5ca63jv53qptxrshacvku",
+    "lp_token_id": "juno1gcamzveq77v32lw7252v0etx9tm2j2jzy3s5ax0cz6dxnzkx5g4qfqunul",
+    "asset_ids": [
+      "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g",
+      "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno17v2d2993me50e6dgzx50ckuuah0vmfyanl0segxsdcg3s4qzqersyrvu8n",
+    "lp_token_id": "juno1s4rn507yhlqw8p7haqpmd3uuvttehact7acsgd9s94pvnkw78t4smkuacv",
+    "asset_ids": [
+      "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
+      "ujuno"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno18nflutunkth2smnh257sxtxn9p5tq6632kqgsw6h0c02wzpnq9rq927heu",
+    "lp_token_id": "juno17w75xxt0uxc8tsrcdtdkx9xgvspkzt7p5fz07lec4azjudnrjvcqhnr2kk",
+    "asset_ids": [
+      "ujuno",
+      "juno1re3x67ppxap48ygndmrc7har2cnc7tcxtm9nplcas4v0gc3wnmvs3s807z"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno19859m5x8kgepwafc3h0n36kz545ngc2vlqnqxx7gx3t2kguv6fws93cu25",
+    "lp_token_id": "juno1vayeejfdzr32rg3kkzqvl7euxqzferxstdal3qlask5f37sxcvxsvk6mse",
+    "asset_ids": [
+      "ujuno",
+      "juno1vaeuky9hqacenay9nmuualugvv54tdhyt2wsvhnjasx9s946hhmqaq3kh7"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1acs6q36t6qje5k82h5g74plr258y2q90cjf9z4wnktt7caln0mhsx8mt7z",
+    "lp_token_id": "juno1k2xzml24sglxlf3hrsmt9a7mtk0jchq279ja5u3asvmtaq3a4uss7xuu5g",
+    "asset_ids": [
+      "ujuno",
+      "juno1vn38rzq0wc7zczp4dhy0h5y5kxh2jjzeahwe30c9cc6dw3lkyk5qn5rmfa"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1ctsmp54v79x7ea970zejlyws50cj9pkrmw49x46085fn80znjmpqz2n642",
+    "lp_token_id": "juno1uwp9rs0ya4p6qk8zezl2y666vvtnfvxfmuwngu95pg6m55mg6xpq65jrje",
+    "asset_ids": [
+      "ujuno",
+      "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1cugrrrryrpl383kfca0w5swywffa08zwqshrsfre82059vxjlx6syhf73y",
+    "lp_token_id": "juno1883e886ujdkgcx94dg35da0l020jcx8y3m6wrf6lf0ntpl5y0mmsq50aru",
+    "asset_ids": [
+      "ujuno",
+      "juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1cvjuc66rdg34guugmxpz6w59rw6ghrun5m33z3hpvx6q60f40knqglhzzx",
+    "lp_token_id": "juno1h0sqa8qtngwe3jl9qpfg03whjvcgczsk985vrpt6h94t0yp8uspssfvugp",
+    "asset_ids": [
+      "ujuno",
+      "juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1d04vn4t3cw494md0xleyqk6hxt8ctn5gmr353h06uvnudlvk5chq93vmjq",
+    "lp_token_id": "juno1m53w7htf3lgtt2mvd336ja8kkwjrhayk7wazpmvjwsenxxeyt4zsgjn6gw",
+    "asset_ids": [
+      "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
+      "ujuno"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1e8n6ch7msks487ecznyeagmzd5ml2pq9tgedqt2u63vra0q0r9mqrjy6ys",
+    "lp_token_id": "juno1jmechmr7w6kwqu8jcy5973rtllxgttyetarys60rtsu0g675mkjsy96t8l",
+    "asset_ids": [
+      "ujuno",
+      "juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1el6rfmz6h9pwpdlf6k2qf4dwt3y5wqd7k3xpyvytklsnkt9uv2aqe8aq4v",
+    "lp_token_id": "juno100pmxfny54wktum5jklg9vme7d5pe44h7va6uw4smccte6wkfaust0untw",
+    "asset_ids": [
+      "ujuno",
+      "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1enl842z00cklnathpv8f3t3w2u70dkrq22crz3gxg38we7xjfq5s8lktmg",
+    "lp_token_id": "juno12snvzgec29vvzhmcc3m4dq2a86vl5apn2gemveqj73ypxhylty3q2ndad4",
+    "asset_ids": [
+      "ujuno",
+      "juno1t8dnpktypue65q0hjz7tr3cvqypgj5vkxhd2twvng4a2ywa3j25spjuk6z"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1fha0ux5k6xxzzknhwk0j2rtwxtczlp8kzk6w9g383lzjhu337k9swvjdlv",
+    "lp_token_id": "juno19dts5x9v2jz2589e42fw8ynn2737a2jawsk8ank8hvu5jveassfqmlvff9",
+    "asset_ids": [
+      "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
+      "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1fjmrqc5tjj2t5mfwkk5utwz2t0gcpkfajjefllrfahuqanctn9ys968emr",
+    "lp_token_id": "juno1dl5efsl4nj07rzc0qrrh0wa2dkn2u6746qtcvnvl0hmfawlm0ctqwmqzm9",
+    "asset_ids": [
+      "juno147t4fd3tny6hws6rha9xs5gah9qa6g7hrjv9tuvv6ce6m25sy39sq6yv52",
+      "ujuno"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1fpphzkkq5uyezm7amk6sslyz8r94wl658zg2ku47v8mtslueyx5q29rkzq",
+    "lp_token_id": "juno1cnggcz546d65mzya527mweksujwmkhhh6gf2juuzrrd4zu6n8tgswxh80c",
+    "asset_ids": [
+      "ujuno",
+      "juno1hy0ky3pe742phd4w55tdfej0ez55h4jx4g06rp4wsa0mne9wzudqy4hum2"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1fzl79pekf8wtd0y37q92dmz5h9dxtfpl97w3kguyc59m7ufnlzvsf46vf8",
+    "lp_token_id": "juno1vqvnmf4vpkkrjp9caahtfxgkcg2zcud3a7t6080rwzceusk8qxjs35n4s5",
+    "asset_ids": [
+      "ujuno",
+      "juno1gzys54drag6753qq75mkt3yhjwyv4rp698kfvesh0wcy5737z4tsn0chtm"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1gpa5ardzal22el6czj4j0d2pwy0m9qj06lr20t2l8fca3gkws63qfnx8eq",
+    "lp_token_id": "juno1fweq070y8lvxmtn7j3p7yltphg8uuksk7p875suwppyzg259rt0s29qgss",
+    "asset_ids": [
+      "ujuno",
+      "ibc/6842C591DC4588411A565C9FF650FB15A17DFE3F0A43201E8141E4D14B8D171A"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1gv2gswtan8wsk54h663waefffywnuc9wcxr7xl5pnnxvjaqunpgs20t39g",
+    "lp_token_id": "juno1gj4rprgp9uvwx25ssez6yl2ll2z32fmv7a3mungqz5nxzqfpvrnsteqejd",
+    "asset_ids": [
+      "ujuno",
+      "ibc/0CB5D60E57FD521FA39D11E3E410144389010AC5EF5F292BC9BDD832FA2FDBF9"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1gxvcltkl0tf20rpsn2wf9q6ex0vr5xk6j3tzezuv6yyjez97w5vqmxk0cv",
+    "lp_token_id": "juno1qjt776qcnrjjhdnqe7ds5sn3cr3sfhsv6awfhvx9ujywv92lty7q45ucx9",
+    "asset_ids": [
+      "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
+      "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1hkz5dhn59w6l29k8w8ceuramqx2f35qpen7xtlx6ezketwh8ndxq8rwq2a",
+    "lp_token_id": "juno1ukhxlrtje0dt2n7k54m8l83rxjrta7fqwvzzhapgzafwzt38u8pqsdfrh8",
+    "asset_ids": [
+      "ujuno",
+      "ibc/B55B08EF3667B0C6F029C2CC9CAA6B00788CF639EBB84B34818C85CBABA33ABD"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1hue3dnrtgf9ly2frnnvf8z5u7e224ctc4hk7wks2xumeu3arj6rs9vgzec",
+    "lp_token_id": "juno1l0z6d7wlwpwequtenwt8pd44685jyhqys6jdnp8xa8ektn0un4zsadyw8y",
+    "asset_ids": [
+      "ujuno",
+      "ibc/2DA4136457810BCB9DAAB620CA67BC342B17C3C70151CA70490A170DF7C9CB27"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1j7pdtemw0qvl6rmnl0sf324409gz2p4sdt6rv659482x9rqqz6mqd653dg",
+    "lp_token_id": "juno18hu00pwvd8kq0cgzk03l2nmp8rr0h5gp6tektz6qazwfapqsl4cqwfgdsv",
+    "asset_ids": [
+      "ujuno",
+      "ibc/008BFD000A10BCE5F0D4DD819AE1C1EC2942396062DABDD6AE64A655ABC7085B"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1jz50fj5zkcv3h6hmcfr3nr6eer7rj5pmsry5qj5jc8rfvpeavyzsgknm83",
+    "lp_token_id": "juno18t52fyupsh8fu48kufyqwneks4enr0u2e0gdvwzvsfravvmkszmswj32nu",
+    "asset_ids": [
+      "ujuno",
+      "juno14lycavan8gvpjn97aapzvwmsj8kyrvf644p05r0hu79namyj3ens87650k"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1lgmtzhn840y9l74azn06w0wnsh4y98mjq5zs98yf96ggm7ejz05sgvpzqc",
+    "lp_token_id": "juno16gsp50vlh8gzz9hjunmd2dzlllafp03a2a6pvch3n5pwfmaladhskwwk49",
+    "asset_ids": [
+      "ujuno",
+      "ibc/436B576861090C1C921D56BA1FAE481A04D2E938EBDFF55C4712670F9754AC40"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1m08vn7klzxh9tmqwajuux202xms2qz3uckle7zvtturcq7vk2yaqpcwxlz",
+    "lp_token_id": "juno10cdmzmh5yya0d0686407qrn92elx4q7ecmmdq0vrprpartjhz99q50frz2",
+    "asset_ids": [
+      "ujuno",
+      "juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1maj5xlggctfwm6ct6x2e3456zxm8chadq9prqxl9kjxzzs9edalsk5wzwh",
+    "lp_token_id": "juno1th2uaedyeat7a8mer6a709mcq67wr7avlt5tlm4pvt9f6v2cf9lqhxwq25",
+    "asset_ids": [
+      "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
+      "ujuno"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1na8zlnp3pqsjfzllcncq2ahsxg9zkdkqrz3sl4ae5lergh2wrjes7jl9gr",
+    "lp_token_id": "juno1p047hllllt4nu487a8qhsf2lr9unxfknal7jm56se3qplehrlunsr8zwyc",
+    "asset_ids": [
+      "ujuno",
+      "juno1kqx9rhc8ksx52tukdx797k4rjrhkgfh4gljs04ql97hmnnkgyvxs5cqt7d"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1p8prj0dddf6d2wp599rtv9c5zp3v5gx0pjpk0hwl8fuhn7x8jslqxvjeqk",
+    "lp_token_id": "juno1l0tx38u7duyh3a6557cfrlevtr8fnr28p7xc7w3wlfw2rtghrujqla27v5",
+    "asset_ids": [
+      "juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3",
+      "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1pxn38k3kz9k8cjlrghdwzmkxz67l343k5xuxn744wa56vfddrepsx72j5x",
+    "lp_token_id": "juno1n5ljavtmj2heu34yvx7kdu8qrr4dqll2j3j8k86jxd03qyd6e3nqtmfgqx",
+    "asset_ids": [
+      "ujuno",
+      "juno173c59crjqeec28cpzs7n0y7hm4cd308zda8z6j4cnl6pct3stenseg2dxp"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1qsmywlded2sdggud5wft44gq2u6c3epl3qhzr4qv7psj536t8yhsfvrcf6",
+    "lp_token_id": "juno1fdj5u026t828yuskgq9h5ehx2gncjjjxvrydtnljn9xchj6xdhdsjx6lxy",
+    "asset_ids": [
+      "ujuno",
+      "ibc/5CB906E82B7A88E62644AD811361F5858B74BA9EBD75C84B6D24B20C01A4819F"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1qt7uzjg9su3mk78jpt695rmxce4sa7evz7wa0edexjrsxghy35hsgje5l9",
+    "lp_token_id": "juno1s6vnzf94d5sa0ax735y3ug4svmg5pc40lumsqygkc5jxngwccqls7z5xjv",
+    "asset_ids": [
+      "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup",
+      "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1rft4xp5e6ffta5a8aqwtu4kgdfjqw4jhnleu8agmmedzrxsat7pqxfgfrs",
+    "lp_token_id": "juno10dvm495wxtlxtda8492dsc2yut0wk2lpnz6h7wad3ecrym5k4a6qh4uvzc",
+    "asset_ids": [
+      "ujuno",
+      "juno1n7n7d5088qlzlj37e9mgmkhx6dfgtvt02hqxq66lcap4dxnzdhwqfmgng3"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1sg6chmktuhyj4lsrxrrdflem7gsnk4ejv6zkcc4d3vcqulzp55wsf4l4gl",
+    "lp_token_id": "juno18ckrreffz9jwmkw84axsvncexfqt7gpgckskk0yy0vzwm9huqkyq6v78xu",
+    "asset_ids": [
+      "ujuno",
+      "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1tmxx3rdnnrcckkh7pjde924lftjs724rzd44sqte5xh8xax0yf2sc7v7dk",
+    "lp_token_id": "juno1plauy5jh7dggc0pvcduaaj4slk7l9w883mecxkew7xaff6uzmztq4d0003",
+    "asset_ids": [
+      "ujuno",
+      "ibc/DFC6F33796D5D0075C5FB54A4D7B8E76915ACF434CB1EE2A1BA0BB8334E17C3A"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1v842hl5mtn2kjeu4sscr4e3y9jmv7tf0h7cy4wm6nusyf4v8j6ssh8gkgp",
+    "lp_token_id": "juno16uhnlsrnwgxk2839zr5rqz74xedcxvhknlpvw8yhv7wqpm0ggvzsa2kfae",
+    "asset_ids": [
+      "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
+      "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1w7l7hetsm4x6hxa55dsjwszqh9elzwqrd6cud2qkqhafrd6u9vrqc2zh48",
+    "lp_token_id": "juno1v7y2wgj4d45t9kcl7qtrezncxr5k6anjqx4avv22s2rj595av2qqrpyw4f",
+    "asset_ids": [
+      "ujuno",
+      "juno17r8dyxuj25muaudhgqgx4xrg6gzr6tvzem6gwtpprnfld58yggcqjhhkjy"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1xkm8tmm7jlqdh8kua9y7wst8fwcxpdnk6gglndfckj6rsjg4xc5q8aaawn",
+    "lp_token_id": "juno1jq40jyxg57kumvaceskedcgsaje8tfagtpxsu8gnray525333yxsk8sl7f",
+    "asset_ids": [
+      "ujuno",
+      "juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1yaff0t6tfheqcdep24euu7w0xhnhs2yjwwv7r2c280vlns8trghq5d72pd",
+    "lp_token_id": "juno1jeh4eqlsge0w8kcmjlt82rzzwe4vr5yxe69nvqt2jcgg4q4e8ypq0c7h7f",
+    "asset_ids": [
+      "ujuno",
+      "ibc/7455B3F2F2737906BACF4AE980069A4CAB7C7F9FDAABAEFBA439DF037AEC5898"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1ytntasjjyzpdfhsw60yp7rt3ww57nqth45lfaek9ae65ylm0xpkqsp47fz",
+    "lp_token_id": "juno1dmtkurpgzyk0p4h26k02txwmk23qu9vq9xn6e6cuahh6n9x52r2qej4gl9",
+    "asset_ids": [
+      "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
+      "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1z5vukf037r6acgln3n37tr8a5rv7wafqzhcq29ddn9etwwtfrytsn6xvux",
+    "lp_token_id": "juno1dhmd8lredr9psu4afk8j3lstdg896pme49mje6maxucuuugmmptstzaj07",
+    "asset_ids": [
+      "ujuno",
+      "ibc/F6B367385300865F654E110976B838502504231705BAC0849B0651C226385885"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1z698dxy9gj4fnrs76xwmtqwh84lamav9xl0w35pd35vnfx7987nqudxyge",
+    "lp_token_id": "juno15g2ghm8u9jtkp5pu2y0n6dlzsewxltdjvygwcg5ggusp7tghxnlqjtvw87",
+    "asset_ids": [
+      "ujuno",
+      "ibc/B9F7C1E4CE9219B5AF06C47B18661DBD49CCD7A6C18FF789E2FB62BB365CFF9C"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1z8c5kqh2yc48wstsq4h68lk78kxmf0rh30qs5f6d7luxzledvjtsxgugzt",
+    "lp_token_id": "juno1d7zwptczk6hya9lx269a5kk6nt5qmlmdzh4zjalcqjwcsctmdeqqyvgl8t",
+    "asset_ids": [
+      "ujuno",
+      "juno1x02k67asfmjawgc96dj8nxq6se3fmx36gedgs5hvkjegdhfy97rs3jgj2h"
+    ],
+    "dex": "JunoSwap",
+    "type": "xyk"
+  },
+  {
+    "id": "juno16sljr0c7fj00s8dnhe0ql8nn40ca9v3fyuga3svnq860fzal5s2qw02j0t",
+    "lp_token_id": "juno1dp2t26a575e5v2dxs3um77k2fa39sk0nzw7qmvhrja5vc3q96rvshv0hw5",
+    "asset_ids": [
+      "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
+      "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "juno199gtrzfha3fz0h2mq4jhlhus3vqgql7u58mp97rea79xw9zmrwrs0mwsvd",
+    "lp_token_id": "juno1skwwlvqdw2499spvzqjyr78tg3d0fxlw3ek0f2y6nnl7xcqe8r8syu42dt",
+    "asset_ids": [
+      "ujuno",
+      "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1aagw3m89ze94v6e56k0eeemldrk8ajmtccmwer9ffrzduw3zuwds0w58xk",
+    "lp_token_id": "juno19u80rx7fyun6q3e5tg0dj0fy78q7rk2rycv94k9dqrkth5kmtttqmkqxpw",
+    "asset_ids": [
+      "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
+      "ujuno"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1dl8zdygs57lcwm3e9tnq4pdmmp8nhhf08jcne72nsjkf7qntfz3s0e99x3",
+    "lp_token_id": "juno1kceqgs9hr4qt2ln87k6hqkgge6545cskpalyxjdyh99gr77kvw7szgctjx",
+    "asset_ids": [
+      "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup",
+      "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1e4gxx99ufal40jkrl90ucjlvuvns942xqg3ycu9gmw4nwgyrap8sk52ua8",
+    "lp_token_id": "juno194m6qvjr424hzqax5kgx2racpg2gx4yeq3d8kg0dm0xte3e7hpvq7ceceu",
+    "asset_ids": [
+      "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
+      "ujuno"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1evlfyl2n0f0z393m3ehu9n2z98znakhwhhvzmxce08uvuzleu8cs7eldh7",
+    "lp_token_id": "juno1g30cu6w3ezng8q00sdhnlz3ynwutpscxvuvqmmf385pw7jrg4shq6tdgy2",
+    "asset_ids": [
+      "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034",
+      "juno17r2vpc5enkyfe2xle9sedxdq3msfpacwcfp9rnr6jc3e7v6av0jqmfyfzp"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1mz8yzrgyp9mmq9aksxgpy83vmu8p4j8h3qyf9waxcd2epchqx5ps0ekj27",
+    "lp_token_id": "juno1eu0cf0eeksxse8g2mgkarhxjfpx9mzmlkjpgmw6cn526sv92zf5shjmnz2",
+    "asset_ids": [
+      "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup",
+      "juno14lycavan8gvpjn97aapzvwmsj8kyrvf644p05r0hu79namyj3ens87650k"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1qc8mrs3hmxm0genzrd92akja5r0v7mfm6uuwhktvzphhz9ygkp8ssl4q07",
+    "lp_token_id": "juno140h0ctxu0ete06a86u4has6ymppqpx30z6yfyumlkfwqjkv3grrs089el6",
+    "asset_ids": [
+      "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup",
+      "ujuno"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1rw5cdwl6cxw882czan4x2ysp30zsm94l6jcqealg82vm2dl989ns63veh8",
+    "lp_token_id": "juno162vk72cy4psyt4f3axw32tyfswswgq37h2rl8gwf7mavdj4mchfqhljfuf",
+    "asset_ids": [
+      "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
+      "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1szc3uak9vqsc8halhx2pxj6yehg67de9tzmw2z2gqxm0cr2ncnpsxre8pc",
+    "lp_token_id": "juno14dfmj338xr5lcnnj2yuqp2f5y3ukn8kr8m2rygvrcw5npwfdz4ps6kqwjn",
+    "asset_ids": [
+      "ujuno",
+      "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1utkr0ep06rkxgsesq6uryug93daklyd6wneesmtvxjkz0xjlte9qdj2s8q",
+    "lp_token_id": "juno17xudkf5a2m2nny7gqzss4wuges5v0ek035m3wzefp3a99x80kxasj5whwu",
+    "asset_ids": [
+      "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup",
+      "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1vyuw20szeykmuq09xmh5g6q0kmezcl08xwz7qhtkdzh9qc0gspgsrgxzxj",
+    "lp_token_id": "juno14t6z9mclx6x47quvnv69hf3lr43d4p5dlvu925eg50t80eflh9eqcgsz80",
+    "asset_ids": [
+      "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518",
+      "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1zqageq56kpl2xru2dc4zvq3z90fykrraqkl6s54qgmcpe0r0ruksq0f77g",
+    "lp_token_id": "juno1xaa0z3u35ence7mvt38uz3cpu77hdt7gdvwrlyh5gpfgm8zghyaqktzl68",
+    "asset_ids": [
+      "ujuno",
+      "juno17r2vpc5enkyfe2xle9sedxdq3msfpacwcfp9rnr6jc3e7v6av0jqmfyfzp"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "juno180jzqh7vefwuks6eyvf0lkecdl2mp8u08d844245faunja969p3s8w3t3q",
+    "lp_token_id": "UNABLE TO GET DATA FROM: Marble",
+    "asset_ids": [
+      "juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
+      "juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl"
+    ],
+    "dex": "Marble",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1nljy8gst5agtc0zstfjytf2hrnj8vcxgcdzrp4qj7k2dcnrfz4wsu6ty4f",
+    "lp_token_id": "UNABLE TO GET DATA FROM: Marble",
+    "asset_ids": [
+      "juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
+      "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
+    ],
+    "dex": "Marble",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1xf32js0lc6v7quxj5twuna97hwff7dhkz6psujavvknh2yzty5uq6wut8j",
+    "lp_token_id": "UNABLE TO GET DATA FROM: Marble",
+    "asset_ids": [
+      "juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
+      "ujuno"
+    ],
+    "dex": "Marble",
+    "type": "xyk"
+  },
+  {
+    "id": "juno158mcxa5ajpjfxgy60asrg3m0823m2el5n333xdypcw8h5uwhuvyqkyc4a7",
+    "lp_token_id": "juno1zmsgdpdej4g4m4fc5y5p6wr8gn6peh9vx5dk5vf7v7w32jjmcetshl0yw4",
+    "asset_ids": [
+      "ujuno",
+      "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup"
+    ],
+    "dex": "WhiteWhale",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1k9cw9yghf04cqlu290n4zlveker5cev5ahweqkh07y7zc3xq9hrshjruk8",
+    "lp_token_id": "juno1fkejwm7alyfnjngtpgtxvreqfcz8uwer2jgwjn40suvgq20tm8ss73cj05",
+    "asset_ids": [
+      "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
+      "ibc/107D152BB3176FAEBF4C2A84C5FFDEEA7C7CB4FE1BBDAB710F1FD25BCD055CBF"
+    ],
+    "dex": "WhiteWhale",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1p9z8xe96fyvg3h5gtvnpjjv2u47q6l7sdhg6asmyfgc6q8l8ttgqfvxnxh",
+    "lp_token_id": "juno1g3549wm0tffdzdpasufjr0nccu9ynzpzway5g3u6ucmhfd4ds05swswasc",
+    "asset_ids": [
+      "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
+      "ujuno"
+    ],
+    "dex": "WhiteWhale",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1v6stcdrvwrthfvcwvlmmzht32ft9g9nw85tthcjqer242xg3nvdq8fjasx",
+    "lp_token_id": "juno12caca3ymhxr7a73wtdefye86djs69704ktzkv02xkf59se8hx72qwyxq72",
+    "asset_ids": [
+      "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
+      "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
+    ],
+    "dex": "WhiteWhale",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1wkjy5wl0pd5xxvwtrx37r7ydkt3dkwvghs00tvvqyd3xnjukah7qpj0vj7",
+    "lp_token_id": "juno19mkjyvydnq440a3ms4fccpltrzmxlvlz6nvz6qul0mgxvse42n2q9qkf72",
+    "asset_ids": [
+      "ujuno",
+      "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
+    ],
+    "dex": "WhiteWhale",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1xpt9mkncxadadn5t8s4t74nmw5zlarghmpme26857s07xz388d6sukvtnz",
+    "lp_token_id": "juno1zetjfu8j0ndt4d3mgewhatgpfrj8pwhev2tdp3sa9dwwmqlgdxws4257we",
+    "asset_ids": [
+      "ujuno",
+      "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g"
+    ],
+    "dex": "WhiteWhale",
+    "type": "xyk"
+  },
+  {
+    "id": "juno13lulw8mm9w8ww99dvr35tfaw5tdmwvc7xn6nsn28pnlre8uw7j6srce67z",
+    "lp_token_id": "juno107v6e3vga87v3y777wcgznrlu6jyljzdpgecaegec9ccyqsx97pszq3598",
+    "asset_ids": [
+      "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
+      "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno14ke9xn3qfmnjsrh9lh6rfu7zmm90duvj4lpkcrrnzemh0tjpwarqfk97n6",
+    "lp_token_id": "juno1yw5mpl9rq64y6wt88ual5fneckksuudhl9u9c0w2gvvj99q7vmdsvmvu3a",
+    "asset_ids": [
+      "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
+      "juno1hnftys64ectjfynm6qjk9my8jd3f6l9dq9utcd3dy8ehwrsx9q4q7n9uxt"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno16k0f2mksg7swautzgfynve2ns3kq95ggp0z9t5dvxg56q45x67nqckmzru",
+    "lp_token_id": "juno1n965ux7p8qhph9j3g378qqr9fa5qup7jz089k0xjzqg99e787ekq84g8we",
+    "asset_ids": [
+      "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
+      "ibc/F6B367385300865F654E110976B838502504231705BAC0849B0651C226385885"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno16r20f55kp59l0v5ne6hzell3qu27jhuzrqmu59w2nxzcsnj90y0sh2m6p5",
+    "lp_token_id": "juno1k5vhzkssgh35zlv9hqaasetslgqyal6jane86umrqvrjav9eg3hq3pxa0l",
+    "asset_ids": [
+      "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
+      "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno16vvu2fjrgg6rnddrcvtaeukzl3weau63gc3d3c7mvq05ygnzklvs3peqmt",
+    "lp_token_id": "juno10zj5zme4g0zj6hc79tkld5p47gjpe8qvxlky650gwan4tf0a4u8qzg5kc9",
+    "asset_ids": [
+      "ujuno",
+      "juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno16xrz7kd26j0qmdg706qyesqs56g2f6dulplsajtl0t9z8frd8tfqsx2lkj",
+    "lp_token_id": "juno14kjhrjmdzkwgy4pvm5xeuj58960y5ku95sup2apstla3jzf829lqq5zkws",
+    "asset_ids": [
+      "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
+      "juno1w7kspnu3j4hmzvsltsk00xujfa84sf502vs2zjcawl03vgn7vj3sww9mh7"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno177xtcl6dax47kg3xptr5n48kd7twmzm49ltugfxuc76x9v05qq6q63hsm9",
+    "lp_token_id": "juno1kqeqglacd8l48347tttjlqc4yvxpcvhdekqrtrhv76frjh96gruqx36efv",
+    "asset_ids": [
+      "ujuno",
+      "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno17ckp36lmgtt7jtuggdv2j39eh4alcnl35szu6quh747nujags07swwq0nh",
+    "lp_token_id": "juno1ev8qxfpen3yh9cxc9m5yu4qkuujlaxztw83kdh7txextvc5q8gdqpqxxzc",
+    "asset_ids": [
+      "ujuno",
+      "juno1vn38rzq0wc7zczp4dhy0h5y5kxh2jjzeahwe30c9cc6dw3lkyk5qn5rmfa"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno17jv00cm4f3twr548jzayu57g9txvd4zdh54mdg9qpjs7samlphjsykylsq",
+    "lp_token_id": "juno1qwpr47n9djzm7erghmatudva8chvg63ejuvqzhfvq7u4ckl62t2sh8uk4k",
+    "asset_ids": [
+      "ujuno",
+      "juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno17uv02azt545ag23xq7whw6z3r3chw7jwztnr9lypugy62drq3caqeyd2r3",
+    "lp_token_id": "juno1an2xhen0fzme85dpy7vx60f6ecrufqj6vqkh8gdvlyhfhjmp24qqqleeav",
+    "asset_ids": [
+      "ujuno",
+      "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno18zk9xqj9xjm0ry39jjam8qsysj7qh49xwt4qdfp9lgtrk08sd58s2n54ve",
+    "lp_token_id": "juno13ld2eq3w8k6rap5n5vsmwr8c4zhqhtfu9vjx0gqmhpefefl97nxq4u4pap",
+    "asset_ids": [
+      "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
+      "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1a7lmc8e04hcs4y2275cultvg83u636ult4pmnwktr6l9nhrh2e8qzxfdwf",
+    "lp_token_id": "juno1stg339rrg9guqsuv205yayq2ttzwz4583luc9pznvexe7rtrtrksdxstg3",
+    "asset_ids": [
+      "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
+      "ujuno"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1gqy6rzary8vwnslmdavqre6jdhakcd4n2z4r803ajjmdq08r66hq7zcwrj",
+    "lp_token_id": "juno1jn6t0dsxryht8ljxulavxrfd22l87dvac8e9a99a7tuj29ysxksqffhf5k",
+    "asset_ids": [
+      "ujuno",
+      "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1h6x5jlvn6jhpnu63ufe4sgv4utyk8hsfl5rqnrpg2cvp6ccuq4lqwqnzra",
+    "lp_token_id": "juno1uu3cewmpynvgsdu3lfqv2rh2n5nwtrguahkw64wjk99eg8r6fsss0e757x",
+    "asset_ids": [
+      "ujuno",
+      "juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1jtendlawm8rv96hnfuwn04y8uhwzp9epcxy5f0ms973pspueqcgsy3qzt0",
+    "lp_token_id": "juno14kdxq8eumdgj0sxg9h4sca8cga34avkanv9psujrxsn42350m7hshyuwm0",
+    "asset_ids": [
+      "ujuno",
+      "juno1w7kspnu3j4hmzvsltsk00xujfa84sf502vs2zjcawl03vgn7vj3sww9mh7"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1ls5un4a8zyn4f05k0ekq5aa9uhn88y8362ww38elqfpcwllme0jqelamke",
+    "lp_token_id": "juno1h52qvcp5phaqmhzeu9urzsfvtehn9d98ql6xj05sr6z78zjgjv6sletkec",
+    "asset_ids": [
+      "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
+      "juno1vn38rzq0wc7zczp4dhy0h5y5kxh2jjzeahwe30c9cc6dw3lkyk5qn5rmfa"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1mz5uz38h89dxj6c8w69rg7l060p8vq8pfetykk2gvrrxhjcsa5yqru9g7v",
+    "lp_token_id": "juno1as45s9detrnjwsn9vgcejz6erxttdtvu6kga4xrge3ny4lyfmjqq7lpgsj",
+    "asset_ids": [
+      "ujuno",
+      "juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1ndw52eaajcn8wpx7e503ly3j07666hhufx6cyp0s9v703rvzrpksfujv3h",
+    "lp_token_id": "juno1k58efu65v6m0kgnq0fpgk8fxhsqah74r4lsuyk68308a35xxyels2qkl5z",
+    "asset_ids": [
+      "ujuno",
+      "juno1x02k67asfmjawgc96dj8nxq6se3fmx36gedgs5hvkjegdhfy97rs3jgj2h"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1p3eed298qx3nyhs3grld07jrf9vjsjsmdd2kmmh3crk87emjcx5stp409y",
+    "lp_token_id": "juno1flax8ja0u2lzuv5qundw9k7hmc5ttf3jh98lgk4ttnx5s7jdq5dq6qzts3",
+    "asset_ids": [
+      "ujuno",
+      "juno14lycavan8gvpjn97aapzvwmsj8kyrvf644p05r0hu79namyj3ens87650k"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1ptdt6dg7ke6rn5k8xr8kh87zjnxhp832l5q07y3c9htz8z88cptqlthu5f",
+    "lp_token_id": "juno1gf7d9kp59na60zr9z4yl5chmf0x7ype3xutszc9gg270l2mtac9sratca6",
+    "asset_ids": [
+      "ujuno",
+      "juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1q0f3nlghr350e7lhmxej3ev0j25m5caws5y4kyr5huawwr24hfkq74fsnq",
+    "lp_token_id": "juno1r8lzdyydak2832m35wzg9g7l6z8whpm68t950cgncv2wnug8lhwseulms4",
+    "asset_ids": [
+      "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
+      "juno1x02k67asfmjawgc96dj8nxq6se3fmx36gedgs5hvkjegdhfy97rs3jgj2h"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1rcssjyqgr6vzalss77d43v30c2qpyzzg607ua8gte2shqgtvu24sg8gs8r",
+    "lp_token_id": "juno18khfnt4052e9s2y2c5kra5n9uw84hh8qc6k5t4aey70erlz500cqfum00n",
+    "asset_ids": [
+      "ujuno",
+      "juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1s00g9axpxgmwcrlc6xqcxzcjmaqpxhftkx62xfh64xends8ls5dqyyjnnl",
+    "lp_token_id": "juno1dx6djxrsr4f4mqjn3vsp6v0yrg78stv3d8qyp66k209qmzn7r3eqne7mwf",
+    "asset_ids": [
+      "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
+      "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1syxlvk6pjpuxplqxwxr6n6fveqaz069dzya0ass9vrfwn9qxpvpqhq7msy",
+    "lp_token_id": "juno1kpqf3lm2drxzf98xw5ptsqdd483wgtjdsr4dvcr3j89tv6rqvw2q9y383s",
+    "asset_ids": [
+      "ujuno",
+      "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1tndfgq4kfgm6wwvfem3uwqcpf4ac3cqfcf5df4efagucm32ywaasugr9mq",
+    "lp_token_id": "juno1au3mzqfams8axufpemtvufw78zetl3pl5qn4cn9r2tz9pgly79ws92kr46",
+    "asset_ids": [
+      "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
+      "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1u2pl8ql778655wakqmnhpln65q9pughd6jnrp93xwf4zakqjdh6qx3y9yt",
+    "lp_token_id": "juno1yhtyn2dv5k7ladzrznxlep2xm6q7dsd332wak3hhdrw0staer0ps83q8jw",
+    "asset_ids": [
+      "ujuno",
+      "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  },
+  {
+    "id": "juno1x9r54vejw4hnxe7xm4haaf0ymf825frm30xqf9cud6cmnrgkx9lsxpj475",
+    "lp_token_id": "juno1e2gc84wkm7d738gn49mjnc25j6979a0sjf3d6qpmdjhzrh2x0zdq2a866u",
+    "asset_ids": [
+      "ujuno",
+      "juno1hnftys64ectjfynm6qjk9my8jd3f6l9dq9utcd3dy8ehwrsx9q4q7n9uxt"
+    ],
+    "dex": "Wynd",
+    "type": "xyk"
+  }
+]

--- a/juno/pool.json
+++ b/juno/pool.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "juno1dug89d22vtu7v27ee9gg4xq5seu2tu705d6eh3kmvh0uvy7depaqg45qdj",
-    "lp_token_id": "UNABLE TO GET DATA FROM: Fortis",
+    "lp_token_id": "juno19qetspgghczk5hvw3su602vjqqdhgl062eftgh897cdka6lny5sq6yhmg4",
     "asset_ids": [
       "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
       "juno1vaeuky9hqacenay9nmuualugvv54tdhyt2wsvhnjasx9s946hhmqaq3kh7"
@@ -11,7 +11,7 @@
   },
   {
     "id": "juno1qg9m2zdqaxx4udxxyun4cjq5myazlldymdmhkuy7fmvretyxz92q89zdvv",
-    "lp_token_id": "UNABLE TO GET DATA FROM: Fortis",
+    "lp_token_id": "juno1te6t7zar4jrme4re7za0vzxf72rjkwwzxrksu83505l89gdzcy9sd93v4c",
     "asset_ids": [
       "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
       "ibc/2DA4136457810BCB9DAAB620CA67BC342B17C3C70151CA70490A170DF7C9CB27"
@@ -21,7 +21,7 @@
   },
   {
     "id": "juno1r72th8l800djmhu8f0xhfkw046a4zlm0kcrela2vxwf0ehh3l68qumh53q",
-    "lp_token_id": "UNABLE TO GET DATA FROM: Fortis",
+    "lp_token_id": "juno129xs226p0lqtdmkca7p27ajc6y8lv3xqgx9mzzyueazd8fzd8y6svnvu4q",
     "asset_ids": [
       "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
       "juno10ynpq4wchr4ruu6mhrfh29495ep4cja5vjnkhz3j5lrgcsap9vtssyeekl"
@@ -31,7 +31,7 @@
   },
   {
     "id": "juno1wjpdhpv7x5cusg028xglazr8ldxr7cnm0tss8sd9pg4r959rlgtqjkf70x",
-    "lp_token_id": "UNABLE TO GET DATA FROM: Fortis",
+    "lp_token_id": "juno10v5rhl4rth8ce77rld5m5wm79apxqjctkjquwx2qgrs9npvtjlqq5syjxw",
     "asset_ids": [
       "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
@@ -41,7 +41,7 @@
   },
   {
     "id": "juno1wuu8nwr37kmg0njg6p3ag7j4qcm08vs6z9e9j28aendnfnuxmd3sc4yrhm",
-    "lp_token_id": "UNABLE TO GET DATA FROM: Fortis",
+    "lp_token_id": "juno1jsl0d3e3ncrzmkyz77kkkcdpu4r638l35jpzs7hmqg5g7ypwwsnsln5hvt",
     "asset_ids": [
       "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
       "ujuno"
@@ -741,7 +741,7 @@
   },
   {
     "id": "juno180jzqh7vefwuks6eyvf0lkecdl2mp8u08d844245faunja969p3s8w3t3q",
-    "lp_token_id": "UNABLE TO GET DATA FROM: Marble",
+    "lp_token_id": "juno17sf282da63uwxfht9nuzslgan4jh7qvya0k78mc9v3muuckvjndsu8dy9m",
     "asset_ids": [
       "juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
       "juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl"
@@ -751,7 +751,7 @@
   },
   {
     "id": "juno1nljy8gst5agtc0zstfjytf2hrnj8vcxgcdzrp4qj7k2dcnrfz4wsu6ty4f",
-    "lp_token_id": "UNABLE TO GET DATA FROM: Marble",
+    "lp_token_id": "juno1eqj3unwgq5najlyzyjtqdjjqx9esxpmkv2gffjsvhyszasyzwejqerpwgl",
     "asset_ids": [
       "juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
@@ -761,7 +761,7 @@
   },
   {
     "id": "juno1xf32js0lc6v7quxj5twuna97hwff7dhkz6psujavvknh2yzty5uq6wut8j",
-    "lp_token_id": "UNABLE TO GET DATA FROM: Marble",
+    "lp_token_id": "juno1jzz4t6p2dpcteqay5yt4khyha0z3u3uhghzszv7c24r7pj02scwswsygzh",
     "asset_ids": [
       "juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
       "ujuno"

--- a/juno/pool.json
+++ b/juno/pool.json
@@ -1,1102 +1,1102 @@
 [
   {
     "id": "juno1dug89d22vtu7v27ee9gg4xq5seu2tu705d6eh3kmvh0uvy7depaqg45qdj",
-    "lp_token_id": "juno19qetspgghczk5hvw3su602vjqqdhgl062eftgh897cdka6lny5sq6yhmg4",
     "asset_ids": [
       "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
       "juno1vaeuky9hqacenay9nmuualugvv54tdhyt2wsvhnjasx9s946hhmqaq3kh7"
     ],
     "dex": "Fortis",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno19qetspgghczk5hvw3su602vjqqdhgl062eftgh897cdka6lny5sq6yhmg4"
   },
   {
     "id": "juno1qg9m2zdqaxx4udxxyun4cjq5myazlldymdmhkuy7fmvretyxz92q89zdvv",
-    "lp_token_id": "juno1te6t7zar4jrme4re7za0vzxf72rjkwwzxrksu83505l89gdzcy9sd93v4c",
     "asset_ids": [
       "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
       "ibc/2DA4136457810BCB9DAAB620CA67BC342B17C3C70151CA70490A170DF7C9CB27"
     ],
     "dex": "Fortis",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1te6t7zar4jrme4re7za0vzxf72rjkwwzxrksu83505l89gdzcy9sd93v4c"
   },
   {
     "id": "juno1r72th8l800djmhu8f0xhfkw046a4zlm0kcrela2vxwf0ehh3l68qumh53q",
-    "lp_token_id": "juno129xs226p0lqtdmkca7p27ajc6y8lv3xqgx9mzzyueazd8fzd8y6svnvu4q",
     "asset_ids": [
       "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
       "juno10ynpq4wchr4ruu6mhrfh29495ep4cja5vjnkhz3j5lrgcsap9vtssyeekl"
     ],
     "dex": "Fortis",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno129xs226p0lqtdmkca7p27ajc6y8lv3xqgx9mzzyueazd8fzd8y6svnvu4q"
   },
   {
     "id": "juno1wjpdhpv7x5cusg028xglazr8ldxr7cnm0tss8sd9pg4r959rlgtqjkf70x",
-    "lp_token_id": "juno10v5rhl4rth8ce77rld5m5wm79apxqjctkjquwx2qgrs9npvtjlqq5syjxw",
     "asset_ids": [
       "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
     ],
     "dex": "Fortis",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno10v5rhl4rth8ce77rld5m5wm79apxqjctkjquwx2qgrs9npvtjlqq5syjxw"
   },
   {
     "id": "juno1wuu8nwr37kmg0njg6p3ag7j4qcm08vs6z9e9j28aendnfnuxmd3sc4yrhm",
-    "lp_token_id": "juno1jsl0d3e3ncrzmkyz77kkkcdpu4r638l35jpzs7hmqg5g7ypwwsnsln5hvt",
     "asset_ids": [
       "juno17c7zyezg3m8p2tf9hqgue9jhahvle70d59e8j9nmrvhw9anrpk8qxlrghx",
       "ujuno"
     ],
     "dex": "Fortis",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1jsl0d3e3ncrzmkyz77kkkcdpu4r638l35jpzs7hmqg5g7ypwwsnsln5hvt"
   },
   {
     "id": "juno107l74mj5q7d6zdzqzwpmdkk76628az2p9z08z9cj5pa7s5fpucws96f57e",
-    "lp_token_id": "juno1a7cyletk5w0v7w4v2h65w4qx6hfrjq6p054ymeldn57tta0pnrdqlh2enk",
     "asset_ids": [
       "ujuno",
       "juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1a7cyletk5w0v7w4v2h65w4qx6hfrjq6p054ymeldn57tta0pnrdqlh2enk"
   },
   {
     "id": "juno10epwgtux4th7ka26lnd7x9r7de90lvurx65ealw5djdt6dyhzp3q4ghpnu",
-    "lp_token_id": "juno1w606gnjcvpswgltkj4qzs5avpgrrukjxv7wtsnsl3rund6s6v7zst3g06t",
     "asset_ids": [
       "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
       "ujuno"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1w606gnjcvpswgltkj4qzs5avpgrrukjxv7wtsnsl3rund6s6v7zst3g06t"
   },
   {
     "id": "juno10mrlcttkwt99wxnqfyk6327lq3ac9yhfle2fd0c5s4rp8dzqy9ps3sjzyf",
-    "lp_token_id": "juno1jpdjyc3c973frxkjkmvgr5ececzf9qslzrunxd2xkstem8zr338scnzt27",
     "asset_ids": [
       "ujuno",
       "ibc/8F865D9760B482FF6254EDFEC1FF2F1273B9AB6873A7DE484F89639795D73D75"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1jpdjyc3c973frxkjkmvgr5ececzf9qslzrunxd2xkstem8zr338scnzt27"
   },
   {
     "id": "juno10yvrummu6ma72z9ne82k888acn5que7s8ef3xtadd3fkhtq9xkuq80dhjs",
-    "lp_token_id": "juno168cj6jad3s33gdgepresplqapn7vydqqxdx8jwy7nkqmhwc30gnqhd9e5u",
     "asset_ids": [
       "ujuno",
       "juno1a0khag6cfzu5lrwazmyndjgvlsuk7g4vn9jd8ceym8f4jf6v2l9q6d348a"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno168cj6jad3s33gdgepresplqapn7vydqqxdx8jwy7nkqmhwc30gnqhd9e5u"
   },
   {
     "id": "juno124d0zymrkdxv72ccyuqrquur8dkesmxmx2unfn7dej95yqx5yn8s70x3yj",
-    "lp_token_id": "juno1u57ju64c5qdmkrjgch2e3amutpjqrez6cq0jp7h2pytuthpfns7s4jln57",
     "asset_ids": [
       "ujuno",
       "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1u57ju64c5qdmkrjgch2e3amutpjqrez6cq0jp7h2pytuthpfns7s4jln57"
   },
   {
     "id": "juno133xa84qnue3uy0mj9emvauddxzw554rfl9rr6eadhfau50ws7gvs4ynm79",
-    "lp_token_id": "juno1khupy0j42e4xlc6x6qp70gzrf80x90m9ff0067l2zyn3qdg6djlsw8h404",
     "asset_ids": [
       "ujuno",
       "juno1wurfx334prlceydmda3aecldn2xh4axhqtly05n8gptgl69ee7msrewg6y"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1khupy0j42e4xlc6x6qp70gzrf80x90m9ff0067l2zyn3qdg6djlsw8h404"
   },
   {
     "id": "juno14hrt7htv42234xwpsxmxaxu7wywak7zflpk9jf5nze3w6e93czdsfwe0ly",
-    "lp_token_id": "juno1pca9ws39kps48dd0gmw7nxy5zgha2qhs8mxstswyyhcjd29jwpaq2uk9p8",
     "asset_ids": [
       "juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf",
       "ujuno"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1pca9ws39kps48dd0gmw7nxy5zgha2qhs8mxstswyyhcjd29jwpaq2uk9p8"
   },
   {
     "id": "juno14nak8v6xeawstrq7r7qmpa67qqfc9xzzymfdfpnp0luycv8knyuq5a6w2m",
-    "lp_token_id": "juno15jjyzdr4e9jc6ztnpdev4xzf5zzg0wm3tx96szn320r6q2nvgj9snyx0jc",
     "asset_ids": [
       "ujuno",
       "juno1cl2ewl842wcnagz5psd68z4dpp4gfxrrm9atm807uvyyg235h85stg7awy"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno15jjyzdr4e9jc6ztnpdev4xzf5zzg0wm3tx96szn320r6q2nvgj9snyx0jc"
   },
   {
     "id": "juno14p3wvpeezqueenfu9jy29s96xuk0hp38k5d5k4ysyzk789v032sqp8uvh3",
-    "lp_token_id": "juno1g62krgjk45ww5kle0nxugxfl5rskse5gd6zgh8hazn87uf8l942sfpxm8a",
     "asset_ids": [
       "ujuno",
       "juno1p32te9zfhd99ehpxfd06hka6hc9p7tv5kyl5909mzedg5klze09qrg08ry"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1g62krgjk45ww5kle0nxugxfl5rskse5gd6zgh8hazn87uf8l942sfpxm8a"
   },
   {
     "id": "juno150vj5jusg4g8n82q40nd9cmq3unc255u3hf5qh6pud4dexkgyp0ss7yvwq",
-    "lp_token_id": "juno1luhat2afjej7m3aypxyn7hyk0c4w8y823f5qcuxkkljyvwwtwnrsq6qrvy",
     "asset_ids": [
       "ujuno",
       "juno13926947pmrjly5p9hf5juey65c6rget0gqrnx3us3r6pvnpf4hwqm8mchy"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1luhat2afjej7m3aypxyn7hyk0c4w8y823f5qcuxkkljyvwwtwnrsq6qrvy"
   },
   {
     "id": "juno152lfpmadpxh2xha5wmlh2np5rj8fuy06sk72j55v686wd4q4c9jsvwj0gm",
-    "lp_token_id": "juno1s82s62c3q5cnjfhcqmvthjd58t6jetxmf8rxp9xmqmyy05fu2qusp9fg97",
     "asset_ids": [
       "ujuno",
       "ibc/946AD96F278770521526D7283F58268DA2F6ACDDE40324A9D1C86811D78C86A0"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1s82s62c3q5cnjfhcqmvthjd58t6jetxmf8rxp9xmqmyy05fu2qusp9fg97"
   },
   {
     "id": "juno1653nhx2330rnhmzk2qe9w74kwwa3jtxe4lrfs5cfq8szfms8pqzsra5fvq",
-    "lp_token_id": "juno1dtmjggsjx56ehpdjccqlzzls7u4wsnxejt4rj46x3g2jqayls87svgemgq",
     "asset_ids": [
       "ujuno",
       "ibc/52423136339C1CE8C91F6A586DFE41591BDDD4665AE526DFFA8421F9ACF95196"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1dtmjggsjx56ehpdjccqlzzls7u4wsnxejt4rj46x3g2jqayls87svgemgq"
   },
   {
     "id": "juno16zn96yf3vnxengke3vcf6mg9x7qyppgsdh3dnnmvdd8hvtpw58wsrjuu56",
-    "lp_token_id": "juno1pe2umwzqea0hvstzug2mm2ntrcxm336374954p5f6e52s5gf2zusklhqqr",
     "asset_ids": [
       "ujuno",
       "juno1pshrvuw5ng2q4nwcsuceypjkp48d95gmcgjdxlus2ytm4k5kvz2s7t9ldx"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1pe2umwzqea0hvstzug2mm2ntrcxm336374954p5f6e52s5gf2zusklhqqr"
   },
   {
     "id": "juno1730cx75d8uevqvrkcwxpy9trhqqfksu5u9xwqss0qe4tn7x0tt3shakhk8",
-    "lp_token_id": "juno1lgprt38gkp4nvggjl0dm0e7k5lgd80e525f8rjg60tc6fk2xexcqhpp6sm",
     "asset_ids": [
       "ujuno",
       "ibc/D836B191CDAE8EDACDEBE7B64B504C5E06CC17C6A072DAF278F9A96DF66F6241"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1lgprt38gkp4nvggjl0dm0e7k5lgd80e525f8rjg60tc6fk2xexcqhpp6sm"
   },
   {
     "id": "juno17h4sgpaksygdnswpx74szv98hggddc08ny4zv5ca63jv53qptxrshacvku",
-    "lp_token_id": "juno1gcamzveq77v32lw7252v0etx9tm2j2jzy3s5ax0cz6dxnzkx5g4qfqunul",
     "asset_ids": [
       "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g",
       "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1gcamzveq77v32lw7252v0etx9tm2j2jzy3s5ax0cz6dxnzkx5g4qfqunul"
   },
   {
     "id": "juno17v2d2993me50e6dgzx50ckuuah0vmfyanl0segxsdcg3s4qzqersyrvu8n",
-    "lp_token_id": "juno1s4rn507yhlqw8p7haqpmd3uuvttehact7acsgd9s94pvnkw78t4smkuacv",
     "asset_ids": [
       "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
       "ujuno"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1s4rn507yhlqw8p7haqpmd3uuvttehact7acsgd9s94pvnkw78t4smkuacv"
   },
   {
     "id": "juno18nflutunkth2smnh257sxtxn9p5tq6632kqgsw6h0c02wzpnq9rq927heu",
-    "lp_token_id": "juno17w75xxt0uxc8tsrcdtdkx9xgvspkzt7p5fz07lec4azjudnrjvcqhnr2kk",
     "asset_ids": [
       "ujuno",
       "juno1re3x67ppxap48ygndmrc7har2cnc7tcxtm9nplcas4v0gc3wnmvs3s807z"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno17w75xxt0uxc8tsrcdtdkx9xgvspkzt7p5fz07lec4azjudnrjvcqhnr2kk"
   },
   {
     "id": "juno19859m5x8kgepwafc3h0n36kz545ngc2vlqnqxx7gx3t2kguv6fws93cu25",
-    "lp_token_id": "juno1vayeejfdzr32rg3kkzqvl7euxqzferxstdal3qlask5f37sxcvxsvk6mse",
     "asset_ids": [
       "ujuno",
       "juno1vaeuky9hqacenay9nmuualugvv54tdhyt2wsvhnjasx9s946hhmqaq3kh7"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1vayeejfdzr32rg3kkzqvl7euxqzferxstdal3qlask5f37sxcvxsvk6mse"
   },
   {
     "id": "juno1acs6q36t6qje5k82h5g74plr258y2q90cjf9z4wnktt7caln0mhsx8mt7z",
-    "lp_token_id": "juno1k2xzml24sglxlf3hrsmt9a7mtk0jchq279ja5u3asvmtaq3a4uss7xuu5g",
     "asset_ids": [
       "ujuno",
       "juno1vn38rzq0wc7zczp4dhy0h5y5kxh2jjzeahwe30c9cc6dw3lkyk5qn5rmfa"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1k2xzml24sglxlf3hrsmt9a7mtk0jchq279ja5u3asvmtaq3a4uss7xuu5g"
   },
   {
     "id": "juno1ctsmp54v79x7ea970zejlyws50cj9pkrmw49x46085fn80znjmpqz2n642",
-    "lp_token_id": "juno1uwp9rs0ya4p6qk8zezl2y666vvtnfvxfmuwngu95pg6m55mg6xpq65jrje",
     "asset_ids": [
       "ujuno",
       "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1uwp9rs0ya4p6qk8zezl2y666vvtnfvxfmuwngu95pg6m55mg6xpq65jrje"
   },
   {
     "id": "juno1cugrrrryrpl383kfca0w5swywffa08zwqshrsfre82059vxjlx6syhf73y",
-    "lp_token_id": "juno1883e886ujdkgcx94dg35da0l020jcx8y3m6wrf6lf0ntpl5y0mmsq50aru",
     "asset_ids": [
       "ujuno",
       "juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1883e886ujdkgcx94dg35da0l020jcx8y3m6wrf6lf0ntpl5y0mmsq50aru"
   },
   {
     "id": "juno1cvjuc66rdg34guugmxpz6w59rw6ghrun5m33z3hpvx6q60f40knqglhzzx",
-    "lp_token_id": "juno1h0sqa8qtngwe3jl9qpfg03whjvcgczsk985vrpt6h94t0yp8uspssfvugp",
     "asset_ids": [
       "ujuno",
       "juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1h0sqa8qtngwe3jl9qpfg03whjvcgczsk985vrpt6h94t0yp8uspssfvugp"
   },
   {
     "id": "juno1d04vn4t3cw494md0xleyqk6hxt8ctn5gmr353h06uvnudlvk5chq93vmjq",
-    "lp_token_id": "juno1m53w7htf3lgtt2mvd336ja8kkwjrhayk7wazpmvjwsenxxeyt4zsgjn6gw",
     "asset_ids": [
       "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
       "ujuno"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1m53w7htf3lgtt2mvd336ja8kkwjrhayk7wazpmvjwsenxxeyt4zsgjn6gw"
   },
   {
     "id": "juno1e8n6ch7msks487ecznyeagmzd5ml2pq9tgedqt2u63vra0q0r9mqrjy6ys",
-    "lp_token_id": "juno1jmechmr7w6kwqu8jcy5973rtllxgttyetarys60rtsu0g675mkjsy96t8l",
     "asset_ids": [
       "ujuno",
       "juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1jmechmr7w6kwqu8jcy5973rtllxgttyetarys60rtsu0g675mkjsy96t8l"
   },
   {
     "id": "juno1el6rfmz6h9pwpdlf6k2qf4dwt3y5wqd7k3xpyvytklsnkt9uv2aqe8aq4v",
-    "lp_token_id": "juno100pmxfny54wktum5jklg9vme7d5pe44h7va6uw4smccte6wkfaust0untw",
     "asset_ids": [
       "ujuno",
       "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno100pmxfny54wktum5jklg9vme7d5pe44h7va6uw4smccte6wkfaust0untw"
   },
   {
     "id": "juno1enl842z00cklnathpv8f3t3w2u70dkrq22crz3gxg38we7xjfq5s8lktmg",
-    "lp_token_id": "juno12snvzgec29vvzhmcc3m4dq2a86vl5apn2gemveqj73ypxhylty3q2ndad4",
     "asset_ids": [
       "ujuno",
       "juno1t8dnpktypue65q0hjz7tr3cvqypgj5vkxhd2twvng4a2ywa3j25spjuk6z"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno12snvzgec29vvzhmcc3m4dq2a86vl5apn2gemveqj73ypxhylty3q2ndad4"
   },
   {
     "id": "juno1fha0ux5k6xxzzknhwk0j2rtwxtczlp8kzk6w9g383lzjhu337k9swvjdlv",
-    "lp_token_id": "juno19dts5x9v2jz2589e42fw8ynn2737a2jawsk8ank8hvu5jveassfqmlvff9",
     "asset_ids": [
       "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno19dts5x9v2jz2589e42fw8ynn2737a2jawsk8ank8hvu5jveassfqmlvff9"
   },
   {
     "id": "juno1fjmrqc5tjj2t5mfwkk5utwz2t0gcpkfajjefllrfahuqanctn9ys968emr",
-    "lp_token_id": "juno1dl5efsl4nj07rzc0qrrh0wa2dkn2u6746qtcvnvl0hmfawlm0ctqwmqzm9",
     "asset_ids": [
       "juno147t4fd3tny6hws6rha9xs5gah9qa6g7hrjv9tuvv6ce6m25sy39sq6yv52",
       "ujuno"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1dl5efsl4nj07rzc0qrrh0wa2dkn2u6746qtcvnvl0hmfawlm0ctqwmqzm9"
   },
   {
     "id": "juno1fpphzkkq5uyezm7amk6sslyz8r94wl658zg2ku47v8mtslueyx5q29rkzq",
-    "lp_token_id": "juno1cnggcz546d65mzya527mweksujwmkhhh6gf2juuzrrd4zu6n8tgswxh80c",
     "asset_ids": [
       "ujuno",
       "juno1hy0ky3pe742phd4w55tdfej0ez55h4jx4g06rp4wsa0mne9wzudqy4hum2"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1cnggcz546d65mzya527mweksujwmkhhh6gf2juuzrrd4zu6n8tgswxh80c"
   },
   {
     "id": "juno1fzl79pekf8wtd0y37q92dmz5h9dxtfpl97w3kguyc59m7ufnlzvsf46vf8",
-    "lp_token_id": "juno1vqvnmf4vpkkrjp9caahtfxgkcg2zcud3a7t6080rwzceusk8qxjs35n4s5",
     "asset_ids": [
       "ujuno",
       "juno1gzys54drag6753qq75mkt3yhjwyv4rp698kfvesh0wcy5737z4tsn0chtm"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1vqvnmf4vpkkrjp9caahtfxgkcg2zcud3a7t6080rwzceusk8qxjs35n4s5"
   },
   {
     "id": "juno1gpa5ardzal22el6czj4j0d2pwy0m9qj06lr20t2l8fca3gkws63qfnx8eq",
-    "lp_token_id": "juno1fweq070y8lvxmtn7j3p7yltphg8uuksk7p875suwppyzg259rt0s29qgss",
     "asset_ids": [
       "ujuno",
       "ibc/6842C591DC4588411A565C9FF650FB15A17DFE3F0A43201E8141E4D14B8D171A"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1fweq070y8lvxmtn7j3p7yltphg8uuksk7p875suwppyzg259rt0s29qgss"
   },
   {
     "id": "juno1gv2gswtan8wsk54h663waefffywnuc9wcxr7xl5pnnxvjaqunpgs20t39g",
-    "lp_token_id": "juno1gj4rprgp9uvwx25ssez6yl2ll2z32fmv7a3mungqz5nxzqfpvrnsteqejd",
     "asset_ids": [
       "ujuno",
       "ibc/0CB5D60E57FD521FA39D11E3E410144389010AC5EF5F292BC9BDD832FA2FDBF9"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1gj4rprgp9uvwx25ssez6yl2ll2z32fmv7a3mungqz5nxzqfpvrnsteqejd"
   },
   {
     "id": "juno1gxvcltkl0tf20rpsn2wf9q6ex0vr5xk6j3tzezuv6yyjez97w5vqmxk0cv",
-    "lp_token_id": "juno1qjt776qcnrjjhdnqe7ds5sn3cr3sfhsv6awfhvx9ujywv92lty7q45ucx9",
     "asset_ids": [
       "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
       "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1qjt776qcnrjjhdnqe7ds5sn3cr3sfhsv6awfhvx9ujywv92lty7q45ucx9"
   },
   {
     "id": "juno1hkz5dhn59w6l29k8w8ceuramqx2f35qpen7xtlx6ezketwh8ndxq8rwq2a",
-    "lp_token_id": "juno1ukhxlrtje0dt2n7k54m8l83rxjrta7fqwvzzhapgzafwzt38u8pqsdfrh8",
     "asset_ids": [
       "ujuno",
       "ibc/B55B08EF3667B0C6F029C2CC9CAA6B00788CF639EBB84B34818C85CBABA33ABD"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1ukhxlrtje0dt2n7k54m8l83rxjrta7fqwvzzhapgzafwzt38u8pqsdfrh8"
   },
   {
     "id": "juno1hue3dnrtgf9ly2frnnvf8z5u7e224ctc4hk7wks2xumeu3arj6rs9vgzec",
-    "lp_token_id": "juno1l0z6d7wlwpwequtenwt8pd44685jyhqys6jdnp8xa8ektn0un4zsadyw8y",
     "asset_ids": [
       "ujuno",
       "ibc/2DA4136457810BCB9DAAB620CA67BC342B17C3C70151CA70490A170DF7C9CB27"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1l0z6d7wlwpwequtenwt8pd44685jyhqys6jdnp8xa8ektn0un4zsadyw8y"
   },
   {
     "id": "juno1j7pdtemw0qvl6rmnl0sf324409gz2p4sdt6rv659482x9rqqz6mqd653dg",
-    "lp_token_id": "juno18hu00pwvd8kq0cgzk03l2nmp8rr0h5gp6tektz6qazwfapqsl4cqwfgdsv",
     "asset_ids": [
       "ujuno",
       "ibc/008BFD000A10BCE5F0D4DD819AE1C1EC2942396062DABDD6AE64A655ABC7085B"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno18hu00pwvd8kq0cgzk03l2nmp8rr0h5gp6tektz6qazwfapqsl4cqwfgdsv"
   },
   {
     "id": "juno1jz50fj5zkcv3h6hmcfr3nr6eer7rj5pmsry5qj5jc8rfvpeavyzsgknm83",
-    "lp_token_id": "juno18t52fyupsh8fu48kufyqwneks4enr0u2e0gdvwzvsfravvmkszmswj32nu",
     "asset_ids": [
       "ujuno",
       "juno14lycavan8gvpjn97aapzvwmsj8kyrvf644p05r0hu79namyj3ens87650k"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno18t52fyupsh8fu48kufyqwneks4enr0u2e0gdvwzvsfravvmkszmswj32nu"
   },
   {
     "id": "juno1lgmtzhn840y9l74azn06w0wnsh4y98mjq5zs98yf96ggm7ejz05sgvpzqc",
-    "lp_token_id": "juno16gsp50vlh8gzz9hjunmd2dzlllafp03a2a6pvch3n5pwfmaladhskwwk49",
     "asset_ids": [
       "ujuno",
       "ibc/436B576861090C1C921D56BA1FAE481A04D2E938EBDFF55C4712670F9754AC40"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno16gsp50vlh8gzz9hjunmd2dzlllafp03a2a6pvch3n5pwfmaladhskwwk49"
   },
   {
     "id": "juno1m08vn7klzxh9tmqwajuux202xms2qz3uckle7zvtturcq7vk2yaqpcwxlz",
-    "lp_token_id": "juno10cdmzmh5yya0d0686407qrn92elx4q7ecmmdq0vrprpartjhz99q50frz2",
     "asset_ids": [
       "ujuno",
       "juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno10cdmzmh5yya0d0686407qrn92elx4q7ecmmdq0vrprpartjhz99q50frz2"
   },
   {
     "id": "juno1maj5xlggctfwm6ct6x2e3456zxm8chadq9prqxl9kjxzzs9edalsk5wzwh",
-    "lp_token_id": "juno1th2uaedyeat7a8mer6a709mcq67wr7avlt5tlm4pvt9f6v2cf9lqhxwq25",
     "asset_ids": [
       "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
       "ujuno"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1th2uaedyeat7a8mer6a709mcq67wr7avlt5tlm4pvt9f6v2cf9lqhxwq25"
   },
   {
     "id": "juno1na8zlnp3pqsjfzllcncq2ahsxg9zkdkqrz3sl4ae5lergh2wrjes7jl9gr",
-    "lp_token_id": "juno1p047hllllt4nu487a8qhsf2lr9unxfknal7jm56se3qplehrlunsr8zwyc",
     "asset_ids": [
       "ujuno",
       "juno1kqx9rhc8ksx52tukdx797k4rjrhkgfh4gljs04ql97hmnnkgyvxs5cqt7d"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1p047hllllt4nu487a8qhsf2lr9unxfknal7jm56se3qplehrlunsr8zwyc"
   },
   {
     "id": "juno1p8prj0dddf6d2wp599rtv9c5zp3v5gx0pjpk0hwl8fuhn7x8jslqxvjeqk",
-    "lp_token_id": "juno1l0tx38u7duyh3a6557cfrlevtr8fnr28p7xc7w3wlfw2rtghrujqla27v5",
     "asset_ids": [
       "juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3",
       "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1l0tx38u7duyh3a6557cfrlevtr8fnr28p7xc7w3wlfw2rtghrujqla27v5"
   },
   {
     "id": "juno1pxn38k3kz9k8cjlrghdwzmkxz67l343k5xuxn744wa56vfddrepsx72j5x",
-    "lp_token_id": "juno1n5ljavtmj2heu34yvx7kdu8qrr4dqll2j3j8k86jxd03qyd6e3nqtmfgqx",
     "asset_ids": [
       "ujuno",
       "juno173c59crjqeec28cpzs7n0y7hm4cd308zda8z6j4cnl6pct3stenseg2dxp"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1n5ljavtmj2heu34yvx7kdu8qrr4dqll2j3j8k86jxd03qyd6e3nqtmfgqx"
   },
   {
     "id": "juno1qsmywlded2sdggud5wft44gq2u6c3epl3qhzr4qv7psj536t8yhsfvrcf6",
-    "lp_token_id": "juno1fdj5u026t828yuskgq9h5ehx2gncjjjxvrydtnljn9xchj6xdhdsjx6lxy",
     "asset_ids": [
       "ujuno",
       "ibc/5CB906E82B7A88E62644AD811361F5858B74BA9EBD75C84B6D24B20C01A4819F"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1fdj5u026t828yuskgq9h5ehx2gncjjjxvrydtnljn9xchj6xdhdsjx6lxy"
   },
   {
     "id": "juno1qt7uzjg9su3mk78jpt695rmxce4sa7evz7wa0edexjrsxghy35hsgje5l9",
-    "lp_token_id": "juno1s6vnzf94d5sa0ax735y3ug4svmg5pc40lumsqygkc5jxngwccqls7z5xjv",
     "asset_ids": [
       "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup",
       "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1s6vnzf94d5sa0ax735y3ug4svmg5pc40lumsqygkc5jxngwccqls7z5xjv"
   },
   {
     "id": "juno1rft4xp5e6ffta5a8aqwtu4kgdfjqw4jhnleu8agmmedzrxsat7pqxfgfrs",
-    "lp_token_id": "juno10dvm495wxtlxtda8492dsc2yut0wk2lpnz6h7wad3ecrym5k4a6qh4uvzc",
     "asset_ids": [
       "ujuno",
       "juno1n7n7d5088qlzlj37e9mgmkhx6dfgtvt02hqxq66lcap4dxnzdhwqfmgng3"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno10dvm495wxtlxtda8492dsc2yut0wk2lpnz6h7wad3ecrym5k4a6qh4uvzc"
   },
   {
     "id": "juno1sg6chmktuhyj4lsrxrrdflem7gsnk4ejv6zkcc4d3vcqulzp55wsf4l4gl",
-    "lp_token_id": "juno18ckrreffz9jwmkw84axsvncexfqt7gpgckskk0yy0vzwm9huqkyq6v78xu",
     "asset_ids": [
       "ujuno",
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno18ckrreffz9jwmkw84axsvncexfqt7gpgckskk0yy0vzwm9huqkyq6v78xu"
   },
   {
     "id": "juno1tmxx3rdnnrcckkh7pjde924lftjs724rzd44sqte5xh8xax0yf2sc7v7dk",
-    "lp_token_id": "juno1plauy5jh7dggc0pvcduaaj4slk7l9w883mecxkew7xaff6uzmztq4d0003",
     "asset_ids": [
       "ujuno",
       "ibc/DFC6F33796D5D0075C5FB54A4D7B8E76915ACF434CB1EE2A1BA0BB8334E17C3A"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1plauy5jh7dggc0pvcduaaj4slk7l9w883mecxkew7xaff6uzmztq4d0003"
   },
   {
     "id": "juno1v842hl5mtn2kjeu4sscr4e3y9jmv7tf0h7cy4wm6nusyf4v8j6ssh8gkgp",
-    "lp_token_id": "juno16uhnlsrnwgxk2839zr5rqz74xedcxvhknlpvw8yhv7wqpm0ggvzsa2kfae",
     "asset_ids": [
       "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno16uhnlsrnwgxk2839zr5rqz74xedcxvhknlpvw8yhv7wqpm0ggvzsa2kfae"
   },
   {
     "id": "juno1w7l7hetsm4x6hxa55dsjwszqh9elzwqrd6cud2qkqhafrd6u9vrqc2zh48",
-    "lp_token_id": "juno1v7y2wgj4d45t9kcl7qtrezncxr5k6anjqx4avv22s2rj595av2qqrpyw4f",
     "asset_ids": [
       "ujuno",
       "juno17r8dyxuj25muaudhgqgx4xrg6gzr6tvzem6gwtpprnfld58yggcqjhhkjy"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1v7y2wgj4d45t9kcl7qtrezncxr5k6anjqx4avv22s2rj595av2qqrpyw4f"
   },
   {
     "id": "juno1xkm8tmm7jlqdh8kua9y7wst8fwcxpdnk6gglndfckj6rsjg4xc5q8aaawn",
-    "lp_token_id": "juno1jq40jyxg57kumvaceskedcgsaje8tfagtpxsu8gnray525333yxsk8sl7f",
     "asset_ids": [
       "ujuno",
       "juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1jq40jyxg57kumvaceskedcgsaje8tfagtpxsu8gnray525333yxsk8sl7f"
   },
   {
     "id": "juno1yaff0t6tfheqcdep24euu7w0xhnhs2yjwwv7r2c280vlns8trghq5d72pd",
-    "lp_token_id": "juno1jeh4eqlsge0w8kcmjlt82rzzwe4vr5yxe69nvqt2jcgg4q4e8ypq0c7h7f",
     "asset_ids": [
       "ujuno",
       "ibc/7455B3F2F2737906BACF4AE980069A4CAB7C7F9FDAABAEFBA439DF037AEC5898"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1jeh4eqlsge0w8kcmjlt82rzzwe4vr5yxe69nvqt2jcgg4q4e8ypq0c7h7f"
   },
   {
     "id": "juno1ytntasjjyzpdfhsw60yp7rt3ww57nqth45lfaek9ae65ylm0xpkqsp47fz",
-    "lp_token_id": "juno1dmtkurpgzyk0p4h26k02txwmk23qu9vq9xn6e6cuahh6n9x52r2qej4gl9",
     "asset_ids": [
       "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
       "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1dmtkurpgzyk0p4h26k02txwmk23qu9vq9xn6e6cuahh6n9x52r2qej4gl9"
   },
   {
     "id": "juno1z5vukf037r6acgln3n37tr8a5rv7wafqzhcq29ddn9etwwtfrytsn6xvux",
-    "lp_token_id": "juno1dhmd8lredr9psu4afk8j3lstdg896pme49mje6maxucuuugmmptstzaj07",
     "asset_ids": [
       "ujuno",
       "ibc/F6B367385300865F654E110976B838502504231705BAC0849B0651C226385885"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1dhmd8lredr9psu4afk8j3lstdg896pme49mje6maxucuuugmmptstzaj07"
   },
   {
     "id": "juno1z698dxy9gj4fnrs76xwmtqwh84lamav9xl0w35pd35vnfx7987nqudxyge",
-    "lp_token_id": "juno15g2ghm8u9jtkp5pu2y0n6dlzsewxltdjvygwcg5ggusp7tghxnlqjtvw87",
     "asset_ids": [
       "ujuno",
       "ibc/B9F7C1E4CE9219B5AF06C47B18661DBD49CCD7A6C18FF789E2FB62BB365CFF9C"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno15g2ghm8u9jtkp5pu2y0n6dlzsewxltdjvygwcg5ggusp7tghxnlqjtvw87"
   },
   {
     "id": "juno1z8c5kqh2yc48wstsq4h68lk78kxmf0rh30qs5f6d7luxzledvjtsxgugzt",
-    "lp_token_id": "juno1d7zwptczk6hya9lx269a5kk6nt5qmlmdzh4zjalcqjwcsctmdeqqyvgl8t",
     "asset_ids": [
       "ujuno",
       "juno1x02k67asfmjawgc96dj8nxq6se3fmx36gedgs5hvkjegdhfy97rs3jgj2h"
     ],
     "dex": "JunoSwap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1d7zwptczk6hya9lx269a5kk6nt5qmlmdzh4zjalcqjwcsctmdeqqyvgl8t"
   },
   {
     "id": "juno16sljr0c7fj00s8dnhe0ql8nn40ca9v3fyuga3svnq860fzal5s2qw02j0t",
-    "lp_token_id": "juno1dp2t26a575e5v2dxs3um77k2fa39sk0nzw7qmvhrja5vc3q96rvshv0hw5",
     "asset_ids": [
       "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
       "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1dp2t26a575e5v2dxs3um77k2fa39sk0nzw7qmvhrja5vc3q96rvshv0hw5"
   },
   {
     "id": "juno199gtrzfha3fz0h2mq4jhlhus3vqgql7u58mp97rea79xw9zmrwrs0mwsvd",
-    "lp_token_id": "juno1skwwlvqdw2499spvzqjyr78tg3d0fxlw3ek0f2y6nnl7xcqe8r8syu42dt",
     "asset_ids": [
       "ujuno",
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1skwwlvqdw2499spvzqjyr78tg3d0fxlw3ek0f2y6nnl7xcqe8r8syu42dt"
   },
   {
     "id": "juno1aagw3m89ze94v6e56k0eeemldrk8ajmtccmwer9ffrzduw3zuwds0w58xk",
-    "lp_token_id": "juno19u80rx7fyun6q3e5tg0dj0fy78q7rk2rycv94k9dqrkth5kmtttqmkqxpw",
     "asset_ids": [
       "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv",
       "ujuno"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno19u80rx7fyun6q3e5tg0dj0fy78q7rk2rycv94k9dqrkth5kmtttqmkqxpw"
   },
   {
     "id": "juno1dl8zdygs57lcwm3e9tnq4pdmmp8nhhf08jcne72nsjkf7qntfz3s0e99x3",
-    "lp_token_id": "juno1kceqgs9hr4qt2ln87k6hqkgge6545cskpalyxjdyh99gr77kvw7szgctjx",
     "asset_ids": [
       "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup",
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1kceqgs9hr4qt2ln87k6hqkgge6545cskpalyxjdyh99gr77kvw7szgctjx"
   },
   {
     "id": "juno1e4gxx99ufal40jkrl90ucjlvuvns942xqg3ycu9gmw4nwgyrap8sk52ua8",
-    "lp_token_id": "juno194m6qvjr424hzqax5kgx2racpg2gx4yeq3d8kg0dm0xte3e7hpvq7ceceu",
     "asset_ids": [
       "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
       "ujuno"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno194m6qvjr424hzqax5kgx2racpg2gx4yeq3d8kg0dm0xte3e7hpvq7ceceu"
   },
   {
     "id": "juno1evlfyl2n0f0z393m3ehu9n2z98znakhwhhvzmxce08uvuzleu8cs7eldh7",
-    "lp_token_id": "juno1g30cu6w3ezng8q00sdhnlz3ynwutpscxvuvqmmf385pw7jrg4shq6tdgy2",
     "asset_ids": [
       "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034",
       "juno17r2vpc5enkyfe2xle9sedxdq3msfpacwcfp9rnr6jc3e7v6av0jqmfyfzp"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1g30cu6w3ezng8q00sdhnlz3ynwutpscxvuvqmmf385pw7jrg4shq6tdgy2"
   },
   {
     "id": "juno1mz8yzrgyp9mmq9aksxgpy83vmu8p4j8h3qyf9waxcd2epchqx5ps0ekj27",
-    "lp_token_id": "juno1eu0cf0eeksxse8g2mgkarhxjfpx9mzmlkjpgmw6cn526sv92zf5shjmnz2",
     "asset_ids": [
       "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup",
       "juno14lycavan8gvpjn97aapzvwmsj8kyrvf644p05r0hu79namyj3ens87650k"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1eu0cf0eeksxse8g2mgkarhxjfpx9mzmlkjpgmw6cn526sv92zf5shjmnz2"
   },
   {
     "id": "juno1qc8mrs3hmxm0genzrd92akja5r0v7mfm6uuwhktvzphhz9ygkp8ssl4q07",
-    "lp_token_id": "juno140h0ctxu0ete06a86u4has6ymppqpx30z6yfyumlkfwqjkv3grrs089el6",
     "asset_ids": [
       "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup",
       "ujuno"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno140h0ctxu0ete06a86u4has6ymppqpx30z6yfyumlkfwqjkv3grrs089el6"
   },
   {
     "id": "juno1rw5cdwl6cxw882czan4x2ysp30zsm94l6jcqealg82vm2dl989ns63veh8",
-    "lp_token_id": "juno162vk72cy4psyt4f3axw32tyfswswgq37h2rl8gwf7mavdj4mchfqhljfuf",
     "asset_ids": [
       "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3",
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno162vk72cy4psyt4f3axw32tyfswswgq37h2rl8gwf7mavdj4mchfqhljfuf"
   },
   {
     "id": "juno1szc3uak9vqsc8halhx2pxj6yehg67de9tzmw2z2gqxm0cr2ncnpsxre8pc",
-    "lp_token_id": "juno14dfmj338xr5lcnnj2yuqp2f5y3ukn8kr8m2rygvrcw5npwfdz4ps6kqwjn",
     "asset_ids": [
       "ujuno",
       "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno14dfmj338xr5lcnnj2yuqp2f5y3ukn8kr8m2rygvrcw5npwfdz4ps6kqwjn"
   },
   {
     "id": "juno1utkr0ep06rkxgsesq6uryug93daklyd6wneesmtvxjkz0xjlte9qdj2s8q",
-    "lp_token_id": "juno17xudkf5a2m2nny7gqzss4wuges5v0ek035m3wzefp3a99x80kxasj5whwu",
     "asset_ids": [
       "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup",
       "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno17xudkf5a2m2nny7gqzss4wuges5v0ek035m3wzefp3a99x80kxasj5whwu"
   },
   {
     "id": "juno1vyuw20szeykmuq09xmh5g6q0kmezcl08xwz7qhtkdzh9qc0gspgsrgxzxj",
-    "lp_token_id": "juno14t6z9mclx6x47quvnv69hf3lr43d4p5dlvu925eg50t80eflh9eqcgsz80",
     "asset_ids": [
       "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518",
       "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno14t6z9mclx6x47quvnv69hf3lr43d4p5dlvu925eg50t80eflh9eqcgsz80"
   },
   {
     "id": "juno1zqageq56kpl2xru2dc4zvq3z90fykrraqkl6s54qgmcpe0r0ruksq0f77g",
-    "lp_token_id": "juno1xaa0z3u35ence7mvt38uz3cpu77hdt7gdvwrlyh5gpfgm8zghyaqktzl68",
     "asset_ids": [
       "ujuno",
       "juno17r2vpc5enkyfe2xle9sedxdq3msfpacwcfp9rnr6jc3e7v6av0jqmfyfzp"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1xaa0z3u35ence7mvt38uz3cpu77hdt7gdvwrlyh5gpfgm8zghyaqktzl68"
   },
   {
     "id": "juno180jzqh7vefwuks6eyvf0lkecdl2mp8u08d844245faunja969p3s8w3t3q",
-    "lp_token_id": "juno17sf282da63uwxfht9nuzslgan4jh7qvya0k78mc9v3muuckvjndsu8dy9m",
     "asset_ids": [
       "juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
       "juno1g2g7ucurum66d42g8k5twk34yegdq8c82858gz0tq2fc75zy7khssgnhjl"
     ],
     "dex": "Marble",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno17sf282da63uwxfht9nuzslgan4jh7qvya0k78mc9v3muuckvjndsu8dy9m"
   },
   {
     "id": "juno1nljy8gst5agtc0zstfjytf2hrnj8vcxgcdzrp4qj7k2dcnrfz4wsu6ty4f",
-    "lp_token_id": "juno1eqj3unwgq5najlyzyjtqdjjqx9esxpmkv2gffjsvhyszasyzwejqerpwgl",
     "asset_ids": [
       "juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
     ],
     "dex": "Marble",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1eqj3unwgq5najlyzyjtqdjjqx9esxpmkv2gffjsvhyszasyzwejqerpwgl"
   },
   {
     "id": "juno1xf32js0lc6v7quxj5twuna97hwff7dhkz6psujavvknh2yzty5uq6wut8j",
-    "lp_token_id": "juno1jzz4t6p2dpcteqay5yt4khyha0z3u3uhghzszv7c24r7pj02scwswsygzh",
     "asset_ids": [
       "juno1y9rf7ql6ffwkv02hsgd4yruz23pn4w97p75e2slsnkm0mnamhzysvqnxaq",
       "ujuno"
     ],
     "dex": "Marble",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1jzz4t6p2dpcteqay5yt4khyha0z3u3uhghzszv7c24r7pj02scwswsygzh"
   },
   {
     "id": "juno158mcxa5ajpjfxgy60asrg3m0823m2el5n333xdypcw8h5uwhuvyqkyc4a7",
-    "lp_token_id": "juno1zmsgdpdej4g4m4fc5y5p6wr8gn6peh9vx5dk5vf7v7w32jjmcetshl0yw4",
     "asset_ids": [
       "ujuno",
       "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup"
     ],
     "dex": "WhiteWhale",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1zmsgdpdej4g4m4fc5y5p6wr8gn6peh9vx5dk5vf7v7w32jjmcetshl0yw4"
   },
   {
     "id": "juno1k9cw9yghf04cqlu290n4zlveker5cev5ahweqkh07y7zc3xq9hrshjruk8",
-    "lp_token_id": "juno1fkejwm7alyfnjngtpgtxvreqfcz8uwer2jgwjn40suvgq20tm8ss73cj05",
     "asset_ids": [
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
       "ibc/107D152BB3176FAEBF4C2A84C5FFDEEA7C7CB4FE1BBDAB710F1FD25BCD055CBF"
     ],
     "dex": "WhiteWhale",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1fkejwm7alyfnjngtpgtxvreqfcz8uwer2jgwjn40suvgq20tm8ss73cj05"
   },
   {
     "id": "juno1p9z8xe96fyvg3h5gtvnpjjv2u47q6l7sdhg6asmyfgc6q8l8ttgqfvxnxh",
-    "lp_token_id": "juno1g3549wm0tffdzdpasufjr0nccu9ynzpzway5g3u6ucmhfd4ds05swswasc",
     "asset_ids": [
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
       "ujuno"
     ],
     "dex": "WhiteWhale",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1g3549wm0tffdzdpasufjr0nccu9ynzpzway5g3u6ucmhfd4ds05swswasc"
   },
   {
     "id": "juno1v6stcdrvwrthfvcwvlmmzht32ft9g9nw85tthcjqer242xg3nvdq8fjasx",
-    "lp_token_id": "juno12caca3ymhxr7a73wtdefye86djs69704ktzkv02xkf59se8hx72qwyxq72",
     "asset_ids": [
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
       "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
     ],
     "dex": "WhiteWhale",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno12caca3ymhxr7a73wtdefye86djs69704ktzkv02xkf59se8hx72qwyxq72"
   },
   {
     "id": "juno1wkjy5wl0pd5xxvwtrx37r7ydkt3dkwvghs00tvvqyd3xnjukah7qpj0vj7",
-    "lp_token_id": "juno19mkjyvydnq440a3ms4fccpltrzmxlvlz6nvz6qul0mgxvse42n2q9qkf72",
     "asset_ids": [
       "ujuno",
       "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
     ],
     "dex": "WhiteWhale",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno19mkjyvydnq440a3ms4fccpltrzmxlvlz6nvz6qul0mgxvse42n2q9qkf72"
   },
   {
     "id": "juno1xpt9mkncxadadn5t8s4t74nmw5zlarghmpme26857s07xz388d6sukvtnz",
-    "lp_token_id": "juno1zetjfu8j0ndt4d3mgewhatgpfrj8pwhev2tdp3sa9dwwmqlgdxws4257we",
     "asset_ids": [
       "ujuno",
       "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g"
     ],
     "dex": "WhiteWhale",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1zetjfu8j0ndt4d3mgewhatgpfrj8pwhev2tdp3sa9dwwmqlgdxws4257we"
   },
   {
     "id": "juno13lulw8mm9w8ww99dvr35tfaw5tdmwvc7xn6nsn28pnlre8uw7j6srce67z",
-    "lp_token_id": "juno107v6e3vga87v3y777wcgznrlu6jyljzdpgecaegec9ccyqsx97pszq3598",
     "asset_ids": [
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
       "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno107v6e3vga87v3y777wcgznrlu6jyljzdpgecaegec9ccyqsx97pszq3598"
   },
   {
     "id": "juno14ke9xn3qfmnjsrh9lh6rfu7zmm90duvj4lpkcrrnzemh0tjpwarqfk97n6",
-    "lp_token_id": "juno1yw5mpl9rq64y6wt88ual5fneckksuudhl9u9c0w2gvvj99q7vmdsvmvu3a",
     "asset_ids": [
       "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
       "juno1hnftys64ectjfynm6qjk9my8jd3f6l9dq9utcd3dy8ehwrsx9q4q7n9uxt"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1yw5mpl9rq64y6wt88ual5fneckksuudhl9u9c0w2gvvj99q7vmdsvmvu3a"
   },
   {
     "id": "juno16k0f2mksg7swautzgfynve2ns3kq95ggp0z9t5dvxg56q45x67nqckmzru",
-    "lp_token_id": "juno1n965ux7p8qhph9j3g378qqr9fa5qup7jz089k0xjzqg99e787ekq84g8we",
     "asset_ids": [
       "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
       "ibc/F6B367385300865F654E110976B838502504231705BAC0849B0651C226385885"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1n965ux7p8qhph9j3g378qqr9fa5qup7jz089k0xjzqg99e787ekq84g8we"
   },
   {
     "id": "juno16r20f55kp59l0v5ne6hzell3qu27jhuzrqmu59w2nxzcsnj90y0sh2m6p5",
-    "lp_token_id": "juno1k5vhzkssgh35zlv9hqaasetslgqyal6jane86umrqvrjav9eg3hq3pxa0l",
     "asset_ids": [
       "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1k5vhzkssgh35zlv9hqaasetslgqyal6jane86umrqvrjav9eg3hq3pxa0l"
   },
   {
     "id": "juno16vvu2fjrgg6rnddrcvtaeukzl3weau63gc3d3c7mvq05ygnzklvs3peqmt",
-    "lp_token_id": "juno10zj5zme4g0zj6hc79tkld5p47gjpe8qvxlky650gwan4tf0a4u8qzg5kc9",
     "asset_ids": [
       "ujuno",
       "juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno10zj5zme4g0zj6hc79tkld5p47gjpe8qvxlky650gwan4tf0a4u8qzg5kc9"
   },
   {
     "id": "juno16xrz7kd26j0qmdg706qyesqs56g2f6dulplsajtl0t9z8frd8tfqsx2lkj",
-    "lp_token_id": "juno14kjhrjmdzkwgy4pvm5xeuj58960y5ku95sup2apstla3jzf829lqq5zkws",
     "asset_ids": [
       "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
       "juno1w7kspnu3j4hmzvsltsk00xujfa84sf502vs2zjcawl03vgn7vj3sww9mh7"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno14kjhrjmdzkwgy4pvm5xeuj58960y5ku95sup2apstla3jzf829lqq5zkws"
   },
   {
     "id": "juno177xtcl6dax47kg3xptr5n48kd7twmzm49ltugfxuc76x9v05qq6q63hsm9",
-    "lp_token_id": "juno1kqeqglacd8l48347tttjlqc4yvxpcvhdekqrtrhv76frjh96gruqx36efv",
     "asset_ids": [
       "ujuno",
       "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1kqeqglacd8l48347tttjlqc4yvxpcvhdekqrtrhv76frjh96gruqx36efv"
   },
   {
     "id": "juno17ckp36lmgtt7jtuggdv2j39eh4alcnl35szu6quh747nujags07swwq0nh",
-    "lp_token_id": "juno1ev8qxfpen3yh9cxc9m5yu4qkuujlaxztw83kdh7txextvc5q8gdqpqxxzc",
     "asset_ids": [
       "ujuno",
       "juno1vn38rzq0wc7zczp4dhy0h5y5kxh2jjzeahwe30c9cc6dw3lkyk5qn5rmfa"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1ev8qxfpen3yh9cxc9m5yu4qkuujlaxztw83kdh7txextvc5q8gdqpqxxzc"
   },
   {
     "id": "juno17jv00cm4f3twr548jzayu57g9txvd4zdh54mdg9qpjs7samlphjsykylsq",
-    "lp_token_id": "juno1qwpr47n9djzm7erghmatudva8chvg63ejuvqzhfvq7u4ckl62t2sh8uk4k",
     "asset_ids": [
       "ujuno",
       "juno1rws84uz7969aaa7pej303udhlkt3j9ca0l3egpcae98jwak9quzq8szn2l"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1qwpr47n9djzm7erghmatudva8chvg63ejuvqzhfvq7u4ckl62t2sh8uk4k"
   },
   {
     "id": "juno17uv02azt545ag23xq7whw6z3r3chw7jwztnr9lypugy62drq3caqeyd2r3",
-    "lp_token_id": "juno1an2xhen0fzme85dpy7vx60f6ecrufqj6vqkh8gdvlyhfhjmp24qqqleeav",
     "asset_ids": [
       "ujuno",
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1an2xhen0fzme85dpy7vx60f6ecrufqj6vqkh8gdvlyhfhjmp24qqqleeav"
   },
   {
     "id": "juno18zk9xqj9xjm0ry39jjam8qsysj7qh49xwt4qdfp9lgtrk08sd58s2n54ve",
-    "lp_token_id": "juno13ld2eq3w8k6rap5n5vsmwr8c4zhqhtfu9vjx0gqmhpefefl97nxq4u4pap",
     "asset_ids": [
       "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
       "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno13ld2eq3w8k6rap5n5vsmwr8c4zhqhtfu9vjx0gqmhpefefl97nxq4u4pap"
   },
   {
     "id": "juno1a7lmc8e04hcs4y2275cultvg83u636ult4pmnwktr6l9nhrh2e8qzxfdwf",
-    "lp_token_id": "juno1stg339rrg9guqsuv205yayq2ttzwz4583luc9pznvexe7rtrtrksdxstg3",
     "asset_ids": [
       "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
       "ujuno"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1stg339rrg9guqsuv205yayq2ttzwz4583luc9pznvexe7rtrtrksdxstg3"
   },
   {
     "id": "juno1gqy6rzary8vwnslmdavqre6jdhakcd4n2z4r803ajjmdq08r66hq7zcwrj",
-    "lp_token_id": "juno1jn6t0dsxryht8ljxulavxrfd22l87dvac8e9a99a7tuj29ysxksqffhf5k",
     "asset_ids": [
       "ujuno",
       "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1jn6t0dsxryht8ljxulavxrfd22l87dvac8e9a99a7tuj29ysxksqffhf5k"
   },
   {
     "id": "juno1h6x5jlvn6jhpnu63ufe4sgv4utyk8hsfl5rqnrpg2cvp6ccuq4lqwqnzra",
-    "lp_token_id": "juno1uu3cewmpynvgsdu3lfqv2rh2n5nwtrguahkw64wjk99eg8r6fsss0e757x",
     "asset_ids": [
       "ujuno",
       "juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1uu3cewmpynvgsdu3lfqv2rh2n5nwtrguahkw64wjk99eg8r6fsss0e757x"
   },
   {
     "id": "juno1jtendlawm8rv96hnfuwn04y8uhwzp9epcxy5f0ms973pspueqcgsy3qzt0",
-    "lp_token_id": "juno14kdxq8eumdgj0sxg9h4sca8cga34avkanv9psujrxsn42350m7hshyuwm0",
     "asset_ids": [
       "ujuno",
       "juno1w7kspnu3j4hmzvsltsk00xujfa84sf502vs2zjcawl03vgn7vj3sww9mh7"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno14kdxq8eumdgj0sxg9h4sca8cga34avkanv9psujrxsn42350m7hshyuwm0"
   },
   {
     "id": "juno1ls5un4a8zyn4f05k0ekq5aa9uhn88y8362ww38elqfpcwllme0jqelamke",
-    "lp_token_id": "juno1h52qvcp5phaqmhzeu9urzsfvtehn9d98ql6xj05sr6z78zjgjv6sletkec",
     "asset_ids": [
       "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
       "juno1vn38rzq0wc7zczp4dhy0h5y5kxh2jjzeahwe30c9cc6dw3lkyk5qn5rmfa"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1h52qvcp5phaqmhzeu9urzsfvtehn9d98ql6xj05sr6z78zjgjv6sletkec"
   },
   {
     "id": "juno1mz5uz38h89dxj6c8w69rg7l060p8vq8pfetykk2gvrrxhjcsa5yqru9g7v",
-    "lp_token_id": "juno1as45s9detrnjwsn9vgcejz6erxttdtvu6kga4xrge3ny4lyfmjqq7lpgsj",
     "asset_ids": [
       "ujuno",
       "juno1r4pzw8f9z0sypct5l9j906d47z998ulwvhvqe5xdwgy8wf84583sxwh0pa"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1as45s9detrnjwsn9vgcejz6erxttdtvu6kga4xrge3ny4lyfmjqq7lpgsj"
   },
   {
     "id": "juno1ndw52eaajcn8wpx7e503ly3j07666hhufx6cyp0s9v703rvzrpksfujv3h",
-    "lp_token_id": "juno1k58efu65v6m0kgnq0fpgk8fxhsqah74r4lsuyk68308a35xxyels2qkl5z",
     "asset_ids": [
       "ujuno",
       "juno1x02k67asfmjawgc96dj8nxq6se3fmx36gedgs5hvkjegdhfy97rs3jgj2h"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1k58efu65v6m0kgnq0fpgk8fxhsqah74r4lsuyk68308a35xxyels2qkl5z"
   },
   {
     "id": "juno1p3eed298qx3nyhs3grld07jrf9vjsjsmdd2kmmh3crk87emjcx5stp409y",
-    "lp_token_id": "juno1flax8ja0u2lzuv5qundw9k7hmc5ttf3jh98lgk4ttnx5s7jdq5dq6qzts3",
     "asset_ids": [
       "ujuno",
       "juno14lycavan8gvpjn97aapzvwmsj8kyrvf644p05r0hu79namyj3ens87650k"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1flax8ja0u2lzuv5qundw9k7hmc5ttf3jh98lgk4ttnx5s7jdq5dq6qzts3"
   },
   {
     "id": "juno1ptdt6dg7ke6rn5k8xr8kh87zjnxhp832l5q07y3c9htz8z88cptqlthu5f",
-    "lp_token_id": "juno1gf7d9kp59na60zr9z4yl5chmf0x7ype3xutszc9gg270l2mtac9sratca6",
     "asset_ids": [
       "ujuno",
       "juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1gf7d9kp59na60zr9z4yl5chmf0x7ype3xutszc9gg270l2mtac9sratca6"
   },
   {
     "id": "juno1q0f3nlghr350e7lhmxej3ev0j25m5caws5y4kyr5huawwr24hfkq74fsnq",
-    "lp_token_id": "juno1r8lzdyydak2832m35wzg9g7l6z8whpm68t950cgncv2wnug8lhwseulms4",
     "asset_ids": [
       "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
       "juno1x02k67asfmjawgc96dj8nxq6se3fmx36gedgs5hvkjegdhfy97rs3jgj2h"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1r8lzdyydak2832m35wzg9g7l6z8whpm68t950cgncv2wnug8lhwseulms4"
   },
   {
     "id": "juno1rcssjyqgr6vzalss77d43v30c2qpyzzg607ua8gte2shqgtvu24sg8gs8r",
-    "lp_token_id": "juno18khfnt4052e9s2y2c5kra5n9uw84hh8qc6k5t4aey70erlz500cqfum00n",
     "asset_ids": [
       "ujuno",
       "juno1p8x807f6h222ur0vssqy3qk6mcpa40gw2pchquz5atl935t7kvyq894ne3"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno18khfnt4052e9s2y2c5kra5n9uw84hh8qc6k5t4aey70erlz500cqfum00n"
   },
   {
     "id": "juno1s00g9axpxgmwcrlc6xqcxzcjmaqpxhftkx62xfh64xends8ls5dqyyjnnl",
-    "lp_token_id": "juno1dx6djxrsr4f4mqjn3vsp6v0yrg78stv3d8qyp66k209qmzn7r3eqne7mwf",
     "asset_ids": [
       "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
       "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1dx6djxrsr4f4mqjn3vsp6v0yrg78stv3d8qyp66k209qmzn7r3eqne7mwf"
   },
   {
     "id": "juno1syxlvk6pjpuxplqxwxr6n6fveqaz069dzya0ass9vrfwn9qxpvpqhq7msy",
-    "lp_token_id": "juno1kpqf3lm2drxzf98xw5ptsqdd483wgtjdsr4dvcr3j89tv6rqvw2q9y383s",
     "asset_ids": [
       "ujuno",
       "juno1wwnhkagvcd3tjz6f8vsdsw5plqnw8qy2aj3rrhqr2axvktzv9q2qz8jxn3"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1kpqf3lm2drxzf98xw5ptsqdd483wgtjdsr4dvcr3j89tv6rqvw2q9y383s"
   },
   {
     "id": "juno1tndfgq4kfgm6wwvfem3uwqcpf4ac3cqfcf5df4efagucm32ywaasugr9mq",
-    "lp_token_id": "juno1au3mzqfams8axufpemtvufw78zetl3pl5qn4cn9r2tz9pgly79ws92kr46",
     "asset_ids": [
       "juno1mkw83sv6c7sjdvsaplrzc8yaes9l42p4mhy0ssuxjnyzl87c9eps7ce3m9",
       "juno1dd0k0um5rqncfueza62w9sentdfh3ec4nw4aq4lk5hkjl63vljqscth9gv"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1au3mzqfams8axufpemtvufw78zetl3pl5qn4cn9r2tz9pgly79ws92kr46"
   },
   {
     "id": "juno1u2pl8ql778655wakqmnhpln65q9pughd6jnrp93xwf4zakqjdh6qx3y9yt",
-    "lp_token_id": "juno1yhtyn2dv5k7ladzrznxlep2xm6q7dsd332wak3hhdrw0staer0ps83q8jw",
     "asset_ids": [
       "ujuno",
       "ibc/ED07A3391A112B175915CD8FAF43A2DA8E4790EDE12566649D0C2F97716B8518"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1yhtyn2dv5k7ladzrznxlep2xm6q7dsd332wak3hhdrw0staer0ps83q8jw"
   },
   {
     "id": "juno1x9r54vejw4hnxe7xm4haaf0ymf825frm30xqf9cud6cmnrgkx9lsxpj475",
-    "lp_token_id": "juno1e2gc84wkm7d738gn49mjnc25j6979a0sjf3d6qpmdjhzrh2x0zdq2a866u",
     "asset_ids": [
       "ujuno",
       "juno1hnftys64ectjfynm6qjk9my8jd3f6l9dq9utcd3dy8ehwrsx9q4q7n9uxt"
     ],
     "dex": "Wynd",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "juno1e2gc84wkm7d738gn49mjnc25j6979a0sjf3d6qpmdjhzrh2x0zdq2a866u"
   }
 ]

--- a/juno/pool.json
+++ b/juno/pool.json
@@ -775,7 +775,7 @@
       "ujuno",
       "juno1qsrercqegvs4ye0yqg93knv73ye5dc3prqwd6jcdcuj8ggp6w0us66deup"
     ],
-    "dex": "WhiteWhale",
+    "dex": "White Whale",
     "type": "xyk",
     "lp_token_id": "juno1zmsgdpdej4g4m4fc5y5p6wr8gn6peh9vx5dk5vf7v7w32jjmcetshl0yw4"
   },
@@ -785,7 +785,7 @@
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
       "ibc/107D152BB3176FAEBF4C2A84C5FFDEEA7C7CB4FE1BBDAB710F1FD25BCD055CBF"
     ],
-    "dex": "WhiteWhale",
+    "dex": "White Whale",
     "type": "xyk",
     "lp_token_id": "juno1fkejwm7alyfnjngtpgtxvreqfcz8uwer2jgwjn40suvgq20tm8ss73cj05"
   },
@@ -795,7 +795,7 @@
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
       "ujuno"
     ],
-    "dex": "WhiteWhale",
+    "dex": "White Whale",
     "type": "xyk",
     "lp_token_id": "juno1g3549wm0tffdzdpasufjr0nccu9ynzpzway5g3u6ucmhfd4ds05swswasc"
   },
@@ -805,7 +805,7 @@
       "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
       "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
     ],
-    "dex": "WhiteWhale",
+    "dex": "White Whale",
     "type": "xyk",
     "lp_token_id": "juno12caca3ymhxr7a73wtdefye86djs69704ktzkv02xkf59se8hx72qwyxq72"
   },
@@ -815,7 +815,7 @@
       "ujuno",
       "ibc/EAC38D55372F38F1AFD68DF7FE9EF762DCF69F26520643CF3F9D292A738D8034"
     ],
-    "dex": "WhiteWhale",
+    "dex": "White Whale",
     "type": "xyk",
     "lp_token_id": "juno19mkjyvydnq440a3ms4fccpltrzmxlvlz6nvz6qul0mgxvse42n2q9qkf72"
   },
@@ -825,7 +825,7 @@
       "ujuno",
       "juno15u3dt79t6sxxa3x3kpkhzsy56edaa5a66wvt3kxmukqjz2sx0hes5sn38g"
     ],
-    "dex": "WhiteWhale",
+    "dex": "White Whale",
     "type": "xyk",
     "lp_token_id": "juno1zetjfu8j0ndt4d3mgewhatgpfrj8pwhev2tdp3sa9dwwmqlgdxws4257we"
   },

--- a/kujira/asset.json
+++ b/kujira/asset.json
@@ -15,6 +15,38 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.svg"
   },
   {
+    "id": "ibc/3914BDEF46F429A26917E4D8D434620EC4817DC6B6E68FB327E190902F1E9242",
+    "entity": "Axelar",
+    "name": "Dai Stablecoin",
+    "symbol": "DAI",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dai.svg"
+  },
+  {
+    "id": "ibc/F2331645B9683116188EF36FC04A809C28BD36B54555E8705A37146D0182F045",
+    "entity": "Axelar",
+    "name": "Tether USD",
+    "symbol": "USDT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdt.svg"
+  },
+  {
+    "id": "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F",
+    "entity": "Axelar",
+    "name": "USD Coin",
+    "symbol": "USDC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.svg"
+  },
+  {
+    "id": "ibc/1B38805B1C75352B28169284F96DF56BDEBD9E8FAC005BDCC8CF0378C82AA8E7",
+    "entity": "Axelar",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/weth.png"
+  },
+  {
     "id": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
     "entity": "Cosmos",
     "name": "Cosmos",
@@ -28,6 +60,14 @@
     "name": "Eris Amplified LUNA",
     "symbol": "ampLUNA",
     "decimals": "6"
+  },
+  {
+    "id": "ibc/F3AA7EF362EC5E791FE78A0F4CCC69FEE1F9A7485EB1A8CAB3F6601C00522F10",
+    "entity": "Evmos",
+    "name": "Evmos",
+    "symbol": "EVMOS",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg"
   },
   {
     "id": "ibc/2F1447818CF99498AE62D9FB4D5E0C9FD48C68FC118C34D2ECFFFED0AD082196",
@@ -63,6 +103,14 @@
     "icon": "https://i.ibb.co/V3ZM8WF/usk.png"
   },
   {
+    "id": "ibc/8318B7E036E50C0CF799848F23ED84778AAA8749D9C0BCD4FF3F4AF73C53387F",
+    "entity": "Loop",
+    "name": "Loop Protocol",
+    "symbol": "LOOP",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/a46f3a10b8e67105233f358aa1de114fc34df221/images/loop.png"
+  },
+  {
     "id": "ibc/47BD209179859CDE4A2806763D7189B6E6FE13A17880FE2B42DE1E6C1E329E23",
     "entity": "Osmosis",
     "name": "Osmosis",
@@ -79,6 +127,30 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg"
   },
   {
+    "id": "ibc/4F393C3FCA4190C0A6756CE7F6D897D5D1BE57D6CCB80D0BC87393566A7B6602",
+    "entity": "Stargaze",
+    "name": "Stargaze",
+    "symbol": "STARS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png"
+  },
+  {
+    "id": "ibc/0306D6B66EAA2EDBB7EAD23C0EC9DDFC69BB43E80B398035E90FBCFEF3FD1A87",
+    "entity": "Stride",
+    "name": "stATOM",
+    "symbol": "stATOM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg"
+  },
+  {
+    "id": "ibc/239BFF83852F67DF5243DB89F339FF7FDBF858437F961CAB6DA5B5ADEFB2BC07",
+    "entity": "Stride",
+    "name": "Stride",
+    "symbol": "STRD",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg"
+  },
+  {
     "id": "ibc/DA59C009A0B3B95E0549E6BF7B075C8239285989FF457A8EDDBB56F10B2A6986",
     "entity": "Terra Money",
     "name": "Luna",
@@ -93,14 +165,6 @@
     "symbol": "WAVAX",
     "decimals": "18",
     "icon": "https://raw.githubusercontent.com/axelarnetwork/axelar-docs/main/public/images/assets/wavax.png"
-  },
-  {
-    "id": "ibc/1B38805B1C75352B28169284F96DF56BDEBD9E8FAC005BDCC8CF0378C82AA8E7",
-    "entity": "Wormhole",
-    "name": "Wrapped Ether",
-    "symbol": "WETH",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/weth.png"
   },
   {
     "id": "ibc/D36D2BBE441D3605EEF340EAFAC57D669880597073050A2650B1468F1634A5F5",
@@ -137,20 +201,6 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/images/cronos.png"
   },
   {
-    "id": "ibc/3914BDEF46F429A26917E4D8D434620EC4817DC6B6E68FB327E190902F1E9242",
-    "name": "Dai Stablecoin",
-    "symbol": "DAI",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dai.svg"
-  },
-  {
-    "id": "ibc/F3AA7EF362EC5E791FE78A0F4CCC69FEE1F9A7485EB1A8CAB3F6601C00522F10",
-    "name": "Evmos",
-    "symbol": "EVMOS",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg"
-  },
-  {
     "id": "ibc/53796B3762678CD80784A7DD426EB45B89C024BE3D45224CC83FDE3DED7DA0A1",
     "name": "Fury",
     "symbol": "FURY",
@@ -171,53 +221,11 @@
     "icon": "https://localmoney.io/local-logo-dark.png"
   },
   {
-    "id": "ibc/8318B7E036E50C0CF799848F23ED84778AAA8749D9C0BCD4FF3F4AF73C53387F",
-    "name": "Loop Protocol",
-    "symbol": "LOOP",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/a46f3a10b8e67105233f358aa1de114fc34df221/images/loop.png"
-  },
-  {
     "id": "ibc/DBF6ABDB5F3D4267C039967515594453F4A31007FD838A566F563A01D2C2FB80",
     "name": "Mars",
     "symbol": "MARS",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg"
-  },
-  {
-    "id": "ibc/4F393C3FCA4190C0A6756CE7F6D897D5D1BE57D6CCB80D0BC87393566A7B6602",
-    "name": "Stargaze",
-    "symbol": "STARS",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png"
-  },
-  {
-    "id": "ibc/0306D6B66EAA2EDBB7EAD23C0EC9DDFC69BB43E80B398035E90FBCFEF3FD1A87",
-    "name": "stATOM",
-    "symbol": "stATOM",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg"
-  },
-  {
-    "id": "ibc/239BFF83852F67DF5243DB89F339FF7FDBF858437F961CAB6DA5B5ADEFB2BC07",
-    "name": "Stride",
-    "symbol": "STRD",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg"
-  },
-  {
-    "id": "ibc/F2331645B9683116188EF36FC04A809C28BD36B54555E8705A37146D0182F045",
-    "name": "Tether USD",
-    "symbol": "USDT",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdt.svg"
-  },
-  {
-    "id": "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F",
-    "name": "USD Coin",
-    "symbol": "USDC",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.svg"
   },
   {
     "id": "ibc/E67ADA2204A941CD4743E70771BA08E24885E1ADD6FD140CE1F9E0FEBB68C6B2",

--- a/kujira/asset.json
+++ b/kujira/asset.json
@@ -1,0 +1,282 @@
+[
+  {
+    "id": "ibc/640E1C3E28FD45F611971DF891AE3DC90C825DF759DF8FAA8F33F7F72B35AD56",
+    "entity": "Astroport",
+    "name": "Astroport",
+    "symbol": "ASTRO",
+    "decimals": "6"
+  },
+  {
+    "id": "ibc/C01154C2547F4CB10A985EA78E7CD4BA891C1504360703A37E1D7043F06B5E1F",
+    "entity": "Axelar",
+    "name": "Axelar",
+    "symbol": "AXL",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/axelar-network"
+  },
+  {
+    "id": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+    "entity": "Cosmos",
+    "name": "Cosmos",
+    "symbol": "ATOM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/cosmos"
+  },
+  {
+    "id": "ibc/F33B313325B1C99B646B1B786F1EA621E3794D787B90C204C30FE1D4D45970AE",
+    "entity": "Eris Protocol",
+    "name": "Eris Amplified LUNA",
+    "symbol": "ampLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "ibc/2F1447818CF99498AE62D9FB4D5E0C9FD48C68FC118C34D2ECFFFED0AD082196",
+    "entity": "Gravity Bridge",
+    "name": "Graviton",
+    "symbol": "GRAV",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/graviton"
+  },
+  {
+    "id": "ibc/EFF323CC632EC4F747C61BCE238A758EFDB7699C3226565F7C20DA06509D59A5",
+    "entity": "Juno",
+    "name": "Juno",
+    "symbol": "JUNO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/juno-network"
+  },
+  {
+    "id": "ukuji",
+    "entity": "Kujira",
+    "name": "Kuji",
+    "symbol": "KUJI",
+    "decimals": "6",
+    "circ_supply_api": "https://api.kujira.app/api/kuji/circulating",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png",
+    "coingecko": "https://www.coingecko.com/en/coins/kujira"
+  },
+  {
+    "id": "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk",
+    "entity": "Kujira",
+    "name": "USK",
+    "symbol": "USK",
+    "decimals": "6",
+    "icon": "https://i.ibb.co/V3ZM8WF/usk.png"
+  },
+  {
+    "id": "ibc/47BD209179859CDE4A2806763D7189B6E6FE13A17880FE2B42DE1E6C1E329E23",
+    "entity": "Osmosis",
+    "name": "Osmosis",
+    "symbol": "OSMO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/osmosis"
+  },
+  {
+    "id": "ibc/A358D7F19237777AF6D8AD0E0F53268F8B18AE8A53ED318095C14D6D7F3B2DB5",
+    "entity": "Secret Network",
+    "name": "Secret Network",
+    "symbol": "SCRT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/secret"
+  },
+  {
+    "id": "ibc/DA59C009A0B3B95E0549E6BF7B075C8239285989FF457A8EDDBB56F10B2A6986",
+    "entity": "Terra Money",
+    "name": "Luna",
+    "symbol": "LUNA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.png",
+    "coingecko": "https://www.coingecko.com/en/coins/terra-luna-2"
+  },
+  {
+    "id": "ibc/004EBF085BBED1029326D56BE8A2E67C08CECE670A94AC1947DF413EF5130EB2",
+    "entity": "Wormhole",
+    "name": "WAVAX - Wrapped AVAX",
+    "symbol": "WAVAX",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/axelarnetwork/axelar-docs/main/public/images/assets/wavax.png"
+  },
+  {
+    "id": "ibc/1B38805B1C75352B28169284F96DF56BDEBD9E8FAC005BDCC8CF0378C82AA8E7",
+    "entity": "Wormhole",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/weth.png",
+    "coingecko": "https://www.coingecko.com/en/coins/weth"
+  },
+  {
+    "id": "ibc/D36D2BBE441D3605EEF340EAFAC57D669880597073050A2650B1468F1634A5F5",
+    "name": "AQUA",
+    "symbol": "AQUA",
+    "decimals": "6"
+  },
+  {
+    "id": "ibc/FC59D6840A41252352263CEA2B832BB86D68D03CBA194263CB9F3C15946796FB",
+    "name": "Chainlink",
+    "symbol": "LINK",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/link.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/chainlink"
+  },
+  {
+    "id": "ibc/1603E8643A49AD47F536F645A4BF0E4C1E06C76F0A98CBE8054B177F1EE7C39A",
+    "name": "CMST",
+    "symbol": "CMST",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmst.png",
+    "coingecko": "https://www.coingecko.com/en/coins/composite"
+  },
+  {
+    "id": "ibc/3607EB5B5E64DD1C0E12E07F077FF470D5BC4706AFCBC98FE1BA960E5AE4CE07",
+    "name": "Comdex",
+    "symbol": "CMDX",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png",
+    "coingecko": "https://www.coingecko.com/en/coins/comdex"
+  },
+  {
+    "id": "ibc/BBC45F1B65B6D3C11C3C56A9428D38C3A8D03944473791C52DFB7CD3F8342CBC",
+    "name": "Cronos",
+    "symbol": "CRO",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/images/cronos.png",
+    "coingecko": "https://www.coingecko.com/en/coins/crypto-com-chain"
+  },
+  {
+    "id": "ibc/3914BDEF46F429A26917E4D8D434620EC4817DC6B6E68FB327E190902F1E9242",
+    "name": "Dai Stablecoin",
+    "symbol": "DAI",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dai.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/dai"
+  },
+  {
+    "id": "ibc/F3AA7EF362EC5E791FE78A0F4CCC69FEE1F9A7485EB1A8CAB3F6601C00522F10",
+    "name": "Evmos",
+    "symbol": "EVMOS",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/evmos"
+  },
+  {
+    "id": "ibc/53796B3762678CD80784A7DD426EB45B89C024BE3D45224CC83FDE3DED7DA0A1",
+    "name": "Fury",
+    "symbol": "FURY",
+    "decimals": "6"
+  },
+  {
+    "id": "ibc/5A3DCF59BC9EC5C0BB7AA0CA0279FC2BB126640CB8B8F704F7BC2DC42495041B",
+    "name": "Injective",
+    "symbol": "INJ",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/injective-protocol"
+  },
+  {
+    "id": "factory/kujira1swkuyt08z74n5jl7zr6hx0ru5sa2yev5v896p6/local",
+    "name": "Local Money",
+    "symbol": "LOCAL",
+    "decimals": "6",
+    "icon": "https://localmoney.io/local-logo-dark.png"
+  },
+  {
+    "id": "ibc/8318B7E036E50C0CF799848F23ED84778AAA8749D9C0BCD4FF3F4AF73C53387F",
+    "name": "Loop Protocol",
+    "symbol": "LOOP",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/a46f3a10b8e67105233f358aa1de114fc34df221/images/loop.png"
+  },
+  {
+    "id": "ibc/DBF6ABDB5F3D4267C039967515594453F4A31007FD838A566F563A01D2C2FB80",
+    "name": "Mars",
+    "symbol": "MARS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg"
+  },
+  {
+    "id": "ibc/4F393C3FCA4190C0A6756CE7F6D897D5D1BE57D6CCB80D0BC87393566A7B6602",
+    "name": "Stargaze",
+    "symbol": "STARS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png",
+    "coingecko": "https://www.coingecko.com/en/coins/stargaze"
+  },
+  {
+    "id": "ibc/0306D6B66EAA2EDBB7EAD23C0EC9DDFC69BB43E80B398035E90FBCFEF3FD1A87",
+    "name": "stATOM",
+    "symbol": "stATOM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/stride-staked-atom"
+  },
+  {
+    "id": "ibc/239BFF83852F67DF5243DB89F339FF7FDBF858437F961CAB6DA5B5ADEFB2BC07",
+    "name": "Stride",
+    "symbol": "STRD",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/stride"
+  },
+  {
+    "id": "ibc/F2331645B9683116188EF36FC04A809C28BD36B54555E8705A37146D0182F045",
+    "name": "Tether USD",
+    "symbol": "USDT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/tether"
+  },
+  {
+    "id": "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F",
+    "name": "USD Coin",
+    "symbol": "USDC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/usd-coin"
+  },
+  {
+    "id": "ibc/E67ADA2204A941CD4743E70771BA08E24885E1ADD6FD140CE1F9E0FEBB68C6B2",
+    "name": "WFTM - Wrapped Fantom",
+    "symbol": "WFTM",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/axelarnetwork/axelar-docs/main/public/images/assets/wftm.svg"
+  },
+  {
+    "id": "ibc/301DAF9CB0A9E247CD478533EF0E21F48FF8118C4A51F77C8BC3EB70E5566DBC",
+    "name": "Wrapped Bitcoin",
+    "symbol": "WBTC",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wbtc.png",
+    "coingecko": "https://www.coingecko.com/en/coins/wrapped-bitcoin"
+  },
+  {
+    "id": "ibc/DADB399E742FCEE71853E98225D13E44E90292852CD0033DF5CABAB96F80B833",
+    "name": "Wrapped BNB",
+    "symbol": "WBNB",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/wbnb"
+  },
+  {
+    "id": "ibc/A64467480BBE4CCFC3CF7E25AD1446AA9BDBD4F5BCB9EF6038B83D6964C784E6",
+    "name": "Wrapped Matic",
+    "symbol": "WMATIC",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/wmatic.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/matic-network"
+  },
+  {
+    "id": "ibc/B37E4D9FB5B30F3E1E20A4B2DE2A005E584C5C822C44527546556AE2470B4539",
+    "name": "Wrapped Polkadot",
+    "symbol": "DOT",
+    "decimals": "10",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/polkadot"
+  }
+]

--- a/kujira/asset.json
+++ b/kujira/asset.json
@@ -7,52 +7,13 @@
     "decimals": "6"
   },
   {
-    "id": "ibc/C01154C2547F4CB10A985EA78E7CD4BA891C1504360703A37E1D7043F06B5E1F",
-    "entity": "Axelar",
-    "name": "Axelar",
-    "symbol": "AXL",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.svg"
-  },
-  {
-    "id": "ibc/3914BDEF46F429A26917E4D8D434620EC4817DC6B6E68FB327E190902F1E9242",
-    "entity": "Axelar",
-    "name": "Dai Stablecoin",
-    "symbol": "DAI",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dai.svg"
-  },
-  {
-    "id": "ibc/F2331645B9683116188EF36FC04A809C28BD36B54555E8705A37146D0182F045",
-    "entity": "Axelar",
-    "name": "Tether USD",
-    "symbol": "USDT",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdt.svg"
-  },
-  {
-    "id": "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F",
-    "entity": "Axelar",
-    "name": "USD Coin",
-    "symbol": "USDC",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.svg"
-  },
-  {
-    "id": "ibc/1B38805B1C75352B28169284F96DF56BDEBD9E8FAC005BDCC8CF0378C82AA8E7",
-    "entity": "Axelar",
-    "name": "Wrapped Ether",
-    "symbol": "WETH",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/weth.png"
-  },
-  {
     "id": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
     "entity": "Cosmos",
     "name": "Cosmos",
     "symbol": "ATOM",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/cosmos"
   },
   {
     "id": "ibc/F33B313325B1C99B646B1B786F1EA621E3794D787B90C204C30FE1D4D45970AE",
@@ -62,20 +23,13 @@
     "decimals": "6"
   },
   {
-    "id": "ibc/F3AA7EF362EC5E791FE78A0F4CCC69FEE1F9A7485EB1A8CAB3F6601C00522F10",
-    "entity": "Evmos",
-    "name": "Evmos",
-    "symbol": "EVMOS",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg"
-  },
-  {
     "id": "ibc/2F1447818CF99498AE62D9FB4D5E0C9FD48C68FC118C34D2ECFFFED0AD082196",
     "entity": "Gravity Bridge",
     "name": "Graviton",
     "symbol": "GRAV",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/graviton"
   },
   {
     "id": "ibc/EFF323CC632EC4F747C61BCE238A758EFDB7699C3226565F7C20DA06509D59A5",
@@ -83,7 +37,8 @@
     "name": "Juno",
     "symbol": "JUNO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/juno-network"
   },
   {
     "id": "ukuji",
@@ -92,7 +47,8 @@
     "symbol": "KUJI",
     "decimals": "6",
     "circ_supply_api": "https://api.kujira.app/api/kuji/circulating",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png",
+    "coingecko": "https://www.coingecko.com/en/coins/kujira"
   },
   {
     "id": "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk",
@@ -103,20 +59,13 @@
     "icon": "https://i.ibb.co/V3ZM8WF/usk.png"
   },
   {
-    "id": "ibc/8318B7E036E50C0CF799848F23ED84778AAA8749D9C0BCD4FF3F4AF73C53387F",
-    "entity": "Loop",
-    "name": "Loop Protocol",
-    "symbol": "LOOP",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/a46f3a10b8e67105233f358aa1de114fc34df221/images/loop.png"
-  },
-  {
     "id": "ibc/47BD209179859CDE4A2806763D7189B6E6FE13A17880FE2B42DE1E6C1E329E23",
     "entity": "Osmosis",
     "name": "Osmosis",
     "symbol": "OSMO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/osmosis"
   },
   {
     "id": "ibc/A358D7F19237777AF6D8AD0E0F53268F8B18AE8A53ED318095C14D6D7F3B2DB5",
@@ -124,31 +73,8 @@
     "name": "Secret Network",
     "symbol": "SCRT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg"
-  },
-  {
-    "id": "ibc/4F393C3FCA4190C0A6756CE7F6D897D5D1BE57D6CCB80D0BC87393566A7B6602",
-    "entity": "Stargaze",
-    "name": "Stargaze",
-    "symbol": "STARS",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png"
-  },
-  {
-    "id": "ibc/0306D6B66EAA2EDBB7EAD23C0EC9DDFC69BB43E80B398035E90FBCFEF3FD1A87",
-    "entity": "Stride",
-    "name": "stATOM",
-    "symbol": "stATOM",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg"
-  },
-  {
-    "id": "ibc/239BFF83852F67DF5243DB89F339FF7FDBF858437F961CAB6DA5B5ADEFB2BC07",
-    "entity": "Stride",
-    "name": "Stride",
-    "symbol": "STRD",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/secret"
   },
   {
     "id": "ibc/DA59C009A0B3B95E0549E6BF7B075C8239285989FF457A8EDDBB56F10B2A6986",
@@ -156,7 +82,8 @@
     "name": "Luna",
     "symbol": "LUNA",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.png",
+    "coingecko": "https://www.coingecko.com/en/coins/terra-luna-2"
   },
   {
     "id": "ibc/004EBF085BBED1029326D56BE8A2E67C08CECE670A94AC1947DF413EF5130EB2",
@@ -167,38 +94,75 @@
     "icon": "https://raw.githubusercontent.com/axelarnetwork/axelar-docs/main/public/images/assets/wavax.png"
   },
   {
+    "id": "ibc/1B38805B1C75352B28169284F96DF56BDEBD9E8FAC005BDCC8CF0378C82AA8E7",
+    "entity": "Wormhole",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/weth.png",
+    "coingecko": "https://www.coingecko.com/en/coins/weth"
+  },
+  {
     "id": "ibc/D36D2BBE441D3605EEF340EAFAC57D669880597073050A2650B1468F1634A5F5",
     "name": "AQUA",
     "symbol": "AQUA",
     "decimals": "6"
   },
   {
+    "id": "ibc/C01154C2547F4CB10A985EA78E7CD4BA891C1504360703A37E1D7043F06B5E1F",
+    "name": "Axelar",
+    "symbol": "AXL",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/axelar-network"
+  },
+  {
     "id": "ibc/FC59D6840A41252352263CEA2B832BB86D68D03CBA194263CB9F3C15946796FB",
     "name": "Chainlink",
     "symbol": "LINK",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/link.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/link.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/chainlink"
   },
   {
     "id": "ibc/1603E8643A49AD47F536F645A4BF0E4C1E06C76F0A98CBE8054B177F1EE7C39A",
     "name": "CMST",
     "symbol": "CMST",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmst.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmst.png",
+    "coingecko": "https://www.coingecko.com/en/coins/composite"
   },
   {
     "id": "ibc/3607EB5B5E64DD1C0E12E07F077FF470D5BC4706AFCBC98FE1BA960E5AE4CE07",
     "name": "Comdex",
     "symbol": "CMDX",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png",
+    "coingecko": "https://www.coingecko.com/en/coins/comdex"
   },
   {
     "id": "ibc/BBC45F1B65B6D3C11C3C56A9428D38C3A8D03944473791C52DFB7CD3F8342CBC",
     "name": "Cronos",
     "symbol": "CRO",
     "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/images/cronos.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/images/cronos.png",
+    "coingecko": "https://www.coingecko.com/en/coins/crypto-com-chain"
+  },
+  {
+    "id": "ibc/3914BDEF46F429A26917E4D8D434620EC4817DC6B6E68FB327E190902F1E9242",
+    "name": "Dai Stablecoin",
+    "symbol": "DAI",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dai.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/dai"
+  },
+  {
+    "id": "ibc/F3AA7EF362EC5E791FE78A0F4CCC69FEE1F9A7485EB1A8CAB3F6601C00522F10",
+    "name": "Evmos",
+    "symbol": "EVMOS",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/evmos"
   },
   {
     "id": "ibc/53796B3762678CD80784A7DD426EB45B89C024BE3D45224CC83FDE3DED7DA0A1",
@@ -211,7 +175,8 @@
     "name": "Injective",
     "symbol": "INJ",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/injective-protocol"
   },
   {
     "id": "factory/kujira1swkuyt08z74n5jl7zr6hx0ru5sa2yev5v896p6/local",
@@ -221,11 +186,58 @@
     "icon": "https://localmoney.io/local-logo-dark.png"
   },
   {
+    "id": "ibc/8318B7E036E50C0CF799848F23ED84778AAA8749D9C0BCD4FF3F4AF73C53387F",
+    "name": "Loop Protocol",
+    "symbol": "LOOP",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmoscontracts/junoswap-asset-list/a46f3a10b8e67105233f358aa1de114fc34df221/images/loop.png"
+  },
+  {
     "id": "ibc/DBF6ABDB5F3D4267C039967515594453F4A31007FD838A566F563A01D2C2FB80",
     "name": "Mars",
     "symbol": "MARS",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg"
+  },
+  {
+    "id": "ibc/4F393C3FCA4190C0A6756CE7F6D897D5D1BE57D6CCB80D0BC87393566A7B6602",
+    "name": "Stargaze",
+    "symbol": "STARS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png",
+    "coingecko": "https://www.coingecko.com/en/coins/stargaze"
+  },
+  {
+    "id": "ibc/0306D6B66EAA2EDBB7EAD23C0EC9DDFC69BB43E80B398035E90FBCFEF3FD1A87",
+    "name": "stATOM",
+    "symbol": "stATOM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/stride-staked-atom"
+  },
+  {
+    "id": "ibc/239BFF83852F67DF5243DB89F339FF7FDBF858437F961CAB6DA5B5ADEFB2BC07",
+    "name": "Stride",
+    "symbol": "STRD",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/stride"
+  },
+  {
+    "id": "ibc/F2331645B9683116188EF36FC04A809C28BD36B54555E8705A37146D0182F045",
+    "name": "Tether USD",
+    "symbol": "USDT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/tether"
+  },
+  {
+    "id": "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F",
+    "name": "USD Coin",
+    "symbol": "USDC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/usd-coin"
   },
   {
     "id": "ibc/E67ADA2204A941CD4743E70771BA08E24885E1ADD6FD140CE1F9E0FEBB68C6B2",
@@ -239,27 +251,31 @@
     "name": "Wrapped Bitcoin",
     "symbol": "WBTC",
     "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wbtc.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wbtc.png",
+    "coingecko": "https://www.coingecko.com/en/coins/wrapped-bitcoin"
   },
   {
     "id": "ibc/DADB399E742FCEE71853E98225D13E44E90292852CD0033DF5CABAB96F80B833",
     "name": "Wrapped BNB",
     "symbol": "WBNB",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/wbnb"
   },
   {
     "id": "ibc/A64467480BBE4CCFC3CF7E25AD1446AA9BDBD4F5BCB9EF6038B83D6964C784E6",
     "name": "Wrapped Matic",
     "symbol": "WMATIC",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/wmatic.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/wmatic.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/matic-network"
   },
   {
     "id": "ibc/B37E4D9FB5B30F3E1E20A4B2DE2A005E584C5C822C44527546556AE2470B4539",
     "name": "Wrapped Polkadot",
     "symbol": "DOT",
     "decimals": "10",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/polkadot"
   }
 ]

--- a/kujira/asset.json
+++ b/kujira/asset.json
@@ -12,8 +12,7 @@
     "name": "Axelar",
     "symbol": "AXL",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/axelar-network"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axl.svg"
   },
   {
     "id": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
@@ -21,8 +20,7 @@
     "name": "Cosmos",
     "symbol": "ATOM",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/cosmos"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
   },
   {
     "id": "ibc/F33B313325B1C99B646B1B786F1EA621E3794D787B90C204C30FE1D4D45970AE",
@@ -37,8 +35,7 @@
     "name": "Graviton",
     "symbol": "GRAV",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/graviton"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.svg"
   },
   {
     "id": "ibc/EFF323CC632EC4F747C61BCE238A758EFDB7699C3226565F7C20DA06509D59A5",
@@ -46,8 +43,7 @@
     "name": "Juno",
     "symbol": "JUNO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/juno-network"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.svg"
   },
   {
     "id": "ukuji",
@@ -56,8 +52,7 @@
     "symbol": "KUJI",
     "decimals": "6",
     "circ_supply_api": "https://api.kujira.app/api/kuji/circulating",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png",
-    "coingecko": "https://www.coingecko.com/en/coins/kujira"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png"
   },
   {
     "id": "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk",
@@ -73,8 +68,7 @@
     "name": "Osmosis",
     "symbol": "OSMO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/osmosis"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
   },
   {
     "id": "ibc/A358D7F19237777AF6D8AD0E0F53268F8B18AE8A53ED318095C14D6D7F3B2DB5",
@@ -82,8 +76,7 @@
     "name": "Secret Network",
     "symbol": "SCRT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/secret"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg"
   },
   {
     "id": "ibc/DA59C009A0B3B95E0549E6BF7B075C8239285989FF457A8EDDBB56F10B2A6986",
@@ -91,8 +84,7 @@
     "name": "Luna",
     "symbol": "LUNA",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.png",
-    "coingecko": "https://www.coingecko.com/en/coins/terra-luna-2"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.png"
   },
   {
     "id": "ibc/004EBF085BBED1029326D56BE8A2E67C08CECE670A94AC1947DF413EF5130EB2",
@@ -108,8 +100,7 @@
     "name": "Wrapped Ether",
     "symbol": "WETH",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/weth.png",
-    "coingecko": "https://www.coingecko.com/en/coins/weth"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/weth.png"
   },
   {
     "id": "ibc/D36D2BBE441D3605EEF340EAFAC57D669880597073050A2650B1468F1634A5F5",
@@ -122,48 +113,42 @@
     "name": "Chainlink",
     "symbol": "LINK",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/link.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/chainlink"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/link.svg"
   },
   {
     "id": "ibc/1603E8643A49AD47F536F645A4BF0E4C1E06C76F0A98CBE8054B177F1EE7C39A",
     "name": "CMST",
     "symbol": "CMST",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmst.png",
-    "coingecko": "https://www.coingecko.com/en/coins/composite"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmst.png"
   },
   {
     "id": "ibc/3607EB5B5E64DD1C0E12E07F077FF470D5BC4706AFCBC98FE1BA960E5AE4CE07",
     "name": "Comdex",
     "symbol": "CMDX",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png",
-    "coingecko": "https://www.coingecko.com/en/coins/comdex"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png"
   },
   {
     "id": "ibc/BBC45F1B65B6D3C11C3C56A9428D38C3A8D03944473791C52DFB7CD3F8342CBC",
     "name": "Cronos",
     "symbol": "CRO",
     "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/images/cronos.png",
-    "coingecko": "https://www.coingecko.com/en/coins/crypto-com-chain"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cronos/images/cronos.png"
   },
   {
     "id": "ibc/3914BDEF46F429A26917E4D8D434620EC4817DC6B6E68FB327E190902F1E9242",
     "name": "Dai Stablecoin",
     "symbol": "DAI",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dai.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/dai"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/dai.svg"
   },
   {
     "id": "ibc/F3AA7EF362EC5E791FE78A0F4CCC69FEE1F9A7485EB1A8CAB3F6601C00522F10",
     "name": "Evmos",
     "symbol": "EVMOS",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/evmos"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg"
   },
   {
     "id": "ibc/53796B3762678CD80784A7DD426EB45B89C024BE3D45224CC83FDE3DED7DA0A1",
@@ -176,8 +161,7 @@
     "name": "Injective",
     "symbol": "INJ",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/injective-protocol"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg"
   },
   {
     "id": "factory/kujira1swkuyt08z74n5jl7zr6hx0ru5sa2yev5v896p6/local",
@@ -205,40 +189,35 @@
     "name": "Stargaze",
     "symbol": "STARS",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png",
-    "coingecko": "https://www.coingecko.com/en/coins/stargaze"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png"
   },
   {
     "id": "ibc/0306D6B66EAA2EDBB7EAD23C0EC9DDFC69BB43E80B398035E90FBCFEF3FD1A87",
     "name": "stATOM",
     "symbol": "stATOM",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/stride-staked-atom"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg"
   },
   {
     "id": "ibc/239BFF83852F67DF5243DB89F339FF7FDBF858437F961CAB6DA5B5ADEFB2BC07",
     "name": "Stride",
     "symbol": "STRD",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/stride"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg"
   },
   {
     "id": "ibc/F2331645B9683116188EF36FC04A809C28BD36B54555E8705A37146D0182F045",
     "name": "Tether USD",
     "symbol": "USDT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdt.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/tether"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdt.svg"
   },
   {
     "id": "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F",
     "name": "USD Coin",
     "symbol": "USDC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/usd-coin"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/usdc.svg"
   },
   {
     "id": "ibc/E67ADA2204A941CD4743E70771BA08E24885E1ADD6FD140CE1F9E0FEBB68C6B2",
@@ -252,31 +231,27 @@
     "name": "Wrapped Bitcoin",
     "symbol": "WBTC",
     "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wbtc.png",
-    "coingecko": "https://www.coingecko.com/en/coins/wrapped-bitcoin"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wbtc.png"
   },
   {
     "id": "ibc/DADB399E742FCEE71853E98225D13E44E90292852CD0033DF5CABAB96F80B833",
     "name": "Wrapped BNB",
     "symbol": "WBNB",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/wbnb"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchain/images/wbnb.svg"
   },
   {
     "id": "ibc/A64467480BBE4CCFC3CF7E25AD1446AA9BDBD4F5BCB9EF6038B83D6964C784E6",
     "name": "Wrapped Matic",
     "symbol": "WMATIC",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/wmatic.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/matic-network"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polygon/images/wmatic.svg"
   },
   {
     "id": "ibc/B37E4D9FB5B30F3E1E20A4B2DE2A005E584C5C822C44527546556AE2470B4539",
     "name": "Wrapped Polkadot",
     "symbol": "DOT",
     "decimals": "10",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/polkadot"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/polkadot/images/dot.svg"
   }
 ]

--- a/kujira/entity.json
+++ b/kujira/entity.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "alentejo.money"
+    "name": "AQUA"
   },
   {
     "name": "Astroport",
@@ -14,7 +14,13 @@
     "twitter": "https://twitter.com/axelarcore"
   },
   {
-    "name": "boneLuna"
+    "name": "Chainlink"
+  },
+  {
+    "name": "CMST"
+  },
+  {
+    "name": "Comdex"
   },
   {
     "name": "Cosmos",
@@ -23,10 +29,7 @@
     "twitter": "https://twitter.com/cosmos"
   },
   {
-    "name": "Crescent Network",
-    "website": "crescent.network",
-    "telegram": "http://t.me/crescentnetwork",
-    "twitter": "https://twitter.com/crescenthub"
+    "name": "Cronos"
   },
   {
     "name": "Eris Protocol",
@@ -35,12 +38,18 @@
     "twitter": "https://twitter.com/eris_protocol"
   },
   {
-    "name": "Gidorah"
+    "name": "Evmos"
+  },
+  {
+    "name": "Fury"
   },
   {
     "name": "Gravity Bridge",
     "website": "https://t.co/rSb0msPbRI",
     "twitter": "https://twitter.com/gravity_bridge"
+  },
+  {
+    "name": "Injective"
   },
   {
     "name": "Juno",
@@ -52,13 +61,13 @@
     "name": "Kujira"
   },
   {
-    "name": "Lira Financial"
+    "name": "Local Money"
   },
   {
-    "name": "Luna Bird"
+    "name": "Loop"
   },
   {
-    "name": "Orne"
+    "name": "Mars"
   },
   {
     "name": "Osmosis",
@@ -67,39 +76,16 @@
     "twitter": "https://twitter.com/osmosiszone"
   },
   {
-    "name": "Phoenix"
-  },
-  {
-    "name": "portugal.protocol"
-  },
-  {
-    "name": "Redacted Money"
-  },
-  {
-    "name": "Santerra",
-    "website": "https://santerra.app/",
-    "twitter": "https://twitter.com/Santerra_SANT"
-  },
-  {
-    "name": "Sayve Protocol",
-    "website": "https://sayve.money/",
-    "telegram": "https://t.me/SayveProtocolChat",
-    "twitter": "https://twitter.com/sayve_protocol"
-  },
-  {
     "name": "Secret Network",
     "website": "scrt.network",
     "telegram": "https://t.me/scrtCommunity",
     "twitter": "https://twitter.com/SecretNetwork"
   },
   {
-    "name": "Stader Labs"
+    "name": "Stargaze"
   },
   {
-    "name": "Steak",
-    "website": "https://app.steak.club/",
-    "telegram": "https://t.me/+PadO-WwMDxNjMGEx",
-    "twitter": "https://twitter.com/st4k3h0us3"
+    "name": "Stride"
   },
   {
     "name": "Terra Money",
@@ -108,29 +94,23 @@
     "twitter": "https://twitter.com/terra_money"
   },
   {
-    "name": "Terra Poker",
-    "website": "https://terra.poker/",
-    "telegram": "https://t.me/terrapoker_community",
-    "twitter": "https://twitter.com/TP_TerraPoker"
-  },
-  {
-    "name": "TerraFloki",
-    "website": "https://terrafloki.io/",
-    "telegram": "https://t.co/tFOOeLO45t",
-    "twitter": "https://twitter.com/MetaFrens_"
-  },
-  {
-    "name": "Terraswap"
-  },
-  {
-    "name": "Valkyrie Protocol",
-    "website": "https://valkyrieprotocol.com/",
-    "telegram": "https://t.co/ltQoXM3far",
-    "twitter": "https://twitter.com/valkyrie_money"
+    "name": "WFTM - Wrapped Fantom"
   },
   {
     "name": "Wormhole",
     "website": "https://wormholenetwork.com/",
     "twitter": "https://twitter.com/wormholecrypto"
+  },
+  {
+    "name": "Wrapped Bitcoin"
+  },
+  {
+    "name": "Wrapped BNB"
+  },
+  {
+    "name": "Wrapped Matic"
+  },
+  {
+    "name": "Wrapped Polkadot"
   }
 ]

--- a/kujira/pool.json
+++ b/kujira/pool.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "kujira10fqy0npt7djm8lg847v9rqlng88kqfdvl8tyt4ge204wf52sy68qwmj07l",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/8318B7E036E50C0CF799848F23ED84778AAA8749D9C0BCD4FF3F4AF73C53387F",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -11,7 +11,7 @@
   },
   {
     "id": "kujira10j648ftg2g8p5vhgsu5kzfh6d907vpkrn0a5l3qch479eqy2qssqm905c4",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/BBC45F1B65B6D3C11C3C56A9428D38C3A8D03944473791C52DFB7CD3F8342CBC",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -21,7 +21,7 @@
   },
   {
     "id": "kujira12jdezs3kk6y04q3fnl7kq5567pcw0zfr7j0yfsxjqgggdkktut9s2gm7cm",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/301DAF9CB0A9E247CD478533EF0E21F48FF8118C4A51F77C8BC3EB70E5566DBC",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -31,7 +31,7 @@
   },
   {
     "id": "kujira12p30cr4gstmp2yucwxtaq92turrzsxxar8upz3rhmfjxh6gdgk4s5vsyse",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/B4DCACF7753C05040AF0A7BF2B583402C4B8C9B0A86FCECE32EF63CB7F0A46B3",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -41,7 +41,7 @@
   },
   {
     "id": "kujira12zjpumtfh88k6s2s8k4wks37ezr2c3zeha5xx6qpd65e5ehz50nq0afvrv",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/FC59D6840A41252352263CEA2B832BB86D68D03CBA194263CB9F3C15946796FB",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -51,7 +51,7 @@
   },
   {
     "id": "kujira13l8gwanf37938wgfv5yktmfzxjwaj4ysn4gl96vj78xcqqxlcrgssfl797",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/D36D2BBE441D3605EEF340EAFAC57D669880597073050A2650B1468F1634A5F5",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -61,7 +61,7 @@
   },
   {
     "id": "kujira149m52kn7nvsg5nftvv4fh85scsavpdfxp5nr7zasz97dum89dp5qevttd9",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/DBF6ABDB5F3D4267C039967515594453F4A31007FD838A566F563A01D2C2FB80",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -71,7 +71,7 @@
   },
   {
     "id": "kujira14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sl4e867",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ukuji",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -81,7 +81,7 @@
   },
   {
     "id": "kujira1538ukswznmuek3hfv7mcxem9hjqz8sa4ypl2ul0zncu3tdgfvwmq8pxkwp",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/A2146858B5E3CFE759E32F47CA54591F8E27FAEDFF731D30B448E5AB25CA8EC5",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -91,7 +91,7 @@
   },
   {
     "id": "kujira158zzjcvkz7r3j5hueurcw22qrjerqw4dtrzlalztr7whjykjwvrsrahdnq",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/0306D6B66EAA2EDBB7EAD23C0EC9DDFC69BB43E80B398035E90FBCFEF3FD1A87",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -101,7 +101,7 @@
   },
   {
     "id": "kujira16y344e8ryydmeu2g8yyfznq79j7jfnar4p59ngpvaazcj83jzsms6tju67",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/3607EB5B5E64DD1C0E12E07F077FF470D5BC4706AFCBC98FE1BA960E5AE4CE07",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -111,7 +111,7 @@
   },
   {
     "id": "kujira172qjrk8g9l86w0shz4cc3e6rt5h9janaen4j4u6ze7xkjvjnaqfskwyyqm",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/F33B313325B1C99B646B1B786F1EA621E3794D787B90C204C30FE1D4D45970AE",
       "ibc/DA59C009A0B3B95E0549E6BF7B075C8239285989FF457A8EDDBB56F10B2A6986"
@@ -121,7 +121,7 @@
   },
   {
     "id": "kujira17qp8g5n5wwelrsnfdakrv0p550nzg72agpcz5t0ea6thlqd300hquxljcc",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/A2146858B5E3CFE759E32F47CA54591F8E27FAEDFF731D30B448E5AB25CA8EC5",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -131,7 +131,7 @@
   },
   {
     "id": "kujira17w9r23r8v8r7z5lphwj99296fhlye9ej5nq3hlqw554u63m88avspdl9tc",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/1B38805B1C75352B28169284F96DF56BDEBD9E8FAC005BDCC8CF0378C82AA8E7",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -141,7 +141,7 @@
   },
   {
     "id": "kujira182nff4ttmvshn6yjlqj5czapfcav9434l2qzz8aahf5pxnyd33tsz30aw6",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/F3AA7EF362EC5E791FE78A0F4CCC69FEE1F9A7485EB1A8CAB3F6601C00522F10",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -151,7 +151,7 @@
   },
   {
     "id": "kujira18638dsuf7p3a2e23seqz8zegqrcpsdr5nw6j2a50qg6r3q8vn3qqrg9lzp",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/2F1447818CF99498AE62D9FB4D5E0C9FD48C68FC118C34D2ECFFFED0AD082196",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -161,7 +161,7 @@
   },
   {
     "id": "kujira18lm235jzuh4t7hh5z8lqyz08dmz67magj8z0fc4a0vn6c0hzk0es3r4glx",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/3914BDEF46F429A26917E4D8D434620EC4817DC6B6E68FB327E190902F1E9242",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -171,7 +171,7 @@
   },
   {
     "id": "kujira18v47nqmhvejx3vc498pantg8vr435xa0rt6x0m6kzhp6yuqmcp8s4x8j2c",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ukuji",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -181,7 +181,7 @@
   },
   {
     "id": "kujira193dzcmy7lwuj4eda3zpwwt9ejal00xva0vawcvhgsyyp5cfh6jyq66wfrf",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ukuji",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -191,7 +191,7 @@
   },
   {
     "id": "kujira1a0fyanyqm496fpgneqawhlsug6uqfvqg2epnw39q0jdenw3zs8zqsjhdr0",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/DADB399E742FCEE71853E98225D13E44E90292852CD0033DF5CABAB96F80B833",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -201,7 +201,7 @@
   },
   {
     "id": "kujira1aakfpghcanxtc45gpqlx8j3rq0zcpyf49qmhm9mdjrfx036h4z5sfmexun",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/47BD209179859CDE4A2806763D7189B6E6FE13A17880FE2B42DE1E6C1E329E23",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -211,7 +211,7 @@
   },
   {
     "id": "kujira1apkgj87fgfsq84swvkyfaemrq7t4deuh60887lek0hkgdjh5fj0qaz7fhx",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/DADB399E742FCEE71853E98225D13E44E90292852CD0033DF5CABAB96F80B833",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -221,7 +221,7 @@
   },
   {
     "id": "kujira1cduudfszcm9slm8qxlaqvnpzg2u0hkus94fe3pwt9x446dtw6eeql8ualz",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/21038E447A2D4A1183628C0EC366FE79C2E0B0BD91F9A85E6C906CD911FD676E",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -231,7 +231,7 @@
   },
   {
     "id": "kujira1cn922pcqrt4g2dr4va9vxk8h3w3jfxnxjqq2qp6zktjsehdzde6sz66um0",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/239BFF83852F67DF5243DB89F339FF7FDBF858437F961CAB6DA5B5ADEFB2BC07",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -241,7 +241,7 @@
   },
   {
     "id": "kujira1ddeadmhum3umygv84frhc87gl2grzjmx9x8fuhjts7zqwuc39xuq53w3d8",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/5A3DCF59BC9EC5C0BB7AA0CA0279FC2BB126640CB8B8F704F7BC2DC42495041B",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -251,7 +251,7 @@
   },
   {
     "id": "kujira1dtaqwlmzlk3jku5un6h6rfunttmwsqnfz7evvdf4pwr0wypsl68q49aaud",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/C01154C2547F4CB10A985EA78E7CD4BA891C1504360703A37E1D7043F06B5E1F",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -261,7 +261,7 @@
   },
   {
     "id": "kujira1fkwjqyfdyktgu5f59jpwhvl23zh8aav7f98ml9quly62jx2sehysqa4unf",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/A358D7F19237777AF6D8AD0E0F53268F8B18AE8A53ED318095C14D6D7F3B2DB5",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -271,7 +271,7 @@
   },
   {
     "id": "kujira1fphguznhazgqdlr9mpfh6nmn3vjjr73ksz3ukznv6q7s9ndfq2cs8vhapj",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/004EBF085BBED1029326D56BE8A2E67C08CECE670A94AC1947DF413EF5130EB2",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -281,7 +281,7 @@
   },
   {
     "id": "kujira1gl8js9zn7h9u2h37fx7qg8xy65jrk9t4zpa6s7j5hdlanud2uwxshqq67m",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "factory/kujira13y8hs83sk0la7na2w5g5nzrnjjpnkvmd7e87yd35g8dcph7dn0ksenay2a/ulp",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -291,7 +291,7 @@
   },
   {
     "id": "kujira1h7eenquygffwsmc8csrlx88zcddwx0aqspq3x2dsl20lwk4r9n2q9t86ht",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/3607EB5B5E64DD1C0E12E07F077FF470D5BC4706AFCBC98FE1BA960E5AE4CE07",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -301,7 +301,7 @@
   },
   {
     "id": "kujira1hs95lgvuy0p6jn4v7js5x8plfdqw867lsuh5xv6d2ua20jprkgesw2pujt",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "factory/kujira13y8hs83sk0la7na2w5g5nzrnjjpnkvmd7e87yd35g8dcph7dn0ksenay2a/ulp",
       "ukuji"
@@ -311,7 +311,7 @@
   },
   {
     "id": "kujira1hulx7cgvpfcvg83wk5h96sedqgn72n026w6nl47uht554xhvj9nsra5j5u",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/47BD209179859CDE4A2806763D7189B6E6FE13A17880FE2B42DE1E6C1E329E23"
@@ -321,7 +321,7 @@
   },
   {
     "id": "kujira1jkte0pytr85qg0whmgux3vmz9ehmh82w40h8gaqeg435fnkyfxqq5m32qy",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/4F393C3FCA4190C0A6756CE7F6D897D5D1BE57D6CCB80D0BC87393566A7B6602",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -331,7 +331,7 @@
   },
   {
     "id": "kujira1jlzw6xal0n2c580g3wxs09tjhlzdht9y8dgszq3tupf8fhl7xjus7ep7ap",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/B37E4D9FB5B30F3E1E20A4B2DE2A005E584C5C822C44527546556AE2470B4539",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -341,7 +341,7 @@
   },
   {
     "id": "kujira1k7rg9vscg2uldw6868mecryxhlze5e3f4z0f00295ddu7cz3l4ws4d9dfj",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/8318B7E036E50C0CF799848F23ED84778AAA8749D9C0BCD4FF3F4AF73C53387F",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -351,7 +351,7 @@
   },
   {
     "id": "kujira1ky9kv2m4dnykm90d0lj5089k4efttgfpx34zyvkklxnew48c522sggqjsg",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/E67ADA2204A941CD4743E70771BA08E24885E1ADD6FD140CE1F9E0FEBB68C6B2",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -361,7 +361,7 @@
   },
   {
     "id": "kujira1nm3yktzcgpnvwu6qpzqgl2ktyvlgsstc7ev849dd3ulaygw75mqqxvtnck",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/4F393C3FCA4190C0A6756CE7F6D897D5D1BE57D6CCB80D0BC87393566A7B6602",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -371,7 +371,7 @@
   },
   {
     "id": "kujira1qjxu65ucccpg8c5kac8ng6yxfqq85fluwd0p9nt74g2304qw8eyq930y7w",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/004EBF085BBED1029326D56BE8A2E67C08CECE670A94AC1947DF413EF5130EB2",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -381,7 +381,7 @@
   },
   {
     "id": "kujira1qqlk2773dvj8cyv3ftnzvyrknq78yryghp3uyumnumaxu656yreszrdph0",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/640E1C3E28FD45F611971DF891AE3DC90C825DF759DF8FAA8F33F7F72B35AD56",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -391,7 +391,7 @@
   },
   {
     "id": "kujira1qw5hdcmcf4aq5xmnu6znscurvkgvhxfsyvhz3jvxhasxjwtk3l7sccwcs8",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/1603E8643A49AD47F536F645A4BF0E4C1E06C76F0A98CBE8054B177F1EE7C39A",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -401,7 +401,7 @@
   },
   {
     "id": "kujira1rpxf55u22q2tly9y8rgdrjgx9p52sus7jugaevj3hdt0z7sgvkcsyrhrv0",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/A358D7F19237777AF6D8AD0E0F53268F8B18AE8A53ED318095C14D6D7F3B2DB5",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -411,7 +411,7 @@
   },
   {
     "id": "kujira1rrnacml8zeqq3ve2t98r5x88t4uahahdk66y9qpcrjp9qxhnuvysv59zx8",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/A64467480BBE4CCFC3CF7E25AD1446AA9BDBD4F5BCB9EF6038B83D6964C784E6",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -421,7 +421,7 @@
   },
   {
     "id": "kujira1rtpn4nxkx7u5y4uf5lp4ywrhmnms07p8p8wc3pmw53hfv0lhyxdqlfhgrt",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/B4DCACF7753C05040AF0A7BF2B583402C4B8C9B0A86FCECE32EF63CB7F0A46B3",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -431,7 +431,7 @@
   },
   {
     "id": "kujira1rwx6w02alc4kaz7xpyg3rlxpjl4g63x5jq292mkxgg65zqpn5llq202vh5",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -441,7 +441,7 @@
   },
   {
     "id": "kujira1sse6a00arh9dalzsyrd3q825dsn2zmrag0u4qx8q0dyks4ftnxyqrj0xds",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "factory/kujira1swkuyt08z74n5jl7zr6hx0ru5sa2yev5v896p6/local",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -451,7 +451,7 @@
   },
   {
     "id": "kujira1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrsqq4jjh",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/1B38805B1C75352B28169284F96DF56BDEBD9E8FAC005BDCC8CF0378C82AA8E7",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -461,7 +461,7 @@
   },
   {
     "id": "kujira1ulyrqqtx9vqsk92805jk7xxwz77lszmm2f548juyced96tj4lg7qugewsf",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/301DAF9CB0A9E247CD478533EF0E21F48FF8118C4A51F77C8BC3EB70E5566DBC",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -471,7 +471,7 @@
   },
   {
     "id": "kujira1uvqk5vj9vn4gjemrp0myz4ku49aaemulgaqw7pfe0nuvfwp3gukq64r3ws",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/F33B313325B1C99B646B1B786F1EA621E3794D787B90C204C30FE1D4D45970AE",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -481,7 +481,7 @@
   },
   {
     "id": "kujira1v8kh6mqxq7awcvl936xeyzv8fnmdkd3yxggvkyek5d0ecut4a6zs0larj2",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/DBF6ABDB5F3D4267C039967515594453F4A31007FD838A566F563A01D2C2FB80",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -491,7 +491,7 @@
   },
   {
     "id": "kujira1v8lkqws3gd6npr0rdk9ch54amh9guas86r4u62jq27hee88lryfsxwrvlk",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/53796B3762678CD80784A7DD426EB45B89C024BE3D45224CC83FDE3DED7DA0A1",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -501,7 +501,7 @@
   },
   {
     "id": "kujira1w2l4w5p66l5t2nmrmsvz7k4cu50s7e8dc6h59gcxsnmp2tgy7q7s5lux8a",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/47BD209179859CDE4A2806763D7189B6E6FE13A17880FE2B42DE1E6C1E329E23",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -511,7 +511,7 @@
   },
   {
     "id": "kujira1w4t2qpwvhyhz0g2mwgqjzgsw63dcy5hkfch0tgr8xj9qjcsauq8q5x0zxz",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/B37E4D9FB5B30F3E1E20A4B2DE2A005E584C5C822C44527546556AE2470B4539",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -521,7 +521,7 @@
   },
   {
     "id": "kujira1xqhakgvn3jeqfade0z4aufer9xylx7ft45fgyhg6z75mauhkjwks9cucyq",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ukuji",
       "ibc/DA59C009A0B3B95E0549E6BF7B075C8239285989FF457A8EDDBB56F10B2A6986"
@@ -531,7 +531,7 @@
   },
   {
     "id": "kujira1xr3rq8yvd7qplsw5yx90ftsr2zdhg4e9z60h5duusgxpv72hud3sl8nek6",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -541,7 +541,7 @@
   },
   {
     "id": "kujira1xut80d09q0tgtch8p0z4k5f88d3uvt8cvtzm5h3tu3tsy4jk9xlscem692",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/F2331645B9683116188EF36FC04A809C28BD36B54555E8705A37146D0182F045",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -551,7 +551,7 @@
   },
   {
     "id": "kujira1yg8930mj8pk288lmkjex0qz85mj8wgtns5uzwyn2hs25pwdnw42skp0kur",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/DA59C009A0B3B95E0549E6BF7B075C8239285989FF457A8EDDBB56F10B2A6986",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -561,7 +561,7 @@
   },
   {
     "id": "kujira1yum4v0v5l92jkxn8xpn9mjg7wuldk784ctg424ue8gqvdp88qzlqr2qp2j",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -571,7 +571,7 @@
   },
   {
     "id": "kujira1z7asfxkwv0t863rllul570eh5pf2zk07k3d86ag4vtghaue37l5s9epdvn",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/EFF323CC632EC4F747C61BCE238A758EFDB7699C3226565F7C20DA06509D59A5",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -581,7 +581,7 @@
   },
   {
     "id": "kujira1z7quf5t6g7spjnu2qhcp2x2ksnz4zfut9k73uutpg2q95dd008fqsprtvl",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/EFF323CC632EC4F747C61BCE238A758EFDB7699C3226565F7C20DA06509D59A5",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -591,7 +591,7 @@
   },
   {
     "id": "kujira1zz74gvmq6ss3pg5vgahvx47ugpfzr80qu75l97lf2ggdgxq04ddqxkdzey",
-    "lp_token_id": "-1",
+    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/DA59C009A0B3B95E0549E6BF7B075C8239285989FF457A8EDDBB56F10B2A6986",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"

--- a/kujira/pool.json
+++ b/kujira/pool.json
@@ -1,7 +1,6 @@
 [
   {
     "id": "kujira10fqy0npt7djm8lg847v9rqlng88kqfdvl8tyt4ge204wf52sy68qwmj07l",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/8318B7E036E50C0CF799848F23ED84778AAA8749D9C0BCD4FF3F4AF73C53387F",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -11,7 +10,6 @@
   },
   {
     "id": "kujira10j648ftg2g8p5vhgsu5kzfh6d907vpkrn0a5l3qch479eqy2qssqm905c4",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/BBC45F1B65B6D3C11C3C56A9428D38C3A8D03944473791C52DFB7CD3F8342CBC",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -21,7 +19,6 @@
   },
   {
     "id": "kujira12jdezs3kk6y04q3fnl7kq5567pcw0zfr7j0yfsxjqgggdkktut9s2gm7cm",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/301DAF9CB0A9E247CD478533EF0E21F48FF8118C4A51F77C8BC3EB70E5566DBC",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -31,7 +28,6 @@
   },
   {
     "id": "kujira12p30cr4gstmp2yucwxtaq92turrzsxxar8upz3rhmfjxh6gdgk4s5vsyse",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/B4DCACF7753C05040AF0A7BF2B583402C4B8C9B0A86FCECE32EF63CB7F0A46B3",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -41,7 +37,6 @@
   },
   {
     "id": "kujira12zjpumtfh88k6s2s8k4wks37ezr2c3zeha5xx6qpd65e5ehz50nq0afvrv",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/FC59D6840A41252352263CEA2B832BB86D68D03CBA194263CB9F3C15946796FB",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -51,7 +46,6 @@
   },
   {
     "id": "kujira13l8gwanf37938wgfv5yktmfzxjwaj4ysn4gl96vj78xcqqxlcrgssfl797",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/D36D2BBE441D3605EEF340EAFAC57D669880597073050A2650B1468F1634A5F5",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -61,7 +55,6 @@
   },
   {
     "id": "kujira149m52kn7nvsg5nftvv4fh85scsavpdfxp5nr7zasz97dum89dp5qevttd9",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/DBF6ABDB5F3D4267C039967515594453F4A31007FD838A566F563A01D2C2FB80",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -71,7 +64,6 @@
   },
   {
     "id": "kujira14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sl4e867",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ukuji",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -81,7 +73,6 @@
   },
   {
     "id": "kujira1538ukswznmuek3hfv7mcxem9hjqz8sa4ypl2ul0zncu3tdgfvwmq8pxkwp",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/A2146858B5E3CFE759E32F47CA54591F8E27FAEDFF731D30B448E5AB25CA8EC5",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -91,7 +82,6 @@
   },
   {
     "id": "kujira158zzjcvkz7r3j5hueurcw22qrjerqw4dtrzlalztr7whjykjwvrsrahdnq",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/0306D6B66EAA2EDBB7EAD23C0EC9DDFC69BB43E80B398035E90FBCFEF3FD1A87",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -101,7 +91,6 @@
   },
   {
     "id": "kujira16y344e8ryydmeu2g8yyfznq79j7jfnar4p59ngpvaazcj83jzsms6tju67",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/3607EB5B5E64DD1C0E12E07F077FF470D5BC4706AFCBC98FE1BA960E5AE4CE07",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -111,7 +100,6 @@
   },
   {
     "id": "kujira172qjrk8g9l86w0shz4cc3e6rt5h9janaen4j4u6ze7xkjvjnaqfskwyyqm",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/F33B313325B1C99B646B1B786F1EA621E3794D787B90C204C30FE1D4D45970AE",
       "ibc/DA59C009A0B3B95E0549E6BF7B075C8239285989FF457A8EDDBB56F10B2A6986"
@@ -121,7 +109,6 @@
   },
   {
     "id": "kujira17qp8g5n5wwelrsnfdakrv0p550nzg72agpcz5t0ea6thlqd300hquxljcc",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/A2146858B5E3CFE759E32F47CA54591F8E27FAEDFF731D30B448E5AB25CA8EC5",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -131,7 +118,6 @@
   },
   {
     "id": "kujira17w9r23r8v8r7z5lphwj99296fhlye9ej5nq3hlqw554u63m88avspdl9tc",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/1B38805B1C75352B28169284F96DF56BDEBD9E8FAC005BDCC8CF0378C82AA8E7",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -141,7 +127,6 @@
   },
   {
     "id": "kujira182nff4ttmvshn6yjlqj5czapfcav9434l2qzz8aahf5pxnyd33tsz30aw6",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/F3AA7EF362EC5E791FE78A0F4CCC69FEE1F9A7485EB1A8CAB3F6601C00522F10",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -151,7 +136,6 @@
   },
   {
     "id": "kujira18638dsuf7p3a2e23seqz8zegqrcpsdr5nw6j2a50qg6r3q8vn3qqrg9lzp",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/2F1447818CF99498AE62D9FB4D5E0C9FD48C68FC118C34D2ECFFFED0AD082196",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -161,7 +145,6 @@
   },
   {
     "id": "kujira18lm235jzuh4t7hh5z8lqyz08dmz67magj8z0fc4a0vn6c0hzk0es3r4glx",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/3914BDEF46F429A26917E4D8D434620EC4817DC6B6E68FB327E190902F1E9242",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -171,7 +154,6 @@
   },
   {
     "id": "kujira18v47nqmhvejx3vc498pantg8vr435xa0rt6x0m6kzhp6yuqmcp8s4x8j2c",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ukuji",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -181,7 +163,6 @@
   },
   {
     "id": "kujira193dzcmy7lwuj4eda3zpwwt9ejal00xva0vawcvhgsyyp5cfh6jyq66wfrf",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ukuji",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -191,7 +172,6 @@
   },
   {
     "id": "kujira1a0fyanyqm496fpgneqawhlsug6uqfvqg2epnw39q0jdenw3zs8zqsjhdr0",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/DADB399E742FCEE71853E98225D13E44E90292852CD0033DF5CABAB96F80B833",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -201,7 +181,6 @@
   },
   {
     "id": "kujira1aakfpghcanxtc45gpqlx8j3rq0zcpyf49qmhm9mdjrfx036h4z5sfmexun",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/47BD209179859CDE4A2806763D7189B6E6FE13A17880FE2B42DE1E6C1E329E23",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -211,7 +190,6 @@
   },
   {
     "id": "kujira1apkgj87fgfsq84swvkyfaemrq7t4deuh60887lek0hkgdjh5fj0qaz7fhx",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/DADB399E742FCEE71853E98225D13E44E90292852CD0033DF5CABAB96F80B833",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -221,7 +199,6 @@
   },
   {
     "id": "kujira1cduudfszcm9slm8qxlaqvnpzg2u0hkus94fe3pwt9x446dtw6eeql8ualz",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/21038E447A2D4A1183628C0EC366FE79C2E0B0BD91F9A85E6C906CD911FD676E",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -231,7 +208,6 @@
   },
   {
     "id": "kujira1cn922pcqrt4g2dr4va9vxk8h3w3jfxnxjqq2qp6zktjsehdzde6sz66um0",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/239BFF83852F67DF5243DB89F339FF7FDBF858437F961CAB6DA5B5ADEFB2BC07",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -241,7 +217,6 @@
   },
   {
     "id": "kujira1ddeadmhum3umygv84frhc87gl2grzjmx9x8fuhjts7zqwuc39xuq53w3d8",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/5A3DCF59BC9EC5C0BB7AA0CA0279FC2BB126640CB8B8F704F7BC2DC42495041B",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -251,7 +226,6 @@
   },
   {
     "id": "kujira1dtaqwlmzlk3jku5un6h6rfunttmwsqnfz7evvdf4pwr0wypsl68q49aaud",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/C01154C2547F4CB10A985EA78E7CD4BA891C1504360703A37E1D7043F06B5E1F",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -261,7 +235,6 @@
   },
   {
     "id": "kujira1fkwjqyfdyktgu5f59jpwhvl23zh8aav7f98ml9quly62jx2sehysqa4unf",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/A358D7F19237777AF6D8AD0E0F53268F8B18AE8A53ED318095C14D6D7F3B2DB5",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -271,7 +244,6 @@
   },
   {
     "id": "kujira1fphguznhazgqdlr9mpfh6nmn3vjjr73ksz3ukznv6q7s9ndfq2cs8vhapj",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/004EBF085BBED1029326D56BE8A2E67C08CECE670A94AC1947DF413EF5130EB2",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -281,7 +253,6 @@
   },
   {
     "id": "kujira1gl8js9zn7h9u2h37fx7qg8xy65jrk9t4zpa6s7j5hdlanud2uwxshqq67m",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "factory/kujira13y8hs83sk0la7na2w5g5nzrnjjpnkvmd7e87yd35g8dcph7dn0ksenay2a/ulp",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -291,7 +262,6 @@
   },
   {
     "id": "kujira1h7eenquygffwsmc8csrlx88zcddwx0aqspq3x2dsl20lwk4r9n2q9t86ht",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/3607EB5B5E64DD1C0E12E07F077FF470D5BC4706AFCBC98FE1BA960E5AE4CE07",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -301,7 +271,6 @@
   },
   {
     "id": "kujira1hs95lgvuy0p6jn4v7js5x8plfdqw867lsuh5xv6d2ua20jprkgesw2pujt",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "factory/kujira13y8hs83sk0la7na2w5g5nzrnjjpnkvmd7e87yd35g8dcph7dn0ksenay2a/ulp",
       "ukuji"
@@ -311,7 +280,6 @@
   },
   {
     "id": "kujira1hulx7cgvpfcvg83wk5h96sedqgn72n026w6nl47uht554xhvj9nsra5j5u",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/47BD209179859CDE4A2806763D7189B6E6FE13A17880FE2B42DE1E6C1E329E23"
@@ -321,7 +289,6 @@
   },
   {
     "id": "kujira1jkte0pytr85qg0whmgux3vmz9ehmh82w40h8gaqeg435fnkyfxqq5m32qy",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/4F393C3FCA4190C0A6756CE7F6D897D5D1BE57D6CCB80D0BC87393566A7B6602",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -331,7 +298,6 @@
   },
   {
     "id": "kujira1jlzw6xal0n2c580g3wxs09tjhlzdht9y8dgszq3tupf8fhl7xjus7ep7ap",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/B37E4D9FB5B30F3E1E20A4B2DE2A005E584C5C822C44527546556AE2470B4539",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -341,7 +307,6 @@
   },
   {
     "id": "kujira1k7rg9vscg2uldw6868mecryxhlze5e3f4z0f00295ddu7cz3l4ws4d9dfj",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/8318B7E036E50C0CF799848F23ED84778AAA8749D9C0BCD4FF3F4AF73C53387F",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -351,7 +316,6 @@
   },
   {
     "id": "kujira1ky9kv2m4dnykm90d0lj5089k4efttgfpx34zyvkklxnew48c522sggqjsg",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/E67ADA2204A941CD4743E70771BA08E24885E1ADD6FD140CE1F9E0FEBB68C6B2",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -361,7 +325,6 @@
   },
   {
     "id": "kujira1nm3yktzcgpnvwu6qpzqgl2ktyvlgsstc7ev849dd3ulaygw75mqqxvtnck",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/4F393C3FCA4190C0A6756CE7F6D897D5D1BE57D6CCB80D0BC87393566A7B6602",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -371,7 +334,6 @@
   },
   {
     "id": "kujira1qjxu65ucccpg8c5kac8ng6yxfqq85fluwd0p9nt74g2304qw8eyq930y7w",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/004EBF085BBED1029326D56BE8A2E67C08CECE670A94AC1947DF413EF5130EB2",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -381,7 +343,6 @@
   },
   {
     "id": "kujira1qqlk2773dvj8cyv3ftnzvyrknq78yryghp3uyumnumaxu656yreszrdph0",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/640E1C3E28FD45F611971DF891AE3DC90C825DF759DF8FAA8F33F7F72B35AD56",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -391,7 +352,6 @@
   },
   {
     "id": "kujira1qw5hdcmcf4aq5xmnu6znscurvkgvhxfsyvhz3jvxhasxjwtk3l7sccwcs8",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/1603E8643A49AD47F536F645A4BF0E4C1E06C76F0A98CBE8054B177F1EE7C39A",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -401,7 +361,6 @@
   },
   {
     "id": "kujira1rpxf55u22q2tly9y8rgdrjgx9p52sus7jugaevj3hdt0z7sgvkcsyrhrv0",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/A358D7F19237777AF6D8AD0E0F53268F8B18AE8A53ED318095C14D6D7F3B2DB5",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -411,7 +370,6 @@
   },
   {
     "id": "kujira1rrnacml8zeqq3ve2t98r5x88t4uahahdk66y9qpcrjp9qxhnuvysv59zx8",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/A64467480BBE4CCFC3CF7E25AD1446AA9BDBD4F5BCB9EF6038B83D6964C784E6",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -421,7 +379,6 @@
   },
   {
     "id": "kujira1rtpn4nxkx7u5y4uf5lp4ywrhmnms07p8p8wc3pmw53hfv0lhyxdqlfhgrt",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/B4DCACF7753C05040AF0A7BF2B583402C4B8C9B0A86FCECE32EF63CB7F0A46B3",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -431,7 +388,6 @@
   },
   {
     "id": "kujira1rwx6w02alc4kaz7xpyg3rlxpjl4g63x5jq292mkxgg65zqpn5llq202vh5",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -441,7 +397,6 @@
   },
   {
     "id": "kujira1sse6a00arh9dalzsyrd3q825dsn2zmrag0u4qx8q0dyks4ftnxyqrj0xds",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "factory/kujira1swkuyt08z74n5jl7zr6hx0ru5sa2yev5v896p6/local",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -451,7 +406,6 @@
   },
   {
     "id": "kujira1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrsqq4jjh",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/1B38805B1C75352B28169284F96DF56BDEBD9E8FAC005BDCC8CF0378C82AA8E7",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -461,7 +415,6 @@
   },
   {
     "id": "kujira1ulyrqqtx9vqsk92805jk7xxwz77lszmm2f548juyced96tj4lg7qugewsf",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/301DAF9CB0A9E247CD478533EF0E21F48FF8118C4A51F77C8BC3EB70E5566DBC",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -471,7 +424,6 @@
   },
   {
     "id": "kujira1uvqk5vj9vn4gjemrp0myz4ku49aaemulgaqw7pfe0nuvfwp3gukq64r3ws",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/F33B313325B1C99B646B1B786F1EA621E3794D787B90C204C30FE1D4D45970AE",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -481,7 +433,6 @@
   },
   {
     "id": "kujira1v8kh6mqxq7awcvl936xeyzv8fnmdkd3yxggvkyek5d0ecut4a6zs0larj2",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/DBF6ABDB5F3D4267C039967515594453F4A31007FD838A566F563A01D2C2FB80",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -491,7 +442,6 @@
   },
   {
     "id": "kujira1v8lkqws3gd6npr0rdk9ch54amh9guas86r4u62jq27hee88lryfsxwrvlk",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/53796B3762678CD80784A7DD426EB45B89C024BE3D45224CC83FDE3DED7DA0A1",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -501,7 +451,6 @@
   },
   {
     "id": "kujira1w2l4w5p66l5t2nmrmsvz7k4cu50s7e8dc6h59gcxsnmp2tgy7q7s5lux8a",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/47BD209179859CDE4A2806763D7189B6E6FE13A17880FE2B42DE1E6C1E329E23",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -511,7 +460,6 @@
   },
   {
     "id": "kujira1w4t2qpwvhyhz0g2mwgqjzgsw63dcy5hkfch0tgr8xj9qjcsauq8q5x0zxz",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/B37E4D9FB5B30F3E1E20A4B2DE2A005E584C5C822C44527546556AE2470B4539",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -521,7 +469,6 @@
   },
   {
     "id": "kujira1xqhakgvn3jeqfade0z4aufer9xylx7ft45fgyhg6z75mauhkjwks9cucyq",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ukuji",
       "ibc/DA59C009A0B3B95E0549E6BF7B075C8239285989FF457A8EDDBB56F10B2A6986"
@@ -531,7 +478,6 @@
   },
   {
     "id": "kujira1xr3rq8yvd7qplsw5yx90ftsr2zdhg4e9z60h5duusgxpv72hud3sl8nek6",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -541,7 +487,6 @@
   },
   {
     "id": "kujira1xut80d09q0tgtch8p0z4k5f88d3uvt8cvtzm5h3tu3tsy4jk9xlscem692",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/F2331645B9683116188EF36FC04A809C28BD36B54555E8705A37146D0182F045",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -551,7 +496,6 @@
   },
   {
     "id": "kujira1yg8930mj8pk288lmkjex0qz85mj8wgtns5uzwyn2hs25pwdnw42skp0kur",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/DA59C009A0B3B95E0549E6BF7B075C8239285989FF457A8EDDBB56F10B2A6986",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -561,7 +505,6 @@
   },
   {
     "id": "kujira1yum4v0v5l92jkxn8xpn9mjg7wuldk784ctg424ue8gqvdp88qzlqr2qp2j",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -571,7 +514,6 @@
   },
   {
     "id": "kujira1z7asfxkwv0t863rllul570eh5pf2zk07k3d86ag4vtghaue37l5s9epdvn",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/EFF323CC632EC4F747C61BCE238A758EFDB7699C3226565F7C20DA06509D59A5",
       "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
@@ -581,7 +523,6 @@
   },
   {
     "id": "kujira1z7quf5t6g7spjnu2qhcp2x2ksnz4zfut9k73uutpg2q95dd008fqsprtvl",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/EFF323CC632EC4F747C61BCE238A758EFDB7699C3226565F7C20DA06509D59A5",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
@@ -591,7 +532,6 @@
   },
   {
     "id": "kujira1zz74gvmq6ss3pg5vgahvx47ugpfzr80qu75l97lf2ggdgxq04ddqxkdzey",
-    "lp_token_id": "Orderbook",
     "asset_ids": [
       "ibc/DA59C009A0B3B95E0549E6BF7B075C8239285989FF457A8EDDBB56F10B2A6986",
       "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"

--- a/kujira/pool.json
+++ b/kujira/pool.json
@@ -1,0 +1,602 @@
+[
+  {
+    "id": "kujira10fqy0npt7djm8lg847v9rqlng88kqfdvl8tyt4ge204wf52sy68qwmj07l",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/8318B7E036E50C0CF799848F23ED84778AAA8749D9C0BCD4FF3F4AF73C53387F",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira10j648ftg2g8p5vhgsu5kzfh6d907vpkrn0a5l3qch479eqy2qssqm905c4",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/BBC45F1B65B6D3C11C3C56A9428D38C3A8D03944473791C52DFB7CD3F8342CBC",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira12jdezs3kk6y04q3fnl7kq5567pcw0zfr7j0yfsxjqgggdkktut9s2gm7cm",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/301DAF9CB0A9E247CD478533EF0E21F48FF8118C4A51F77C8BC3EB70E5566DBC",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira12p30cr4gstmp2yucwxtaq92turrzsxxar8upz3rhmfjxh6gdgk4s5vsyse",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/B4DCACF7753C05040AF0A7BF2B583402C4B8C9B0A86FCECE32EF63CB7F0A46B3",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira12zjpumtfh88k6s2s8k4wks37ezr2c3zeha5xx6qpd65e5ehz50nq0afvrv",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/FC59D6840A41252352263CEA2B832BB86D68D03CBA194263CB9F3C15946796FB",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira13l8gwanf37938wgfv5yktmfzxjwaj4ysn4gl96vj78xcqqxlcrgssfl797",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/D36D2BBE441D3605EEF340EAFAC57D669880597073050A2650B1468F1634A5F5",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira149m52kn7nvsg5nftvv4fh85scsavpdfxp5nr7zasz97dum89dp5qevttd9",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/DBF6ABDB5F3D4267C039967515594453F4A31007FD838A566F563A01D2C2FB80",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9sl4e867",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ukuji",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1538ukswznmuek3hfv7mcxem9hjqz8sa4ypl2ul0zncu3tdgfvwmq8pxkwp",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/A2146858B5E3CFE759E32F47CA54591F8E27FAEDFF731D30B448E5AB25CA8EC5",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira158zzjcvkz7r3j5hueurcw22qrjerqw4dtrzlalztr7whjykjwvrsrahdnq",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/0306D6B66EAA2EDBB7EAD23C0EC9DDFC69BB43E80B398035E90FBCFEF3FD1A87",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira16y344e8ryydmeu2g8yyfznq79j7jfnar4p59ngpvaazcj83jzsms6tju67",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/3607EB5B5E64DD1C0E12E07F077FF470D5BC4706AFCBC98FE1BA960E5AE4CE07",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira172qjrk8g9l86w0shz4cc3e6rt5h9janaen4j4u6ze7xkjvjnaqfskwyyqm",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/F33B313325B1C99B646B1B786F1EA621E3794D787B90C204C30FE1D4D45970AE",
+      "ibc/DA59C009A0B3B95E0549E6BF7B075C8239285989FF457A8EDDBB56F10B2A6986"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira17qp8g5n5wwelrsnfdakrv0p550nzg72agpcz5t0ea6thlqd300hquxljcc",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/A2146858B5E3CFE759E32F47CA54591F8E27FAEDFF731D30B448E5AB25CA8EC5",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira17w9r23r8v8r7z5lphwj99296fhlye9ej5nq3hlqw554u63m88avspdl9tc",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/1B38805B1C75352B28169284F96DF56BDEBD9E8FAC005BDCC8CF0378C82AA8E7",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira182nff4ttmvshn6yjlqj5czapfcav9434l2qzz8aahf5pxnyd33tsz30aw6",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/F3AA7EF362EC5E791FE78A0F4CCC69FEE1F9A7485EB1A8CAB3F6601C00522F10",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira18638dsuf7p3a2e23seqz8zegqrcpsdr5nw6j2a50qg6r3q8vn3qqrg9lzp",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/2F1447818CF99498AE62D9FB4D5E0C9FD48C68FC118C34D2ECFFFED0AD082196",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira18lm235jzuh4t7hh5z8lqyz08dmz67magj8z0fc4a0vn6c0hzk0es3r4glx",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/3914BDEF46F429A26917E4D8D434620EC4817DC6B6E68FB327E190902F1E9242",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira18v47nqmhvejx3vc498pantg8vr435xa0rt6x0m6kzhp6yuqmcp8s4x8j2c",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ukuji",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira193dzcmy7lwuj4eda3zpwwt9ejal00xva0vawcvhgsyyp5cfh6jyq66wfrf",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ukuji",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1a0fyanyqm496fpgneqawhlsug6uqfvqg2epnw39q0jdenw3zs8zqsjhdr0",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/DADB399E742FCEE71853E98225D13E44E90292852CD0033DF5CABAB96F80B833",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1aakfpghcanxtc45gpqlx8j3rq0zcpyf49qmhm9mdjrfx036h4z5sfmexun",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/47BD209179859CDE4A2806763D7189B6E6FE13A17880FE2B42DE1E6C1E329E23",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1apkgj87fgfsq84swvkyfaemrq7t4deuh60887lek0hkgdjh5fj0qaz7fhx",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/DADB399E742FCEE71853E98225D13E44E90292852CD0033DF5CABAB96F80B833",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1cduudfszcm9slm8qxlaqvnpzg2u0hkus94fe3pwt9x446dtw6eeql8ualz",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/21038E447A2D4A1183628C0EC366FE79C2E0B0BD91F9A85E6C906CD911FD676E",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1cn922pcqrt4g2dr4va9vxk8h3w3jfxnxjqq2qp6zktjsehdzde6sz66um0",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/239BFF83852F67DF5243DB89F339FF7FDBF858437F961CAB6DA5B5ADEFB2BC07",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1ddeadmhum3umygv84frhc87gl2grzjmx9x8fuhjts7zqwuc39xuq53w3d8",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/5A3DCF59BC9EC5C0BB7AA0CA0279FC2BB126640CB8B8F704F7BC2DC42495041B",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1dtaqwlmzlk3jku5un6h6rfunttmwsqnfz7evvdf4pwr0wypsl68q49aaud",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/C01154C2547F4CB10A985EA78E7CD4BA891C1504360703A37E1D7043F06B5E1F",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1fkwjqyfdyktgu5f59jpwhvl23zh8aav7f98ml9quly62jx2sehysqa4unf",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/A358D7F19237777AF6D8AD0E0F53268F8B18AE8A53ED318095C14D6D7F3B2DB5",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1fphguznhazgqdlr9mpfh6nmn3vjjr73ksz3ukznv6q7s9ndfq2cs8vhapj",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/004EBF085BBED1029326D56BE8A2E67C08CECE670A94AC1947DF413EF5130EB2",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1gl8js9zn7h9u2h37fx7qg8xy65jrk9t4zpa6s7j5hdlanud2uwxshqq67m",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "factory/kujira13y8hs83sk0la7na2w5g5nzrnjjpnkvmd7e87yd35g8dcph7dn0ksenay2a/ulp",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1h7eenquygffwsmc8csrlx88zcddwx0aqspq3x2dsl20lwk4r9n2q9t86ht",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/3607EB5B5E64DD1C0E12E07F077FF470D5BC4706AFCBC98FE1BA960E5AE4CE07",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1hs95lgvuy0p6jn4v7js5x8plfdqw867lsuh5xv6d2ua20jprkgesw2pujt",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "factory/kujira13y8hs83sk0la7na2w5g5nzrnjjpnkvmd7e87yd35g8dcph7dn0ksenay2a/ulp",
+      "ukuji"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1hulx7cgvpfcvg83wk5h96sedqgn72n026w6nl47uht554xhvj9nsra5j5u",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/47BD209179859CDE4A2806763D7189B6E6FE13A17880FE2B42DE1E6C1E329E23"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1jkte0pytr85qg0whmgux3vmz9ehmh82w40h8gaqeg435fnkyfxqq5m32qy",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/4F393C3FCA4190C0A6756CE7F6D897D5D1BE57D6CCB80D0BC87393566A7B6602",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1jlzw6xal0n2c580g3wxs09tjhlzdht9y8dgszq3tupf8fhl7xjus7ep7ap",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/B37E4D9FB5B30F3E1E20A4B2DE2A005E584C5C822C44527546556AE2470B4539",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1k7rg9vscg2uldw6868mecryxhlze5e3f4z0f00295ddu7cz3l4ws4d9dfj",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/8318B7E036E50C0CF799848F23ED84778AAA8749D9C0BCD4FF3F4AF73C53387F",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1ky9kv2m4dnykm90d0lj5089k4efttgfpx34zyvkklxnew48c522sggqjsg",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/E67ADA2204A941CD4743E70771BA08E24885E1ADD6FD140CE1F9E0FEBB68C6B2",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1nm3yktzcgpnvwu6qpzqgl2ktyvlgsstc7ev849dd3ulaygw75mqqxvtnck",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/4F393C3FCA4190C0A6756CE7F6D897D5D1BE57D6CCB80D0BC87393566A7B6602",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1qjxu65ucccpg8c5kac8ng6yxfqq85fluwd0p9nt74g2304qw8eyq930y7w",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/004EBF085BBED1029326D56BE8A2E67C08CECE670A94AC1947DF413EF5130EB2",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1qqlk2773dvj8cyv3ftnzvyrknq78yryghp3uyumnumaxu656yreszrdph0",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/640E1C3E28FD45F611971DF891AE3DC90C825DF759DF8FAA8F33F7F72B35AD56",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1qw5hdcmcf4aq5xmnu6znscurvkgvhxfsyvhz3jvxhasxjwtk3l7sccwcs8",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/1603E8643A49AD47F536F645A4BF0E4C1E06C76F0A98CBE8054B177F1EE7C39A",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1rpxf55u22q2tly9y8rgdrjgx9p52sus7jugaevj3hdt0z7sgvkcsyrhrv0",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/A358D7F19237777AF6D8AD0E0F53268F8B18AE8A53ED318095C14D6D7F3B2DB5",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1rrnacml8zeqq3ve2t98r5x88t4uahahdk66y9qpcrjp9qxhnuvysv59zx8",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/A64467480BBE4CCFC3CF7E25AD1446AA9BDBD4F5BCB9EF6038B83D6964C784E6",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1rtpn4nxkx7u5y4uf5lp4ywrhmnms07p8p8wc3pmw53hfv0lhyxdqlfhgrt",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/B4DCACF7753C05040AF0A7BF2B583402C4B8C9B0A86FCECE32EF63CB7F0A46B3",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1rwx6w02alc4kaz7xpyg3rlxpjl4g63x5jq292mkxgg65zqpn5llq202vh5",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1sse6a00arh9dalzsyrd3q825dsn2zmrag0u4qx8q0dyks4ftnxyqrj0xds",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "factory/kujira1swkuyt08z74n5jl7zr6hx0ru5sa2yev5v896p6/local",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1suhgf5svhu4usrurvxzlgn54ksxmn8gljarjtxqnapv8kjnp4nrsqq4jjh",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/1B38805B1C75352B28169284F96DF56BDEBD9E8FAC005BDCC8CF0378C82AA8E7",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1ulyrqqtx9vqsk92805jk7xxwz77lszmm2f548juyced96tj4lg7qugewsf",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/301DAF9CB0A9E247CD478533EF0E21F48FF8118C4A51F77C8BC3EB70E5566DBC",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1uvqk5vj9vn4gjemrp0myz4ku49aaemulgaqw7pfe0nuvfwp3gukq64r3ws",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/F33B313325B1C99B646B1B786F1EA621E3794D787B90C204C30FE1D4D45970AE",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1v8kh6mqxq7awcvl936xeyzv8fnmdkd3yxggvkyek5d0ecut4a6zs0larj2",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/DBF6ABDB5F3D4267C039967515594453F4A31007FD838A566F563A01D2C2FB80",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1v8lkqws3gd6npr0rdk9ch54amh9guas86r4u62jq27hee88lryfsxwrvlk",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/53796B3762678CD80784A7DD426EB45B89C024BE3D45224CC83FDE3DED7DA0A1",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1w2l4w5p66l5t2nmrmsvz7k4cu50s7e8dc6h59gcxsnmp2tgy7q7s5lux8a",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/47BD209179859CDE4A2806763D7189B6E6FE13A17880FE2B42DE1E6C1E329E23",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1w4t2qpwvhyhz0g2mwgqjzgsw63dcy5hkfch0tgr8xj9qjcsauq8q5x0zxz",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/B37E4D9FB5B30F3E1E20A4B2DE2A005E584C5C822C44527546556AE2470B4539",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1xqhakgvn3jeqfade0z4aufer9xylx7ft45fgyhg6z75mauhkjwks9cucyq",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ukuji",
+      "ibc/DA59C009A0B3B95E0549E6BF7B075C8239285989FF457A8EDDBB56F10B2A6986"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1xr3rq8yvd7qplsw5yx90ftsr2zdhg4e9z60h5duusgxpv72hud3sl8nek6",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1xut80d09q0tgtch8p0z4k5f88d3uvt8cvtzm5h3tu3tsy4jk9xlscem692",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/F2331645B9683116188EF36FC04A809C28BD36B54555E8705A37146D0182F045",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1yg8930mj8pk288lmkjex0qz85mj8wgtns5uzwyn2hs25pwdnw42skp0kur",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/DA59C009A0B3B95E0549E6BF7B075C8239285989FF457A8EDDBB56F10B2A6986",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1yum4v0v5l92jkxn8xpn9mjg7wuldk784ctg424ue8gqvdp88qzlqr2qp2j",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1z7asfxkwv0t863rllul570eh5pf2zk07k3d86ag4vtghaue37l5s9epdvn",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/EFF323CC632EC4F747C61BCE238A758EFDB7699C3226565F7C20DA06509D59A5",
+      "ibc/295548A78785A1007F232DE286149A6FF512F180AF5657780FC89C009E2C348F"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1z7quf5t6g7spjnu2qhcp2x2ksnz4zfut9k73uutpg2q95dd008fqsprtvl",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/EFF323CC632EC4F747C61BCE238A758EFDB7699C3226565F7C20DA06509D59A5",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  },
+  {
+    "id": "kujira1zz74gvmq6ss3pg5vgahvx47ugpfzr80qu75l97lf2ggdgxq04ddqxkdzey",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/DA59C009A0B3B95E0549E6BF7B075C8239285989FF457A8EDDBB56F10B2A6986",
+      "factory/kujira1qk00h5atutpsv900x202pxx42npjr9thg58dnqpa72f2p7m2luase444a7/uusk"
+    ],
+    "dex": "FIN",
+    "type": "orderbook"
+  }
+]

--- a/osmosis/asset.json
+++ b/osmosis/asset.json
@@ -1,5 +1,133 @@
 [
   {
+    "id": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+    "entity": "Akash Network",
+    "name": "Akash Network",
+    "symbol": "AKT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg"
+  },
+  {
+    "id": "ibc/384E5DD50BDE042E1AAF51F312B55F08F95BC985C503880189258B4D9374CBBE",
+    "entity": "Axelar",
+    "name": "Aave",
+    "symbol": "AAVE.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/aave.svg"
+  },
+  {
+    "id": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
+    "entity": "Axelar",
+    "name": "Axelar",
+    "symbol": "AXL",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/axelarnetwork/axelar-docs/main/public/images/assets/axl.svg"
+  },
+  {
+    "id": "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
+    "entity": "Axelar",
+    "name": "Binance USD",
+    "symbol": "BUSD.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.png"
+  },
+  {
+    "id": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
+    "entity": "Axelar",
+    "name": "Chainlink",
+    "symbol": "LINK.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axllink.svg"
+  },
+  {
+    "id": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+    "entity": "Axelar",
+    "name": "Dai Stablecoin",
+    "symbol": "DAI.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axldai.svg"
+  },
+  {
+    "id": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
+    "entity": "Axelar",
+    "name": "DOT",
+    "symbol": "DOT.axl",
+    "decimals": "10",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axldot.svg"
+  },
+  {
+    "id": "ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE",
+    "entity": "Axelar",
+    "name": "Frax",
+    "symbol": "FRAX.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlfrax.svg"
+  },
+  {
+    "id": "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3",
+    "entity": "Axelar",
+    "name": "Maker",
+    "symbol": "MKR.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlmkr.svg"
+  },
+  {
+    "id": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
+    "entity": "Axelar",
+    "name": "Tether USD",
+    "symbol": "USDT.axl",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlusdt.svg"
+  },
+  {
+    "id": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+    "entity": "Axelar",
+    "name": "USD Coin",
+    "symbol": "USDC.axl",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlusdc.svg"
+  },
+  {
+    "id": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
+    "entity": "Axelar",
+    "name": "Wrapped Bitcoin",
+    "symbol": "WBTC.axl",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlwbtc.png"
+  },
+  {
+    "id": "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
+    "entity": "Axelar",
+    "name": "Wrapped BNB",
+    "symbol": "WBNB.axl",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchainoonbeam/images/wbnb.svg"
+  },
+  {
+    "id": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
+    "entity": "Axelar",
+    "name": "Wrapped Ether",
+    "symbol": "WETH.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlweth.png"
+  },
+  {
+    "id": "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",
+    "entity": "Axelar",
+    "name": "Wrapped GLMR",
+    "symbol": "WGLMR.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/moonbeam/images/glmr.svg"
+  },
+  {
+    "id": "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
+    "entity": "Axelar",
+    "name": "Wrapped Matic",
+    "symbol": "WMATIC.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wmatic-wei L@3x.png"
+  },
+  {
     "id": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
     "entity": "Cosmos",
     "name": "Cosmos",
@@ -16,12 +144,84 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.svg"
   },
   {
+    "id": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+    "entity": "e-Money",
+    "name": "e-Money",
+    "symbol": "NGM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.svg"
+  },
+  {
+    "id": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+    "entity": "e-Money",
+    "name": "e-Money EUR",
+    "symbol": "EEUR",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.svg"
+  },
+  {
+    "id": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
+    "entity": "Evmos",
+    "name": "Evmos",
+    "symbol": "EVMOS",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg"
+  },
+  {
+    "id": "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5",
+    "entity": "Gravity Bridge",
+    "name": "Dai Stablecoin",
+    "symbol": "DAI.grv",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gdai.svg"
+  },
+  {
     "id": "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
     "entity": "Gravity Bridge",
     "name": "Graviton",
     "symbol": "GRAV",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.svg"
+  },
+  {
+    "id": "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
+    "entity": "Gravity Bridge",
+    "name": "Tether USD",
+    "symbol": "USDT.grv",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdt.svg"
+  },
+  {
+    "id": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
+    "entity": "Gravity Bridge",
+    "name": "USD Coin",
+    "symbol": "USDC.grv",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdc.svg"
+  },
+  {
+    "id": "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796",
+    "entity": "Gravity Bridge",
+    "name": "Wrapped Bitcoin",
+    "symbol": "WBTC.grv",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gwbtc.png"
+  },
+  {
+    "id": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
+    "entity": "Gravity Bridge",
+    "name": "Wrapped Ethereum",
+    "symbol": "WETH.grv",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gweth.png"
+  },
+  {
+    "id": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
+    "entity": "Injective Protocol",
+    "name": "Injective",
+    "symbol": "INJ",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg"
   },
   {
     "id": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
@@ -48,12 +248,52 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/usk.png"
   },
   {
+    "id": "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
+    "entity": "Neta",
+    "name": "Neta",
+    "symbol": "NETA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.png"
+  },
+  {
+    "id": "uion",
+    "entity": "Osmosis",
+    "name": "Ion",
+    "symbol": "ION",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg"
+  },
+  {
     "id": "uosmo",
     "entity": "Osmosis",
     "name": "Osmosis",
     "symbol": "OSMO",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
+  },
+  {
+    "id": "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+    "entity": "Persistence",
+    "name": "Persistence",
+    "symbol": "XPRT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg"
+  },
+  {
+    "id": "ibc/8061A06D3BD4D52C4A28FFECF7150D370393AF0BA661C3776C54FF32836C3961",
+    "entity": "PSTAKE",
+    "name": "PSTAKE",
+    "symbol": "PSTAKE",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.svg"
+  },
+  {
+    "id": "ibc/46C83BB054E12E189882B5284542DB605D94C99827E367C9192CF0579CD5BC83",
+    "entity": "Quicksilver",
+    "name": "Quicksilver Liquid Staked STARS",
+    "symbol": "qSTARS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qstars.svg"
   },
   {
     "id": "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
@@ -64,6 +304,94 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg"
   },
   {
+    "id": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
+    "entity": "Sifchain",
+    "name": "Sifchain Rowan",
+    "symbol": "ROWAN",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.svg"
+  },
+  {
+    "id": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
+    "entity": "Sommelier",
+    "name": "Sommelier",
+    "symbol": "SOMM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.svg"
+  },
+  {
+    "id": "ibc/C2DF5C3949CA835B221C575625991F09BAB4E48FB9C11A4EE357194F736111E3",
+    "entity": "StakeEasy",
+    "name": "StakeEasy bJUNO",
+    "symbol": "BJUNO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.svg"
+  },
+  {
+    "id": "ibc/18A676A074F73B9B42DA4F9DFC8E5AEF334C9A6636DDEC8D34682F52F1DECDF6",
+    "entity": "StakeEasy",
+    "name": "StakeEasy SEASY",
+    "symbol": "SEASY",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.svg"
+  },
+  {
+    "id": "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B",
+    "entity": "StakeEasy",
+    "name": "StakeEasy seJUNO",
+    "symbol": "SEJUNO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.svg"
+  },
+  {
+    "id": "ibc/5DD1F95ED336014D00CE2520977EC71566D282F9749170ADC83A392E0EA7426A",
+    "entity": "StakeEasy",
+    "name": "Stride Staked Stars",
+    "symbol": "stSTARS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/ststars.svg"
+  },
+  {
+    "id": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
+    "entity": "Stargaze",
+    "name": "Stargaze",
+    "symbol": "STARS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png"
+  },
+  {
+    "id": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
+    "entity": "Stride",
+    "name": "stATOM",
+    "symbol": "stATOM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg"
+  },
+  {
+    "id": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
+    "entity": "Stride",
+    "name": "Stride",
+    "symbol": "STRD",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg"
+  },
+  {
+    "id": "ibc/84502A75BCA4A5F68D464C00B3F610CE2585847D59B52E5FFB7C3C9D2DDCD3FE",
+    "entity": "Stride",
+    "name": "Stride Juno",
+    "symbol": "stJUNO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.svg"
+  },
+  {
+    "id": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
+    "entity": "Stride",
+    "name": "Stride Staked osmo",
+    "symbol": "stOSMO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.svg"
+  },
+  {
     "id": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
     "entity": "Terra Money",
     "name": "Luna",
@@ -72,18 +400,19 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png"
   },
   {
+    "id": "ibc/2FBAC4BF296D7844796844B35978E5899984BA5A6314B2DD8F83C215550010B3",
+    "entity": "Wynd",
+    "name": "Wynd DAO Governance Token",
+    "symbol": "WYND",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/wynd.svg"
+  },
+  {
     "id": "ibc/B797E4F42CD33C50511B341E50C5CC0E8EF0D93B1E1247ABAA071583B8619202",
     "name": "404Deep Records FanToken",
     "symbol": "404DR",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft99091610CCC66F4277C66D14AF2BC4C5EE52E27A.png"
-  },
-  {
-    "id": "ibc/384E5DD50BDE042E1AAF51F312B55F08F95BC985C503880189258B4D9374CBBE",
-    "name": "Aave",
-    "symbol": "AAVE.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/aave.svg"
   },
   {
     "id": "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
@@ -112,13 +441,6 @@
     "symbol": "BLD",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/bld.png"
-  },
-  {
-    "id": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
-    "name": "Akash Network",
-    "symbol": "AKT",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg"
   },
   {
     "id": "ibc/A6383B6CF5EA23E067666C06BC34E2A96869927BD9744DC0C1643E589C710AA3",
@@ -170,13 +492,6 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.svg"
   },
   {
-    "id": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
-    "name": "Axelar",
-    "symbol": "AXL",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/axelarnetwork/axelar-docs/main/public/images/assets/axl.svg"
-  },
-  {
     "id": "ibc/6C0CB8653012DC2BC1820FD0B6B3AFF8A07D18630BDAEE066FEFB2D92F477C24",
     "name": "Axie Infinity Shard",
     "symbol": "AXS.axl",
@@ -196,13 +511,6 @@
     "symbol": "BZE",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/bze.svg"
-  },
-  {
-    "id": "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
-    "name": "Binance USD",
-    "symbol": "BUSD.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.png"
   },
   {
     "id": "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5",
@@ -282,13 +590,6 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/xcn.svg"
   },
   {
-    "id": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
-    "name": "Chainlink",
-    "symbol": "LINK.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axllink.svg"
-  },
-  {
     "id": "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
     "name": "Cheqd",
     "symbol": "CHEQ",
@@ -331,20 +632,6 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.svg"
   },
   {
-    "id": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-    "name": "Dai Stablecoin",
-    "symbol": "DAI.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axldai.svg"
-  },
-  {
-    "id": "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5",
-    "name": "Dai Stablecoin",
-    "symbol": "DAI.grv",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gdai.svg"
-  },
-  {
     "id": "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84",
     "name": "Decentr",
     "symbol": "DEC",
@@ -380,32 +667,11 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dig/images/dig.png"
   },
   {
-    "id": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
-    "name": "DOT",
-    "symbol": "DOT.axl",
-    "decimals": "10",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axldot.svg"
-  },
-  {
     "id": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
     "name": "Dyson Protocol",
     "symbol": "DYS",
     "decimals": "0",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dyson/images/dys.png"
-  },
-  {
-    "id": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
-    "name": "e-Money",
-    "symbol": "NGM",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.svg"
-  },
-  {
-    "id": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
-    "name": "e-Money EUR",
-    "symbol": "EEUR",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.svg"
   },
   {
     "id": "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
@@ -429,13 +695,6 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft85AE1716C5E39EA6D64BBD7898C3899A7B500626.png"
   },
   {
-    "id": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
-    "name": "Evmos",
-    "symbol": "EVMOS",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg"
-  },
-  {
     "id": "ibc/7CE5F388D661D82A0774E47B5129DA51CC7129BD1A70B5FA6BCEBB5B0A2FAEAF",
     "name": "Fanfury",
     "symbol": "FURY",
@@ -455,13 +714,6 @@
     "symbol": "FONTI",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft56664FC98A2CF5F4FBAC3566D1A11D891AD88305.png"
-  },
-  {
-    "id": "ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE",
-    "name": "Frax",
-    "symbol": "FRAX.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlfrax.svg"
   },
   {
     "id": "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
@@ -527,25 +779,11 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/imversed/images/imversed.svg"
   },
   {
-    "id": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
-    "name": "Injective",
-    "symbol": "INJ",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg"
-  },
-  {
     "id": "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
     "name": "Inter Protocol USD",
     "symbol": "IST",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/ist.png"
-  },
-  {
-    "id": "uion",
-    "name": "Ion",
-    "symbol": "ION",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg"
   },
   {
     "id": "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
@@ -660,13 +898,6 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/lvn.png"
   },
   {
-    "id": "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3",
-    "name": "Maker",
-    "symbol": "MKR.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlmkr.svg"
-  },
-  {
     "id": "ibc/F6B691D5F7126579DDC87357B09D653B47FDCE0A3383FF33C8D8B544FE29A8A6",
     "name": "Marble",
     "symbol": "MARBLE",
@@ -730,13 +961,6 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft387C1C279D962ED80C09C1D592A92C4275FD7C5D.png"
   },
   {
-    "id": "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
-    "name": "Neta",
-    "symbol": "NETA",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.png"
-  },
-  {
     "id": "ibc/423967B46B1A51D78619085105B04FCFA14F7CBC0BE7539A316B2DCDFC7D8C07",
     "name": "Nicola Fasano FanToken",
     "symbol": "FASANO",
@@ -772,13 +996,6 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.svg"
   },
   {
-    "id": "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
-    "name": "Persistence",
-    "symbol": "XPRT",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg"
-  },
-  {
     "id": "ibc/B1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF",
     "name": "Planq",
     "symbol": "PLQ",
@@ -800,13 +1017,6 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/hash.svg"
   },
   {
-    "id": "ibc/8061A06D3BD4D52C4A28FFECF7150D370393AF0BA661C3776C54FF32836C3961",
-    "name": "PSTAKE",
-    "symbol": "PSTAKE",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.svg"
-  },
-  {
     "id": "ibc/CAA179E40F0266B0B29FB5EAA288FB9212E628822265D4141EBD1C47C3CBFCBC",
     "name": "PSTAKE staked ATOM",
     "symbol": "stkATOM",
@@ -819,13 +1029,6 @@
     "symbol": "LOBO",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft24C9FA4F10B0F235F4A815B15FC774E046A2B2EB.png"
-  },
-  {
-    "id": "ibc/46C83BB054E12E189882B5284542DB605D94C99827E367C9192CF0579CD5BC83",
-    "name": "Quicksilver Liquid Staked STARS",
-    "symbol": "qSTARS",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qstars.svg"
   },
   {
     "id": "ibc/6BDB4C8CCD45033F9604E4B93ED395008A753E01EECD6992E7D1EA23D9D3B788",
@@ -905,13 +1108,6 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/sienna.svg"
   },
   {
-    "id": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
-    "name": "Sifchain Rowan",
-    "symbol": "ROWAN",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.svg"
-  },
-  {
     "id": "ibc/C3FC4DED273E7D1DD2E7BAA3317EC9A53CD3252B577AA33DC00D9DF2BDF3ED5C",
     "name": "Solarbank DAO",
     "symbol": "SOLAR",
@@ -919,81 +1115,11 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.svg"
   },
   {
-    "id": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
-    "name": "Sommelier",
-    "symbol": "SOMM",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.svg"
-  },
-  {
-    "id": "ibc/C2DF5C3949CA835B221C575625991F09BAB4E48FB9C11A4EE357194F736111E3",
-    "name": "StakeEasy bJUNO",
-    "symbol": "BJUNO",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.svg"
-  },
-  {
-    "id": "ibc/18A676A074F73B9B42DA4F9DFC8E5AEF334C9A6636DDEC8D34682F52F1DECDF6",
-    "name": "StakeEasy SEASY",
-    "symbol": "SEASY",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.svg"
-  },
-  {
-    "id": "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B",
-    "name": "StakeEasy seJUNO",
-    "symbol": "SEJUNO",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.svg"
-  },
-  {
-    "id": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
-    "name": "Stargaze",
-    "symbol": "STARS",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png"
-  },
-  {
     "id": "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
     "name": "Starname",
     "symbol": "IOV",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.svg"
-  },
-  {
-    "id": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
-    "name": "stATOM",
-    "symbol": "stATOM",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg"
-  },
-  {
-    "id": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
-    "name": "Stride",
-    "symbol": "STRD",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg"
-  },
-  {
-    "id": "ibc/84502A75BCA4A5F68D464C00B3F610CE2585847D59B52E5FFB7C3C9D2DDCD3FE",
-    "name": "Stride Juno",
-    "symbol": "stJUNO",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.svg"
-  },
-  {
-    "id": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
-    "name": "Stride Staked osmo",
-    "symbol": "stOSMO",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.svg"
-  },
-  {
-    "id": "ibc/5DD1F95ED336014D00CE2520977EC71566D282F9749170ADC83A392E0EA7426A",
-    "name": "Stride Staked Stars",
-    "symbol": "stSTARS",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/ststars.svg"
   },
   {
     "id": "ibc/70CF1A54E23EA4E480DEDA9E12082D3FD5684C3483CBDCE190C5C807227688C5",
@@ -1024,20 +1150,6 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/ust.png"
   },
   {
-    "id": "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
-    "name": "Tether USD",
-    "symbol": "USDT.grv",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdt.svg"
-  },
-  {
-    "id": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
-    "name": "Tether USD",
-    "symbol": "USDT.axl",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlusdt.svg"
-  },
-  {
     "id": "ibc/1E09CB0F506ACF12FDE4683FB6B34DA62FB4BE122641E0D93AAF98A87675676C",
     "name": "Tgrade",
     "symbol": "TGD",
@@ -1064,20 +1176,6 @@
     "symbol": "UNI.axl",
     "decimals": "18",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/uni.svg"
-  },
-  {
-    "id": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
-    "name": "USD Coin",
-    "symbol": "USDC.grv",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdc.svg"
-  },
-  {
-    "id": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-    "name": "USD Coin",
-    "symbol": "USDC.axl",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlusdc.svg"
   },
   {
     "id": "ibc/C78F65E1648A3DFE0BAEB6C4CDA69CC2A75437F1793C0E6386DFDA26393790AE",
@@ -1108,66 +1206,10 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/avalanche/images/avax.png"
   },
   {
-    "id": "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796",
-    "name": "Wrapped Bitcoin",
-    "symbol": "WBTC.grv",
-    "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gwbtc.png"
-  },
-  {
-    "id": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
-    "name": "Wrapped Bitcoin",
-    "symbol": "WBTC.axl",
-    "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlwbtc.png"
-  },
-  {
-    "id": "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
-    "name": "Wrapped BNB",
-    "symbol": "WBNB.axl",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchainoonbeam/images/wbnb.svg"
-  },
-  {
-    "id": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-    "name": "Wrapped Ether",
-    "symbol": "WETH.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlweth.png"
-  },
-  {
-    "id": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
-    "name": "Wrapped Ethereum",
-    "symbol": "WETH.grv",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gweth.png"
-  },
-  {
     "id": "ibc/5E2DFDF1734137302129EA1C1BA21A580F96F778D4F021815EA4F6DB378DA1A4",
     "name": "Wrapped FTM",
     "symbol": "wFTM",
     "decimals": "18",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/fantom/images/ftm.png"
-  },
-  {
-    "id": "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",
-    "name": "Wrapped GLMR",
-    "symbol": "WGLMR.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/moonbeam/images/glmr.svg"
-  },
-  {
-    "id": "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
-    "name": "Wrapped Matic",
-    "symbol": "WMATIC.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wmatic-wei L@3x.png"
-  },
-  {
-    "id": "ibc/2FBAC4BF296D7844796844B35978E5899984BA5A6314B2DD8F83C215550010B3",
-    "name": "Wynd DAO Governance Token",
-    "symbol": "WYND",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/wynd.svg"
   }
 ]

--- a/osmosis/asset.json
+++ b/osmosis/asset.json
@@ -1,0 +1,1296 @@
+[
+  {
+    "id": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+    "entity": "Cosmos",
+    "name": "Cosmos",
+    "symbol": "ATOM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/cosmos"
+  },
+  {
+    "id": "ibc/5A7C219BA5F7582B99629BA3B2A01A61BFDA0F6FD1FE95B5366F7334C4BC0580",
+    "entity": "Crescent Network",
+    "name": "Crescent",
+    "symbol": "CRE",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/crescent-network"
+  },
+  {
+    "id": "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
+    "entity": "Gravity Bridge",
+    "name": "Graviton",
+    "symbol": "GRAV",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/graviton"
+  },
+  {
+    "id": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+    "entity": "Juno",
+    "name": "Juno",
+    "symbol": "JUNO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/juno-network"
+  },
+  {
+    "id": "ibc/BB6BCDB515050BAE97516111873CCD7BCF1FD0CCB723CC12F3C4F704D6C646CE",
+    "entity": "Kujira",
+    "name": "Kuji",
+    "symbol": "KUJI",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png",
+    "coingecko": "https://www.coingecko.com/en/coins/kujira"
+  },
+  {
+    "id": "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
+    "entity": "Kujira",
+    "name": "USK",
+    "symbol": "USK",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/usk.png",
+    "coingecko": "https://www.coingecko.com/en/coins/usk"
+  },
+  {
+    "id": "uosmo",
+    "entity": "Osmosis",
+    "name": "Osmosis",
+    "symbol": "OSMO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/osmosis"
+  },
+  {
+    "id": "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
+    "entity": "Secret Network",
+    "name": "Secret Network",
+    "symbol": "SCRT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/secret"
+  },
+  {
+    "id": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
+    "entity": "Terra Money",
+    "name": "Luna",
+    "symbol": "LUNA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png",
+    "coingecko": "https://www.coingecko.com/en/coins/terra-luna-2"
+  },
+  {
+    "id": "ibc/B797E4F42CD33C50511B341E50C5CC0E8EF0D93B1E1247ABAA071583B8619202",
+    "name": "404Deep Records FanToken",
+    "symbol": "404DR",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft99091610CCC66F4277C66D14AF2BC4C5EE52E27A.png"
+  },
+  {
+    "id": "ibc/384E5DD50BDE042E1AAF51F312B55F08F95BC985C503880189258B4D9374CBBE",
+    "name": "Aave",
+    "symbol": "AAVE.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/aave.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/aave"
+  },
+  {
+    "id": "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
+    "name": "Acre",
+    "symbol": "ACRE",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/acre.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/arable-protocol"
+  },
+  {
+    "id": "ibc/7ABF696369EFB3387DF22B6A24204459FE5EFD010220E8E5618DC49DB877047B",
+    "name": "Adam Clay FanToken",
+    "symbol": "CLAY",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft2D8E7041556CE93E1EFD66C07C45D551A6AAAE09.png"
+  },
+  {
+    "id": "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
+    "name": "Agoric",
+    "symbol": "BLD",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/bld.png"
+  },
+  {
+    "id": "ubld",
+    "name": "Agoric Staking Token",
+    "symbol": "BLD",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/bld.png"
+  },
+  {
+    "id": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+    "name": "Akash Network",
+    "symbol": "AKT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/akash-network"
+  },
+  {
+    "id": "ibc/A6383B6CF5EA23E067666C06BC34E2A96869927BD9744DC0C1643E589C710AA3",
+    "name": "Alter",
+    "symbol": "ALTER",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/alter.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/alter"
+  },
+  {
+    "id": "ibc/18A1B70E3205A48DE8590C0D11030E7146CDBF1048789261D53FFFD7527F8B55",
+    "name": "Amber",
+    "symbol": "AMBER",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/amber.svg"
+  },
+  {
+    "id": "ibc/AA1C80225BCA7B32ED1FC6ABF8B8E899BEB48ECDB4B417FD69873C6D715F97E7",
+    "name": "Another.Software Validator Token",
+    "symbol": "ASVT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/asvt.png"
+  },
+  {
+    "id": "ibc/F83CC6471DA4D4B508F437244F10B9E4C68975344E551A2DEB6B8617AB08F0D4",
+    "name": "ApeCoin",
+    "symbol": "APE.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/ape.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/apecoin"
+  },
+  {
+    "id": "ibc/5D270A584B1078FBE07D14570ED5E88EC1FEDA8518B76C322606291E6FD8286F",
+    "name": "Arable USD",
+    "symbol": "arUSD",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/arusd.png",
+    "coingecko": "https://www.coingecko.com/en/coins/arable-usd"
+  },
+  {
+    "id": "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
+    "name": "AssetMantle",
+    "symbol": "MNTL",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/images/mntl.png",
+    "coingecko": "https://www.coingecko.com/en/coins/assetmantle"
+  },
+  {
+    "id": "ibc/2716E3F2E146664BEFA9217F1A03BFCEDBCD5178B3C71CACB1A0D7584451D219",
+    "name": "Atolo",
+    "symbol": "ATOLO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/rizon"
+  },
+  {
+    "id": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
+    "name": "Axelar",
+    "symbol": "AXL",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/axelarnetwork/axelar-docs/main/public/images/assets/axl.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/axelar"
+  },
+  {
+    "id": "ibc/6C0CB8653012DC2BC1820FD0B6B3AFF8A07D18630BDAEE066FEFB2D92F477C24",
+    "name": "Axie Infinity Shard",
+    "symbol": "AXS.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/axs.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/axie-infinity"
+  },
+  {
+    "id": "ibc/F867AE2112EFE646EC71A25CD2DFABB8927126AC1E19F1BBF0FF693A4ECA05DE",
+    "name": "Band Protocol",
+    "symbol": "BAND",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/band-protocol"
+  },
+  {
+    "id": "ibc/C822645522FC3EECF817609AA38C24B64D04F5C267A23BCCF8F2E3BC5755FA88",
+    "name": "BeeZee",
+    "symbol": "BZE",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/bze.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/bzedge"
+  },
+  {
+    "id": "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
+    "name": "Binance USD",
+    "symbol": "BUSD.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.png",
+    "coingecko": "https://www.coingecko.com/en/coins/binance-usd"
+  },
+  {
+    "id": "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5",
+    "name": "BitCanna",
+    "symbol": "BCNA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/bitcanna"
+  },
+  {
+    "id": "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+    "name": "BitSong",
+    "symbol": "BTSG",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/bitsong"
+  },
+  {
+    "id": "ibc/B3FB7128CE957DE1ADB687A919AA0786C77C62FB1280C07CDD78AEA032D56853",
+    "name": "BlackJack FanToken",
+    "symbol": "BJKS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft52EEB0EE509AC546ED92EAC8591F731F213DDD16.png"
+  },
+  {
+    "id": "ibc/DB9755CB6FE55192948AE074D18FA815E1429D3D374D5BDA8D89623C6CF235C3",
+    "name": "Block",
+    "symbol": "BLOCK",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/block.svg"
+  },
+  {
+    "id": "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
+    "name": "Bostrom",
+    "symbol": "BOOT",
+    "decimals": "0",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/boot.png",
+    "coingecko": "https://www.coingecko.com/en/coins/bostrom"
+  },
+  {
+    "id": "ibc/1FBA9E763B8679BEF7BAAAF2D16BCA78C3B297D226C3F31312C769D7B8F992D8",
+    "name": "Button",
+    "symbol": "BUTT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/butt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/buttcoin-2"
+  },
+  {
+    "id": "ibc/47CAF2DB8C016FAC960F33BC492FD8E454593B65CC59D70FA9D9F30424F9C32F",
+    "name": "Canto",
+    "symbol": "CANTO",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/canto/images/canto.png",
+    "coingecko": "https://www.coingecko.com/en/coins/canto"
+  },
+  {
+    "id": "ibc/8FEFAE6AECF6E2A255585617F781F35A8D5709A545A804482A261C0C9548A9D3",
+    "name": "Carbon",
+    "symbol": "SWTH",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/switcheo"
+  },
+  {
+    "id": "ibc/C1CEF00F016FE89EA6E5B07DA895AACD91B0AAD69A991033D846B988AD4FB69D",
+    "name": "Carolina Marquez FanToken",
+    "symbol": "CMQZ",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ftD4B6290EDEE1EC7B97AB5A1DC6C177EFD08ADCC3.png"
+  },
+  {
+    "id": "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
+    "name": "Cerberus",
+    "symbol": "CRBRUS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/images/crbrus.png",
+    "coingecko": "https://www.coingecko.com/en/coins/cerberus-2"
+  },
+  {
+    "id": "ibc/B901BEC1B71D0573E6EE874FEC39E2DF4C2BDB1DB74CB3DA0A9CACC4A435B0EC",
+    "name": "Chain",
+    "symbol": "XCN.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/xcn.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/chain-2"
+  },
+  {
+    "id": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
+    "name": "Chainlink",
+    "symbol": "LINK.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axllink.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/chainlink"
+  },
+  {
+    "id": "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
+    "name": "Cheqd",
+    "symbol": "CHEQ",
+    "decimals": "9",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/cheqd-network"
+  },
+  {
+    "id": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
+    "name": "Chihuahua",
+    "symbol": "HUAHUA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/huahua.png",
+    "coingecko": "https://www.coingecko.com/en/coins/chihuahua-token"
+  },
+  {
+    "id": "ibc/23CA6C8D1AB2145DD13EB1E089A2E3F960DC298B468CCE034E19E5A78B61136E",
+    "name": "CMST",
+    "symbol": "CMST",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmst.png"
+  },
+  {
+    "id": "ibc/EA3E1640F9B1532AB129A571203A0B9F789A7F14BB66E350DCBFA18E1A1931F0",
+    "name": "Comdex",
+    "symbol": "CMDX",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png",
+    "coingecko": "https://www.coingecko.com/en/coins/comdex"
+  },
+  {
+    "id": "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+    "name": "Cronos",
+    "symbol": "CRO",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cryptoorgchain/images/cro.png",
+    "coingecko": "https://www.coingecko.com/en/coins/crypto-com-chain"
+  },
+  {
+    "id": "ibc/E09ED39F390EC51FA9F3F69BEA08B5BBE6A48B3057B2B1C3467FAAE9E58B021B",
+    "name": "Cudos",
+    "symbol": "CUDOS",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/cudos"
+  },
+  {
+    "id": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+    "name": "Dai Stablecoin",
+    "symbol": "DAI.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axldai.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/dai"
+  },
+  {
+    "id": "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5",
+    "name": "Dai Stablecoin",
+    "symbol": "DAI.grv",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gdai.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/dai"
+  },
+  {
+    "id": "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84",
+    "name": "Decentr",
+    "symbol": "DEC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/decentr"
+  },
+  {
+    "id": "ibc/1DE9A32D603EE05E9B8619DF24D90FD518C932AE0B5B3209A986B7262DBADE2A",
+    "name": "Delta 9 FanToken",
+    "symbol": "D9X",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft575B10B0CEE2C164D9ED6A96313496F164A9607C.png"
+  },
+  {
+    "id": "ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C",
+    "name": "Desmos",
+    "symbol": "DSM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/desmos"
+  },
+  {
+    "id": "ibc/52E12CF5CA2BB903D84F5298B4BFD725D66CAB95E09AA4FC75B2904CA5485FEB",
+    "name": "DHK",
+    "symbol": "DHK",
+    "decimals": "0",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/dhk.svg"
+  },
+  {
+    "id": "ibc/307E5C96C8F60D1CBEE269A9A86C0834E1DB06F2B3788AE4F716EDB97A48B97D",
+    "name": "Dig Chain",
+    "symbol": "DIG",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dig/images/dig.png",
+    "coingecko": "https://www.coingecko.com/en/coins/dig-chain"
+  },
+  {
+    "id": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
+    "name": "DOT",
+    "symbol": "DOT.axl",
+    "decimals": "10",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axldot.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/polkadot"
+  },
+  {
+    "id": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
+    "name": "Dyson Protocol",
+    "symbol": "DYS",
+    "decimals": "0",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dyson/images/dys.png"
+  },
+  {
+    "id": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+    "name": "e-Money",
+    "symbol": "NGM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/e-money"
+  },
+  {
+    "id": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+    "name": "e-Money EUR",
+    "symbol": "EEUR",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/e-money-eur"
+  },
+  {
+    "id": "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
+    "name": "Echelon",
+    "symbol": "ECH",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/echelon.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/echelon"
+  },
+  {
+    "id": "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
+    "name": "Echelon",
+    "symbol": "ECH",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/echelon.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/echelon"
+  },
+  {
+    "id": "ibc/051A38BBEF92B9D8293AFBE1FA293E704359E9CB28297A0FD5DBA3E9CCEE9AB1",
+    "name": "Enmoda FanToken",
+    "symbol": "ENMODA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft85AE1716C5E39EA6D64BBD7898C3899A7B500626.png"
+  },
+  {
+    "id": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
+    "name": "Evmos",
+    "symbol": "EVMOS",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/evmos"
+  },
+  {
+    "id": "ibc/7CE5F388D661D82A0774E47B5129DA51CC7129BD1A70B5FA6BCEBB5B0A2FAEAF",
+    "name": "Fanfury",
+    "symbol": "FURY",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/fanfury.png",
+    "coingecko": "https://www.coingecko.com/en/coins/fanfury"
+  },
+  {
+    "id": "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
+    "name": "Fetch.ai",
+    "symbol": "FET",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/fetch-ai"
+  },
+  {
+    "id": "ibc/239A507997222805E441956EBE8087D7E2D05D6535C6D4C75EF8DCF83B3DE1A1",
+    "name": "FONTI FanToken",
+    "symbol": "FONTI",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft56664FC98A2CF5F4FBAC3566D1A11D891AD88305.png"
+  },
+  {
+    "id": "ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE",
+    "name": "Frax",
+    "symbol": "FRAX.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlfrax.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/frax"
+  },
+  {
+    "id": "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
+    "name": "Galaxy",
+    "symbol": "GLX",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/galaxy/images/galaxy.svg"
+  },
+  {
+    "id": "ibc/52C57FCA7D6854AA178E7A183DDBE4EF322B904B1D719FC485F6FFBC1F72A19E",
+    "name": "Gelotto",
+    "symbol": "GLTO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/glto.png"
+  },
+  {
+    "id": "ibc/F16FDC11A7662B86BC0B9CE61871CBACF7C20606F95E86260FD38915184B75B4",
+    "name": "GenesisL1",
+    "symbol": "L1",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/genesisl1/images/l1.svg"
+  },
+  {
+    "id": "ibc/9B6FBABA36BB4A3BF127AE5E96B572A5197FD9F3111D895D8919B07BC290764A",
+    "name": "GEO",
+    "symbol": "GEO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/geo.svg"
+  },
+  {
+    "id": "ibc/7C781B4C2082CD62129A972D47486D78EC17155C299270E3C89348EA026BEAF8",
+    "name": "GKey",
+    "symbol": "GKEY",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/gkey.png"
+  },
+  {
+    "id": "ibc/D6C28E07F7343360AC41E15DDD44D79701DDCA2E0C2C41279739C8D4AE5264BC",
+    "name": "Hard",
+    "symbol": "HARD",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/hard-protocol"
+  },
+  {
+    "id": "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B",
+    "name": "Hope Galaxy",
+    "symbol": "HOPE",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/hope-galaxy"
+  },
+  {
+    "id": "ibc/D3ADAF73F84CDF205BCB72C142FDAEEA2C612AB853CEE6D6C06F184FA38B1099",
+    "name": "HOPERS",
+    "symbol": "hopers",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hopers.png"
+  },
+  {
+    "id": "ibc/92B223EBFA74DB99BEA92B23DEAA6050734FEEAABB84689CB8E1AE8F9C9F9AF4",
+    "name": "Imversed",
+    "symbol": "IMV",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/imversed/images/imversed.svg"
+  },
+  {
+    "id": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
+    "name": "Injective",
+    "symbol": "INJ",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/injective-protocol"
+  },
+  {
+    "id": "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
+    "name": "Inter Protocol USD",
+    "symbol": "IST",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/ist.png"
+  },
+  {
+    "id": "uion",
+    "name": "Ion",
+    "symbol": "ION",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/ion"
+  },
+  {
+    "id": "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+    "name": "IRISnet",
+    "symbol": "IRIS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/iris-network"
+  },
+  {
+    "id": "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B",
+    "name": "IXO",
+    "symbol": "IXO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.png",
+    "coingecko": "https://www.coingecko.com/en/coins/ixo"
+  },
+  {
+    "id": "ibc/8E697BDABE97ACE8773C6DF7402B2D1D5104DD1EEABE12608E3469B7F64C15BA",
+    "name": "Jackal",
+    "symbol": "JKL",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/jackal/images/jkl.svg"
+  },
+  {
+    "id": "ibc/0CB9DB3441D0D50F35699DEE22B9C965487E83FB2D9F483D1CC5CA34E856C484",
+    "name": "JoeDAO",
+    "symbol": "JOE",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/joe.png"
+  },
+  {
+    "id": "ibc/00B6E60AD3D65CBEF5579AC8AF609527C0B57535B6E32D96C80A735344FD9DCC",
+    "name": "JunoSwap",
+    "symbol": "RAW",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/raw.png"
+  },
+  {
+    "id": "ibc/6A6174468758D207DD2D880363BF699C6568A29E87651337AEDAFD9E69EA7E58",
+    "name": "Karina FanToken",
+    "symbol": "KARINA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft2DD67F5D99E9A141142B48474FA7B6B3FF00A3FE.png"
+  },
+  {
+    "id": "ibc/57AA1A70A4BC9769C525EBF6386F7A21536E04A79D62E1981EFCEF9428EBB205",
+    "name": "Kava",
+    "symbol": "KAVA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/kava.png",
+    "coingecko": "https://www.coingecko.com/en/coins/kava"
+  },
+  {
+    "id": "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
+    "name": "Ki",
+    "symbol": "XKI",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/ki"
+  },
+  {
+    "id": "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593",
+    "name": "Konstellation",
+    "symbol": "DARC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/darcmatter-coin"
+  },
+  {
+    "id": "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB",
+    "name": "Lambda",
+    "symbol": "LAMB",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.png",
+    "coingecko": "https://www.coingecko.com/en/coins/lambda"
+  },
+  {
+    "id": "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
+    "name": "LikeCoin",
+    "symbol": "LIKE",
+    "decimals": "9",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/likecoin"
+  },
+  {
+    "id": "ibc/022A879A5301CBCACF96216C967805F15C33C615B74DC7236027C1BA1BF664FF",
+    "name": "Luca Testa FanToken",
+    "symbol": "TESTA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft4B030260D99E3ABE2B604EA2B33BAF3C085CDA12.png"
+  },
+  {
+    "id": "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2",
+    "name": "Lum",
+    "symbol": "LUM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/images/lum.png",
+    "coingecko": "https://www.coingecko.com/en/coins/lum-network"
+  },
+  {
+    "id": "ibc/FFA652599C77E853F017193E36B5AB2D4D9AFC4B54721A74904F80C9236BF3B7",
+    "name": "LumenX",
+    "symbol": "LUMEN",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumenx/images/lumen.png"
+  },
+  {
+    "id": "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+    "name": "Luna Classic",
+    "symbol": "LUNC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/terra-luna"
+  },
+  {
+    "id": "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
+    "name": "Lvn",
+    "symbol": "LVN",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/lvn.png",
+    "coingecko": "https://www.coingecko.com/en/coins/lvn"
+  },
+  {
+    "id": "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3",
+    "name": "Maker",
+    "symbol": "MKR.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlmkr.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/maker"
+  },
+  {
+    "id": "ibc/F6B691D5F7126579DDC87357B09D653B47FDCE0A3383FF33C8D8B544FE29A8A6",
+    "name": "Marble",
+    "symbol": "MARBLE",
+    "decimals": "3",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/marble"
+  },
+  {
+    "id": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
+    "name": "Mars",
+    "symbol": "MARS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/mars/images/mars-token.svg"
+  },
+  {
+    "id": "ibc/01e94a5ff29b8ddefc86f412cc3927f7330e9b523cc63a6194b1108f5276025c",
+    "name": "MedasDigital",
+    "symbol": "MEDAS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/medasdigital/images/medas.svg"
+  },
+  {
+    "id": "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
+    "name": "MedasDigital",
+    "symbol": "MEDAS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/medasdigital/images/medas.svg"
+  },
+  {
+    "id": "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB",
+    "name": "MediBloc",
+    "symbol": "MED",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/panacea/images/med.png",
+    "coingecko": "https://www.coingecko.com/en/coins/medibloc"
+  },
+  {
+    "id": "ibc/67C89B8B0A70C08F093C909A4DD996DD10E0494C87E28FD9A551697BF173D4CA",
+    "name": "Meme",
+    "symbol": "MEME",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/meme/images/meme.svg"
+  },
+  {
+    "id": "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8",
+    "name": "Microtick",
+    "symbol": "TICK",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/microtick"
+  },
+  {
+    "id": "ibc/6B982170CE024689E8DD0E7555B129B488005130D4EDA426733D552D10B36D8F",
+    "name": "MUSE",
+    "symbol": "MUSE",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/muse.png"
+  },
+  {
+    "id": "ibc/E4FFAACCDB7D55CE2D257DF637C00158CB841F11D0013B2D03E31FF7800A2C58",
+    "name": "N43 FanToken",
+    "symbol": "N43",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft387C1C279D962ED80C09C1D592A92C4275FD7C5D.png"
+  },
+  {
+    "id": "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
+    "name": "Neta",
+    "symbol": "NETA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.png",
+    "coingecko": "https://www.coingecko.com/en/coins/neta"
+  },
+  {
+    "id": "ibc/423967B46B1A51D78619085105B04FCFA14F7CBC0BE7539A316B2DCDFC7D8C07",
+    "name": "Nicola Fasano FanToken",
+    "symbol": "FASANO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft25B30C386CDDEBD1413D5AE1180956AE9EB3B9F7.png"
+  },
+  {
+    "id": "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163",
+    "name": "Nom",
+    "symbol": "NOM",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/onomy/images/nom.png"
+  },
+  {
+    "id": "ibc/0CD46223FEABD2AEAAAF1F057D01E63BCA79B7D4BD6B68F1EB973A987344695D",
+    "name": "O9W",
+    "symbol": "O9W",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/o9w.svg"
+  },
+  {
+    "id": "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
+    "name": "ODIN",
+    "symbol": "ODIN",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/odin-protocol"
+  },
+  {
+    "id": "ibc/161D7D62BAB3B9C39003334F1671208F43C06B643CC9EDBBE82B64793C857F1D",
+    "name": "Oraichain",
+    "symbol": "ORAI",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/oraichain-token"
+  },
+  {
+    "id": "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+    "name": "Persistence",
+    "symbol": "XPRT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/persistence"
+  },
+  {
+    "id": "ibc/B1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF",
+    "name": "Planq",
+    "symbol": "PLQ",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/planq/images/planq.svg"
+  },
+  {
+    "id": "ibc/D3B574938631B0A1BA704879020C696E514CFADAA7643CDE4BD5EB010BDE327B",
+    "name": "POSTHUMAN",
+    "symbol": "PHMN",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/phmn.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/posthuman"
+  },
+  {
+    "id": "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
+    "name": "Provenance",
+    "symbol": "HASH",
+    "decimals": "9",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/hash.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/provenance-blockchain"
+  },
+  {
+    "id": "ibc/8061A06D3BD4D52C4A28FFECF7150D370393AF0BA661C3776C54FF32836C3961",
+    "name": "PSTAKE",
+    "symbol": "PSTAKE",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/pstake-finance"
+  },
+  {
+    "id": "ibc/CAA179E40F0266B0B29FB5EAA288FB9212E628822265D4141EBD1C47C3CBFCBC",
+    "name": "PSTAKE staked ATOM",
+    "symbol": "stkATOM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/stkatom.svg"
+  },
+  {
+    "id": "ibc/C9864D1B9623F703C75BBF72B7FF8A7317E1535C96538D21467A4311246DC3B5",
+    "name": "Puro Lobo FanToken",
+    "symbol": "LOBO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft24C9FA4F10B0F235F4A815B15FC774E046A2B2EB.png"
+  },
+  {
+    "id": "ibc/46C83BB054E12E189882B5284542DB605D94C99827E367C9192CF0579CD5BC83",
+    "name": "Quicksilver Liquid Staked STARS",
+    "symbol": "qSTARS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qstars.svg"
+  },
+  {
+    "id": "ibc/6BDB4C8CCD45033F9604E4B93ED395008A753E01EECD6992E7D1EA23D9D3B788",
+    "name": "Racoon",
+    "symbol": "RAC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/racoon"
+  },
+  {
+    "id": "ibc/BD796662F8825327D41C96355DF62045A5BA225BAE31C0A86289B9D88ED3F44E",
+    "name": "Rai Reflex Index",
+    "symbol": "RAI.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/rai.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/rai"
+  },
+  {
+    "id": "ibc/56C276FC136E239449DCE664292DBEEF5795C4EF4B5B35DB98BD1C0948274867",
+    "name": "Rawanne FanToken",
+    "symbol": "RWNE",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ftE4903ECC861CA45F2C2BC7EAB8255D2E6E87A33A.png"
+  },
+  {
+    "id": "ibc/A1AC7F9EE2F643A68E3A35BCEB22040120BEA4059773BB56985C76BDFEBC71D9",
+    "name": "Rebuschain",
+    "symbol": "REBUS",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/rebus"
+  },
+  {
+    "id": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+    "name": "Regen Network",
+    "symbol": "REGEN",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/regen.png",
+    "coingecko": "https://www.coingecko.com/en/coins/regen"
+  },
+  {
+    "id": "ibc/D0E5BF2940FB58D9B283A339032DE88111407AAD7D94A7F1F3EB78874F8616D4",
+    "name": "SCRT Staking Derivatives",
+    "symbol": "stkd-SCRT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/stkd-scrt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/stkd-scrt"
+  },
+  {
+    "id": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+    "name": "Sentinel",
+    "symbol": "DVPN",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/images/dvpn.png",
+    "coingecko": "https://www.coingecko.com/en/coins/sentinel"
+  },
+  {
+    "id": "ibc/71055835C7639739EAE03AACD1324FE162DBA41D09F197CB72D966D014225B1C",
+    "name": "Shade",
+    "symbol": "SHD",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/shd.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/shade-protocol"
+  },
+  {
+    "id": "ibc/7ED954CFFFC06EE8419387F3FC688837FF64EF264DE14219935F724EEEDBF8D3",
+    "name": "Shentu",
+    "symbol": "CTK",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/images/ctk.png",
+    "coingecko": "https://www.coingecko.com/en/coins/certik"
+  },
+  {
+    "id": "ibc/19305E20681911F14D1FB275E538CDE524C3BF88CF9AE5D5F78F4D4DA05E85B2",
+    "name": "Shiba Inu",
+    "symbol": "SHIB.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/shib.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/shiba-inu"
+  },
+  {
+    "id": "ibc/9A8A93D04917A149C8AC7C16D3DA8F470D59E8D867499C4DA97450E1D7363213",
+    "name": "SIENNA",
+    "symbol": "SIENNA",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/sienna.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/sienna"
+  },
+  {
+    "id": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
+    "name": "Sifchain Rowan",
+    "symbol": "ROWAN",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/sifchain"
+  },
+  {
+    "id": "ibc/C3FC4DED273E7D1DD2E7BAA3317EC9A53CD3252B577AA33DC00D9DF2BDF3ED5C",
+    "name": "Solarbank DAO",
+    "symbol": "SOLAR",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.svg"
+  },
+  {
+    "id": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
+    "name": "Sommelier",
+    "symbol": "SOMM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/sommelier"
+  },
+  {
+    "id": "ibc/C2DF5C3949CA835B221C575625991F09BAB4E48FB9C11A4EE357194F736111E3",
+    "name": "StakeEasy bJUNO",
+    "symbol": "BJUNO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.svg"
+  },
+  {
+    "id": "ibc/18A676A074F73B9B42DA4F9DFC8E5AEF334C9A6636DDEC8D34682F52F1DECDF6",
+    "name": "StakeEasy SEASY",
+    "symbol": "SEASY",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.svg",
+    "website": "https://stakeeasy.finance/",
+    "telegram": "https://t.me/StakeEasyProtocol",
+    "twitter": "https://twitter.com/StakeEasy",
+    "discord": "https://discord.gg/gKjzApDstD",
+    "coingecko": "https://www.coingecko.com/en/coins/seasy"
+  },
+  {
+    "id": "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B",
+    "name": "StakeEasy seJUNO",
+    "symbol": "SEJUNO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.svg"
+  },
+  {
+    "id": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
+    "name": "Stargaze",
+    "symbol": "STARS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png",
+    "coingecko": "https://www.coingecko.com/en/coins/stargaze"
+  },
+  {
+    "id": "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+    "name": "Starname",
+    "symbol": "IOV",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/starname"
+  },
+  {
+    "id": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
+    "name": "stATOM",
+    "symbol": "stATOM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/stride-staked-atom"
+  },
+  {
+    "id": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
+    "name": "Stride",
+    "symbol": "STRD",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg",
+    "website": "https://stride.zone/",
+    "telegram": "https://t.me/stride_official",
+    "twitter": "https://twitter.com/stride_zone",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/stride",
+    "coingecko": "https://www.coingecko.com/en/coins/stride"
+  },
+  {
+    "id": "ibc/84502A75BCA4A5F68D464C00B3F610CE2585847D59B52E5FFB7C3C9D2DDCD3FE",
+    "name": "Stride Juno",
+    "symbol": "stJUNO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.svg",
+    "website": "https://stride.zone/",
+    "telegram": "https://t.me/stride_official",
+    "twitter": "https://twitter.com/stride_zone"
+  },
+  {
+    "id": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
+    "name": "Stride Staked osmo",
+    "symbol": "stOSMO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/stride-staked-osmo"
+  },
+  {
+    "id": "ibc/5DD1F95ED336014D00CE2520977EC71566D282F9749170ADC83A392E0EA7426A",
+    "name": "Stride Staked Stars",
+    "symbol": "stSTARS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/ststars.svg"
+  },
+  {
+    "id": "ibc/70CF1A54E23EA4E480DEDA9E12082D3FD5684C3483CBDCE190C5C807227688C5",
+    "name": "Swap",
+    "symbol": "SWP",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/kava-swap"
+  },
+  {
+    "id": "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
+    "name": "teritori",
+    "symbol": "TORI",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/teritori/images/tori.svg"
+  },
+  {
+    "id": "ibc/204A582244FC241613DBB50B04D1D454116C58C4AF7866C186AA0D6EEAD42780",
+    "name": "TerraClassicKRW",
+    "symbol": "KRTC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/krt.png",
+    "coingecko": "https://www.coingecko.com/en/coins/terra-krw"
+  },
+  {
+    "id": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+    "name": "TerraClassicUSD",
+    "symbol": "USTC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/ust.png",
+    "coingecko": "https://www.coingecko.com/en/coins/terrausd"
+  },
+  {
+    "id": "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
+    "name": "Tether USD",
+    "symbol": "USDT.grv",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/usd-coin"
+  },
+  {
+    "id": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
+    "name": "Tether USD",
+    "symbol": "USDT.axl",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlusdt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/tether"
+  },
+  {
+    "id": "ibc/1E09CB0F506ACF12FDE4683FB6B34DA62FB4BE122641E0D93AAF98A87675676C",
+    "name": "Tgrade",
+    "symbol": "TGD",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/tgrade/images/tgrade-symbol-gradient.svg"
+  },
+  {
+    "id": "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
+    "name": "Umee",
+    "symbol": "UMEE",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/images/umee.png",
+    "coingecko": "https://www.coingecko.com/en/coins/umee"
+  },
+  {
+    "id": "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
+    "name": "Unification",
+    "symbol": "FUND",
+    "decimals": "9",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/unification/images/fund.png",
+    "coingecko": "https://www.coingecko.com/en/coins/unification"
+  },
+  {
+    "id": "ibc/AE2719773D6FCDD05AC17B1ED63F672F5F9D84144A61965F348C86C2A83AD161",
+    "name": "Uniswap",
+    "symbol": "UNI.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/uni.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/uniswap"
+  },
+  {
+    "id": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
+    "name": "USD Coin",
+    "symbol": "USDC.grv",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdc.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/usd-coin"
+  },
+  {
+    "id": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+    "name": "USD Coin",
+    "symbol": "USDC.axl",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlusdc.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/usd-coin"
+  },
+  {
+    "id": "ibc/C78F65E1648A3DFE0BAEB6C4CDA69CC2A75437F1793C0E6386DFDA26393790AE",
+    "name": "USDX",
+    "symbol": "USDX",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/usdx.png",
+    "coingecko": "https://www.coingecko.com/en/coins/usdx"
+  },
+  {
+    "id": "ibc/8A07D4BD40E0F44ECFDF360F7EA7008B288926FB87C54489FE54DB81A5340E0C",
+    "name": "Vibranium FanToken",
+    "symbol": "VIBRA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft7020C2A8E984EEBCBB383E91CD6FBB067BB2272B.png"
+  },
+  {
+    "id": "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD",
+    "name": "Vidulum",
+    "symbol": "VDL",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/vidulum/images/vdl.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/vidulum"
+  },
+  {
+    "id": "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
+    "name": "Wrapped AVAX",
+    "symbol": "wAVAX",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/avalanche/images/avax.png"
+  },
+  {
+    "id": "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796",
+    "name": "Wrapped Bitcoin",
+    "symbol": "WBTC.grv",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gwbtc.png",
+    "coingecko": "https://www.coingecko.com/en/coins/wrapped-bitcoin"
+  },
+  {
+    "id": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
+    "name": "Wrapped Bitcoin",
+    "symbol": "WBTC.axl",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlwbtc.png",
+    "coingecko": "https://www.coingecko.com/en/coins/wrapped-bitcoin"
+  },
+  {
+    "id": "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
+    "name": "Wrapped BNB",
+    "symbol": "WBNB.axl",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchainoonbeam/images/wbnb.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/wbnb"
+  },
+  {
+    "id": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
+    "name": "Wrapped Ether",
+    "symbol": "WETH.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlweth.png",
+    "coingecko": "https://www.coingecko.com/en/coins/weth"
+  },
+  {
+    "id": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
+    "name": "Wrapped Ethereum",
+    "symbol": "WETH.grv",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gweth.png",
+    "coingecko": "https://www.coingecko.com/en/coins/weth"
+  },
+  {
+    "id": "ibc/5E2DFDF1734137302129EA1C1BA21A580F96F778D4F021815EA4F6DB378DA1A4",
+    "name": "Wrapped FTM",
+    "symbol": "wFTM",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/fantom/images/ftm.png"
+  },
+  {
+    "id": "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",
+    "name": "Wrapped GLMR",
+    "symbol": "WGLMR.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/moonbeam/images/glmr.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/wrapped-moonbeam"
+  },
+  {
+    "id": "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
+    "name": "Wrapped Matic",
+    "symbol": "WMATIC.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wmatic-wei L@3x.png",
+    "coingecko": "https://www.coingecko.com/en/coins/wmatic"
+  },
+  {
+    "id": "ibc/2FBAC4BF296D7844796844B35978E5899984BA5A6314B2DD8F83C215550010B3",
+    "name": "Wynd DAO Governance Token",
+    "symbol": "WYND",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/wynd.svg"
+  }
+]

--- a/osmosis/asset.json
+++ b/osmosis/asset.json
@@ -1,139 +1,12 @@
 [
   {
-    "id": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
-    "entity": "Akash Network",
-    "name": "Akash Network",
-    "symbol": "AKT",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg"
-  },
-  {
-    "id": "ibc/384E5DD50BDE042E1AAF51F312B55F08F95BC985C503880189258B4D9374CBBE",
-    "entity": "Axelar",
-    "name": "Aave",
-    "symbol": "AAVE.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/aave.svg"
-  },
-  {
-    "id": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
-    "entity": "Axelar",
-    "name": "Axelar",
-    "symbol": "AXL",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/axelarnetwork/axelar-docs/main/public/images/assets/axl.svg"
-  },
-  {
-    "id": "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
-    "entity": "Axelar",
-    "name": "Binance USD",
-    "symbol": "BUSD.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.png"
-  },
-  {
-    "id": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
-    "entity": "Axelar",
-    "name": "Chainlink",
-    "symbol": "LINK.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axllink.svg"
-  },
-  {
-    "id": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
-    "entity": "Axelar",
-    "name": "Dai Stablecoin",
-    "symbol": "DAI.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axldai.svg"
-  },
-  {
-    "id": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
-    "entity": "Axelar",
-    "name": "DOT",
-    "symbol": "DOT.axl",
-    "decimals": "10",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axldot.svg"
-  },
-  {
-    "id": "ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE",
-    "entity": "Axelar",
-    "name": "Frax",
-    "symbol": "FRAX.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlfrax.svg"
-  },
-  {
-    "id": "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3",
-    "entity": "Axelar",
-    "name": "Maker",
-    "symbol": "MKR.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlmkr.svg"
-  },
-  {
-    "id": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
-    "entity": "Axelar",
-    "name": "Tether USD",
-    "symbol": "USDT.axl",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlusdt.svg"
-  },
-  {
-    "id": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-    "entity": "Axelar",
-    "name": "USD Coin",
-    "symbol": "USDC.axl",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlusdc.svg"
-  },
-  {
-    "id": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
-    "entity": "Axelar",
-    "name": "Wrapped Bitcoin",
-    "symbol": "WBTC.axl",
-    "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlwbtc.png"
-  },
-  {
-    "id": "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
-    "entity": "Axelar",
-    "name": "Wrapped BNB",
-    "symbol": "WBNB.axl",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchainoonbeam/images/wbnb.svg"
-  },
-  {
-    "id": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-    "entity": "Axelar",
-    "name": "Wrapped Ether",
-    "symbol": "WETH.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlweth.png"
-  },
-  {
-    "id": "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",
-    "entity": "Axelar",
-    "name": "Wrapped GLMR",
-    "symbol": "WGLMR.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/moonbeam/images/glmr.svg"
-  },
-  {
-    "id": "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
-    "entity": "Axelar",
-    "name": "Wrapped Matic",
-    "symbol": "WMATIC.axl",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wmatic-wei L@3x.png"
-  },
-  {
     "id": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
     "entity": "Cosmos",
     "name": "Cosmos",
     "symbol": "ATOM",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/cosmos"
   },
   {
     "id": "ibc/5A7C219BA5F7582B99629BA3B2A01A61BFDA0F6FD1FE95B5366F7334C4BC0580",
@@ -141,39 +14,8 @@
     "name": "Crescent",
     "symbol": "CRE",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.svg"
-  },
-  {
-    "id": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
-    "entity": "e-Money",
-    "name": "e-Money",
-    "symbol": "NGM",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.svg"
-  },
-  {
-    "id": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
-    "entity": "e-Money",
-    "name": "e-Money EUR",
-    "symbol": "EEUR",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.svg"
-  },
-  {
-    "id": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
-    "entity": "Evmos",
-    "name": "Evmos",
-    "symbol": "EVMOS",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg"
-  },
-  {
-    "id": "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5",
-    "entity": "Gravity Bridge",
-    "name": "Dai Stablecoin",
-    "symbol": "DAI.grv",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gdai.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/crescent-network"
   },
   {
     "id": "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
@@ -181,47 +23,8 @@
     "name": "Graviton",
     "symbol": "GRAV",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.svg"
-  },
-  {
-    "id": "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
-    "entity": "Gravity Bridge",
-    "name": "Tether USD",
-    "symbol": "USDT.grv",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdt.svg"
-  },
-  {
-    "id": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
-    "entity": "Gravity Bridge",
-    "name": "USD Coin",
-    "symbol": "USDC.grv",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdc.svg"
-  },
-  {
-    "id": "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796",
-    "entity": "Gravity Bridge",
-    "name": "Wrapped Bitcoin",
-    "symbol": "WBTC.grv",
-    "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gwbtc.png"
-  },
-  {
-    "id": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
-    "entity": "Gravity Bridge",
-    "name": "Wrapped Ethereum",
-    "symbol": "WETH.grv",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gweth.png"
-  },
-  {
-    "id": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
-    "entity": "Injective Protocol",
-    "name": "Injective",
-    "symbol": "INJ",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/graviton"
   },
   {
     "id": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
@@ -229,7 +32,8 @@
     "name": "Juno",
     "symbol": "JUNO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/juno-network"
   },
   {
     "id": "ibc/BB6BCDB515050BAE97516111873CCD7BCF1FD0CCB723CC12F3C4F704D6C646CE",
@@ -237,7 +41,8 @@
     "name": "Kuji",
     "symbol": "KUJI",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png",
+    "coingecko": "https://www.coingecko.com/en/coins/kujira"
   },
   {
     "id": "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
@@ -245,23 +50,8 @@
     "name": "USK",
     "symbol": "USK",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/usk.png"
-  },
-  {
-    "id": "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
-    "entity": "Neta",
-    "name": "Neta",
-    "symbol": "NETA",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.png"
-  },
-  {
-    "id": "uion",
-    "entity": "Osmosis",
-    "name": "Ion",
-    "symbol": "ION",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/usk.png",
+    "coingecko": "https://www.coingecko.com/en/coins/usk"
   },
   {
     "id": "uosmo",
@@ -269,31 +59,8 @@
     "name": "Osmosis",
     "symbol": "OSMO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
-  },
-  {
-    "id": "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
-    "entity": "Persistence",
-    "name": "Persistence",
-    "symbol": "XPRT",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg"
-  },
-  {
-    "id": "ibc/8061A06D3BD4D52C4A28FFECF7150D370393AF0BA661C3776C54FF32836C3961",
-    "entity": "PSTAKE",
-    "name": "PSTAKE",
-    "symbol": "PSTAKE",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.svg"
-  },
-  {
-    "id": "ibc/46C83BB054E12E189882B5284542DB605D94C99827E367C9192CF0579CD5BC83",
-    "entity": "Quicksilver",
-    "name": "Quicksilver Liquid Staked STARS",
-    "symbol": "qSTARS",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qstars.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/osmosis"
   },
   {
     "id": "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
@@ -301,95 +68,8 @@
     "name": "Secret Network",
     "symbol": "SCRT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg"
-  },
-  {
-    "id": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
-    "entity": "Sifchain",
-    "name": "Sifchain Rowan",
-    "symbol": "ROWAN",
-    "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.svg"
-  },
-  {
-    "id": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
-    "entity": "Sommelier",
-    "name": "Sommelier",
-    "symbol": "SOMM",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.svg"
-  },
-  {
-    "id": "ibc/C2DF5C3949CA835B221C575625991F09BAB4E48FB9C11A4EE357194F736111E3",
-    "entity": "StakeEasy",
-    "name": "StakeEasy bJUNO",
-    "symbol": "BJUNO",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.svg"
-  },
-  {
-    "id": "ibc/18A676A074F73B9B42DA4F9DFC8E5AEF334C9A6636DDEC8D34682F52F1DECDF6",
-    "entity": "StakeEasy",
-    "name": "StakeEasy SEASY",
-    "symbol": "SEASY",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.svg"
-  },
-  {
-    "id": "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B",
-    "entity": "StakeEasy",
-    "name": "StakeEasy seJUNO",
-    "symbol": "SEJUNO",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.svg"
-  },
-  {
-    "id": "ibc/5DD1F95ED336014D00CE2520977EC71566D282F9749170ADC83A392E0EA7426A",
-    "entity": "StakeEasy",
-    "name": "Stride Staked Stars",
-    "symbol": "stSTARS",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/ststars.svg"
-  },
-  {
-    "id": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
-    "entity": "Stargaze",
-    "name": "Stargaze",
-    "symbol": "STARS",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png"
-  },
-  {
-    "id": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
-    "entity": "Stride",
-    "name": "stATOM",
-    "symbol": "stATOM",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg"
-  },
-  {
-    "id": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
-    "entity": "Stride",
-    "name": "Stride",
-    "symbol": "STRD",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg"
-  },
-  {
-    "id": "ibc/84502A75BCA4A5F68D464C00B3F610CE2585847D59B52E5FFB7C3C9D2DDCD3FE",
-    "entity": "Stride",
-    "name": "Stride Juno",
-    "symbol": "stJUNO",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.svg"
-  },
-  {
-    "id": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
-    "entity": "Stride",
-    "name": "Stride Staked osmo",
-    "symbol": "stOSMO",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/secret"
   },
   {
     "id": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
@@ -397,15 +77,8 @@
     "name": "Luna",
     "symbol": "LUNA",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png"
-  },
-  {
-    "id": "ibc/2FBAC4BF296D7844796844B35978E5899984BA5A6314B2DD8F83C215550010B3",
-    "entity": "Wynd",
-    "name": "Wynd DAO Governance Token",
-    "symbol": "WYND",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/wynd.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png",
+    "coingecko": "https://www.coingecko.com/en/coins/terra-luna-2"
   },
   {
     "id": "ibc/B797E4F42CD33C50511B341E50C5CC0E8EF0D93B1E1247ABAA071583B8619202",
@@ -415,11 +88,20 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft99091610CCC66F4277C66D14AF2BC4C5EE52E27A.png"
   },
   {
+    "id": "ibc/384E5DD50BDE042E1AAF51F312B55F08F95BC985C503880189258B4D9374CBBE",
+    "name": "Aave",
+    "symbol": "AAVE.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/aave.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/aave"
+  },
+  {
     "id": "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
     "name": "Acre",
     "symbol": "ACRE",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/acre.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/acre.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/arable-protocol"
   },
   {
     "id": "ibc/7ABF696369EFB3387DF22B6A24204459FE5EFD010220E8E5618DC49DB877047B",
@@ -443,11 +125,20 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/bld.png"
   },
   {
+    "id": "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+    "name": "Akash Network",
+    "symbol": "AKT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/akash-network"
+  },
+  {
     "id": "ibc/A6383B6CF5EA23E067666C06BC34E2A96869927BD9744DC0C1643E589C710AA3",
     "name": "Alter",
     "symbol": "ALTER",
     "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/alter.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/alter.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/alter"
   },
   {
     "id": "ibc/18A1B70E3205A48DE8590C0D11030E7146CDBF1048789261D53FFFD7527F8B55",
@@ -468,63 +159,88 @@
     "name": "ApeCoin",
     "symbol": "APE.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/ape.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/ape.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/apecoin"
   },
   {
     "id": "ibc/5D270A584B1078FBE07D14570ED5E88EC1FEDA8518B76C322606291E6FD8286F",
     "name": "Arable USD",
     "symbol": "arUSD",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/arusd.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/arusd.png",
+    "coingecko": "https://www.coingecko.com/en/coins/arable-usd"
   },
   {
     "id": "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
     "name": "AssetMantle",
     "symbol": "MNTL",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/images/mntl.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/images/mntl.png",
+    "coingecko": "https://www.coingecko.com/en/coins/assetmantle"
   },
   {
     "id": "ibc/2716E3F2E146664BEFA9217F1A03BFCEDBCD5178B3C71CACB1A0D7584451D219",
     "name": "Atolo",
     "symbol": "ATOLO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/rizon"
+  },
+  {
+    "id": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
+    "name": "Axelar",
+    "symbol": "AXL",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/axelarnetwork/axelar-docs/main/public/images/assets/axl.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/axelar"
   },
   {
     "id": "ibc/6C0CB8653012DC2BC1820FD0B6B3AFF8A07D18630BDAEE066FEFB2D92F477C24",
     "name": "Axie Infinity Shard",
     "symbol": "AXS.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/axs.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/axs.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/axie-infinity"
   },
   {
     "id": "ibc/F867AE2112EFE646EC71A25CD2DFABB8927126AC1E19F1BBF0FF693A4ECA05DE",
     "name": "Band Protocol",
     "symbol": "BAND",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/band-protocol"
   },
   {
     "id": "ibc/C822645522FC3EECF817609AA38C24B64D04F5C267A23BCCF8F2E3BC5755FA88",
     "name": "BeeZee",
     "symbol": "BZE",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/bze.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/bze.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/bzedge"
+  },
+  {
+    "id": "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
+    "name": "Binance USD",
+    "symbol": "BUSD.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.png",
+    "coingecko": "https://www.coingecko.com/en/coins/binance-usd"
   },
   {
     "id": "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5",
     "name": "BitCanna",
     "symbol": "BCNA",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/bitcanna"
   },
   {
     "id": "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
     "name": "BitSong",
     "symbol": "BTSG",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/bitsong"
   },
   {
     "id": "ibc/B3FB7128CE957DE1ADB687A919AA0786C77C62FB1280C07CDD78AEA032D56853",
@@ -545,28 +261,32 @@
     "name": "Bostrom",
     "symbol": "BOOT",
     "decimals": "0",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/boot.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/boot.png",
+    "coingecko": "https://www.coingecko.com/en/coins/bostrom"
   },
   {
     "id": "ibc/1FBA9E763B8679BEF7BAAAF2D16BCA78C3B297D226C3F31312C769D7B8F992D8",
     "name": "Button",
     "symbol": "BUTT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/butt.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/butt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/buttcoin-2"
   },
   {
     "id": "ibc/47CAF2DB8C016FAC960F33BC492FD8E454593B65CC59D70FA9D9F30424F9C32F",
     "name": "Canto",
     "symbol": "CANTO",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/canto/images/canto.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/canto/images/canto.png",
+    "coingecko": "https://www.coingecko.com/en/coins/canto"
   },
   {
     "id": "ibc/8FEFAE6AECF6E2A255585617F781F35A8D5709A545A804482A261C0C9548A9D3",
     "name": "Carbon",
     "symbol": "SWTH",
     "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/switcheo"
   },
   {
     "id": "ibc/C1CEF00F016FE89EA6E5B07DA895AACD91B0AAD69A991033D846B988AD4FB69D",
@@ -580,28 +300,40 @@
     "name": "Cerberus",
     "symbol": "CRBRUS",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/images/crbrus.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/images/crbrus.png",
+    "coingecko": "https://www.coingecko.com/en/coins/cerberus-2"
   },
   {
     "id": "ibc/B901BEC1B71D0573E6EE874FEC39E2DF4C2BDB1DB74CB3DA0A9CACC4A435B0EC",
     "name": "Chain",
     "symbol": "XCN.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/xcn.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/xcn.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/chain-2"
+  },
+  {
+    "id": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
+    "name": "Chainlink",
+    "symbol": "LINK.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axllink.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/chainlink"
   },
   {
     "id": "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
     "name": "Cheqd",
     "symbol": "CHEQ",
     "decimals": "9",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/cheqd-network"
   },
   {
     "id": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
     "name": "Chihuahua",
     "symbol": "HUAHUA",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/huahua.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/huahua.png",
+    "coingecko": "https://www.coingecko.com/en/coins/chihuahua-token"
   },
   {
     "id": "ibc/23CA6C8D1AB2145DD13EB1E089A2E3F960DC298B468CCE034E19E5A78B61136E",
@@ -615,28 +347,48 @@
     "name": "Comdex",
     "symbol": "CMDX",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png",
+    "coingecko": "https://www.coingecko.com/en/coins/comdex"
   },
   {
     "id": "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
     "name": "Cronos",
     "symbol": "CRO",
     "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cryptoorgchain/images/cro.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cryptoorgchain/images/cro.png",
+    "coingecko": "https://www.coingecko.com/en/coins/crypto-com-chain"
   },
   {
     "id": "ibc/E09ED39F390EC51FA9F3F69BEA08B5BBE6A48B3057B2B1C3467FAAE9E58B021B",
     "name": "Cudos",
     "symbol": "CUDOS",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/cudos"
+  },
+  {
+    "id": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+    "name": "Dai Stablecoin",
+    "symbol": "DAI.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axldai.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/dai"
+  },
+  {
+    "id": "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5",
+    "name": "Dai Stablecoin",
+    "symbol": "DAI.grv",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gdai.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/dai"
   },
   {
     "id": "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84",
     "name": "Decentr",
     "symbol": "DEC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/decentr"
   },
   {
     "id": "ibc/1DE9A32D603EE05E9B8619DF24D90FD518C932AE0B5B3209A986B7262DBADE2A",
@@ -650,7 +402,8 @@
     "name": "Desmos",
     "symbol": "DSM",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/desmos"
   },
   {
     "id": "ibc/52E12CF5CA2BB903D84F5298B4BFD725D66CAB95E09AA4FC75B2904CA5485FEB",
@@ -664,7 +417,16 @@
     "name": "Dig Chain",
     "symbol": "DIG",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dig/images/dig.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dig/images/dig.png",
+    "coingecko": "https://www.coingecko.com/en/coins/dig-chain"
+  },
+  {
+    "id": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
+    "name": "DOT",
+    "symbol": "DOT.axl",
+    "decimals": "10",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axldot.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/polkadot"
   },
   {
     "id": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
@@ -674,18 +436,36 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dyson/images/dys.png"
   },
   {
+    "id": "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+    "name": "e-Money",
+    "symbol": "NGM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/e-money"
+  },
+  {
+    "id": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+    "name": "e-Money EUR",
+    "symbol": "EEUR",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/e-money-eur"
+  },
+  {
     "id": "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
     "name": "Echelon",
     "symbol": "ECH",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/echelon.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/echelon.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/echelon"
   },
   {
     "id": "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
     "name": "Echelon",
     "symbol": "ECH",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/echelon.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/echelon.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/echelon"
   },
   {
     "id": "ibc/051A38BBEF92B9D8293AFBE1FA293E704359E9CB28297A0FD5DBA3E9CCEE9AB1",
@@ -695,18 +475,28 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft85AE1716C5E39EA6D64BBD7898C3899A7B500626.png"
   },
   {
+    "id": "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
+    "name": "Evmos",
+    "symbol": "EVMOS",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/evmos"
+  },
+  {
     "id": "ibc/7CE5F388D661D82A0774E47B5129DA51CC7129BD1A70B5FA6BCEBB5B0A2FAEAF",
     "name": "Fanfury",
     "symbol": "FURY",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/fanfury.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/fanfury.png",
+    "coingecko": "https://www.coingecko.com/en/coins/fanfury"
   },
   {
     "id": "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
     "name": "Fetch.ai",
     "symbol": "FET",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/fetch-ai"
   },
   {
     "id": "ibc/239A507997222805E441956EBE8087D7E2D05D6535C6D4C75EF8DCF83B3DE1A1",
@@ -714,6 +504,14 @@
     "symbol": "FONTI",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft56664FC98A2CF5F4FBAC3566D1A11D891AD88305.png"
+  },
+  {
+    "id": "ibc/0E43EDE2E2A3AFA36D0CD38BDDC0B49FECA64FA426A82E102F304E430ECF46EE",
+    "name": "Frax",
+    "symbol": "FRAX.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlfrax.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/frax"
   },
   {
     "id": "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
@@ -755,14 +553,16 @@
     "name": "Hard",
     "symbol": "HARD",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/hard-protocol"
   },
   {
     "id": "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B",
     "name": "Hope Galaxy",
     "symbol": "HOPE",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/hope-galaxy"
   },
   {
     "id": "ibc/D3ADAF73F84CDF205BCB72C142FDAEEA2C612AB853CEE6D6C06F184FA38B1099",
@@ -779,6 +579,14 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/imversed/images/imversed.svg"
   },
   {
+    "id": "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
+    "name": "Injective",
+    "symbol": "INJ",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/injective-protocol"
+  },
+  {
     "id": "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
     "name": "Inter Protocol USD",
     "symbol": "IST",
@@ -786,18 +594,28 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/agoric/images/ist.png"
   },
   {
+    "id": "uion",
+    "name": "Ion",
+    "symbol": "ION",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/ion"
+  },
+  {
     "id": "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
     "name": "IRISnet",
     "symbol": "IRIS",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/iris-network"
   },
   {
     "id": "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B",
     "name": "IXO",
     "symbol": "IXO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.png",
+    "coingecko": "https://www.coingecko.com/en/coins/ixo"
   },
   {
     "id": "ibc/8E697BDABE97ACE8773C6DF7402B2D1D5104DD1EEABE12608E3469B7F64C15BA",
@@ -832,35 +650,40 @@
     "name": "Kava",
     "symbol": "KAVA",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/kava.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/kava.png",
+    "coingecko": "https://www.coingecko.com/en/coins/kava"
   },
   {
     "id": "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
     "name": "Ki",
     "symbol": "XKI",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/ki"
   },
   {
     "id": "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593",
     "name": "Konstellation",
     "symbol": "DARC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/darcmatter-coin"
   },
   {
     "id": "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB",
     "name": "Lambda",
     "symbol": "LAMB",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.png",
+    "coingecko": "https://www.coingecko.com/en/coins/lambda"
   },
   {
     "id": "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
     "name": "LikeCoin",
     "symbol": "LIKE",
     "decimals": "9",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/likecoin"
   },
   {
     "id": "ibc/022A879A5301CBCACF96216C967805F15C33C615B74DC7236027C1BA1BF664FF",
@@ -874,7 +697,8 @@
     "name": "Lum",
     "symbol": "LUM",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/images/lum.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/images/lum.png",
+    "coingecko": "https://www.coingecko.com/en/coins/lum-network"
   },
   {
     "id": "ibc/FFA652599C77E853F017193E36B5AB2D4D9AFC4B54721A74904F80C9236BF3B7",
@@ -888,21 +712,32 @@
     "name": "Luna Classic",
     "symbol": "LUNC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/terra-luna"
   },
   {
     "id": "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
     "name": "Lvn",
     "symbol": "LVN",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/lvn.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/lvn.png",
+    "coingecko": "https://www.coingecko.com/en/coins/lvn"
+  },
+  {
+    "id": "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3",
+    "name": "Maker",
+    "symbol": "MKR.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlmkr.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/maker"
   },
   {
     "id": "ibc/F6B691D5F7126579DDC87357B09D653B47FDCE0A3383FF33C8D8B544FE29A8A6",
     "name": "Marble",
     "symbol": "MARBLE",
     "decimals": "3",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/marble"
   },
   {
     "id": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
@@ -930,7 +765,8 @@
     "name": "MediBloc",
     "symbol": "MED",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/panacea/images/med.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/panacea/images/med.png",
+    "coingecko": "https://www.coingecko.com/en/coins/medibloc"
   },
   {
     "id": "ibc/67C89B8B0A70C08F093C909A4DD996DD10E0494C87E28FD9A551697BF173D4CA",
@@ -944,7 +780,8 @@
     "name": "Microtick",
     "symbol": "TICK",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/microtick"
   },
   {
     "id": "ibc/6B982170CE024689E8DD0E7555B129B488005130D4EDA426733D552D10B36D8F",
@@ -959,6 +796,14 @@
     "symbol": "N43",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft387C1C279D962ED80C09C1D592A92C4275FD7C5D.png"
+  },
+  {
+    "id": "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
+    "name": "Neta",
+    "symbol": "NETA",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.png",
+    "coingecko": "https://www.coingecko.com/en/coins/neta"
   },
   {
     "id": "ibc/423967B46B1A51D78619085105B04FCFA14F7CBC0BE7539A316B2DCDFC7D8C07",
@@ -986,14 +831,24 @@
     "name": "ODIN",
     "symbol": "ODIN",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/odin-protocol"
   },
   {
     "id": "ibc/161D7D62BAB3B9C39003334F1671208F43C06B643CC9EDBBE82B64793C857F1D",
     "name": "Oraichain",
     "symbol": "ORAI",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/oraichain-token"
+  },
+  {
+    "id": "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+    "name": "Persistence",
+    "symbol": "XPRT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/persistence"
   },
   {
     "id": "ibc/B1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF",
@@ -1007,14 +862,24 @@
     "name": "POSTHUMAN",
     "symbol": "PHMN",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/phmn.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/phmn.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/posthuman"
   },
   {
     "id": "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
     "name": "Provenance",
     "symbol": "HASH",
     "decimals": "9",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/hash.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/hash.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/provenance-blockchain"
+  },
+  {
+    "id": "ibc/8061A06D3BD4D52C4A28FFECF7150D370393AF0BA661C3776C54FF32836C3961",
+    "name": "PSTAKE",
+    "symbol": "PSTAKE",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/pstake-finance"
   },
   {
     "id": "ibc/CAA179E40F0266B0B29FB5EAA288FB9212E628822265D4141EBD1C47C3CBFCBC",
@@ -1031,18 +896,27 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/ft24C9FA4F10B0F235F4A815B15FC774E046A2B2EB.png"
   },
   {
+    "id": "ibc/46C83BB054E12E189882B5284542DB605D94C99827E367C9192CF0579CD5BC83",
+    "name": "Quicksilver Liquid Staked STARS",
+    "symbol": "qSTARS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/quicksilver/images/qstars.svg"
+  },
+  {
     "id": "ibc/6BDB4C8CCD45033F9604E4B93ED395008A753E01EECD6992E7D1EA23D9D3B788",
     "name": "Racoon",
     "symbol": "RAC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/racoon"
   },
   {
     "id": "ibc/BD796662F8825327D41C96355DF62045A5BA225BAE31C0A86289B9D88ED3F44E",
     "name": "Rai Reflex Index",
     "symbol": "RAI.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/rai.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/rai.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/rai"
   },
   {
     "id": "ibc/56C276FC136E239449DCE664292DBEEF5795C4EF4B5B35DB98BD1C0948274867",
@@ -1056,56 +930,72 @@
     "name": "Rebuschain",
     "symbol": "REBUS",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/rebus"
   },
   {
     "id": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
     "name": "Regen Network",
     "symbol": "REGEN",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/regen.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/regen.png",
+    "coingecko": "https://www.coingecko.com/en/coins/regen"
   },
   {
     "id": "ibc/D0E5BF2940FB58D9B283A339032DE88111407AAD7D94A7F1F3EB78874F8616D4",
     "name": "SCRT Staking Derivatives",
     "symbol": "stkd-SCRT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/stkd-scrt.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/stkd-scrt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/stkd-scrt"
   },
   {
     "id": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
     "name": "Sentinel",
     "symbol": "DVPN",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/images/dvpn.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/images/dvpn.png",
+    "coingecko": "https://www.coingecko.com/en/coins/sentinel"
   },
   {
     "id": "ibc/71055835C7639739EAE03AACD1324FE162DBA41D09F197CB72D966D014225B1C",
     "name": "Shade",
     "symbol": "SHD",
     "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/shd.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/shd.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/shade-protocol"
   },
   {
     "id": "ibc/7ED954CFFFC06EE8419387F3FC688837FF64EF264DE14219935F724EEEDBF8D3",
     "name": "Shentu",
     "symbol": "CTK",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/images/ctk.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/images/ctk.png",
+    "coingecko": "https://www.coingecko.com/en/coins/certik"
   },
   {
     "id": "ibc/19305E20681911F14D1FB275E538CDE524C3BF88CF9AE5D5F78F4D4DA05E85B2",
     "name": "Shiba Inu",
     "symbol": "SHIB.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/shib.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/shib.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/shiba-inu"
   },
   {
     "id": "ibc/9A8A93D04917A149C8AC7C16D3DA8F470D59E8D867499C4DA97450E1D7363213",
     "name": "SIENNA",
     "symbol": "SIENNA",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/sienna.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/sienna.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/sienna"
+  },
+  {
+    "id": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
+    "name": "Sifchain Rowan",
+    "symbol": "ROWAN",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/sifchain"
   },
   {
     "id": "ibc/C3FC4DED273E7D1DD2E7BAA3317EC9A53CD3252B577AA33DC00D9DF2BDF3ED5C",
@@ -1115,18 +1005,97 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/solar.svg"
   },
   {
+    "id": "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
+    "name": "Sommelier",
+    "symbol": "SOMM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/sommelier"
+  },
+  {
+    "id": "ibc/C2DF5C3949CA835B221C575625991F09BAB4E48FB9C11A4EE357194F736111E3",
+    "name": "StakeEasy bJUNO",
+    "symbol": "BJUNO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/bjuno.svg"
+  },
+  {
+    "id": "ibc/18A676A074F73B9B42DA4F9DFC8E5AEF334C9A6636DDEC8D34682F52F1DECDF6",
+    "name": "StakeEasy SEASY",
+    "symbol": "SEASY",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/seasy"
+  },
+  {
+    "id": "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B",
+    "name": "StakeEasy seJUNO",
+    "symbol": "SEJUNO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/sejuno.svg"
+  },
+  {
+    "id": "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
+    "name": "Stargaze",
+    "symbol": "STARS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png",
+    "coingecko": "https://www.coingecko.com/en/coins/stargaze"
+  },
+  {
     "id": "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
     "name": "Starname",
     "symbol": "IOV",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/starname"
+  },
+  {
+    "id": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
+    "name": "stATOM",
+    "symbol": "stATOM",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/stride-staked-atom"
+  },
+  {
+    "id": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
+    "name": "Stride",
+    "symbol": "STRD",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/stride",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/stride"
+  },
+  {
+    "id": "ibc/84502A75BCA4A5F68D464C00B3F610CE2585847D59B52E5FFB7C3C9D2DDCD3FE",
+    "name": "Stride Juno",
+    "symbol": "stJUNO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.svg"
+  },
+  {
+    "id": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
+    "name": "Stride Staked osmo",
+    "symbol": "stOSMO",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/stride-staked-osmo"
+  },
+  {
+    "id": "ibc/5DD1F95ED336014D00CE2520977EC71566D282F9749170ADC83A392E0EA7426A",
+    "name": "Stride Staked Stars",
+    "symbol": "stSTARS",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/ststars.svg"
   },
   {
     "id": "ibc/70CF1A54E23EA4E480DEDA9E12082D3FD5684C3483CBDCE190C5C807227688C5",
     "name": "Swap",
     "symbol": "SWP",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/kava-swap"
   },
   {
     "id": "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
@@ -1140,14 +1109,32 @@
     "name": "TerraClassicKRW",
     "symbol": "KRTC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/krt.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/krt.png",
+    "coingecko": "https://www.coingecko.com/en/coins/terra-krw"
   },
   {
     "id": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
     "name": "TerraClassicUSD",
     "symbol": "USTC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/ust.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/ust.png",
+    "coingecko": "https://www.coingecko.com/en/coins/terrausd"
+  },
+  {
+    "id": "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
+    "name": "Tether USD",
+    "symbol": "USDT.grv",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/usd-coin"
+  },
+  {
+    "id": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
+    "name": "Tether USD",
+    "symbol": "USDT.axl",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlusdt.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/tether"
   },
   {
     "id": "ibc/1E09CB0F506ACF12FDE4683FB6B34DA62FB4BE122641E0D93AAF98A87675676C",
@@ -1161,28 +1148,48 @@
     "name": "Umee",
     "symbol": "UMEE",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/images/umee.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/images/umee.png",
+    "coingecko": "https://www.coingecko.com/en/coins/umee"
   },
   {
     "id": "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
     "name": "Unification",
     "symbol": "FUND",
     "decimals": "9",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/unification/images/fund.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/unification/images/fund.png",
+    "coingecko": "https://www.coingecko.com/en/coins/unification"
   },
   {
     "id": "ibc/AE2719773D6FCDD05AC17B1ED63F672F5F9D84144A61965F348C86C2A83AD161",
     "name": "Uniswap",
     "symbol": "UNI.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/uni.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/uni.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/uniswap"
+  },
+  {
+    "id": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
+    "name": "USD Coin",
+    "symbol": "USDC.grv",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdc.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/usd-coin"
+  },
+  {
+    "id": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+    "name": "USD Coin",
+    "symbol": "USDC.axl",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlusdc.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/usd-coin"
   },
   {
     "id": "ibc/C78F65E1648A3DFE0BAEB6C4CDA69CC2A75437F1793C0E6386DFDA26393790AE",
     "name": "USDX",
     "symbol": "USDX",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/usdx.png"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/usdx.png",
+    "coingecko": "https://www.coingecko.com/en/coins/usdx"
   },
   {
     "id": "ibc/8A07D4BD40E0F44ECFDF360F7EA7008B288926FB87C54489FE54DB81A5340E0C",
@@ -1196,7 +1203,8 @@
     "name": "Vidulum",
     "symbol": "VDL",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/vidulum/images/vdl.svg"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/vidulum/images/vdl.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/vidulum"
   },
   {
     "id": "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
@@ -1206,10 +1214,73 @@
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/avalanche/images/avax.png"
   },
   {
+    "id": "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796",
+    "name": "Wrapped Bitcoin",
+    "symbol": "WBTC.grv",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gwbtc.png",
+    "coingecko": "https://www.coingecko.com/en/coins/wrapped-bitcoin"
+  },
+  {
+    "id": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
+    "name": "Wrapped Bitcoin",
+    "symbol": "WBTC.axl",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlwbtc.png",
+    "coingecko": "https://www.coingecko.com/en/coins/wrapped-bitcoin"
+  },
+  {
+    "id": "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
+    "name": "Wrapped BNB",
+    "symbol": "WBNB.axl",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchainoonbeam/images/wbnb.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/wbnb"
+  },
+  {
+    "id": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
+    "name": "Wrapped Ether",
+    "symbol": "WETH.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlweth.png",
+    "coingecko": "https://www.coingecko.com/en/coins/weth"
+  },
+  {
+    "id": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
+    "name": "Wrapped Ethereum",
+    "symbol": "WETH.grv",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gweth.png",
+    "coingecko": "https://www.coingecko.com/en/coins/weth"
+  },
+  {
     "id": "ibc/5E2DFDF1734137302129EA1C1BA21A580F96F778D4F021815EA4F6DB378DA1A4",
     "name": "Wrapped FTM",
     "symbol": "wFTM",
     "decimals": "18",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/fantom/images/ftm.png"
+  },
+  {
+    "id": "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",
+    "name": "Wrapped GLMR",
+    "symbol": "WGLMR.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/moonbeam/images/glmr.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/wrapped-moonbeam"
+  },
+  {
+    "id": "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
+    "name": "Wrapped Matic",
+    "symbol": "WMATIC.axl",
+    "decimals": "18",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wmatic-wei L@3x.png",
+    "coingecko": "https://www.coingecko.com/en/coins/wmatic"
+  },
+  {
+    "id": "ibc/2FBAC4BF296D7844796844B35978E5899984BA5A6314B2DD8F83C215550010B3",
+    "name": "Wynd DAO Governance Token",
+    "symbol": "WYND",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/wynd.svg"
   }
 ]

--- a/osmosis/asset.json
+++ b/osmosis/asset.json
@@ -5,8 +5,7 @@
     "name": "Cosmos",
     "symbol": "ATOM",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/cosmos"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cosmoshub/images/atom.svg"
   },
   {
     "id": "ibc/5A7C219BA5F7582B99629BA3B2A01A61BFDA0F6FD1FE95B5366F7334C4BC0580",
@@ -14,8 +13,7 @@
     "name": "Crescent",
     "symbol": "CRE",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/crescent-network"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/crescent/images/cre.svg"
   },
   {
     "id": "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
@@ -23,8 +21,7 @@
     "name": "Graviton",
     "symbol": "GRAV",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/graviton"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/grav.svg"
   },
   {
     "id": "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
@@ -32,8 +29,7 @@
     "name": "Juno",
     "symbol": "JUNO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/juno-network"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/juno.svg"
   },
   {
     "id": "ibc/BB6BCDB515050BAE97516111873CCD7BCF1FD0CCB723CC12F3C4F704D6C646CE",
@@ -41,8 +37,7 @@
     "name": "Kuji",
     "symbol": "KUJI",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png",
-    "coingecko": "https://www.coingecko.com/en/coins/kujira"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/kuji.png"
   },
   {
     "id": "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
@@ -50,8 +45,7 @@
     "name": "USK",
     "symbol": "USK",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/usk.png",
-    "coingecko": "https://www.coingecko.com/en/coins/usk"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kujira/images/usk.png"
   },
   {
     "id": "uosmo",
@@ -59,8 +53,7 @@
     "name": "Osmosis",
     "symbol": "OSMO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/osmosis"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.svg"
   },
   {
     "id": "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
@@ -68,8 +61,7 @@
     "name": "Secret Network",
     "symbol": "SCRT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/secret"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/scrt.svg"
   },
   {
     "id": "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
@@ -77,8 +69,7 @@
     "name": "Luna",
     "symbol": "LUNA",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png",
-    "coingecko": "https://www.coingecko.com/en/coins/terra-luna-2"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png"
   },
   {
     "id": "ibc/B797E4F42CD33C50511B341E50C5CC0E8EF0D93B1E1247ABAA071583B8619202",
@@ -92,16 +83,14 @@
     "name": "Aave",
     "symbol": "AAVE.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/aave.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/aave"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/aave.svg"
   },
   {
     "id": "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
     "name": "Acre",
     "symbol": "ACRE",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/acre.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/arable-protocol"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/acre.svg"
   },
   {
     "id": "ibc/7ABF696369EFB3387DF22B6A24204459FE5EFD010220E8E5618DC49DB877047B",
@@ -129,16 +118,14 @@
     "name": "Akash Network",
     "symbol": "AKT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/akash-network"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg"
   },
   {
     "id": "ibc/A6383B6CF5EA23E067666C06BC34E2A96869927BD9744DC0C1643E589C710AA3",
     "name": "Alter",
     "symbol": "ALTER",
     "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/alter.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/alter"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/alter.svg"
   },
   {
     "id": "ibc/18A1B70E3205A48DE8590C0D11030E7146CDBF1048789261D53FFFD7527F8B55",
@@ -159,88 +146,77 @@
     "name": "ApeCoin",
     "symbol": "APE.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/ape.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/apecoin"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/ape.svg"
   },
   {
     "id": "ibc/5D270A584B1078FBE07D14570ED5E88EC1FEDA8518B76C322606291E6FD8286F",
     "name": "Arable USD",
     "symbol": "arUSD",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/arusd.png",
-    "coingecko": "https://www.coingecko.com/en/coins/arable-usd"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/acrechain/images/arusd.png"
   },
   {
     "id": "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
     "name": "AssetMantle",
     "symbol": "MNTL",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/images/mntl.png",
-    "coingecko": "https://www.coingecko.com/en/coins/assetmantle"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/assetmantle/images/mntl.png"
   },
   {
     "id": "ibc/2716E3F2E146664BEFA9217F1A03BFCEDBCD5178B3C71CACB1A0D7584451D219",
     "name": "Atolo",
     "symbol": "ATOLO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/rizon"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rizon/images/atolo.svg"
   },
   {
     "id": "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
     "name": "Axelar",
     "symbol": "AXL",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/axelarnetwork/axelar-docs/main/public/images/assets/axl.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/axelar"
+    "icon": "https://raw.githubusercontent.com/axelarnetwork/axelar-docs/main/public/images/assets/axl.svg"
   },
   {
     "id": "ibc/6C0CB8653012DC2BC1820FD0B6B3AFF8A07D18630BDAEE066FEFB2D92F477C24",
     "name": "Axie Infinity Shard",
     "symbol": "AXS.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/axs.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/axie-infinity"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/axs.svg"
   },
   {
     "id": "ibc/F867AE2112EFE646EC71A25CD2DFABB8927126AC1E19F1BBF0FF693A4ECA05DE",
     "name": "Band Protocol",
     "symbol": "BAND",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/band-protocol"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bandchain/images/band.svg"
   },
   {
     "id": "ibc/C822645522FC3EECF817609AA38C24B64D04F5C267A23BCCF8F2E3BC5755FA88",
     "name": "BeeZee",
     "symbol": "BZE",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/bze.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/bzedge"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/beezee/images/bze.svg"
   },
   {
     "id": "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
     "name": "Binance USD",
     "symbol": "BUSD.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.png",
-    "coingecko": "https://www.coingecko.com/en/coins/binance-usd"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/busd.png"
   },
   {
     "id": "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5",
     "name": "BitCanna",
     "symbol": "BCNA",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/bitcanna"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitcanna/images/bcna.svg"
   },
   {
     "id": "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
     "name": "BitSong",
     "symbol": "BTSG",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/bitsong"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bitsong/images/btsg.svg"
   },
   {
     "id": "ibc/B3FB7128CE957DE1ADB687A919AA0786C77C62FB1280C07CDD78AEA032D56853",
@@ -261,32 +237,28 @@
     "name": "Bostrom",
     "symbol": "BOOT",
     "decimals": "0",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/boot.png",
-    "coingecko": "https://www.coingecko.com/en/coins/bostrom"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/bostrom/images/boot.png"
   },
   {
     "id": "ibc/1FBA9E763B8679BEF7BAAAF2D16BCA78C3B297D226C3F31312C769D7B8F992D8",
     "name": "Button",
     "symbol": "BUTT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/butt.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/buttcoin-2"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/butt.svg"
   },
   {
     "id": "ibc/47CAF2DB8C016FAC960F33BC492FD8E454593B65CC59D70FA9D9F30424F9C32F",
     "name": "Canto",
     "symbol": "CANTO",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/canto/images/canto.png",
-    "coingecko": "https://www.coingecko.com/en/coins/canto"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/canto/images/canto.png"
   },
   {
     "id": "ibc/8FEFAE6AECF6E2A255585617F781F35A8D5709A545A804482A261C0C9548A9D3",
     "name": "Carbon",
     "symbol": "SWTH",
     "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/switcheo"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/carbon/images/swth.svg"
   },
   {
     "id": "ibc/C1CEF00F016FE89EA6E5B07DA895AACD91B0AAD69A991033D846B988AD4FB69D",
@@ -300,40 +272,35 @@
     "name": "Cerberus",
     "symbol": "CRBRUS",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/images/crbrus.png",
-    "coingecko": "https://www.coingecko.com/en/coins/cerberus-2"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cerberus/images/crbrus.png"
   },
   {
     "id": "ibc/B901BEC1B71D0573E6EE874FEC39E2DF4C2BDB1DB74CB3DA0A9CACC4A435B0EC",
     "name": "Chain",
     "symbol": "XCN.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/xcn.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/chain-2"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/xcn.svg"
   },
   {
     "id": "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
     "name": "Chainlink",
     "symbol": "LINK.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axllink.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/chainlink"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axllink.svg"
   },
   {
     "id": "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
     "name": "Cheqd",
     "symbol": "CHEQ",
     "decimals": "9",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/cheqd-network"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cheqd/images/cheq.svg"
   },
   {
     "id": "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
     "name": "Chihuahua",
     "symbol": "HUAHUA",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/huahua.png",
-    "coingecko": "https://www.coingecko.com/en/coins/chihuahua-token"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/chihuahua/images/huahua.png"
   },
   {
     "id": "ibc/23CA6C8D1AB2145DD13EB1E089A2E3F960DC298B468CCE034E19E5A78B61136E",
@@ -347,48 +314,42 @@
     "name": "Comdex",
     "symbol": "CMDX",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png",
-    "coingecko": "https://www.coingecko.com/en/coins/comdex"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/comdex/images/cmdx.png"
   },
   {
     "id": "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
     "name": "Cronos",
     "symbol": "CRO",
     "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cryptoorgchain/images/cro.png",
-    "coingecko": "https://www.coingecko.com/en/coins/crypto-com-chain"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cryptoorgchain/images/cro.png"
   },
   {
     "id": "ibc/E09ED39F390EC51FA9F3F69BEA08B5BBE6A48B3057B2B1C3467FAAE9E58B021B",
     "name": "Cudos",
     "symbol": "CUDOS",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/cudos"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/cudos/images/cudos.svg"
   },
   {
     "id": "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
     "name": "Dai Stablecoin",
     "symbol": "DAI.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axldai.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/dai"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axldai.svg"
   },
   {
     "id": "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5",
     "name": "Dai Stablecoin",
     "symbol": "DAI.grv",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gdai.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/dai"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gdai.svg"
   },
   {
     "id": "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84",
     "name": "Decentr",
     "symbol": "DEC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/decentr"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/decentr/images/dec.svg"
   },
   {
     "id": "ibc/1DE9A32D603EE05E9B8619DF24D90FD518C932AE0B5B3209A986B7262DBADE2A",
@@ -402,8 +363,7 @@
     "name": "Desmos",
     "symbol": "DSM",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/desmos"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/desmos/images/dsm.svg"
   },
   {
     "id": "ibc/52E12CF5CA2BB903D84F5298B4BFD725D66CAB95E09AA4FC75B2904CA5485FEB",
@@ -417,16 +377,14 @@
     "name": "Dig Chain",
     "symbol": "DIG",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dig/images/dig.png",
-    "coingecko": "https://www.coingecko.com/en/coins/dig-chain"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/dig/images/dig.png"
   },
   {
     "id": "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
     "name": "DOT",
     "symbol": "DOT.axl",
     "decimals": "10",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axldot.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/polkadot"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axldot.svg"
   },
   {
     "id": "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
@@ -440,32 +398,28 @@
     "name": "e-Money",
     "symbol": "NGM",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/e-money"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/ngm.svg"
   },
   {
     "id": "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
     "name": "e-Money EUR",
     "symbol": "EEUR",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/e-money-eur"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/emoney/images/eeur.svg"
   },
   {
     "id": "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
     "name": "Echelon",
     "symbol": "ECH",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/echelon.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/echelon"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/echelon.svg"
   },
   {
     "id": "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
     "name": "Echelon",
     "symbol": "ECH",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/echelon.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/echelon"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/echelon/images/echelon.svg"
   },
   {
     "id": "ibc/051A38BBEF92B9D8293AFBE1FA293E704359E9CB28297A0FD5DBA3E9CCEE9AB1",
@@ -479,24 +433,21 @@
     "name": "Evmos",
     "symbol": "EVMOS",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/evmos"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/evmos/images/evmos.svg"
   },
   {
     "id": "ibc/7CE5F388D661D82A0774E47B5129DA51CC7129BD1A70B5FA6BCEBB5B0A2FAEAF",
     "name": "Fanfury",
     "symbol": "FURY",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/fanfury.png",
-    "coingecko": "https://www.coingecko.com/en/coins/fanfury"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/fanfury.png"
   },
   {
     "id": "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
     "name": "Fetch.ai",
     "symbol": "FET",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/fetch-ai"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/fetchhub/images/fet.svg"
   },
   {
     "id": "ibc/239A507997222805E441956EBE8087D7E2D05D6535C6D4C75EF8DCF83B3DE1A1",
@@ -510,8 +461,7 @@
     "name": "Frax",
     "symbol": "FRAX.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlfrax.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/frax"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlfrax.svg"
   },
   {
     "id": "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
@@ -553,16 +503,14 @@
     "name": "Hard",
     "symbol": "HARD",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/hard-protocol"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/hard.svg"
   },
   {
     "id": "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B",
     "name": "Hope Galaxy",
     "symbol": "HOPE",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/hope-galaxy"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/hope.svg"
   },
   {
     "id": "ibc/D3ADAF73F84CDF205BCB72C142FDAEEA2C612AB853CEE6D6C06F184FA38B1099",
@@ -583,8 +531,7 @@
     "name": "Injective",
     "symbol": "INJ",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/injective-protocol"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/injective/images/inj.svg"
   },
   {
     "id": "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
@@ -598,24 +545,21 @@
     "name": "Ion",
     "symbol": "ION",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/ion"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/ion.svg"
   },
   {
     "id": "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
     "name": "IRISnet",
     "symbol": "IRIS",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/iris-network"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/irisnet/images/iris.svg"
   },
   {
     "id": "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B",
     "name": "IXO",
     "symbol": "IXO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.png",
-    "coingecko": "https://www.coingecko.com/en/coins/ixo"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/impacthub/images/ixo.png"
   },
   {
     "id": "ibc/8E697BDABE97ACE8773C6DF7402B2D1D5104DD1EEABE12608E3469B7F64C15BA",
@@ -650,40 +594,35 @@
     "name": "Kava",
     "symbol": "KAVA",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/kava.png",
-    "coingecko": "https://www.coingecko.com/en/coins/kava"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/kava.png"
   },
   {
     "id": "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
     "name": "Ki",
     "symbol": "XKI",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/ki"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/xki.svg"
   },
   {
     "id": "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593",
     "name": "Konstellation",
     "symbol": "DARC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/darcmatter-coin"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/konstellation/images/darc.svg"
   },
   {
     "id": "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB",
     "name": "Lambda",
     "symbol": "LAMB",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.png",
-    "coingecko": "https://www.coingecko.com/en/coins/lambda"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lambda/images/lambda.png"
   },
   {
     "id": "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
     "name": "LikeCoin",
     "symbol": "LIKE",
     "decimals": "9",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/likecoin"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/likecoin/images/like.svg"
   },
   {
     "id": "ibc/022A879A5301CBCACF96216C967805F15C33C615B74DC7236027C1BA1BF664FF",
@@ -697,8 +636,7 @@
     "name": "Lum",
     "symbol": "LUM",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/images/lum.png",
-    "coingecko": "https://www.coingecko.com/en/coins/lum-network"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/lumnetwork/images/lum.png"
   },
   {
     "id": "ibc/FFA652599C77E853F017193E36B5AB2D4D9AFC4B54721A74904F80C9236BF3B7",
@@ -712,32 +650,28 @@
     "name": "Luna Classic",
     "symbol": "LUNC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/terra-luna"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/luna.svg"
   },
   {
     "id": "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
     "name": "Lvn",
     "symbol": "LVN",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/lvn.png",
-    "coingecko": "https://www.coingecko.com/en/coins/lvn"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kichain/images/lvn.png"
   },
   {
     "id": "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3",
     "name": "Maker",
     "symbol": "MKR.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlmkr.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/maker"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlmkr.svg"
   },
   {
     "id": "ibc/F6B691D5F7126579DDC87357B09D653B47FDCE0A3383FF33C8D8B544FE29A8A6",
     "name": "Marble",
     "symbol": "MARBLE",
     "decimals": "3",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/marble"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/marble.svg"
   },
   {
     "id": "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
@@ -765,8 +699,7 @@
     "name": "MediBloc",
     "symbol": "MED",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/panacea/images/med.png",
-    "coingecko": "https://www.coingecko.com/en/coins/medibloc"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/panacea/images/med.png"
   },
   {
     "id": "ibc/67C89B8B0A70C08F093C909A4DD996DD10E0494C87E28FD9A551697BF173D4CA",
@@ -780,8 +713,7 @@
     "name": "Microtick",
     "symbol": "TICK",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/microtick"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/microtick/images/tick.svg"
   },
   {
     "id": "ibc/6B982170CE024689E8DD0E7555B129B488005130D4EDA426733D552D10B36D8F",
@@ -802,8 +734,7 @@
     "name": "Neta",
     "symbol": "NETA",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.png",
-    "coingecko": "https://www.coingecko.com/en/coins/neta"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/neta.png"
   },
   {
     "id": "ibc/423967B46B1A51D78619085105B04FCFA14F7CBC0BE7539A316B2DCDFC7D8C07",
@@ -831,24 +762,21 @@
     "name": "ODIN",
     "symbol": "ODIN",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/odin-protocol"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/odin/images/odin.svg"
   },
   {
     "id": "ibc/161D7D62BAB3B9C39003334F1671208F43C06B643CC9EDBBE82B64793C857F1D",
     "name": "Oraichain",
     "symbol": "ORAI",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/oraichain-token"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/oraichain/images/orai-white.svg"
   },
   {
     "id": "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
     "name": "Persistence",
     "symbol": "XPRT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/persistence"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/xprt.svg"
   },
   {
     "id": "ibc/B1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF",
@@ -862,24 +790,21 @@
     "name": "POSTHUMAN",
     "symbol": "PHMN",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/phmn.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/posthuman"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/phmn.svg"
   },
   {
     "id": "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
     "name": "Provenance",
     "symbol": "HASH",
     "decimals": "9",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/hash.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/provenance-blockchain"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/provenance/images/hash.svg"
   },
   {
     "id": "ibc/8061A06D3BD4D52C4A28FFECF7150D370393AF0BA661C3776C54FF32836C3961",
     "name": "PSTAKE",
     "symbol": "PSTAKE",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/pstake-finance"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/persistence/images/pstake.svg"
   },
   {
     "id": "ibc/CAA179E40F0266B0B29FB5EAA288FB9212E628822265D4141EBD1C47C3CBFCBC",
@@ -907,16 +832,14 @@
     "name": "Racoon",
     "symbol": "RAC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/racoon"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/rac.svg"
   },
   {
     "id": "ibc/BD796662F8825327D41C96355DF62045A5BA225BAE31C0A86289B9D88ED3F44E",
     "name": "Rai Reflex Index",
     "symbol": "RAI.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/rai.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/rai"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/rai.svg"
   },
   {
     "id": "ibc/56C276FC136E239449DCE664292DBEEF5795C4EF4B5B35DB98BD1C0948274867",
@@ -930,72 +853,63 @@
     "name": "Rebuschain",
     "symbol": "REBUS",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/rebus"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/rebus/images/rebus.svg"
   },
   {
     "id": "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
     "name": "Regen Network",
     "symbol": "REGEN",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/regen.png",
-    "coingecko": "https://www.coingecko.com/en/coins/regen"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/regen/images/regen.png"
   },
   {
     "id": "ibc/D0E5BF2940FB58D9B283A339032DE88111407AAD7D94A7F1F3EB78874F8616D4",
     "name": "SCRT Staking Derivatives",
     "symbol": "stkd-SCRT",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/stkd-scrt.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/stkd-scrt"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/stkd-scrt.svg"
   },
   {
     "id": "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
     "name": "Sentinel",
     "symbol": "DVPN",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/images/dvpn.png",
-    "coingecko": "https://www.coingecko.com/en/coins/sentinel"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sentinel/images/dvpn.png"
   },
   {
     "id": "ibc/71055835C7639739EAE03AACD1324FE162DBA41D09F197CB72D966D014225B1C",
     "name": "Shade",
     "symbol": "SHD",
     "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/shd.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/shade-protocol"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/shd.svg"
   },
   {
     "id": "ibc/7ED954CFFFC06EE8419387F3FC688837FF64EF264DE14219935F724EEEDBF8D3",
     "name": "Shentu",
     "symbol": "CTK",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/images/ctk.png",
-    "coingecko": "https://www.coingecko.com/en/coins/certik"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/shentu/images/ctk.png"
   },
   {
     "id": "ibc/19305E20681911F14D1FB275E538CDE524C3BF88CF9AE5D5F78F4D4DA05E85B2",
     "name": "Shiba Inu",
     "symbol": "SHIB.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/shib.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/shiba-inu"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/shib.svg"
   },
   {
     "id": "ibc/9A8A93D04917A149C8AC7C16D3DA8F470D59E8D867499C4DA97450E1D7363213",
     "name": "SIENNA",
     "symbol": "SIENNA",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/sienna.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/sienna"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/secretnetwork/images/sienna.svg"
   },
   {
     "id": "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
     "name": "Sifchain Rowan",
     "symbol": "ROWAN",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/sifchain"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sifchain/images/rowan.svg"
   },
   {
     "id": "ibc/C3FC4DED273E7D1DD2E7BAA3317EC9A53CD3252B577AA33DC00D9DF2BDF3ED5C",
@@ -1009,8 +923,7 @@
     "name": "Sommelier",
     "symbol": "SOMM",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/sommelier"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/sommelier/images/somm.svg"
   },
   {
     "id": "ibc/C2DF5C3949CA835B221C575625991F09BAB4E48FB9C11A4EE357194F736111E3",
@@ -1024,12 +937,7 @@
     "name": "StakeEasy SEASY",
     "symbol": "SEASY",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.svg",
-    "website": "https://stakeeasy.finance/",
-    "telegram": "https://t.me/StakeEasyProtocol",
-    "twitter": "https://twitter.com/StakeEasy",
-    "discord": "https://discord.gg/gKjzApDstD",
-    "coingecko": "https://www.coingecko.com/en/coins/seasy"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/juno/images/seasy.svg"
   },
   {
     "id": "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B",
@@ -1043,54 +951,42 @@
     "name": "Stargaze",
     "symbol": "STARS",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png",
-    "coingecko": "https://www.coingecko.com/en/coins/stargaze"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stargaze/images/stars.png"
   },
   {
     "id": "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
     "name": "Starname",
     "symbol": "IOV",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/starname"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/starname/images/iov.svg"
   },
   {
     "id": "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
     "name": "stATOM",
     "symbol": "stATOM",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/stride-staked-atom"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/statom.svg"
   },
   {
     "id": "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
     "name": "Stride",
     "symbol": "STRD",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg",
-    "website": "https://stride.zone/",
-    "telegram": "https://t.me/stride_official",
-    "twitter": "https://twitter.com/stride_zone",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/stride",
-    "coingecko": "https://www.coingecko.com/en/coins/stride"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg"
   },
   {
     "id": "ibc/84502A75BCA4A5F68D464C00B3F610CE2585847D59B52E5FFB7C3C9D2DDCD3FE",
     "name": "Stride Juno",
     "symbol": "stJUNO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.svg",
-    "website": "https://stride.zone/",
-    "telegram": "https://t.me/stride_official",
-    "twitter": "https://twitter.com/stride_zone"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stjuno.svg"
   },
   {
     "id": "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
     "name": "Stride Staked osmo",
     "symbol": "stOSMO",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/stride-staked-osmo"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/stosmo.svg"
   },
   {
     "id": "ibc/5DD1F95ED336014D00CE2520977EC71566D282F9749170ADC83A392E0EA7426A",
@@ -1104,8 +1000,7 @@
     "name": "Swap",
     "symbol": "SWP",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/kava-swap"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/swp.svg"
   },
   {
     "id": "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
@@ -1119,32 +1014,28 @@
     "name": "TerraClassicKRW",
     "symbol": "KRTC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/krt.png",
-    "coingecko": "https://www.coingecko.com/en/coins/terra-krw"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/krt.png"
   },
   {
     "id": "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
     "name": "TerraClassicUSD",
     "symbol": "USTC",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/ust.png",
-    "coingecko": "https://www.coingecko.com/en/coins/terrausd"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra/images/ust.png"
   },
   {
     "id": "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
     "name": "Tether USD",
     "symbol": "USDT.grv",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdt.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/usd-coin"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdt.svg"
   },
   {
     "id": "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
     "name": "Tether USD",
     "symbol": "USDT.axl",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlusdt.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/tether"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlusdt.svg"
   },
   {
     "id": "ibc/1E09CB0F506ACF12FDE4683FB6B34DA62FB4BE122641E0D93AAF98A87675676C",
@@ -1158,48 +1049,42 @@
     "name": "Umee",
     "symbol": "UMEE",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/images/umee.png",
-    "coingecko": "https://www.coingecko.com/en/coins/umee"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/umee/images/umee.png"
   },
   {
     "id": "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
     "name": "Unification",
     "symbol": "FUND",
     "decimals": "9",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/unification/images/fund.png",
-    "coingecko": "https://www.coingecko.com/en/coins/unification"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/unification/images/fund.png"
   },
   {
     "id": "ibc/AE2719773D6FCDD05AC17B1ED63F672F5F9D84144A61965F348C86C2A83AD161",
     "name": "Uniswap",
     "symbol": "UNI.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/uni.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/uniswap"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/uni.svg"
   },
   {
     "id": "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
     "name": "USD Coin",
     "symbol": "USDC.grv",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdc.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/usd-coin"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gusdc.svg"
   },
   {
     "id": "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
     "name": "USD Coin",
     "symbol": "USDC.axl",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlusdc.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/usd-coin"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlusdc.svg"
   },
   {
     "id": "ibc/C78F65E1648A3DFE0BAEB6C4CDA69CC2A75437F1793C0E6386DFDA26393790AE",
     "name": "USDX",
     "symbol": "USDX",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/usdx.png",
-    "coingecko": "https://www.coingecko.com/en/coins/usdx"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/kava/images/usdx.png"
   },
   {
     "id": "ibc/8A07D4BD40E0F44ECFDF360F7EA7008B288926FB87C54489FE54DB81A5340E0C",
@@ -1213,8 +1098,7 @@
     "name": "Vidulum",
     "symbol": "VDL",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/vidulum/images/vdl.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/vidulum"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/vidulum/images/vdl.svg"
   },
   {
     "id": "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
@@ -1228,40 +1112,35 @@
     "name": "Wrapped Bitcoin",
     "symbol": "WBTC.grv",
     "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gwbtc.png",
-    "coingecko": "https://www.coingecko.com/en/coins/wrapped-bitcoin"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gwbtc.png"
   },
   {
     "id": "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
     "name": "Wrapped Bitcoin",
     "symbol": "WBTC.axl",
     "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlwbtc.png",
-    "coingecko": "https://www.coingecko.com/en/coins/wrapped-bitcoin"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlwbtc.png"
   },
   {
     "id": "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
     "name": "Wrapped BNB",
     "symbol": "WBNB.axl",
     "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchainoonbeam/images/wbnb.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/wbnb"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/binancesmartchainoonbeam/images/wbnb.svg"
   },
   {
     "id": "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
     "name": "Wrapped Ether",
     "symbol": "WETH.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlweth.png",
-    "coingecko": "https://www.coingecko.com/en/coins/weth"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/axlweth.png"
   },
   {
     "id": "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
     "name": "Wrapped Ethereum",
     "symbol": "WETH.grv",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gweth.png",
-    "coingecko": "https://www.coingecko.com/en/coins/weth"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/gravitybridge/images/gweth.png"
   },
   {
     "id": "ibc/5E2DFDF1734137302129EA1C1BA21A580F96F778D4F021815EA4F6DB378DA1A4",
@@ -1275,16 +1154,14 @@
     "name": "Wrapped GLMR",
     "symbol": "WGLMR.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/moonbeam/images/glmr.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/wrapped-moonbeam"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/moonbeam/images/glmr.svg"
   },
   {
     "id": "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
     "name": "Wrapped Matic",
     "symbol": "WMATIC.axl",
     "decimals": "18",
-    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wmatic-wei L@3x.png",
-    "coingecko": "https://www.coingecko.com/en/coins/wmatic"
+    "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/axelar/images/wmatic-wei L@3x.png"
   },
   {
     "id": "ibc/2FBAC4BF296D7844796844B35978E5899984BA5A6314B2DD8F83C215550010B3",

--- a/osmosis/asset.json
+++ b/osmosis/asset.json
@@ -1064,8 +1064,8 @@
     "symbol": "STRD",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/cosmos/chain-registry/master/stride/images/strd.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/stride",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/stride"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/stride",
+    "coingecko": "https://www.coingecko.com/en/coins/stride"
   },
   {
     "id": "ibc/84502A75BCA4A5F68D464C00B3F610CE2585847D59B52E5FFB7C3C9D2DDCD3FE",

--- a/osmosis/entity.json
+++ b/osmosis/entity.json
@@ -1,0 +1,432 @@
+[
+  {
+    "name": "404Deep Records FanToken"
+  },
+  {
+    "name": "Acre"
+  },
+  {
+    "name": "Adam Clay FanToken"
+  },
+  {
+    "name": "Agoric"
+  },
+  {
+    "name": "Agoric Staking Token"
+  },
+  {
+    "name": "Akash Network"
+  },
+  {
+    "name": "Alter"
+  },
+  {
+    "name": "Amber"
+  },
+  {
+    "name": "Another.Software Validator Token"
+  },
+  {
+    "name": "ApeCoin"
+  },
+  {
+    "name": "Arable USD"
+  },
+  {
+    "name": "AssetMantle"
+  },
+  {
+    "name": "Atolo"
+  },
+  {
+    "name": "Axelar",
+    "website": "https://axelar.network/",
+    "twitter": "https://twitter.com/axelarcore"
+  },
+  {
+    "name": "Axie Infinity Shard"
+  },
+  {
+    "name": "Band Protocol"
+  },
+  {
+    "name": "BeeZee"
+  },
+  {
+    "name": "BitCanna"
+  },
+  {
+    "name": "BitSong"
+  },
+  {
+    "name": "BlackJack FanToken"
+  },
+  {
+    "name": "Block"
+  },
+  {
+    "name": "Bostrom"
+  },
+  {
+    "name": "Button"
+  },
+  {
+    "name": "Canto"
+  },
+  {
+    "name": "Carbon"
+  },
+  {
+    "name": "Carolina Marquez FanToken"
+  },
+  {
+    "name": "Cerberus"
+  },
+  {
+    "name": "Chain"
+  },
+  {
+    "name": "Cheqd"
+  },
+  {
+    "name": "Chihuahua"
+  },
+  {
+    "name": "CMST"
+  },
+  {
+    "name": "Comdex"
+  },
+  {
+    "name": "Cosmos",
+    "website": "https://cosmos.network/",
+    "telegram": "https://t.me/cosmosproject",
+    "twitter": "https://twitter.com/cosmos"
+  },
+  {
+    "name": "Crescent Network",
+    "website": "crescent.network",
+    "telegram": "http://t.me/crescentnetwork",
+    "twitter": "https://twitter.com/crescenthub"
+  },
+  {
+    "name": "Cronos"
+  },
+  {
+    "name": "Cudos"
+  },
+  {
+    "name": "Decentr"
+  },
+  {
+    "name": "Delta 9 FanToken"
+  },
+  {
+    "name": "Desmos"
+  },
+  {
+    "name": "DHK"
+  },
+  {
+    "name": "Dig Chain"
+  },
+  {
+    "name": "Dyson Protocol"
+  },
+  {
+    "name": "e-Money"
+  },
+  {
+    "name": "Echelon"
+  },
+  {
+    "name": "Enmoda FanToken"
+  },
+  {
+    "name": "Evmos"
+  },
+  {
+    "name": "Fanfury"
+  },
+  {
+    "name": "Fetch.ai"
+  },
+  {
+    "name": "FONTI FanToken"
+  },
+  {
+    "name": "Galaxy"
+  },
+  {
+    "name": "Gelotto"
+  },
+  {
+    "name": "GenesisL1"
+  },
+  {
+    "name": "GEO"
+  },
+  {
+    "name": "GKey"
+  },
+  {
+    "name": "Gravity Bridge",
+    "website": "https://t.co/rSb0msPbRI",
+    "twitter": "https://twitter.com/gravity_bridge"
+  },
+  {
+    "name": "Hard"
+  },
+  {
+    "name": "Hope Galaxy"
+  },
+  {
+    "name": "HOPERS"
+  },
+  {
+    "name": "Imversed"
+  },
+  {
+    "name": "Injective Protocol"
+  },
+  {
+    "name": "Inter Protocol USD"
+  },
+  {
+    "name": "IRISnet"
+  },
+  {
+    "name": "IXO"
+  },
+  {
+    "name": "Jackal"
+  },
+  {
+    "name": "JoeDAO"
+  },
+  {
+    "name": "Juno",
+    "website": "https://www.junonetwork.io/",
+    "telegram": "https://t.me/JunoNetwork",
+    "twitter": "https://twitter.com/JunoNetwork"
+  },
+  {
+    "name": "JunoSwap"
+  },
+  {
+    "name": "Karina FanToken"
+  },
+  {
+    "name": "Kava"
+  },
+  {
+    "name": "Ki"
+  },
+  {
+    "name": "Konstellation"
+  },
+  {
+    "name": "Kujira"
+  },
+  {
+    "name": "Lambda"
+  },
+  {
+    "name": "LikeCoin"
+  },
+  {
+    "name": "Luca Testa FanToken"
+  },
+  {
+    "name": "Lum"
+  },
+  {
+    "name": "LumenX"
+  },
+  {
+    "name": "Luna Classic"
+  },
+  {
+    "name": "Lvn"
+  },
+  {
+    "name": "Marble"
+  },
+  {
+    "name": "Mars"
+  },
+  {
+    "name": "MedasDigital"
+  },
+  {
+    "name": "MediBloc"
+  },
+  {
+    "name": "Meme"
+  },
+  {
+    "name": "Microtick"
+  },
+  {
+    "name": "MUSE"
+  },
+  {
+    "name": "N43 FanToken"
+  },
+  {
+    "name": "Neta"
+  },
+  {
+    "name": "Nicola Fasano FanToken"
+  },
+  {
+    "name": "Nom"
+  },
+  {
+    "name": "O9W"
+  },
+  {
+    "name": "ODIN"
+  },
+  {
+    "name": "Oraichain"
+  },
+  {
+    "name": "Osmosis",
+    "website": "https://osmosis.zone/",
+    "telegram": "https://t.me/osmosis_chat",
+    "twitter": "https://twitter.com/osmosiszone"
+  },
+  {
+    "name": "Persistence"
+  },
+  {
+    "name": "Planq"
+  },
+  {
+    "name": "POSTHUMAN"
+  },
+  {
+    "name": "Provenance"
+  },
+  {
+    "name": "PSTAKE"
+  },
+  {
+    "name": "PSTAKE staked ATOM"
+  },
+  {
+    "name": "Puro Lobo FanToken"
+  },
+  {
+    "name": "Quicksilver"
+  },
+  {
+    "name": "Racoon"
+  },
+  {
+    "name": "Rai Reflex Index"
+  },
+  {
+    "name": "Rawanne FanToken"
+  },
+  {
+    "name": "Rebuschain"
+  },
+  {
+    "name": "Regen Network"
+  },
+  {
+    "name": "SCRT Staking Derivatives"
+  },
+  {
+    "name": "Secret Network",
+    "website": "scrt.network",
+    "telegram": "https://t.me/scrtCommunity",
+    "twitter": "https://twitter.com/SecretNetwork"
+  },
+  {
+    "name": "Sentinel"
+  },
+  {
+    "name": "Shade"
+  },
+  {
+    "name": "Shentu"
+  },
+  {
+    "name": "Shiba Inu"
+  },
+  {
+    "name": "SIENNA"
+  },
+  {
+    "name": "Sifchain"
+  },
+  {
+    "name": "Solarbank DAO"
+  },
+  {
+    "name": "Sommelier"
+  },
+  {
+    "name": "StakeEasy"
+  },
+  {
+    "name": "Stargaze"
+  },
+  {
+    "name": "Starname"
+  },
+  {
+    "name": "Stride"
+  },
+  {
+    "name": "Swap"
+  },
+  {
+    "name": "teritori"
+  },
+  {
+    "name": "Terra Money",
+    "website": "https://www.terra.money/",
+    "telegram": "https://t.me/TerraNetworkLobby",
+    "twitter": "https://twitter.com/terra_money"
+  },
+  {
+    "name": "TerraClassicKRW"
+  },
+  {
+    "name": "TerraClassicUSD"
+  },
+  {
+    "name": "Tgrade"
+  },
+  {
+    "name": "Umee"
+  },
+  {
+    "name": "Unification"
+  },
+  {
+    "name": "Uniswap"
+  },
+  {
+    "name": "USDX"
+  },
+  {
+    "name": "Vibranium FanToken"
+  },
+  {
+    "name": "Vidulum"
+  },
+  {
+    "name": "Wrapped AVAX"
+  },
+  {
+    "name": "Wrapped FTM"
+  },
+  {
+    "name": "Wynd"
+  }
+]

--- a/osmosis/pool.json
+++ b/osmosis/pool.json
@@ -1,8462 +1,8462 @@
 [
   {
     "id": "osmo102ryca72c5ktx2ruzt8ag6mvtczdqeuvm82l09vd5uq597e7hn7sqgw28l",
-    "lp_token_id": "722",
     "asset_ids": [
       "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "722"
   },
   {
     "id": "osmo104w884d9gw9s35ckru66ptl3uu3ss0u60xk7gplj8ky0xan6tfvsrfshe6",
-    "lp_token_id": "835",
     "asset_ids": [
       "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
       "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "835"
   },
   {
     "id": "osmo107cnz52uqdqzvwfvwcl4z55xqlj4rz78yv04a3tgqpkn3wrnkfxqq2ze39",
-    "lp_token_id": "487",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "487"
   },
   {
     "id": "osmo108scuudnnhe70xuwa2etuyxffexexak6rflvsczj9n4fhrz92ajs9zudge",
-    "lp_token_id": "572",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "572"
   },
   {
     "id": "osmo109uqkhlvees202dg6mkhn89actzyfvvlm9u7ym3zzytrp9gmhcvsawlssg",
-    "lp_token_id": "412",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "412"
   },
   {
     "id": "osmo10ce9cnt6hk4jnghvdl5asdsc5rmjfswkk7u5jrfr5ecy5puvsdzs5x6rvc",
-    "lp_token_id": "515",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "515"
   },
   {
     "id": "osmo10cm3vypuxkrvq4uznf4px5lv43ej99f6shushwtur3fpy6z69huq7gfce8",
-    "lp_token_id": "788",
     "asset_ids": [
       "ibc/FFA652599C77E853F017193E36B5AB2D4D9AFC4B54721A74904F80C9236BF3B7",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "788"
   },
   {
     "id": "osmo10d8ddsydag5xrnl2kacmkjtdxddstvz4jvraqqpf6ss2n7fy6lkqw4sx2f",
-    "lp_token_id": "560",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "560"
   },
   {
     "id": "osmo10djas3dkuyvfzaxvgwjqp3aaf63wjrv23hx3pmk8pjaxc3f33k9ssrz8kf",
-    "lp_token_id": "482",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "482"
   },
   {
     "id": "osmo10ecjz4nkzsr8rwmzmk7z6uwf6ux78wyctc98yphu0rc7cey9t5sstj4zyt",
-    "lp_token_id": "478",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "478"
   },
   {
     "id": "osmo10g4gm8px3tfeft8y0w4yc7kyxv9p9dk40aplln59j0nxmmnjnjcqhpftcf",
-    "lp_token_id": "302",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "302"
   },
   {
     "id": "osmo10g7srpl9gqhetplp6d2fr7l25ckjrtcsupk60984w8vf2zugcvjq6ashnq",
-    "lp_token_id": "103",
     "asset_ids": [
       "gamm/pool/102",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "103"
   },
   {
     "id": "osmo10gyurv978mfwmfpd9e824kua3f2vca8626ky93aqndhqzqfmulds36ltrz",
-    "lp_token_id": "443",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "443"
   },
   {
     "id": "osmo10j0kv8lfy5ym3wm8m0shte5p7zu5sjtj6a6s0zslp3suqrkaqyps3kfe06",
-    "lp_token_id": "707",
     "asset_ids": [
       "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
       "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "707"
   },
   {
     "id": "osmo10j25ze5tj5ryxz4jk79au6srhe62jsckk9dd6u5qt3326wv9gvnskn7tu9",
-    "lp_token_id": "500",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "500"
   },
   {
     "id": "osmo10k2x02xa6acekt74fnw4sl6znfgv08k37zgkd0ej303uqc4t2s7sarhsr8",
-    "lp_token_id": "904",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/BE95D1E09F5A44FC5409F4E0F52750DF2A868D865BC91F3C3EE3C83235789D18"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "904"
   },
   {
     "id": "osmo10kepynda48va573sjsn0ch6glf3e2qrs87ukpvd63ljdmkaflg3sjxf5r4",
-    "lp_token_id": "339",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "339"
   },
   {
     "id": "osmo10r9v3xpzzd4752r0cvu50vacp8use9later59jcny07xz80gv6mq4yq70a",
-    "lp_token_id": "619",
     "asset_ids": [
       "ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "619"
   },
   {
     "id": "osmo10rmhpg33dv9unqtw72jh67r8xdjmc07qe9zaef4jjycjyakl8q6sl76dhz",
-    "lp_token_id": "691",
     "asset_ids": [
       "ibc/DB9755CB6FE55192948AE074D18FA815E1429D3D374D5BDA8D89623C6CF235C3",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "691"
   },
   {
     "id": "osmo10sh5u7pl9dwh7ll8wfaahr0trkka4rv2k9amlj88s72k6v8paufs0qnz7p",
-    "lp_token_id": "403",
     "asset_ids": [
       "gamm/pool/222",
       "gamm/pool/402"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "403"
   },
   {
     "id": "osmo10tly0t6ppjaz0uhlskvlluzwwwswdc8tfy65mhhkwst6cfq07rdsxscmm9",
-    "lp_token_id": "349",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "349"
   },
   {
     "id": "osmo10tx2zgul27naq2p5urn9kx7lygfr0zhsk3s42nh0dcfqyudq655sadlyxj",
-    "lp_token_id": "632",
     "asset_ids": [
       "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "632"
   },
   {
     "id": "osmo10uut208crprz36gpw3wwh50e6yuuq8jxf5yamdclg4vr84uw8cmqkunxkx",
-    "lp_token_id": "493",
     "asset_ids": [
       "gamm/pool/1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "493"
   },
   {
     "id": "osmo10v29rzxswcz2facklsfxg7a3ns2lu5vj9f0509ateum9u7ca33tqur69mk",
-    "lp_token_id": "277",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "277"
   },
   {
     "id": "osmo10v35xj20k0jrfgs8p3lqt5gyga0wug3kkh4pq6xt3x4hqh5huvcssp04d3",
-    "lp_token_id": "255",
     "asset_ids": [
       "uion",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "255"
   },
   {
     "id": "osmo10venxtvdglryxkdmvjr8wa6n3ugja40rewddlxtg0pr30vmkf47sllgslg",
-    "lp_token_id": "678",
     "asset_ids": [
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "678"
   },
   {
     "id": "osmo10xnwkjzqpdvgzxpz7eu5mcne5jc73c5h0xuhv9qmz0jsfyyxvr4qvhje97",
-    "lp_token_id": "777",
     "asset_ids": [
       "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "777"
   },
   {
     "id": "osmo10xphw0uxj2k7erakdajxxdwexu4qt0fwlu0xu3a26r76kthxjyxqal4wcf",
-    "lp_token_id": "677",
     "asset_ids": [
       "ibc/DB9755CB6FE55192948AE074D18FA815E1429D3D374D5BDA8D89623C6CF235C3",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "677"
   },
   {
     "id": "osmo10ya3d9gr2cmp268kdu8u5mna0pktqfxkt9ug54z9xrazpk3wpj0qz9zlcg",
-    "lp_token_id": "524",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "524"
   },
   {
     "id": "osmo10yczu0hflmtny52ktkvfrrwj2cktkjn6yk9wsfyxsjf6n8pvwxfscmn4e5",
-    "lp_token_id": "144",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "144"
   },
   {
     "id": "osmo120echqk9sfelg47lrultsc0em257582cxrp86epqhcz8gfqxf6fsluzp7z",
-    "lp_token_id": "849",
     "asset_ids": [
       "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "849"
   },
   {
     "id": "osmo1230t5url8jlyxp9czgjv7p93kkgka4uvr3syxlwum9zjk2gpn6cs4xcxgc",
-    "lp_token_id": "590",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "590"
   },
   {
     "id": "osmo124h7edw5f98xzfgaxmxjpnu66hdt6cn58n4g3awa90cn3h5v6d8s45246p",
-    "lp_token_id": "447",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "447"
   },
   {
     "id": "osmo124qc2hs5jgp2shrmtv2usxyrt52k447702pczyct0zqadlkkh2csvh5pzv",
-    "lp_token_id": "97",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "97"
   },
   {
     "id": "osmo1265edur3evpvmmcter5a3lp93zlyc23wd9qp0vcu0xatn79a4q0qp24n2c",
-    "lp_token_id": "198",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "198"
   },
   {
     "id": "osmo1272l80yvlqm4j6y5296fqhvy8ltgscsj2h4u76pumj2sy0ul82ns7hy0wu",
-    "lp_token_id": "127",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "127"
   },
   {
     "id": "osmo128m3mqa0m6ex57nxkxkyczd3nsqns2p56wm5xu52p4jappg2jamq5jrlxe",
-    "lp_token_id": "265",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "265"
   },
   {
     "id": "osmo12a8gxj8p07rn92zzjug6vq2a39hnqw92zhpmymxxs5avj327zslsszjqxr",
-    "lp_token_id": "229",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "229"
   },
   {
     "id": "osmo12exa7m2esj4a9anudf0e2rpk5yynf049h585sm4zv7rqkjqun5cqs604sd",
-    "lp_token_id": "345",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "345"
   },
   {
     "id": "osmo12fzg5z9xzw8yde57fj5w2rwqmxe6f4g3lgjdrjhhsqx8m43fqpgs7d8x8q",
-    "lp_token_id": "856",
     "asset_ids": [
       "ibc/C822645522FC3EECF817609AA38C24B64D04F5C267A23BCCF8F2E3BC5755FA88",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "856"
   },
   {
     "id": "osmo12h3748gmjdssn3pyxdtu9d6gl6wvlrem03y5e592h05f4kx6aa2ssp8jq7",
-    "lp_token_id": "422",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "422"
   },
   {
     "id": "osmo12huxa5wnwskf8mnmr096yzwyrehm970782j95h25uuxrxxz8wdpq7udusr",
-    "lp_token_id": "303",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "303"
   },
   {
     "id": "osmo12lzydwxr8xmyhrvg7kr0948zz4jnf4wjczwqrngppw4du85ustmqs5vpt6",
-    "lp_token_id": "263",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "263"
   },
   {
     "id": "osmo12ng7y9c5lhyqgl2pxgap64de0fjynnwgtv3j5cme5c2ypmwezd2qwq982h",
-    "lp_token_id": "807",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "807"
   },
   {
     "id": "osmo12nv2sf5qe5t93ly3fktdgrw5u9f5nn9cf8cakgt0pvhhqghvkrnqqhadah",
-    "lp_token_id": "805",
     "asset_ids": [
       "ibc/0CD46223FEABD2AEAAAF1F057D01E63BCA79B7D4BD6B68F1EB973A987344695D",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "805"
   },
   {
     "id": "osmo12nxhn6pc44eguzf53y37nkpjqv80u3n0kxtuffyqrp0h0vkqccfqu2f7pk",
-    "lp_token_id": "393",
     "asset_ids": [
       "gamm/pool/1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "393"
   },
   {
     "id": "osmo12v9c78ctzvthgen8txmmqm06mjtdfu2gy3k68jtldxvssmwq6lrsn2fa8y",
-    "lp_token_id": "431",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "431"
   },
   {
     "id": "osmo12vkrtnxwpkq7hnsnchs06ya7rv0vdpchxrgt7jktjm4kupzx8l2s6nfhny",
-    "lp_token_id": "73",
     "asset_ids": [
       "gamm/pool/41",
       "gamm/pool/53"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "73"
   },
   {
     "id": "osmo12y3z9khxjkhh7yk37c22kxjv5dl8ayxfa9s6fp0g2uekeuptmtmskvguh4",
-    "lp_token_id": "853",
     "asset_ids": [
       "ibc/9A8A93D04917A149C8AC7C16D3DA8F470D59E8D867499C4DA97450E1D7363213",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "853"
   },
   {
     "id": "osmo12zcj6ns9sa4twqn7xnjydcfwpedt3e90y4xg9gs7ught7fq98tcszvt5uq",
-    "lp_token_id": "891",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "891"
   },
   {
     "id": "osmo12zlm0f4wrgvdks83gue66zs97hchhc2mf75xwgg5q89ev6hd45gs7hn0zt",
-    "lp_token_id": "773",
     "asset_ids": [
       "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "773"
   },
   {
     "id": "osmo132pj9lh5cujzql3q8umzk7zu7xyv8l9tplz3ejvra550p0ejwr0q4c3fgq",
-    "lp_token_id": "217",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "217"
   },
   {
     "id": "osmo132qw6zaztxfnjj3a2e20adm3xwzjrycqwcc048x6wpv0w00dgl7qvlln2p",
-    "lp_token_id": "211",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "211"
   },
   {
     "id": "osmo134hkyv9330wdk8jyaltskneqxcc3nndamy5020yn4l8s6987qd9se7042l",
-    "lp_token_id": "110",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "110"
   },
   {
     "id": "osmo137n2magslhhhp77rt0qv2l4s4fksjncj2t8vd43sn9uwzeypqw9ql0enq2",
-    "lp_token_id": "23",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "23"
   },
   {
     "id": "osmo139k7lc44flz23nxzjeermnrzw6faqvys6cjkywevsqaxut93awes9lclqv",
-    "lp_token_id": "224",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "224"
   },
   {
     "id": "osmo13clkaupjee7n5df25v863kl2khxmcvkxk3cv9kwemz0rm77lur7qtg000v",
-    "lp_token_id": "531",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "531"
   },
   {
     "id": "osmo13cslqv80p4uzx4cxjvpnrva68yac6z55yhafqau3k5vy6yw5027q2yx8ms",
-    "lp_token_id": "264",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "264"
   },
   {
     "id": "osmo13dnatwj7l5vdksrh66zqkp6pmvfdtqc8vr6m543dav6x26q6wvyqe3nmv6",
-    "lp_token_id": "538",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "538"
   },
   {
     "id": "osmo13dr6zv7tf2jzvdqza692av7ah77vzt2534luprlkuj6nfk42pcaqgzp7t4",
-    "lp_token_id": "273",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "273"
   },
   {
     "id": "osmo13ejfnt55k897daggmc8z2kpahfufk3tvw4wq44k5y2kjt6tjjgaqm05kyd",
-    "lp_token_id": "793",
     "asset_ids": [
       "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "793"
   },
   {
     "id": "osmo13h85yg9msr3lr6leearsnsv5zt5hv8hv7k54gqtq2lrycn96mytqksgr48",
-    "lp_token_id": "457",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "457"
   },
   {
     "id": "osmo13jr3p5p070h4pu7sxhtldag9899sev9pwx0r2vlvpkyravpxlqssnzsuq9",
-    "lp_token_id": "7",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "7"
   },
   {
     "id": "osmo13k7fkdnkw6urxecxaevy9hq2vzzvxsl40jf3kcywudvkcx0xe0nqulj3yv",
-    "lp_token_id": "875",
     "asset_ids": [
       "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "875"
   },
   {
     "id": "osmo13kxnazqtly05g77xnqsqs95psld5dyspe5f5xa50n06tqqq79sys2ucevl",
-    "lp_token_id": "432",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "432"
   },
   {
     "id": "osmo13l85na80w9vtscftf2054nzwsqc7k8ncd9fv6hl3gvtpxqv84jfs4gkh5m",
-    "lp_token_id": "831",
     "asset_ids": [
       "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "831"
   },
   {
     "id": "osmo13mczv44wvyqn6fys7f9mcv57d9fmg6e7yfkypaykp99amqfw7chq9wa5q9",
-    "lp_token_id": "34",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "34"
   },
   {
     "id": "osmo13mj9ywzw3x8fpqxxnfdffuk6fgf4thv9jw78j8thu9k0uy32s92qa3an68",
-    "lp_token_id": "221",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "221"
   },
   {
     "id": "osmo13mu0c55r8yt9mgycc7zx6jedxh73mf630xwpwvwfm7qf4q7k3edqu209ez",
-    "lp_token_id": "580",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "580"
   },
   {
     "id": "osmo13n2p8v5w5knclf4yprk6hdrfqt3s94ynmjud7gf6djed8759qedsasl446",
-    "lp_token_id": "550",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "550"
   },
   {
     "id": "osmo13nztwp3wht4k8zm6ztkczjqxyu74kvl8xjjfqssd7g2lwghzknhqn9gpek",
-    "lp_token_id": "332",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "332"
   },
   {
     "id": "osmo13p8haggnllu9w0y6e0dsazcsezfywdcz4dqses8cxrnh0n0r393q05995g",
-    "lp_token_id": "544",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "544"
   },
   {
     "id": "osmo13qvyfhzunrxulp7a0ekyn0vrl6yf26urnk8hedrnk7hn74acr49skjy00e",
-    "lp_token_id": "128",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "128"
   },
   {
     "id": "osmo13refp99hxda7acm2rnn9nrejhh0d80ftjzxqulj7js884v3ckc3q02ssf6",
-    "lp_token_id": "334",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "334"
   },
   {
     "id": "osmo13s0uss8gztzsrxqd08kvwmpt7d0k0tvzdfchdw0tr2suzvl3hm3s769ce5",
-    "lp_token_id": "241",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "241"
   },
   {
     "id": "osmo13shtdrvcjzymxxe2s27k93l9xumkd4tjcmcv05pue2mfk20d66cs4r25lw",
-    "lp_token_id": "140",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "140"
   },
   {
     "id": "osmo13tc9ntd0rnxumtlczqefzg5nk2kf6z7agmgj898sd3gl40dkccvqy06vkm",
-    "lp_token_id": "669",
     "asset_ids": [
       "ibc/6BDB4C8CCD45033F9604E4B93ED395008A753E01EECD6992E7D1EA23D9D3B788",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "669"
   },
   {
     "id": "osmo13tp73hg0skhenwrhp4sqg48a4e6459spyvnp7ptnz2galhpcz3lsalsh0w",
-    "lp_token_id": "910",
     "asset_ids": [
       "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "910"
   },
   {
     "id": "osmo13twh7y4pv6rdrxchtjeh7tav4qqujlwxxc9cdqpvruj9dh9xttrq8g5g9c",
-    "lp_token_id": "313",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "313"
   },
   {
     "id": "osmo13u649up5fe79u2aq0d3rsl5x48lulu5yred75lcuw94dlugfxdqq39hz0s",
-    "lp_token_id": "320",
     "asset_ids": [
       "uion",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "320"
   },
   {
     "id": "osmo13xtszjfnwjs5lxetjklspuuzg3tymnepu48p5sp38rhs458kc7yq9jxjf8",
-    "lp_token_id": "231",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "231"
   },
   {
     "id": "osmo140c35lxmkmkzmxyh7293cmettfatdw090n0ttwzxxjwa3jraenwqqpczwd",
-    "lp_token_id": "712",
     "asset_ids": [
       "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "712"
   },
   {
     "id": "osmo140dhzccumruw0u38dt7qlj49ttvw2p5mwgcjqsqjuv443u2s5rgqll980k",
-    "lp_token_id": "187",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "187"
   },
   {
     "id": "osmo140lcj9njcgennv4sk2qtffq0d29s7a9qpv2l30rccghfxfc44mvqphj5uv",
-    "lp_token_id": "401",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "401"
   },
   {
     "id": "osmo142esjq2sxsju345f4germ3zqlc6j73f6tzzxpumkclzwxs9t5nuq5wuaal",
-    "lp_token_id": "577",
     "asset_ids": [
       "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "577"
   },
   {
     "id": "osmo143403qx9vwa0d0m6zzna2r0fw0xyefl4ey3jgtl4krk5qdzvwd9smnr936",
-    "lp_token_id": "496",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "496"
   },
   {
     "id": "osmo146awk6s36fxfqa2hzp974lpmvry6cz20yp52ugrlw5c5983nqgjswz9ltt",
-    "lp_token_id": "479",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "479"
   },
   {
     "id": "osmo1497udspu0fkv9hjv5kep7vglhg8nj986v4e6dz62dleen4m3a50s8evd6c",
-    "lp_token_id": "547",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "547"
   },
   {
     "id": "osmo14azf94grg0qn67tkczejnt87t9yzt5ndg5h3pqc8zapz3hpg7whq5zzsyh",
-    "lp_token_id": "535",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "535"
   },
   {
     "id": "osmo14cg7nxexxmuszptk6kghd7d73r7t6xrjfclcmk3qrc73wpjyxtesywq20q",
-    "lp_token_id": "674",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "674"
   },
   {
     "id": "osmo14dxgrj6qc5t50aedyy9fz7wqvtnv9qjcus7ls6t4lcrt3ged388qsyuhte",
-    "lp_token_id": "266",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "266"
   },
   {
     "id": "osmo14hxmap32awjzck43xeerxmvnyzvsrjrc7559jw97z23664vx4lyst3wly2",
-    "lp_token_id": "111",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "111"
   },
   {
     "id": "osmo14jz33kmx87yv94x4hzh3ylrpt6kwkqvjlsaz06aus2equyjv9w3s5nw2kc",
-    "lp_token_id": "100",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "100"
   },
   {
     "id": "osmo14klwpt49lrs76l24puae7jnct4430ufl9u42rdmz49vews0vu6zqrypt4c",
-    "lp_token_id": "692",
     "asset_ids": [
       "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "692"
   },
   {
     "id": "osmo14me6rlskklxu3rxmlzj27vhyecf8xfvvckwdn76fxkzqgdsy03jqj49ws0",
-    "lp_token_id": "244",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "244"
   },
   {
     "id": "osmo14mwhxhggae403crueknyqshuqzge56w2q4lltmenzqwmt94ys6fqdjgv37",
-    "lp_token_id": "491",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "491"
   },
   {
     "id": "osmo14nkh5n0e6r3qz78zcyygj3wv906qtsgqrm5nq3zwpx2zku2lvdqshfwyv3",
-    "lp_token_id": "485",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "485"
   },
   {
     "id": "osmo14p3mvjdxg5skeh44atnvxvc3l0mf4jjt6uk62yk5nzv7q5dyf70qw6npt2",
-    "lp_token_id": "436",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "436"
   },
   {
     "id": "osmo14pmk24h24cmpne8kzanagwe4f03wlqccwlm4spj4hyk7r0pxru9szmht2q",
-    "lp_token_id": "213",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "213"
   },
   {
     "id": "osmo14ppp79wvq6xlg3tnwr86sgpqv36m4gs3uurrf8wlmgdx8cz9ly0sanpqjr",
-    "lp_token_id": "695",
     "asset_ids": [
       "ibc/52E12CF5CA2BB903D84F5298B4BFD725D66CAB95E09AA4FC75B2904CA5485FEB",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "695"
   },
   {
     "id": "osmo14q5n9efl2lf7txvkfveskzdt4l47n7lpj2lzs7yk8u6hmzerz5ysjg6qx8",
-    "lp_token_id": "568",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "568"
   },
   {
     "id": "osmo14slhuw6gtlsud3p2c79gy92qy72qcvjv6q6upwcrl95m8wyuepvsq9c29d",
-    "lp_token_id": "576",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "576"
   },
   {
     "id": "osmo14sxd3nugue3z44lh55cvn7uq8xzzzkgfknnuxtazr569jyymcqys2eykgs",
-    "lp_token_id": "391",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "391"
   },
   {
     "id": "osmo14sy9cpm4adfrut88u4869ue2sz72rjjcq6hlsmf5uz97tkswvvnqnujj6t",
-    "lp_token_id": "881",
     "asset_ids": [
       "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "881"
   },
   {
     "id": "osmo14wp02k4djfx5yqvtr052lfytdmje05jm00even373h7cdydw78vsrjp52h",
-    "lp_token_id": "672",
     "asset_ids": [
       "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "672"
   },
   {
     "id": "osmo14xpkpdstm4xhwjsw3v8gs99f2xl949wcnxx8a8dvn0qq5460afkqcsxej3",
-    "lp_token_id": "163",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "163"
   },
   {
     "id": "osmo14xt30a3pswr540lp55y7f9gfevmddv84takyjn2p28a27ayc85gs3p292f",
-    "lp_token_id": "730",
     "asset_ids": [
       "ibc/57AA1A70A4BC9769C525EBF6386F7A21536E04A79D62E1981EFCEF9428EBB205",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "730"
   },
   {
     "id": "osmo14y9ejauxnuyr48eu8jterwyhnz4s94s5ywggzmhf3wmu73g28gcsenvnum",
-    "lp_token_id": "223",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "223"
   },
   {
     "id": "osmo14ymxts36p4z2eef06qeeuqd5s0x7fmyhzs382qvnqxsv45zcqf7q0vztv0",
-    "lp_token_id": "762",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/6A6174468758D207DD2D880363BF699C6568A29E87651337AEDAFD9E69EA7E58"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "762"
   },
   {
     "id": "osmo1500hy75krs9e8t50aav6fahk8sxhajn9ctp40qwvvn8tcprkk6wszun4a5",
-    "lp_token_id": "2",
     "asset_ids": [
       "uion",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "2"
   },
   {
     "id": "osmo150wfa0gum6sz5crkpvt9pztjf35dc8gvaufzrc40d6hr99wvyxlqcaddv9",
-    "lp_token_id": "581",
     "asset_ids": [
       "ibc/204A582244FC241613DBB50B04D1D454116C58C4AF7866C186AA0D6EEAD42780",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "581"
   },
   {
     "id": "osmo153ezzm4uwy0dqh0mmxwgxu3mu0pknvgrsn4es3u5zrzhs57jc65qtsyl4c",
-    "lp_token_id": "523",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "523"
   },
   {
     "id": "osmo154fszgu6aqqqtg0zff33leallf4rw3456s6spcsdmjf0u73jtd6suf32zx",
-    "lp_token_id": "282",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "282"
   },
   {
     "id": "osmo155c60gtktr83uvnahsxc3q7gswmuwm7ukhxmz06jwl3yrjgd4k7s7k4wkr",
-    "lp_token_id": "350",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "350"
   },
   {
     "id": "osmo155szru0rpgcjwlcgwtv3r35v4zdc0dkskpr4fwshqcm9r2974htsfujjuh",
-    "lp_token_id": "753",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/B4DED8861763C7674BD726FFFE5CAB09BDC3CC706E77C82E46EFEDCF9DB3B495"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "753"
   },
   {
     "id": "osmo155tdryrz9lqtqtsyjuc2ughrryu6nncr8vr03hepdyqqsgesag6s6ggts0",
-    "lp_token_id": "557",
     "asset_ids": [
       "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "557"
   },
   {
     "id": "osmo157u4eawmj4ux5jth54aw9sfh3zsgvgncm20t9m9vc7er6vrkjnks9naflp",
-    "lp_token_id": "842",
     "asset_ids": [
       "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
       "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "842"
   },
   {
     "id": "osmo157yhlzsnqxvrne3wdpukh7uca40l9mak875u44f9asufvwkldzzs7tpaal",
-    "lp_token_id": "476",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "476"
   },
   {
     "id": "osmo158s5v5kd2nzgrq0fse6tk60r70596e5p8qczj47pfqcqx9rc3l9s0q2v3h",
-    "lp_token_id": "143",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "143"
   },
   {
     "id": "osmo159f0lecgvarm6a9snyqjnz9r32h72fwqq9q2s3py7we0v9mfp5vsx9w3ct",
-    "lp_token_id": "296",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "296"
   },
   {
     "id": "osmo15d7sqmwy2snpxw2w776v0tthr328dzjvpvk7phssyuqszq4lr6xs5dcupr",
-    "lp_token_id": "917",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "917"
   },
   {
     "id": "osmo15dz4u47sdmk4rq67k9v5n9fununc6j7y903azd3sm3yafd9wp68s9s4p5z",
-    "lp_token_id": "592",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "592"
   },
   {
     "id": "osmo15e4a88d0vmd7ywh9e2ll8q447defplgamwza9ezay67z84cxmx7ssu8s6q",
-    "lp_token_id": "106",
     "asset_ids": [
       "gamm/pool/101",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "106"
   },
   {
     "id": "osmo15e9w6y0g8z5as77g29azqwvp37dp96njn7h0vt5suz3un5vw95dsj4uurl",
-    "lp_token_id": "22",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "22"
   },
   {
     "id": "osmo15eg4aq5fxdehdjv5zr385h4zmswamvw6pguqhykd3fs2jrgpgr0qqmlfqc",
-    "lp_token_id": "865",
     "asset_ids": [
       "ibc/92B223EBFA74DB99BEA92B23DEAA6050734FEEAABB84689CB8E1AE8F9C9F9AF4",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "865"
   },
   {
     "id": "osmo15h02q7rzpwn0gahklnek29naae4peg3j4rd5e4hcc264sm3mfugqaw6up7",
-    "lp_token_id": "665",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "665"
   },
   {
     "id": "osmo15j2ttrqclc5j3fz53gps5n4p6eyw7qr3t2qsxna8ekjsahctgf4qe3v89q",
-    "lp_token_id": "353",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "353"
   },
   {
     "id": "osmo15jt5g7jn3m2wem6an2n9m982hr6v2madrhjyt3vxrn00vew3xmmsnah0ct",
-    "lp_token_id": "552",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "552"
   },
   {
     "id": "osmo15k82dwg2xkhm2una73jnq2ftan7c5rncul3fpyzyc9g3g6m0ae5skyswxd",
-    "lp_token_id": "751",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/7ABF696369EFB3387DF22B6A24204459FE5EFD010220E8E5618DC49DB877047B"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "751"
   },
   {
     "id": "osmo15krawmktxe8rzzepj4wxzgeevns9xftpzwhw7uycdg43t2k7nsxq3n6xen",
-    "lp_token_id": "710",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "710"
   },
   {
     "id": "osmo15mym9nr2g994zevcslnf8n96unwnsmqa8nzkef4lgavhjkgsy8gscuq3w9",
-    "lp_token_id": "371",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "371"
   },
   {
     "id": "osmo15p62pdak6vsudduc82h09plethxq5m58k6x6t76y7fee3fgm0upq3x8553",
-    "lp_token_id": "770",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "770"
   },
   {
     "id": "osmo15sg8553z787gk33z47yd8uvux72asllkcywnnplepe6c6lhurs5sfpy7a9",
-    "lp_token_id": "410",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "410"
   },
   {
     "id": "osmo15t7afyxut7eugx0yn4quesujf5snv358g3ureyx46afpwhjrlaas5nl3zp",
-    "lp_token_id": "664",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "664"
   },
   {
     "id": "osmo15u42rnfp5fr0qrdmnncptxvycwdxrdutwjv5v83t9y9yy7xq948qly3844",
-    "lp_token_id": "470",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "470"
   },
   {
     "id": "osmo15u5e6evufc9gjd28n4z9rvhku8lfg3arpejm0gnzhzx05w9h7e7q8665jn",
-    "lp_token_id": "13",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "13"
   },
   {
     "id": "osmo15upcqtt7tupfxdh4229vjwesgm7f3s5a66ke6dhfajxnkdmzm3pqu8y7hv",
-    "lp_token_id": "735",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "735"
   },
   {
     "id": "osmo15v4mn84s9flhzpstkf9ql2mu0rnxh42pm8zhq47kh2fzs5zlwjsqaterkr",
-    "lp_token_id": "833",
     "asset_ids": [
       "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "833"
   },
   {
     "id": "osmo15v7xfk7qnm27r2kwsutegh3jt2ye7haadqlnt5xf89hkp29hx0cq4sgqr6",
-    "lp_token_id": "364",
     "asset_ids": [
       "gamm/pool/361",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "364"
   },
   {
     "id": "osmo15vl4puljq9s6taqzmnsgd43gkz3ltp3hj4aexqj8x2ey4lxrrrks278cn4",
-    "lp_token_id": "640",
     "asset_ids": [
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "640"
   },
   {
     "id": "osmo15w6vtw48yqell0h4t3dyxhczp7dx0vl4f2xe3dgluyvznjdhhkgqnttcxy",
-    "lp_token_id": "726",
     "asset_ids": [
       "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "726"
   },
   {
     "id": "osmo15zzs8muh0lgnhdmzax35e90cskgulz7x566q6fpknguvdw95s0msen0l80",
-    "lp_token_id": "855",
     "asset_ids": [
       "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
       "ibc/71055835C7639739EAE03AACD1324FE162DBA41D09F197CB72D966D014225B1C"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "855"
   },
   {
     "id": "osmo1605py4r32r73csszlqpz6n5t5sgax9gjjfnm68jnd7pv6qe4l54ql0w8ku",
-    "lp_token_id": "8",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "8"
   },
   {
     "id": "osmo1620l9ewga9f6w3wyvfx5vhpuum3wwgz2haamn4t8lckfyzvnxd0q0chmeu",
-    "lp_token_id": "582",
     "asset_ids": [
       "ibc/204A582244FC241613DBB50B04D1D454116C58C4AF7866C186AA0D6EEAD42780",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "582"
   },
   {
     "id": "osmo162yn5ntl2tuuyxxf3dmm3d76q56ch9zlka0v7852wxqd874q388s502qp2",
-    "lp_token_id": "685",
     "asset_ids": [
       "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "685"
   },
   {
     "id": "osmo163pdautlpkrj0au0s0nkqw8ln2r42gdkwjuf77c26h7crd44hj3suggfju",
-    "lp_token_id": "209",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "209"
   },
   {
     "id": "osmo163sn2xvlaalva3td4hcjqmmrzzn4upu35qgdnnr4q0azp0t3v22qgfc8yz",
-    "lp_token_id": "420",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "420"
   },
   {
     "id": "osmo163yhv8mj29c03zd7ktg2gwcpwjj6kcmdx933p3lfxdu66qsajt0skqkmvx",
-    "lp_token_id": "409",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "409"
   },
   {
     "id": "osmo167a9n3f6t8v64pugrqnz88f7w8tlwaxfsgge4tm7jh4gvxrhstyqgyv5jw",
-    "lp_token_id": "536",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "536"
   },
   {
     "id": "osmo167dnkr4k7ezmat3sq4nkdmwel54u7uh496n45djnu9xe82ad2w5s4qpg68",
-    "lp_token_id": "442",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "442"
   },
   {
     "id": "osmo167dycqs0n3dxzfrwctg3p4hg7zxjjptr2p7nvkk9d23wu8spy4csdzvlsx",
-    "lp_token_id": "501",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "501"
   },
   {
     "id": "osmo169wdlgu8tes3qm4un02gwvhxw78yphlf3mks30j3lkwek8j7vpgqcx2zzp",
-    "lp_token_id": "114",
     "asset_ids": [
       "gamm/pool/1",
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "114"
   },
   {
     "id": "osmo16a0su5csdrukz43z284agsqctfutps8eextnvrk3g2nhk2cxmlgsmfh4r8",
-    "lp_token_id": "112",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "112"
   },
   {
     "id": "osmo16cl5fg34wtrnpvz9rcncm37nutywn0765ldkuw59gc68xrajzuwqd9jt88",
-    "lp_token_id": "616",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "616"
   },
   {
     "id": "osmo16cr2suh8wxyd3rdj24s7qe4kr2lnjxmm0495j07tl06jclnwfa2qqs58qg",
-    "lp_token_id": "808",
     "asset_ids": [
       "ibc/18A676A074F73B9B42DA4F9DFC8E5AEF334C9A6636DDEC8D34682F52F1DECDF6",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "808"
   },
   {
     "id": "osmo16d92nnsxj9nyc6j46k0pj6q0phhdu89nrz0y8657nn4el5fm3lwsut9e6k",
-    "lp_token_id": "630",
     "asset_ids": [
       "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "630"
   },
   {
     "id": "osmo16dafzdug0nreqs3h8g2rdtp5dr75ck9k2a9qzyvvgksn6cgukteqkafeu5",
-    "lp_token_id": "697",
     "asset_ids": [
       "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "697"
   },
   {
     "id": "osmo16dn4uk4xlqshzufy3f0as2pnvdpwqlwepp0m5qumwh2c4vgmp9jqaa0zsh",
-    "lp_token_id": "569",
     "asset_ids": [
       "uion",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "569"
   },
   {
     "id": "osmo16h2dp9v34s7dy5f8ut708tf0pjj7772u8f8n77pxs3k5aj4rkg6sl85ehj",
-    "lp_token_id": "322",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "322"
   },
   {
     "id": "osmo16h9xer73q9c4rpwvmxhqdcqc4r8q0ldrgme8f3q3ljntam6sarnsd5tnlf",
-    "lp_token_id": "456",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "456"
   },
   {
     "id": "osmo16hrp33emfwydwnydry5k854ffeya64g6lgxj34ev27tl865msdxs7lpljf",
-    "lp_token_id": "783",
     "asset_ids": [
       "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "783"
   },
   {
     "id": "osmo16qetl32gwxnne8q46qsc4e65rtnx8z9w2dxqas66hllu6c2gty8q7fwz0k",
-    "lp_token_id": "821",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "821"
   },
   {
     "id": "osmo16qzex7q0cpj3dflx79ycqvsujm0dt838lfjv9fjg80zna7jpn2ssn3cta4",
-    "lp_token_id": "395",
     "asset_ids": [
       "uion",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "395"
   },
   {
     "id": "osmo16u8zapr7jvqv63hrnpfzfp4ys2g9ap69rxkdzpsasaa4qlwzx45sme0eus",
-    "lp_token_id": "438",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "438"
   },
   {
     "id": "osmo16w7vk8sus35draftmhuac39vcvcpwcjttvjmee54vd0rx59xqp7s5t4flu",
-    "lp_token_id": "918",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "918"
   },
   {
     "id": "osmo16x4qnfcefwaym3znv2waqh20rfgxpney2pxv4vvnv4p9y9n8ddaq68khcy",
-    "lp_token_id": "797",
     "asset_ids": [
       "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
       "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "797"
   },
   {
     "id": "osmo16zg36xlt7a84deeweraqtf64sw5pedh5c4cquqv0gy4e6498u52sdx2zj9",
-    "lp_token_id": "131",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "131"
   },
   {
     "id": "osmo1702m29rngg2xjsd4mdl3xscfrgv3fy039hc6uvczq8rsfwdtnj0spp4yqx",
-    "lp_token_id": "728",
     "asset_ids": [
       "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "728"
   },
   {
     "id": "osmo1706zqq68yt0gsnq63j3wjn8egqvr5sqylxnjzalvskjqkv3v7xvshu3d36",
-    "lp_token_id": "433",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "433"
   },
   {
     "id": "osmo170f2kcc7ud5mepllczl23jnwrpwt6q3fsrxv0mtwtt2tqydf5u4sx4nesp",
-    "lp_token_id": "424",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "424"
   },
   {
     "id": "osmo1735wj90a09zr4a3pcujmpp85mkz05tu4ynm534eaqw9nl4zw2qkqtzjpw0",
-    "lp_token_id": "305",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "305"
   },
   {
     "id": "osmo1752ysawy2adr7td9an30a8pkk8ngrvcq3tan08lvnar3s7f82y5s4dt8fs",
-    "lp_token_id": "907",
     "asset_ids": [
       "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "907"
   },
   {
     "id": "osmo175hpfs58xklq8aradgemnsufj5w27m4ymeelskntvhuvnwd9wkgqsw5lvd",
-    "lp_token_id": "134",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "134"
   },
   {
     "id": "osmo177r65zqzqs50p8utgyltw2uldlxyq26v2klgyxy5440kha49vwaq6j9z8e",
-    "lp_token_id": "699",
     "asset_ids": [
       "ibc/00B6E60AD3D65CBEF5579AC8AF609527C0B57535B6E32D96C80A735344FD9DCC",
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "699"
   },
   {
     "id": "osmo17atf6ld93djyxf0rehn8fcjka92enqy8jrcf7fc29xer4mafyv2qdz37dh",
-    "lp_token_id": "383",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "383"
   },
   {
     "id": "osmo17dyt6827sq83px7gl7gsuzumlh0je00j0z9slcp08cxy8vn0ye0syrr2gh",
-    "lp_token_id": "696",
     "asset_ids": [
       "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "696"
   },
   {
     "id": "osmo17ehyaducl0pyznms988c7xcfd4w0n054klqr9fp4fmqzz05y9e2q9e3pvg",
-    "lp_token_id": "375",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "375"
   },
   {
     "id": "osmo17ff0mxg5j6xtuh7ma623ejcntuzuvpewu9dyjk00wkadh75au3qs0gp8pv",
-    "lp_token_id": "18",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "18"
   },
   {
     "id": "osmo17gykllhtf9q4hqdrtydgl7jgvyeqf3rsvdrwef4ct6pvfhsmyg0sp423x0",
-    "lp_token_id": "823",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "823"
   },
   {
     "id": "osmo17h0ay5zhcllwgshem7r40a2wyx7a43w2ngfrrc7w2w60rrhdklws7u6zy6",
-    "lp_token_id": "768",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/B3FB7128CE957DE1ADB687A919AA0786C77C62FB1280C07CDD78AEA032D56853"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "768"
   },
   {
     "id": "osmo17k408tt5xf9zz44qxf95q6f8m8tvkethvrwk93gwqgkfrlefkjms68dp7y",
-    "lp_token_id": "435",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "435"
   },
   {
     "id": "osmo17kylujlrmyuxu0yvguv0gsxpvgvp44up8pvxvsyh36d0r9ww4pkq6c9zgp",
-    "lp_token_id": "212",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "212"
   },
   {
     "id": "osmo17lmjln5dhd2c37npal49p2gfr2eqmrdv20h7g2u0rszg7jlqxu2sztwlgk",
-    "lp_token_id": "293",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/CD942F878C80FBE9DEAB8F8E57F592C7252D06335F193635AF002ACBD69139CC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "293"
   },
   {
     "id": "osmo17n6nngjwheahmljdk0k56dh5dfnktn2r2f33sdaj4uwnrk00y4vs0jcc0f",
-    "lp_token_id": "525",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "525"
   },
   {
     "id": "osmo17n6y5d9jqjvjk3yysnuszt9spuyqwcdz6uctuuf2m66906efj0ys333va9",
-    "lp_token_id": "160",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "160"
   },
   {
     "id": "osmo17nsa8pa7cjeu2tj8v5mqen8cye3rrp2h69lzvepveruhvtmujkzq9uzjfw",
-    "lp_token_id": "549",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "549"
   },
   {
     "id": "osmo17pk7pcuqxz2hn0j2rhqknzn4npujncpzdakpe9hclz5jr605023qcgc9ty",
-    "lp_token_id": "905",
     "asset_ids": [
       "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "905"
   },
   {
     "id": "osmo17rudnglqgrcnvn3am3xm02d94y4sa3l43ywkv3cp4je44p2ez5nq590lae",
-    "lp_token_id": "858",
     "asset_ids": [
       "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "858"
   },
   {
     "id": "osmo17rujtwmvk8vp3uqq6xxkymk83n3qethhejuar7ayhyuupcsw66mqmg4k28",
-    "lp_token_id": "344",
     "asset_ids": [
       "uion",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "344"
   },
   {
     "id": "osmo17sk5nv9367kc5jgfmtf64c9esgf4sdeazd8fd5twrlhxqne3tgnqrp2qpz",
-    "lp_token_id": "613",
     "asset_ids": [
       "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "613"
   },
   {
     "id": "osmo17wpv2azveyr59utlztg6cm8ckzyyepklrrs4lswszn0u46s9rrgqpftypp",
-    "lp_token_id": "184",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "184"
   },
   {
     "id": "osmo17yl0x8s78p9nhwgqtdjfeynfzaz25mnv2j8m75ev2jznv782958su68utl",
-    "lp_token_id": "181",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "181"
   },
   {
     "id": "osmo17z485xwwqknnxfcs73w4nxu0ndp4n8jf6ylj730cph4a6p47hawqrg65wr",
-    "lp_token_id": "270",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "270"
   },
   {
     "id": "osmo18503q8ndu9smzuwqm9nlgw4l6373d430xp32yv4gclug6t27qy6qz7dyku",
-    "lp_token_id": "449",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "449"
   },
   {
     "id": "osmo185d7wu8622egqk0hgzpp48nmaeg3fvlc4pglg2zqrgdtcjenr3hstpyagv",
-    "lp_token_id": "425",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "425"
   },
   {
     "id": "osmo185uac6gnxaa7aa9pqxgktpuqhe6ve3jkfa8wl8dcx3p3zmymzkyszj4k6j",
-    "lp_token_id": "890",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "890"
   },
   {
     "id": "osmo1860equ7v4tjdcmr2vtka5kr3mzuh3ekzpcez77y7pd25972wl52q5rk9hd",
-    "lp_token_id": "351",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "351"
   },
   {
     "id": "osmo18864qdsyavwstv9r7kcrtzhnuk5zcevex4gmftk0vkaqczew5sjscf7xmp",
-    "lp_token_id": "262",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "262"
   },
   {
     "id": "osmo18984gjmrtrj8tzz5mlx04lqusrmjpdx28ty8h4zgf3yw7lr9r53s3ruz0e",
-    "lp_token_id": "782",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "782"
   },
   {
     "id": "osmo189lml9kvhv8qac8eewhj3kuvz2zpy47fqlv0ahs3gtymejfty7yqqvdyk3",
-    "lp_token_id": "454",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "454"
   },
   {
     "id": "osmo18ahq029ylafhmmf25wqu6lvpz6nz4nf533sv6hlqht6d49p23ehszdp5gh",
-    "lp_token_id": "38",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "38"
   },
   {
     "id": "osmo18c87zv90lqd59tl6u068dqcs9x80rfwwjs5wr0vrj7shay429ntq05psnd",
-    "lp_token_id": "448",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "448"
   },
   {
     "id": "osmo18dpk6wfldlfzkk2tdas2tztcth26v39tt7sc2t30drzrex6mlnqqa3hd78",
-    "lp_token_id": "757",
     "asset_ids": [
       "ibc/051A38BBEF92B9D8293AFBE1FA293E704359E9CB28297A0FD5DBA3E9CCEE9AB1",
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "757"
   },
   {
     "id": "osmo18et08xm2dag9ppkdcs7epza2dvt423kxpdnr4vc670cm7d8jh22qukx7ls",
-    "lp_token_id": "488",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "488"
   },
   {
     "id": "osmo18f2zqvulx7wfzg95eh864jw7neqhz23sk8g9lffys3l4jnlttleq5r5kl9",
-    "lp_token_id": "203",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "203"
   },
   {
     "id": "osmo18fdae3yzc2ycw27gzftx0czkpszzrsflw8cyqe99ku3c9aj7lfcq3tjzyt",
-    "lp_token_id": "869",
     "asset_ids": [
       "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "869"
   },
   {
     "id": "osmo18ggsma2ef28tlyey053sxv7d3ka45lzpf7zm8mr47duezgghswrq9trxet",
-    "lp_token_id": "915",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "915"
   },
   {
     "id": "osmo18gt77cjyv6xe2gqjp9k6ct0fk2usv67q6jjjeagdttsy8qks78ysfq82fu",
-    "lp_token_id": "747",
     "asset_ids": [
       "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "747"
   },
   {
     "id": "osmo18hd0dfzfwdmlz22qp6dqfd06xryqdaug9y2qwafhkp4znc0rqz5q5ms2wr",
-    "lp_token_id": "555",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "555"
   },
   {
     "id": "osmo18jxduxdcesftwkx8uh2lqrjl6teky87t8rpv9wd704929hpe73cq44xcwy",
-    "lp_token_id": "798",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "798"
   },
   {
     "id": "osmo18ltnsk33a45827l42v89wws3u2evagpfua7v57nnhslnggxkqkgq4qjmcf",
-    "lp_token_id": "20",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "20"
   },
   {
     "id": "osmo18lw3t03dmyv6975kzjgacezvaafflz5aepmqrqqc8y494gwwwpmq9vm7p8",
-    "lp_token_id": "586",
     "asset_ids": [
       "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "586"
   },
   {
     "id": "osmo18p7qaaevs9kzsyuzmva969s4klx4xjxtn93cccpypfkhl3mqpcrqlwvu3j",
-    "lp_token_id": "772",
     "asset_ids": [
       "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
       "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "772"
   },
   {
     "id": "osmo18pr2rasc9428jwr6t8hf4m50fgd35am4s6lr45yae0slmfzqukgq20jmsw",
-    "lp_token_id": "122",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "122"
   },
   {
     "id": "osmo18rqwcrvsfyy9s2tlfvmchclxf2cfw2hqvrjvkuljcrhq2vpg4suse8h6tj",
-    "lp_token_id": "620",
     "asset_ids": [
       "ibc/307E5C96C8F60D1CBEE269A9A86C0834E1DB06F2B3788AE4F716EDB97A48B97D",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "620"
   },
   {
     "id": "osmo18svklenrqknkccu7fyh9lunj4ruw6dfx7kfmmv79s0v6sud2ht9qan8ddk",
-    "lp_token_id": "387",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "387"
   },
   {
     "id": "osmo18taz6el39wzs87vn594z5q39mm8psf4v57jyjpx52dg46ac4mg2sxrj5hy",
-    "lp_token_id": "800",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "800"
   },
   {
     "id": "osmo18vt7x9yuda579ssr668avfe8mlngrf255fx3re23340twmh3ujyqsfr3h8",
-    "lp_token_id": "474",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "474"
   },
   {
     "id": "osmo18yxeq5kpup4k47vhjgu8j4y8d82sna7sdtjlz7hkuphnqtsmh8asc9vgca",
-    "lp_token_id": "29",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "29"
   },
   {
     "id": "osmo1937gh7cem2tn09r7c4uh7zgjvgjyxlffa677rv7zmspphu9dxwyqs6pw8k",
-    "lp_token_id": "668",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "668"
   },
   {
     "id": "osmo193lusv4u9c7xuz7ct6wmcyq0c5evayu4x78pdhvp8ewa4huh6a9s4tt3lp",
-    "lp_token_id": "688",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "688"
   },
   {
     "id": "osmo195dw0uzghljwwt3577352xu5gfmy3zrngfa545hdnfy2dd45acrsnsca44",
-    "lp_token_id": "683",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "683"
   },
   {
     "id": "osmo195vm9cpsdntewfe7l83yx2w28hkfvx33lyu454gvfrr6f5m7gcas420nk8",
-    "lp_token_id": "732",
     "asset_ids": [
       "ibc/F16FDC11A7662B86BC0B9CE61871CBACF7C20606F95E86260FD38915184B75B4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "732"
   },
   {
     "id": "osmo196w6qg0r3cfy9rx00390wkfdj9krd93uaed3nlht5uhqfh2avcyq3aldku",
-    "lp_token_id": "392",
     "asset_ids": [
       "gamm/pool/1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "392"
   },
   {
     "id": "osmo1973kthujxy3xq49dj29t6q90uxj0s8epkg0tan82j2fnzm7ez6usuas27z",
-    "lp_token_id": "215",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "215"
   },
   {
     "id": "osmo19a5l88sxfdjxtm0d7x777g0g7679m0uusepaytqy0wlnnzut83wswvvezu",
-    "lp_token_id": "179",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "179"
   },
   {
     "id": "osmo19a6nnvczjpnjzt3wgrf4h02yej62wpvnq9cayph7ec5klhds487s9kazwf",
-    "lp_token_id": "666",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "666"
   },
   {
     "id": "osmo19apu4h3aqlzhtpd0suftzctxnctwqd0lpzpueus3tughvcfdv4gsnzqxu4",
-    "lp_token_id": "156",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "156"
   },
   {
     "id": "osmo19ecrtx598f0yyg2chk82gtsuzst2jfr6tkmevnwn8538lysws7sqnsg8q2",
-    "lp_token_id": "565",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "565"
   },
   {
     "id": "osmo19eq5d9ng00ttwlsh9j9fs6t898lqltt9ah4ph039a3hznrz3hrns7rxy40",
-    "lp_token_id": "306",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "306"
   },
   {
     "id": "osmo19esg8fulwzufjjarprfpu4mz06zjpkmk7p0wydcw5q900lp2k3mq7afv7m",
-    "lp_token_id": "503",
     "asset_ids": [
       "gamm/pool/502",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "503"
   },
   {
     "id": "osmo19ffd2uz59gf0w594hpwxjgzrkt3c2vd70gzw6lhdtsz07hl2m7sqfky68k",
-    "lp_token_id": "254",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "254"
   },
   {
     "id": "osmo19fm8jtzyw8ujsnsqm5rznudn8fhhkykjh4ra8rvx9lsfslw2pc2sp36h3r",
-    "lp_token_id": "9",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "9"
   },
   {
     "id": "osmo19g97e0xshdd4xefn39wwquftq3g9u0a7jk8wcety6fgv58cpsx5sdjnvre",
-    "lp_token_id": "516",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "516"
   },
   {
     "id": "osmo19gffpaavnhhzryktpskz7782ttt5qfs4cqfmhyuygc3cxytljfcqyggf5t",
-    "lp_token_id": "859",
     "asset_ids": [
       "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "859"
   },
   {
     "id": "osmo19hcj893wcz2cwk7jkzgvqxlwqqp7cl2v66f2e2l68hy4wezuegmqdcuk0e",
-    "lp_token_id": "654",
     "asset_ids": [
       "ibc/6F4EFBEAF2659742F33499C9B4D272CFD824DD785156DF4C5C453F95CEF27D98",
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "654"
   },
   {
     "id": "osmo19hp7h8xhg8r3z8wv0hf3hw95n09q5vxtfefeha97kuwflttq926qe8xs83",
-    "lp_token_id": "267",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "267"
   },
   {
     "id": "osmo19jeyxdr0maeeh9uedgaemyghd8jgfcucv59mjnw867vhwkysf7fsqf2yxk",
-    "lp_token_id": "756",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/56C276FC136E239449DCE664292DBEEF5795C4EF4B5B35DB98BD1C0948274867"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "756"
   },
   {
     "id": "osmo19jglnr7dv7ppezmk5v6sk3drydxc97nda2wxujzjmh8ef33lq0tstn9y4k",
-    "lp_token_id": "834",
     "asset_ids": [
       "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
       "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "834"
   },
   {
     "id": "osmo19kdw6jce9eclvydnl8656z569ygjj060pehg9z8xq2p3ffyger6s6dj7tk",
-    "lp_token_id": "451",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "451"
   },
   {
     "id": "osmo19mzey7tczk8fz5r2u2qnrmt6wlpgfh8k2wcnt20k2rhmspsv6h6s9t9327",
-    "lp_token_id": "415",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "415"
   },
   {
     "id": "osmo19ntgdh5wuu9zeh6svqc7x9h8zv6w7u4p7sxn2t980p7ct8st3s5sc8u9yy",
-    "lp_token_id": "307",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "307"
   },
   {
     "id": "osmo19qawwfrlkz9upglmpqj6akgz9ap7v2mnd05pxzgmxw3ywz58wnvqtet2mg",
-    "lp_token_id": "627",
     "asset_ids": [
       "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "627"
   },
   {
     "id": "osmo19rrapg60r2f6s2h534n8d2tflv6kwed443jguxrvg2lf7pyggmmqq6mu8d",
-    "lp_token_id": "370",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "370"
   },
   {
     "id": "osmo19sp2fqdyr4p8mwn0206jk9ps06ewpavxxxz07zpseyphuy9uwmgspv87l4",
-    "lp_token_id": "228",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "228"
   },
   {
     "id": "osmo19xaz97zcvcmp5q3ur3g4fqe6mlhz7k2dqd8w639yzk3greh6afws2wjlt3",
-    "lp_token_id": "618",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "618"
   },
   {
     "id": "osmo19yat2nwf4h3d667xgyvtr2pg05nsxy2y8z408pnf8ypmkrqwyruqnnn4hz",
-    "lp_token_id": "118",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "118"
   },
   {
     "id": "osmo19zg3tz4q5t3x6d2hdmwfkud4d3l3x8r4szr6clvlssw277y3g35srvkczc",
-    "lp_token_id": "597",
     "asset_ids": [
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "597"
   },
   {
     "id": "osmo1a0ev3jr6fts7y09as95pryn59hzwfkaletpusfzctejjy0wqa47sxqgy3a",
-    "lp_token_id": "358",
     "asset_ids": [
       "gamm/pool/356",
       "gamm/pool/357"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "358"
   },
   {
     "id": "osmo1a482ur89qhmuv07gmnt93jnmqww3ae3mdj4pd5hh4uje7zk57wys258nqn",
-    "lp_token_id": "252",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "252"
   },
   {
     "id": "osmo1a6rvlkd2jw32mjf2pt78fte7f2hqu7gvr0yqsqek2c7anftrunkqqq798z",
-    "lp_token_id": "26",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "26"
   },
   {
     "id": "osmo1a86mk698pzmwsv28pcs5f4hvl22eexc3krc4k03j27fgkeqtaftqgnvlq3",
-    "lp_token_id": "365",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "365"
   },
   {
     "id": "osmo1aaaa5xedavww3s9j48zpfjy4tcqll26wpr6fkt8wys3ufzlwv89qc6f8t8",
-    "lp_token_id": "603",
     "asset_ids": [
       "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "603"
   },
   {
     "id": "osmo1aav62u4pls035r93uuy4h2dckl06hc2atpsdzm8947qvlc34pprs3edc28",
-    "lp_token_id": "400",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "400"
   },
   {
     "id": "osmo1aavgx9ta75dchrwjf46z086pcjr44t4qkvz0c7walmvf5j3lxqnsulxsfw",
-    "lp_token_id": "532",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "532"
   },
   {
     "id": "osmo1adqhma2hfrqr04uy4t4lmu3rft2k7rjj3j7xyye0v3tg09urg0xqcm28q5",
-    "lp_token_id": "567",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "567"
   },
   {
     "id": "osmo1adzv0qftyywfavf06uqh0lutcqz5nz5favasq58rkvnu4l3zvs7shy9kxu",
-    "lp_token_id": "367",
     "asset_ids": [
       "gamm/pool/364",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "367"
   },
   {
     "id": "osmo1ag2w5l8av9msvzhks4vyd920r9lzaesekes6yg3vykp9fch5n22sk6er50",
-    "lp_token_id": "812",
     "asset_ids": [
       "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "812"
   },
   {
     "id": "osmo1ah0sdvddcp3jjgfsyd960gud26l4dwz5gkqtx0qw42sv7kpsakhqyv257p",
-    "lp_token_id": "471",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "471"
   },
   {
     "id": "osmo1ajghgy4ltm4ghn5smlrr29egrk3mq72642jsq8hqqet4cnwv4kssm9mrw8",
-    "lp_token_id": "91",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "91"
   },
   {
     "id": "osmo1ak0lwxqlp70chxtt2fd4kr0ywhuk2fr6ncsjr884psu7h8m59vuqm6p42n",
-    "lp_token_id": "641",
     "asset_ids": [
       "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "641"
   },
   {
     "id": "osmo1amh63u7vgtrak5rmetdjrl67jhl6rate05r792ywyxzp5jt6eq7sx5uphr",
-    "lp_token_id": "585",
     "asset_ids": [
       "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "585"
   },
   {
     "id": "osmo1ang9dlvxrc0n835xyxvwf66mj0mm0sznyqwtu03kdd2dmhg40hlqnq36up",
-    "lp_token_id": "246",
     "asset_ids": [
       "gamm/pool/1",
       "gamm/pool/8"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "246"
   },
   {
     "id": "osmo1avdp69rp58an6hysjh5n6g9w0wx73sytfxcg3qjynnxcar5t5qfqxukm2s",
-    "lp_token_id": "673",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "673"
   },
   {
     "id": "osmo1avm2f4fegrla4wcxft7ct3rksnuxvjl3mhv9gljg2e0c2swvlmqsaxy3xv",
-    "lp_token_id": "37",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "37"
   },
   {
     "id": "osmo1awdgj7l3rjq2hmevgxuha99w39600fek27vsun4rztvy7s5h6n8sklwc8d",
-    "lp_token_id": "477",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "477"
   },
   {
     "id": "osmo1ayjsj697r8ne5pnda82s96hdjvu5svp7ucjj3ekzlj886epq78cs2e48n3",
-    "lp_token_id": "789",
     "asset_ids": [
       "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "789"
   },
   {
     "id": "osmo1c0l0m8tvta5qdr5cutfnydw2h6r6qpzxtwtk8e7677v2h7es3tfsgv986d",
-    "lp_token_id": "826",
     "asset_ids": [
       "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "826"
   },
   {
     "id": "osmo1c0utzzgn56dhacxt2rzf8mvgkql54xnu78fhpnxqnx6hld9hue0qe79a7c",
-    "lp_token_id": "83",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "83"
   },
   {
     "id": "osmo1c2agkt3smeangnelsxqqr97fm6kd0s7erqsgcuvc3nu06yr63qnqcz22mj",
-    "lp_token_id": "606",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "606"
   },
   {
     "id": "osmo1c3vwd6kvev6499jg6tseszqky6p69mwdg5n66j060hvytxd6hjrsvzxk6u",
-    "lp_token_id": "445",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "445"
   },
   {
     "id": "osmo1c4xsza76pfcauuqadpa3gq6mj6zjzjx4upm8p9388jp7tk52qars6p8e30",
-    "lp_token_id": "238",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "238"
   },
   {
     "id": "osmo1c59p7ddraqwrtxe0camylyhra9s6w35qtywuaavravzx6us3cpsqn3dgn3",
-    "lp_token_id": "133",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "133"
   },
   {
     "id": "osmo1c89mqqr6p979nl0jheysulp84zzpg84ujq5r0dzsmn7xl6aj38pq5fvwdw",
-    "lp_token_id": "883",
     "asset_ids": [
       "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "883"
   },
   {
     "id": "osmo1c8gdt3cquepqadv6ys2m9ht8eys40c2ws46ntwm7zknr2hwcsuhsly32ft",
-    "lp_token_id": "81",
     "asset_ids": [
       "gamm/pool/13",
       "gamm/pool/5"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "81"
   },
   {
     "id": "osmo1c9gj5nwxhuh2gz7wwg4r8e8tw8v7ggy9lh2hu7kkdgh0t450754qh9cpvd",
-    "lp_token_id": "3",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "3"
   },
   {
     "id": "osmo1c9x2kvqge4r2z5rf7p64sg0fvdmjsklxcexmmre2amxsqjxeex2qrlmr3h",
-    "lp_token_id": "208",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "208"
   },
   {
     "id": "osmo1cafjr2f6uek4jc7g0sgxwxnssu3uq2c5uvlzkg2mwkg6jdwu6a9sa7qg4m",
-    "lp_token_id": "716",
     "asset_ids": [
       "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
       "ibc/AA1C80225BCA7B32ED1FC6ABF8B8E899BEB48ECDB4B417FD69873C6D715F97E7"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "716"
   },
   {
     "id": "osmo1ccfjmcfe09k0f6fdcfdgkc52c52l2c0jywfc57sn5qd22texqr3qla0e5m",
-    "lp_token_id": "787",
     "asset_ids": [
       "ibc/9B6FBABA36BB4A3BF127AE5E96B572A5197FD9F3111D895D8919B07BC290764A",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "787"
   },
   {
     "id": "osmo1ccjfm7gpa37mc9zwq553p0ttzq3ga5g6jzarz37lcq4qlnsdcxhsghcv3y",
-    "lp_token_id": "810",
     "asset_ids": [
       "ibc/5DD1F95ED336014D00CE2520977EC71566D282F9749170ADC83A392E0EA7426A",
       "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "810"
   },
   {
     "id": "osmo1cdtygs9r2lf9smh79j9l883wfxearsweevfqrrehfh7up3xw4nxqrsjwlw",
-    "lp_token_id": "373",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "373"
   },
   {
     "id": "osmo1cf892ucxz0g5y9tlakunhn6hlgk40w0s6fy6hcjzsqnmx4u77xcqjafnfd",
-    "lp_token_id": "791",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "791"
   },
   {
     "id": "osmo1cgr0zcfetq39yc3zhex2eaw2unczcw90m6qn7msw45r6qae9k0xqputy2m",
-    "lp_token_id": "737",
     "asset_ids": [
       "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "737"
   },
   {
     "id": "osmo1cgw34ya7ndpmplgv5wyec4mz7hq3crc64uqq02qv6zk9vxun2rksk8fcja",
-    "lp_token_id": "75",
     "asset_ids": [
       "gamm/pool/73",
       "gamm/pool/74"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "75"
   },
   {
     "id": "osmo1cj8dxdkgugvj0dysm79zha8mgkn9r7x9yg9n4cmdmqv9ucjkv2dsj5evg5",
-    "lp_token_id": "533",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "533"
   },
   {
     "id": "osmo1csvn07y2n36dy3glfvdxeke80sxrhp8xwtjfds8nhvjullkqzpmq4zzh2s",
-    "lp_token_id": "337",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "337"
   },
   {
     "id": "osmo1cu6nmf563q57u4lc7v9t23sytz25t5cya0f060227vwsy6u0cpaquldl5e",
-    "lp_token_id": "376",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "376"
   },
   {
     "id": "osmo1cu9q2r5r09uct7ykpepyttk64hf30aygjn0ky567qrky5nthl56spqtnxz",
-    "lp_token_id": "593",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "593"
   },
   {
     "id": "osmo1cwauwz0e490vkszxhrfhmawjsaw8ulac8fr03wccssn4eqswdxpsn2ycxj",
-    "lp_token_id": "294",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "294"
   },
   {
     "id": "osmo1cxfkytmxzs55c00anuftly389mzg3gzvncfm8s4u9zeulhj8hsfq87snws",
-    "lp_token_id": "95",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "95"
   },
   {
     "id": "osmo1cyjmqv92kx6trjjjsmemj3hvs9qg5jsrhscmq5km05hpkdsv62zqwpnggf",
-    "lp_token_id": "740",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "740"
   },
   {
     "id": "osmo1cyllu6l6dw88t2wlk5ex4femwvj8nh249uff5uzzt2409aw0gy7su6lq2h",
-    "lp_token_id": "85",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "85"
   },
   {
     "id": "osmo1czqlvqjdlm2raj6t65nansxt5zlv8ny04fn66gcm9llgl24axmksd2px7e",
-    "lp_token_id": "882",
     "asset_ids": [
       "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "882"
   },
   {
     "id": "osmo1czvns32qxxcyckqdfn02j7taflphz5dxawc6ksg7j5h58nlnen2sh8xxyj",
-    "lp_token_id": "138",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "138"
   },
   {
     "id": "osmo1czyl3pef9apzjzwn949jk4lsfcql2mg66xxrmlvcukt2x3q0y03s7v06d3",
-    "lp_token_id": "271",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "271"
   },
   {
     "id": "osmo1d0elgsavwgez5xf0fdan3krzfjm5jkdtcgxzlvunu4jndycs8u8qzs5h33",
-    "lp_token_id": "19",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "19"
   },
   {
     "id": "osmo1d338zex4aayp5r6r4rtrvclcwdx4x0jqnpy0qzyszn700hk9n75snwxtsf",
-    "lp_token_id": "125",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "125"
   },
   {
     "id": "osmo1d3nk4hhy929kyqnrxf874xvdey46szrw4mxk3n8v26kzck6a8r2s677wyq",
-    "lp_token_id": "240",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "240"
   },
   {
     "id": "osmo1d4t6lpc8glprq3nfg49u4887hv8jhxvllsey27mvpu7qf4pawkjsplh3pn",
-    "lp_token_id": "354",
     "asset_ids": [
       "ibc/A91B70554A510310B2A068979C8E7A9B433EF689E82A9321922D8A1B845B95F5",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "354"
   },
   {
     "id": "osmo1d6h0xq4vsgpay9n77yrzuaqyvs96x83c0wrrffr92pkcxnuk6lsqff43ne",
-    "lp_token_id": "452",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "452"
   },
   {
     "id": "osmo1d735wcpt6x0w4ynqe874lr7ch9laufgas0dr2nfs6e4zzlurlf9q5st28n",
-    "lp_token_id": "781",
     "asset_ids": [
       "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "781"
   },
   {
     "id": "osmo1d7khqcglglgvkkj8jwt62mw0h7ak9y7de5js9zccn9kgtmx0j2qsm56cev",
-    "lp_token_id": "551",
     "asset_ids": [
       "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "551"
   },
   {
     "id": "osmo1d7tu6pz4nx5e4yzj2keu6ftvr9u5p22u2vu5t6ts8syqt0e3reesqnpun0",
-    "lp_token_id": "319",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "319"
   },
   {
     "id": "osmo1d9y4rs70crz90a49fa3khad0dxy6yg7ezgdzlvuvjrujwvaspawqjut7t4",
-    "lp_token_id": "818",
     "asset_ids": [
       "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "818"
   },
   {
     "id": "osmo1dal655pjhghjfnlaxppj6kacgdrr50xf47dsheeanwaxzya2dm5qfmljhe",
-    "lp_token_id": "191",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "191"
   },
   {
     "id": "osmo1daztxlwd90kqt7yw7mvakhp9kjd34g250dywutq06nvlze2u6uhsuk26xw",
-    "lp_token_id": "194",
     "asset_ids": [
       "uion",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "194"
   },
   {
     "id": "osmo1dcvgttz6jwepg3gchu097aa2vxjgp3g5gm0t0p7z20lyclu7y0rqmc232t",
-    "lp_token_id": "652",
     "asset_ids": [
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "652"
   },
   {
     "id": "osmo1def45s6km7yvg37czsyxdalscd63w9k2v6yynskcgq3l6slm4tps2kvurk",
-    "lp_token_id": "404",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "404"
   },
   {
     "id": "osmo1dejxnyjlhkfr8vjh9j47vjl9j9cvs3jk6aql6nvmxyyv547mumgqtcfc5w",
-    "lp_token_id": "329",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "329"
   },
   {
     "id": "osmo1dgnr0ajw2p2wxh05lv8s8znts6rpz3n2rcepng368tzr5h4pzm7swkyfru",
-    "lp_token_id": "748",
     "asset_ids": [
       "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "748"
   },
   {
     "id": "osmo1dgnsyv3zj9uhen85ttf0heulkzcjj7nn27jw00hzpzp0ecfwx82slyu0ta",
-    "lp_token_id": "406",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "406"
   },
   {
     "id": "osmo1dgrkc9rt7653dyvkepwk25tqjfnkel0alywgwl35p9jtjw4a92gq7f7mnz",
-    "lp_token_id": "159",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "159"
   },
   {
     "id": "osmo1dh38ppn36hhdl365atjw4anr3d4faxzc6j0tassym738k276rx4q2rqkrs",
-    "lp_token_id": "814",
     "asset_ids": [
       "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
       "ibc/E09ED39F390EC51FA9F3F69BEA08B5BBE6A48B3057B2B1C3467FAAE9E58B021B"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "814"
   },
   {
     "id": "osmo1dj7rqa2r8psqp36asc4r6j20v8u62zjpqqwt8khxe24t5dzwssns3aph35",
-    "lp_token_id": "499",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "499"
   },
   {
     "id": "osmo1djnm5mvg2s9p0appalcypxcjd7cd0xw6564k96r8dylgva3vmfnq0ca434",
-    "lp_token_id": "145",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "145"
   },
   {
     "id": "osmo1dlahvz8g205z94g4xpxfxa77wmm5kn0janhs34ft22yxyljuyfaspawg0m",
-    "lp_token_id": "279",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "279"
   },
   {
     "id": "osmo1dq3745uz8j2qd5fq2wtyvz9xzr5587awdnpn08272946dmn5pq5qjknyr9",
-    "lp_token_id": "520",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "520"
   },
   {
     "id": "osmo1dsdccxrhra2pndxay08s7vajz72kr5vxqayalv7xt4gntey2xkmqa8u2x9",
-    "lp_token_id": "680",
     "asset_ids": [
       "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "680"
   },
   {
     "id": "osmo1dssdhlzawzthqsg60a5zms6xtx4tsktfzswal4qsxgugaad6j6wsxd6yk3",
-    "lp_token_id": "385",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "385"
   },
   {
     "id": "osmo1dt25gt7wgeh9l66adztvyl9x2l94mane2zdkrp29e4y7s3484qcsgv24y5",
-    "lp_token_id": "129",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "129"
   },
   {
     "id": "osmo1dt568undkrrlullpzz0c27548vjdrhnsxwhygxrdtacv2dns2ryqa28jhs",
-    "lp_token_id": "24",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "24"
   },
   {
     "id": "osmo1dtlq83lwessktl65gxz6u8ufqc9lz0knh6nnw3rwklgla6jumrfq5a3clp",
-    "lp_token_id": "546",
     "asset_ids": [
       "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "546"
   },
   {
     "id": "osmo1du947dpr6v3nlcwu8a2x2qtzkqm6z2nay7dqkzj8fgcqmull6mvq8wum5e",
-    "lp_token_id": "167",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "167"
   },
   {
     "id": "osmo1dufw6sdwhp6cxuxh8kfg9t50erne08t9sl37a6jeyswpknufftws5w7w8y",
-    "lp_token_id": "629",
     "asset_ids": [
       "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "629"
   },
   {
     "id": "osmo1dyvjg5eyr58e73fpnw3z6c7wz2h0wvarmpmvq0c60vawm8e6q70q44v94n",
-    "lp_token_id": "147",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "147"
   },
   {
     "id": "osmo1dzwru0m7m0klhxqj84hd3vhhltk07r6try7pj7s3qy47nqq43g0s6fsy2n",
-    "lp_token_id": "214",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "214"
   },
   {
     "id": "osmo1e0m28qylp9k0s4l6quk2skv9g3w0p8qvu8aqmxuf2n6tt7ctkuyqrw5d48",
-    "lp_token_id": "761",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/8A07D4BD40E0F44ECFDF360F7EA7008B288926FB87C54489FE54DB81A5340E0C"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "761"
   },
   {
     "id": "osmo1e5xkxxpszq9t08yuu828rjzrmj5gvpwnf9ywv74ryz4frsyr0zlqyx76xf",
-    "lp_token_id": "766",
     "asset_ids": [
       "ibc/1DE9A32D603EE05E9B8619DF24D90FD518C932AE0B5B3209A986B7262DBADE2A",
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "766"
   },
   {
     "id": "osmo1e63smvqcnxpgxuvhrknfapmyvjy98csgm7z6xr6zjnkwmjf7zeaqsc66vn",
-    "lp_token_id": "236",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "236"
   },
   {
     "id": "osmo1e6szkqkkt3g6u7ukjpdz493mkvm9njknrxpe4vcfahl4dlx358msqgnrxz",
-    "lp_token_id": "292",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "292"
   },
   {
     "id": "osmo1e92udnupts46czvcwtjcpgyvjhjv3grpjg43p60d8el8r24td3zqt8gfv0",
-    "lp_token_id": "792",
     "asset_ids": [
       "ibc/C78F65E1648A3DFE0BAEB6C4CDA69CC2A75437F1793C0E6386DFDA26393790AE",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "792"
   },
   {
     "id": "osmo1e9s595ml68g99m9vtat2jl66v65ravl7wlu3usj7mu3arz56flpssletl2",
-    "lp_token_id": "689",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "689"
   },
   {
     "id": "osmo1ea5ymws7tufhg7v72wjwp3qskngmnpl729uc9h4anusfasmg48tqwje94x",
-    "lp_token_id": "825",
     "asset_ids": [
       "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "825"
   },
   {
     "id": "osmo1ecljlcqy3z4tfrr7rql0tmr83mh3qfjdzmpgwad9zm6q908k347qhc23ht",
-    "lp_token_id": "192",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "192"
   },
   {
     "id": "osmo1edal9l38mgcm2hj27hgz0mcqapkp9yla3pgtusxap824hwqvfttq00m4wy",
-    "lp_token_id": "59",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "59"
   },
   {
     "id": "osmo1efnu25xj2cp6th0jacx9e7qn6zlwnceq24v74pz0wn9gxtlc8pvsqn0l0v",
-    "lp_token_id": "421",
     "asset_ids": [
       "gamm/pool/420",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "421"
   },
   {
     "id": "osmo1eft30ela0axavl9xa3plmv00ah005vkhyexsm0rc0cmfkz8jujjsaqq56h",
-    "lp_token_id": "326",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "326"
   },
   {
     "id": "osmo1eg26w7fg3hdzjxyxv5x846ekjmw0rdewlxlp6rf20efursfurh7q78cyu2",
-    "lp_token_id": "758",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/B797E4F42CD33C50511B341E50C5CC0E8EF0D93B1E1247ABAA071583B8619202"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "758"
   },
   {
     "id": "osmo1egng4w6ht85nhy5038hfs5xvx6ddg0l6mqslaxnudqssq5jm4y2qrh2han",
-    "lp_token_id": "539",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "539"
   },
   {
     "id": "osmo1ehnfys6czdccwsg4twezh3w37a6zxgaa6ud0s0mn0c6yuqnj6dkq6jx9u5",
-    "lp_token_id": "119",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "119"
   },
   {
     "id": "osmo1ejaswj8lcyh0zgnes8zt45e0w7tqm4mrxr74sfwgpdh72shp58ms4fdqsk",
-    "lp_token_id": "611",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "611"
   },
   {
     "id": "osmo1ejcrrmfxaphd6nf270r34467u2a407mewhq5g5cz6hdhzqs7nnxsvpthf9",
-    "lp_token_id": "380",
     "asset_ids": [
       "uion",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "380"
   },
   {
     "id": "osmo1ejm5jcfnsvcw5zxvc5h2k5d2yppww7tk9jt7hnqh9upaudckp8cqjn2578",
-    "lp_token_id": "105",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "105"
   },
   {
     "id": "osmo1ekrucs08jgx45nf5d6rtkd2px4m60v9hwa4l2mj9frkvv908mwvsqz7z96",
-    "lp_token_id": "390",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "390"
   },
   {
     "id": "osmo1eljhrrff3eklwl6t6lv8znt8pyej5k9k54cvr3gyakqmr6xldt7qu2vhgl",
-    "lp_token_id": "434",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "434"
   },
   {
     "id": "osmo1emy3l3y30eqv25kfrwcs54whga4smrzvf39rl8km45rupcjz7uaqcmxtup",
-    "lp_token_id": "609",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "609"
   },
   {
     "id": "osmo1ep9jw2xkuu3mhdqstgpeqw2tr2txw7aulx5cx0lar2lc3pw0huzs6j5ty5",
-    "lp_token_id": "141",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "141"
   },
   {
     "id": "osmo1ephgyd57rw7mzf0p5gdjjezt2j442jpzdezvkjdvpke703fyy06qtstsmk",
-    "lp_token_id": "771",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/AA1C80225BCA7B32ED1FC6ABF8B8E899BEB48ECDB4B417FD69873C6D715F97E7"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "771"
   },
   {
     "id": "osmo1exr9ekmy6ucvp8f8mqzu8qetxzsgzuz4d4h28y70ftwqwfcfvgqq2ywwh9",
-    "lp_token_id": "340",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "340"
   },
   {
     "id": "osmo1ey4fm0hsg5h0el6c4duhkmu8ujgp0ndv0u04jpnkg696lsx6kytscdw7tp",
-    "lp_token_id": "310",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "310"
   },
   {
     "id": "osmo1f2tlf4lnhzsrh9pyu9y3u6wju2nlqzummm3zs70jerk2s7a0fq4qfq9epf",
-    "lp_token_id": "510",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "510"
   },
   {
     "id": "osmo1f33v0n0kn6vtu7vkxuf2rm9dxncnwuga5825tzupc3t9umsgt0rsl6u29e",
-    "lp_token_id": "151",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "151"
   },
   {
     "id": "osmo1f4lp47dxu7w2ykr5dpgd8yeylx94xg5xv4cfmrcsfu4v77tqv73s3y3cmp",
-    "lp_token_id": "253",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "253"
   },
   {
     "id": "osmo1f5fse04elu35trhlkf9dq4crgjay6pfh2nnmgx88acj7xmcarnvqgvq45v",
-    "lp_token_id": "600",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/EA3E1640F9B1532AB129A571203A0B9F789A7F14BB66E350DCBFA18E1A1931F0"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "600"
   },
   {
     "id": "osmo1f602n58fsvphaledcyyxeczukyee0dnum08psrqrl894s3cc57zq6jyvyq",
-    "lp_token_id": "12",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "12"
   },
   {
     "id": "osmo1f7cj0tc02qqwaps8d98s3pnwfyudsvfj9w4zmdmxdrp9gw0sh27spf7yyl",
-    "lp_token_id": "164",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "164"
   },
   {
     "id": "osmo1f7rg0se3mhuwkjuzwdys2j64f4ktk5pz9lmf2cas5xu84urf5ulqy2qmpc",
-    "lp_token_id": "234",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "234"
   },
   {
     "id": "osmo1f7vufh36kuhn8gtjhzzm98h22w6830zww86zwx8f6f47cz76r5yqvg67p5",
-    "lp_token_id": "158",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "158"
   },
   {
     "id": "osmo1f7x8t6zv4tdmu2txgztqc9jwfa0kmx2jpgcmah69njaxc6h5gszsp8884g",
-    "lp_token_id": "561",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "561"
   },
   {
     "id": "osmo1f95y595e89tucsuqrzdpgvtetyc8mzswdrqp4rrt8v8dexa2t4nquuee0m",
-    "lp_token_id": "682",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "682"
   },
   {
     "id": "osmo1f9862pvm6htudctzex2c67ezkkp5z4lt07h76kdjl7gayez95eus2ekuhs",
-    "lp_token_id": "115",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "115"
   },
   {
     "id": "osmo1fcl04ma3dhc080jscyzkgf65u2ctv9v67ec03an3cff0gnfqkllqqkufhx",
-    "lp_token_id": "21",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "21"
   },
   {
     "id": "osmo1fg5xzrgah8mr6uqcgfjv5m0l9n2ce0ptye4sraavt3me3uh7yfeqy755dg",
-    "lp_token_id": "489",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "489"
   },
   {
     "id": "osmo1fharjyp6vl6xx67f59jn2mrc0p6vl5lf32zpweuyevdhpusv5uysamun60",
-    "lp_token_id": "480",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "480"
   },
   {
     "id": "osmo1fjjqzp80dgpq2lr0jzzyc9x05eeu6th36lc9r24x3m26af0vm5tsdzkt00",
-    "lp_token_id": "723",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "723"
   },
   {
     "id": "osmo1fjrk6zk2st8uzgzedh8rx9rt8gk7rmxmstr8923v0xsqn2gjafmqr99vc5",
-    "lp_token_id": "502",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "502"
   },
   {
     "id": "osmo1fksasqaynht6wz2nhzyjnc6ef0d5caevyt9uqczhclfuzd8kyycqpl4g5j",
-    "lp_token_id": "686",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "686"
   },
   {
     "id": "osmo1fmz4zaaj377th482zzrvc5d9rx7hpreyhfprvum9hd2vyedg0trquug78j",
-    "lp_token_id": "528",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "528"
   },
   {
     "id": "osmo1fpv2vn8xz4arzvwjqc52eh085rc4ktnsdwmpg3tum0rvgyf2hfqqw035mc",
-    "lp_token_id": "169",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "169"
   },
   {
     "id": "osmo1fpzttww633v3jqz7vkf9csjcvjlmfl7rq3654uf0j6seq0p4h4esrjmuxw",
-    "lp_token_id": "602",
     "asset_ids": [
       "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "602"
   },
   {
     "id": "osmo1fqu4s8f5dha4tgf3swet43jlmeutxeynmm265mv2m8awauy6cvfstu4xyg",
-    "lp_token_id": "121",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "121"
   },
   {
     "id": "osmo1frnc03evn4vnyrcvqqv85304rgegj3g44xj8vpdktmuaqwaqxtasefugr5",
-    "lp_token_id": "648",
     "asset_ids": [
       "ibc/8061A06D3BD4D52C4A28FFECF7150D370393AF0BA661C3776C54FF32836C3961",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "648"
   },
   {
     "id": "osmo1fwexzng4wjqvga4avsvmqs6ay09yv80g4w6wrn9um05d95vsqw6saqxjgm",
-    "lp_token_id": "441",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "441"
   },
   {
     "id": "osmo1fyav6ky62qrtu5hu6hv6jrx2mu058gvke6ncqyke6ns5mjgvtj5sv52acw",
-    "lp_token_id": "864",
     "asset_ids": [
       "ibc/92B223EBFA74DB99BEA92B23DEAA6050734FEEAABB84689CB8E1AE8F9C9F9AF4",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "864"
   },
   {
     "id": "osmo1fyxn5dnns58s2k0r8h3tf3llj6drwxn2lxqh7gv92hpy4953ka8qx6hey5",
-    "lp_token_id": "518",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "518"
   },
   {
     "id": "osmo1g0c2n00paxpku0t4psy50kz385htrv50yk5szm6z57c0rzpd6qesjhwxwh",
-    "lp_token_id": "724",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "724"
   },
   {
     "id": "osmo1g0e2en7r0juxqx2mmp9gc6nxtx9xfrsll5swvccsskywrfd7utjsmkt4l7",
-    "lp_token_id": "896",
     "asset_ids": [
       "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
       "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "896"
   },
   {
     "id": "osmo1g0jmvyrlmed35fd42rfu8emhn8mndyknn7rmx26943nt8jcz70rsd5su83",
-    "lp_token_id": "463",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "463"
   },
   {
     "id": "osmo1g2y3ptjh8rndpsq6r2cty94nl777fugke3z2rq37ac3uldtfagcsspp8xt",
-    "lp_token_id": "829",
     "asset_ids": [
       "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "829"
   },
   {
     "id": "osmo1g4u4df420klg8xnkuhezz065p7e4q6emwagx3ctd9qv3gcl32h7sfygnlq",
-    "lp_token_id": "651",
     "asset_ids": [
       "ibc/8FEFAE6AECF6E2A255585617F781F35A8D5709A545A804482A261C0C9548A9D3",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "651"
   },
   {
     "id": "osmo1g7jq4a7hw9n65tdv9mn28gckr7zqrzp0czvlxa0gqftrmtw28c5qc82aan",
-    "lp_token_id": "743",
     "asset_ids": [
       "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "743"
   },
   {
     "id": "osmo1g96kuarfld3nfeenuvdke2ec6584qvhrpx8eq0qxntk5llgzdlesk20neg",
-    "lp_token_id": "225",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "225"
   },
   {
     "id": "osmo1gaern4gnnuu05dlzfr9ax5hl9hwt6tcymklv3vy4cs0tz8kkqqnqlxesce",
-    "lp_token_id": "60",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "60"
   },
   {
     "id": "osmo1gdfp7xyv7j7wm7v0z42rqcaumf8emz3c9whfzmhmu6qauu6xfdts9t5dcm",
-    "lp_token_id": "889",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "889"
   },
   {
     "id": "osmo1gesjuqekz3pyuuz0fg7j2ctckeqkltn8h225ce0fd93fckd9sksshu4wzn",
-    "lp_token_id": "566",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "566"
   },
   {
     "id": "osmo1gf86c7l352dk4zcgruldykckr99jn86khvjy2efcvevewrjkv3msxur0kp",
-    "lp_token_id": "514",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "514"
   },
   {
     "id": "osmo1gfzdnqyy95cgvjl3vkr7vs3ra9f06xu7mu0w4ldxj6rqszkhvnts0vs24p",
-    "lp_token_id": "39",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "39"
   },
   {
     "id": "osmo1ghy3kl2fvyzag0q68zwmve4afl26avtt4sn80um6gw7zqx7p35ns83cch8",
-    "lp_token_id": "537",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "537"
   },
   {
     "id": "osmo1gjfqv5vtwnm99dwac9v9ug4l9msyq9wejnatnvj35ex25ak2nrssh3pat9",
-    "lp_token_id": "268",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "268"
   },
   {
     "id": "osmo1gkq0x059rrnv6egs8snzy7m80zrz3uygtu3khxr3llgnljm2wjpqmeqlz4",
-    "lp_token_id": "703",
     "asset_ids": [
       "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "703"
   },
   {
     "id": "osmo1glc2ym96m3tsncmulludzhksuahvk09rwyjlm7t20dewlwk8vzxs529ngm",
-    "lp_token_id": "381",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "381"
   },
   {
     "id": "osmo1glls893n6fdgw2nrx5kl6l940qrxpvd3k5qlf3udu0r5zhgc6dqqs98en8",
-    "lp_token_id": "204",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "204"
   },
   {
     "id": "osmo1gms9szd899acpscedg46za5zjmut2yalkgnr6x2ekw7q3l6ppqvs0h3lu0",
-    "lp_token_id": "459",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "459"
   },
   {
     "id": "osmo1gnq7pvafrxq0yg74ph5r7vxl6dh6rsp5yncrq5gd4sr6vtjppndqsd3jjl",
-    "lp_token_id": "670",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "670"
   },
   {
     "id": "osmo1gr45uf6rm02778wdwlhkdxt3c94fr6eqtk6284fpr804r24nrersnasvtx",
-    "lp_token_id": "684",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "ibc/CD20AC50CE57F1CF2EA680D7D47733DA9213641D2D116C5806A880F508609A7A"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "684"
   },
   {
     "id": "osmo1grw4dy9teaam0u2jywd9sw49max4ua9vj6hgsvjnr3jva8cr3husxrc3g0",
-    "lp_token_id": "175",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "175"
   },
   {
     "id": "osmo1grzll8mqv9c0tkwe0secf225mpxnrx86fffnnlz4ffhwkqsr3gaswfa52j",
-    "lp_token_id": "719",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "719"
   },
   {
     "id": "osmo1grzzz4rwj8l06wuf83dwhhhss39zv3302edgpa3tx6s6g45etsrqjjrz3v",
-    "lp_token_id": "70",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "70"
   },
   {
     "id": "osmo1gs0czr9thyy0fgneenmj5swnew73gk5xktr352qggxlhhm5uwkpq77sgns",
-    "lp_token_id": "741",
     "asset_ids": [
       "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "741"
   },
   {
     "id": "osmo1gtc9dqfscgnlrw73yalnan4v2fwy2hz5447sqgclx68yz46us3xs38v2eh",
-    "lp_token_id": "522",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "522"
   },
   {
     "id": "osmo1gtxfvhhvx8n5xvytrrp48qgu5vflpr0qm5e5c4p3zqwd4mr4u0uq6wv5d4",
-    "lp_token_id": "570",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "570"
   },
   {
     "id": "osmo1gvcvxl68u9rgwgfctxkfuhmyqxqzn3lrxw9cn5qg3q5er27ex65q6vlpuh",
-    "lp_token_id": "289",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "289"
   },
   {
     "id": "osmo1gwzs6qa626az6nhqcg93uxa8mfcfcc4mm7xecctwqaelfl70jewsgtkfh5",
-    "lp_token_id": "348",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "348"
   },
   {
     "id": "osmo1gxdq040aa9qk9d5uvtlt00uwhaskslthdq9k2kpkwm430u4cnyqsj7ml7k",
-    "lp_token_id": "79",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "79"
   },
   {
     "id": "osmo1gy7usssxrzsepfpn9z07456cqqmumtmn5mw3wgc5jpmwt2ha8qdqwxy09x",
-    "lp_token_id": "74",
     "asset_ids": [
       "gamm/pool/1",
       "gamm/pool/73"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "74"
   },
   {
     "id": "osmo1h5hz4uttwlnvvn4xf0r0sr89v6rgtv399le6y0ksv458jvg9vm2q8nyvdh",
-    "lp_token_id": "919",
     "asset_ids": [
       "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "919"
   },
   {
     "id": "osmo1h6tps4e40h66y5xunmgazkd4kvpcl26367ue3ta4ukjzw4j5j7tqxqqxh0",
-    "lp_token_id": "172",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "172"
   },
   {
     "id": "osmo1h7yfu7x4qsv2urnkl4kzydgxegdfyjdry5ee4xzj98jwz0uh07rqdkmprr",
-    "lp_token_id": "497",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "497"
   },
   {
     "id": "osmo1haqvxq0ykcxa5wjzpvpdpu96jdss0v0du7hfly595rhlamtzlmzq9a748l",
-    "lp_token_id": "99",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "99"
   },
   {
     "id": "osmo1hcpnvyer3r93x2ux72w0347plas3vzs0f886lwa4thhdqth04jcqkc0k3c",
-    "lp_token_id": "467",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "467"
   },
   {
     "id": "osmo1hdsvaxe9898kryxy2zlljtazl5dur9qxhph9q0qnrcqylyf9j9gq6peqep",
-    "lp_token_id": "427",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "427"
   },
   {
     "id": "osmo1hecg2sghe8y69el3r9s0ysvlgqrwhg626lwujq5wzh0hah8zsqgspe678n",
-    "lp_token_id": "16",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "16"
   },
   {
     "id": "osmo1hedgxlrrcls3aefh83vhqq4aema6yglhu24w8x67nulyc7655ghsdfvv60",
-    "lp_token_id": "653",
     "asset_ids": [
       "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "653"
   },
   {
     "id": "osmo1hek3fwgtlxgjvsgplhsucpz7w7q9vlp6mjm5m0c84na0x2y9y43qynrs6g",
-    "lp_token_id": "285",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "285"
   },
   {
     "id": "osmo1hg0eeayprkg6a66fqs07sncy09rw6tae9k6g7ryrjk0k4nypfjwqrl6wy4",
-    "lp_token_id": "746",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "746"
   },
   {
     "id": "osmo1hg2963kvsu2arwx69hcqmsl2ms4x5pjw9x7w43lvspn5tgz4aqksk0sk5c",
-    "lp_token_id": "58",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "58"
   },
   {
     "id": "osmo1hgxsqpxghfw7pwwl8jwxzy04cyll8nhf6ejnxpx3wvkszkq6rznqap0yuc",
-    "lp_token_id": "505",
     "asset_ids": [
       "gamm/pool/503",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "505"
   },
   {
     "id": "osmo1hhrh0atndq75k3wws0jp8z4q4sdr5hs2u629wk2l35yuu92mah3sfa06ns",
-    "lp_token_id": "148",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "148"
   },
   {
     "id": "osmo1hjffj5jr5z53gepl9754vl5z8vxahz6r6yq0kaj2kppxrcrzu7lqvuzgqx",
-    "lp_token_id": "146",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "146"
   },
   {
     "id": "osmo1hjkkjcc88t8mf2h4n2rzdxtdpmscv53ek33vs48jxk5x0d2uf9hs59teze",
-    "lp_token_id": "72",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "72"
   },
   {
     "id": "osmo1hl0s405ggpxp8z5svx4myy23s4vsxm2n0040xcug59gx0cmdhqwq5t7x0y",
-    "lp_token_id": "304",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "304"
   },
   {
     "id": "osmo1hlxc9ypgx9pfnrt8vacsyw8d0hj32n8vymg2u7aaxar2f6aulpeq2t095k",
-    "lp_token_id": "662",
     "asset_ids": [
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "662"
   },
   {
     "id": "osmo1hpfr8caa9swnqj2wapqwjfakqkfvdq70uvjv37pdst3xunsde2hqkz0na4",
-    "lp_token_id": "28",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "28"
   },
   {
     "id": "osmo1hpgavxcjzhzrfj6y36ut7klat093w9wq9rdk399gmr8u3s96uqmsmqx9zn",
-    "lp_token_id": "554",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "554"
   },
   {
     "id": "osmo1hs78pxgz4v0tmqs4gau9zpdsaeu4jumkr2r7qy0v40uqnws26ussyxt7ga",
-    "lp_token_id": "506",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "506"
   },
   {
     "id": "osmo1hvm4qlmmpy60ed3ex4zfdlpwmurex6uunudfu0rjh6w87tvtawsq3aj6v5",
-    "lp_token_id": "346",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "346"
   },
   {
     "id": "osmo1hxddxnuw6whdd4e8kwln9xeaws45kz7cuwe5asd05ws7xnltgjwszmq7np",
-    "lp_token_id": "247",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "247"
   },
   {
     "id": "osmo1hz6eyl2u990ge6nq7c3uq8fnlx2ghedkervym8s9psnqjcj44wxqlewm4v",
-    "lp_token_id": "775",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "775"
   },
   {
     "id": "osmo1j4ak6hul4x2m93rqnnjpxx7x6zml435zmv7y7wet0adr3sfw8crsnhd3cl",
-    "lp_token_id": "713",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "713"
   },
   {
     "id": "osmo1j4j7kxkmu6kdenrx9ky50k9x86s36mcaqxukr8sjtl2rwp9vkwfqljjd3r",
-    "lp_token_id": "701",
     "asset_ids": [
       "ibc/67C89B8B0A70C08F093C909A4DD996DD10E0494C87E28FD9A551697BF173D4CA",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "701"
   },
   {
     "id": "osmo1j4xmzkea5t8s077t0s39vs5psp6f6dacpjswn64ln2v4pncwxg3qjs30zl",
-    "lp_token_id": "93",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "93"
   },
   {
     "id": "osmo1j5l9ysw5xv0uqz9uh7mcg0l5rlerqm695ec9kkg2t8rp600zv47q82eqwa",
-    "lp_token_id": "5",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "5"
   },
   {
     "id": "osmo1j5ywgvensu0uez4te9ql2eslg4qt96evhpldwd7j8h2mr66c8s7scvx4w8",
-    "lp_token_id": "623",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "623"
   },
   {
     "id": "osmo1j6vmgahwmxgcpra7dudw570g44cntyvx9pz3k83ny8z0qgytq8aqmf8j0s",
-    "lp_token_id": "634",
     "asset_ids": [
       "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "634"
   },
   {
     "id": "osmo1j8cp3mdc9jq7vmgf0hpr8uz6e3at6uctwtzhn6qlm7g3shvzavwqg4qxyr",
-    "lp_token_id": "251",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "251"
   },
   {
     "id": "osmo1jaemtd5g8h2dwegte0h3r76xt7uahrj4tdmdyypl5ptlswhnfves5cvs3v",
-    "lp_token_id": "227",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "227"
   },
   {
     "id": "osmo1jajfyerkktqn6qfyxefeg078lfrdpkl87gsyhy925nwc6hysrtzq7zx9g4",
-    "lp_token_id": "407",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "407"
   },
   {
     "id": "osmo1jaldjtc7ksfldxgg604zyspyd94p8kn6tleaarcdwl8wakul6w7sy50gam",
-    "lp_token_id": "139",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "139"
   },
   {
     "id": "osmo1jatt233sux9mxjuqmtmaavucvatj23m2v6nyh3rel60qpjegkduqewylk7",
-    "lp_token_id": "912",
     "asset_ids": [
       "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "912"
   },
   {
     "id": "osmo1jeku67d5x534pn4l3ules7yye2s6kkj92hmn0lyldwnv5xv6cq3qjujw5y",
-    "lp_token_id": "512",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "512"
   },
   {
     "id": "osmo1jm5tyuxars5j84jdeeqkp0zpyfk2ea84x7fec8jq03x00708f3qqwr3f57",
-    "lp_token_id": "66",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "66"
   },
   {
     "id": "osmo1jn6lsmjf2qcgqyj6zzl9llunm3u38x3dh3dggyx043ysxy6jjwssq3h7ha",
-    "lp_token_id": "162",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "162"
   },
   {
     "id": "osmo1jn8pdd9kez2n7422vg8qvwn7angtz2v8gjwkff3glprxypr25v0qp7zwkt",
-    "lp_token_id": "610",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "ibc/EA3E1640F9B1532AB129A571203A0B9F789A7F14BB66E350DCBFA18E1A1931F0"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "610"
   },
   {
     "id": "osmo1jqvyxwgq5eujwp58ef2hgaf0xsn6vh0w9at77adyjj3uafrv8r7qjpks4h",
-    "lp_token_id": "847",
     "asset_ids": [
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
       "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "847"
   },
   {
     "id": "osmo1js8gkwluk3uux73v9u83f0egh7862sezq2f80l2c9eetylr9meqq698nvz",
-    "lp_token_id": "84",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "84"
   },
   {
     "id": "osmo1jsfqrh9y0mjvrh09u82ja7az4fsyew64gn2pfg98c8969zg5zmhq2njffj",
-    "lp_token_id": "786",
     "asset_ids": [
       "ibc/5A7C219BA5F7582B99629BA3B2A01A61BFDA0F6FD1FE95B5366F7334C4BC0580",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "786"
   },
   {
     "id": "osmo1jsr3q3yw5pt3gtnsdsr0c6hx23f83cpv6st6ze3pplthwrc67j8sjge00h",
-    "lp_token_id": "815",
     "asset_ids": [
       "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "815"
   },
   {
     "id": "osmo1jtzkz2383cegga8pzq7azm7tp3lcutep95urpvuqxz3x85sfpw7ssaqpc5",
-    "lp_token_id": "596",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "596"
   },
   {
     "id": "osmo1jve7zc9y29kl8jalu0aaz8v38y2vpjucdk7thg79ektq4t7aswcsa6w45d",
-    "lp_token_id": "193",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "193"
   },
   {
     "id": "osmo1jz730xfzjnkp2zaasvqg9e3smv2a4f8qvrm6p8cs83m2srkr56hs4wtm3w",
-    "lp_token_id": "749",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "749"
   },
   {
     "id": "osmo1k33jzr6syz8fs9jlsjerwum53ctu9nzkfdr3uy58ddt2tpsnsw0sl8ff3s",
-    "lp_token_id": "135",
     "asset_ids": [
       "uion",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "135"
   },
   {
     "id": "osmo1k3hmk0dyeu7m0jx6w0ltufvh76kjk0zscthmk0u86u3y95dy4xhqmqgeww",
-    "lp_token_id": "483",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "483"
   },
   {
     "id": "osmo1k4gj3utpx0s3pmtq7shmyhdq2dp605e03hcprvzvec7jq2ge2u7s4r0wp4",
-    "lp_token_id": "545",
     "asset_ids": [
       "uion",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "545"
   },
   {
     "id": "osmo1k4nr7aguzj733ch3kdpl4834ex5uep84gcvtnumj2ekgrh4xlfssslwlpd",
-    "lp_token_id": "767",
     "asset_ids": [
       "ibc/239A507997222805E441956EBE8087D7E2D05D6535C6D4C75EF8DCF83B3DE1A1",
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "767"
   },
   {
     "id": "osmo1k5s6tga7smv266aftu7l4trqsdqg3slgq5kj2q02dppdxlw7pjvsxjzjrk",
-    "lp_token_id": "368",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "368"
   },
   {
     "id": "osmo1k6mv2aefssjt0jq8gwvccwaa0xsv7m0dxl5kzqay47pepy6e8kqq3rage2",
-    "lp_token_id": "718",
     "asset_ids": [
       "ibc/0CB9DB3441D0D50F35699DEE22B9C965487E83FB2D9F483D1CC5CA34E856C484",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "718"
   },
   {
     "id": "osmo1k804l4hsemvreuguf96rnv8f8rmgmr2fm0nuy7z9s7je7j63dktqgamzc3",
-    "lp_token_id": "841",
     "asset_ids": [
       "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "841"
   },
   {
     "id": "osmo1k9a068d7990a52fncvt70magqvzsfkeg9a6qnqehv20qwwdqfrdqux5s24",
-    "lp_token_id": "89",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "89"
   },
   {
     "id": "osmo1kaekqycnekvhhstysh7e9wwkl0w79wt9pr7vusmqfqkfcqgqac7s2fc6dj",
-    "lp_token_id": "845",
     "asset_ids": [
       "ibc/A6383B6CF5EA23E067666C06BC34E2A96869927BD9744DC0C1643E589C710AA3",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "845"
   },
   {
     "id": "osmo1kavqnurym4exfwyz85j68mkggacegptpkvpv08d3g6q9vavhw94qvj756k",
-    "lp_token_id": "848",
     "asset_ids": [
       "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "848"
   },
   {
     "id": "osmo1kchnwg6y2y4r2nyjartp9q3ss4ysjkx9gzgxwdtg6624g6natn3seyj0f4",
-    "lp_token_id": "402",
     "asset_ids": [
       "gamm/pool/222",
       "gamm/pool/323"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "402"
   },
   {
     "id": "osmo1kcra3rvreavuzm94jfwl6pd4kysppvdn0g72d2d846qrg0gaaz2scsukt6",
-    "lp_token_id": "174",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "174"
   },
   {
     "id": "osmo1kdnj8qjhya69n2yj820mzt9wjunjekkyu5ewwn7l5ppyn6qhu9zqzj8fk8",
-    "lp_token_id": "694",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "694"
   },
   {
     "id": "osmo1ked4s6v8a5fnr7wshk3825c4dc44hth4aln264ygjxqw9ck4ry6qg6ysxy",
-    "lp_token_id": "509",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "509"
   },
   {
     "id": "osmo1kg2ga83a9g5rhv5xu2m24q8rnqjv5vr6257cc2ny5x5737ttkg4sjh2zm9",
-    "lp_token_id": "667",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "667"
   },
   {
     "id": "osmo1kgg8uct2yut6etpprx2sdfn2fq7890jez9jd5arunsgg734mv68st55v0w",
-    "lp_token_id": "230",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "230"
   },
   {
     "id": "osmo1kljure6uz60xec9ecmq7sldzgz2x8n2r8snxgvuwla4rn7kpvjzsjczqqx",
-    "lp_token_id": "760",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/C9864D1B9623F703C75BBF72B7FF8A7317E1535C96538D21467A4311246DC3B5"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "760"
   },
   {
     "id": "osmo1knufp26cx4y9p4eecgra5z4deu6hek0hh9let2gwjns2g3tzue0qt4xzsf",
-    "lp_token_id": "458",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "458"
   },
   {
     "id": "osmo1kp5sa9gkqwtcksupd30hdez9mfx4ak65c7m99yqj4pk599tlfh5q96u2e4",
-    "lp_token_id": "453",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "453"
   },
   {
     "id": "osmo1kpf2xfutvfqfum9aj2juvjcjcxzp7k3le389v6ql6lurzcq0hausa6uyx8",
-    "lp_token_id": "14",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "14"
   },
   {
     "id": "osmo1kqmrg9qyqfgkys9q892m8st5mkesez8vpnegppecex0ylqqp8h8sedeu4q",
-    "lp_token_id": "660",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/F6B691D5F7126579DDC87357B09D653B47FDCE0A3383FF33C8D8B544FE29A8A6"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "660"
   },
   {
     "id": "osmo1krp38zzc3zz5as9ndqkyskhkzv6x9e30ckcq5g4lcsu5wpwcqy0sa3dea2",
-    "lp_token_id": "10",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "10"
   },
   {
     "id": "osmo1kskty9u0uvqrn89p4ultt4m2se2jjkrt404d20zgqftdch5t4k6qmysqvn",
-    "lp_token_id": "649",
     "asset_ids": [
       "ibc/F6B691D5F7126579DDC87357B09D653B47FDCE0A3383FF33C8D8B544FE29A8A6",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "649"
   },
   {
     "id": "osmo1ku38urrhfsz29778kcwr7zaesfcv86js2alyy58t6dnzh8nnf73qpwkwtw",
-    "lp_token_id": "564",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "564"
   },
   {
     "id": "osmo1ku7t6f3pcl3e9kfzlzrp5jwktsl7vqu4dym7fzvn2gsj47qp9e5se820kn",
-    "lp_token_id": "256",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "256"
   },
   {
     "id": "osmo1kuceh0se3p3f6xf7ca5yh5ud33my9rzk9jyjh0hk5ufvh02vvn8slg06wy",
-    "lp_token_id": "206",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "206"
   },
   {
     "id": "osmo1kuecnt3tye9q23d5ytw6xmfp70w7gz4te6sjs42ptep9utrx5v4q5uuj9u",
-    "lp_token_id": "446",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "446"
   },
   {
     "id": "osmo1kxlcgxrc2lqn7hmks2ukld6a8f0fdfm0dwstut2uragrugkryyvq7eyxmv",
-    "lp_token_id": "794",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "794"
   },
   {
     "id": "osmo1kyrc9u2g4f44empz8achjdxzkftprxhx56p28ft02lkaucvztyqsrlsrd3",
-    "lp_token_id": "259",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "259"
   },
   {
     "id": "osmo1kyw5a3cuukhc63r7pry549fdzt2wtn9w6fesz70q6lg25rzlas3s0el87c",
-    "lp_token_id": "921",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "921"
   },
   {
     "id": "osmo1kze098t3xxs3w6mfhxkdeehrktjd49582g8vtgfh5cke2jfh2hhsqqjvgx",
-    "lp_token_id": "88",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "88"
   },
   {
     "id": "osmo1l0s5xy5nm9qwdn72nux9dyck9k52l4mg907ghrxc0lw8rn6vxuaseq3t9f",
-    "lp_token_id": "207",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "207"
   },
   {
     "id": "osmo1l265e7cug3tk3eugex8hpq2adk5drdecxzp6lsytn6dls6jpjkssvp9zqe",
-    "lp_token_id": "584",
     "asset_ids": [
       "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "584"
   },
   {
     "id": "osmo1l2a4nmtjuv8mfucrenpujyn9j04vl3gmrsyq0vaj5f8e6apmavvqhtje00",
-    "lp_token_id": "860",
     "asset_ids": [
       "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "860"
   },
   {
     "id": "osmo1l2sd4j9yq6hz0q039hnjydx6zj2lptu34f846yg5jutgu0r7juvszgk2xy",
-    "lp_token_id": "261",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "261"
   },
   {
     "id": "osmo1l45a67tujfxl99qt39a09cqf9ep0vtqyn8xnuua66yvjtc7e8lvsua2hjn",
-    "lp_token_id": "17",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "17"
   },
   {
     "id": "osmo1l5ehe7cqgf5fplxegqaukwygaz8g2h62yhdt06te6uem30l2j9mswf6qct",
-    "lp_token_id": "50",
     "asset_ids": [
       "uion",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "50"
   },
   {
     "id": "osmo1l7vu8utujujfy0j2xrhcfzcz27q85j29vxxyjx4w7lnxzsevjfwq69qxrq",
-    "lp_token_id": "513",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "513"
   },
   {
     "id": "osmo1l87xgwa4j9ntqfuz440pw5xgsw27y227rddfz2knekfk59k0satqj9as7f",
-    "lp_token_id": "575",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "575"
   },
   {
     "id": "osmo1lahkpd2rxat3huy3kqkphvugruzxm3d5n0jxve6c8xzmkcvgfw9qjdnkhf",
-    "lp_token_id": "107",
     "asset_ids": [
       "gamm/pool/104",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "107"
   },
   {
     "id": "osmo1lc77pdqlnj3s7typ0nvq7xxt79gmtec7mvazdsw8c2ffy4j9hjrs6crft0",
-    "lp_token_id": "624",
     "asset_ids": [
       "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "624"
   },
   {
     "id": "osmo1leu9xn7ecn7wq58kz949827zspj7xzf98200mukzctgnrpsqwsfscnwc7s",
-    "lp_token_id": "658",
     "asset_ids": [
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "658"
   },
   {
     "id": "osmo1lg3y6n2qc382ukpl8y6hfxlk6lprw3aye47zsld7xpnktfhvxneqxjf4f7",
-    "lp_token_id": "774",
     "asset_ids": [
       "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "774"
   },
   {
     "id": "osmo1lh3kh39lzupfnupjsl5vda29utlzkaz2673hepw2cdck8rqm3arssz7skt",
-    "lp_token_id": "589",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "589"
   },
   {
     "id": "osmo1lherhrcrxe9yev22rjda9auagvr9nupncmtn4yajs48kvfe42t2sq83s4w",
-    "lp_token_id": "909",
     "asset_ids": [
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
       "ibc/D38BB3DD46864694F009AF01DA5A815B3A875F8CC52FF5679BFFCC35DC7451D5"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "909"
   },
   {
     "id": "osmo1lhg9ec0lmn0wec4tsxwk7kwqd5px203vwvh7wth5wls4jeu2hjlqxn7gte",
-    "lp_token_id": "734",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "734"
   },
   {
     "id": "osmo1lkam7g0tg3r9uaq0y7tgzax5934zaevuhe70evqxaaga7n9wqgasqeale8",
-    "lp_token_id": "687",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "687"
   },
   {
     "id": "osmo1lmk3mgsj2ajp4s34jzfsqscz60nfys4rlsg5u8k03a9420ggyh2qldlmzq",
-    "lp_token_id": "61",
     "asset_ids": [
       "gamm/pool/38",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "61"
   },
   {
     "id": "osmo1lu9gpwx7n5phng70yap748t48ws5p82rher9hvkqqvpczj0f9rwqc3rmy5",
-    "lp_token_id": "430",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "430"
   },
   {
     "id": "osmo1lughuhtdk7fj9n9pzx7hu5ulrcg6g84mk5j3aezgw86f4vae79qqw5wzd4",
-    "lp_token_id": "389",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "389"
   },
   {
     "id": "osmo1lv9ju9nuzr4vgazyma7l8hsw0zcafwwm77vvdjm79mku6ydpq4mskdpsd2",
-    "lp_token_id": "291",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/CD942F878C80FBE9DEAB8F8E57F592C7252D06335F193635AF002ACBD69139CC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "291"
   },
   {
     "id": "osmo1ly2shj6fznqwqskswmpwmrkqxdsavhmlmkr92wg3hcqqxnn2y5vsrkhc6u",
-    "lp_token_id": "601",
     "asset_ids": [
       "ibc/EA3E1640F9B1532AB129A571203A0B9F789A7F14BB66E350DCBFA18E1A1931F0",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "601"
   },
   {
     "id": "osmo1lzwv0glchfcw0fpwzdwfdsepmvluv6z6eh4qunxdml33sj06q3yq7xwtde",
-    "lp_token_id": "4",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "4"
   },
   {
     "id": "osmo1m0qkljyn3a0sm2m9sgj6485frrmxnqpetc0lqstun5nzqj28fctqkt2qeh",
-    "lp_token_id": "843",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/CAA179E40F0266B0B29FB5EAA288FB9212E628822265D4141EBD1C47C3CBFCBC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "843"
   },
   {
     "id": "osmo1m0yntqzum06tc7ztw34sn646clwf32p7x2cfymaf8jx0cyf3jvlqfe5d6x",
-    "lp_token_id": "183",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "183"
   },
   {
     "id": "osmo1m28rqxevywfn76c4lf5vws64shd0hxvxyvzazzswlj5n7q48pxrqvlgry5",
-    "lp_token_id": "643",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "643"
   },
   {
     "id": "osmo1m3690pyfyadnny62ylj44xdlhzen7dluzmlrwwayzmnmm8deqy6sd86xla",
-    "lp_token_id": "517",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "517"
   },
   {
     "id": "osmo1m3lgd2ekfvtde7suplqwgz0c38dfw0rcrnds86876680u0ud8sfqkg63dx",
-    "lp_token_id": "729",
     "asset_ids": [
       "ibc/2716E3F2E146664BEFA9217F1A03BFCEDBCD5178B3C71CACB1A0D7584451D219",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "729"
   },
   {
     "id": "osmo1m4qg2yg542hp38yrdnp7wxhpm8j3agu78sg7f6lz0dzpmk4t4cysy9x5mj",
-    "lp_token_id": "177",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "177"
   },
   {
     "id": "osmo1m728dvj3vg684xgcv3skek3ylzjxryu5v0qyyl9jv3zz7vkga9fq7jpkck",
-    "lp_token_id": "308",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "308"
   },
   {
     "id": "osmo1m80fnqvvsd83we8gnh998re55jq8cq2mdkccclqmuqw8xpm69agsm8ffd6",
-    "lp_token_id": "553",
     "asset_ids": [
       "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "553"
   },
   {
     "id": "osmo1masvawn2hnrddygr7czdkhjgnnuf86qgf657u4jpm4xg3qz53nkq0hkjy7",
-    "lp_token_id": "355",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "355"
   },
   {
     "id": "osmo1maw9j25fppqf3c2l4ufxxhn7leu58ke2c5lm9r8ehm60fnzgpzfsu8jzhk",
-    "lp_token_id": "32",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "32"
   },
   {
     "id": "osmo1mdqhf078cs0qe7gfcv9rdw0yzvzf0wejvyrlx8hyzcpsfn2zgpyq7l9ly6",
-    "lp_token_id": "153",
     "asset_ids": [
       "gamm/pool/108",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "153"
   },
   {
     "id": "osmo1mel7yxyqx2n39zrw8eqrxv8gjltvlchqaycjz6gg0x8qgs7zhe9sc5gavj",
-    "lp_token_id": "507",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "507"
   },
   {
     "id": "osmo1mh2eclfdnq5e9pz8ejyz7q245nry7p0q4u6t6xj363xw9uxt0uqqf26dzm",
-    "lp_token_id": "300",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "300"
   },
   {
     "id": "osmo1mhnddjymtcxxn9mj9en37ufnf9s9tfg0rzgy24y7f06d7t5v340sdhlfen",
-    "lp_token_id": "171",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "171"
   },
   {
     "id": "osmo1mrlrvqret269x5aqvkycy0fnu4jz3fqqf6tqflptygpewn264jpsw8kega",
-    "lp_token_id": "195",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "195"
   },
   {
     "id": "osmo1mrltfv8y3jf4v3ggw0hnjjxzmwmq749rsjgvgvjuk0ezzs4hycfskm6c6a",
-    "lp_token_id": "301",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "301"
   },
   {
     "id": "osmo1mtarz7hmt5m0h7muks3pdnwfmwqps9nndrrq6xrz5rhdsl6s3cwssm4vv3",
-    "lp_token_id": "867",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/D3B574938631B0A1BA704879020C696E514CFADAA7643CDE4BD5EB010BDE327B"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "867"
   },
   {
     "id": "osmo1mtn55pzt3huxrskm986s89e465u3kvln9uum5deeza27f0vtmucs9ysvr6",
-    "lp_token_id": "542",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "542"
   },
   {
     "id": "osmo1mvpqp7xujzf7c5jyamxg3u23zflz6ye0vnalx94khkyf4fp4m7aq96z76w",
-    "lp_token_id": "844",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "844"
   },
   {
     "id": "osmo1mw0ac6rwlp5r8wapwk3zs6g29h8fcscxqakdzw9emkne6c8wjp9q0t3v8t",
-    "lp_token_id": "1",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "1"
   },
   {
     "id": "osmo1mxcjnczrsd9ge4pkczpt9e84rntk08h27ez0d36yaxumsk2smdys3vsucj",
-    "lp_token_id": "625",
     "asset_ids": [
       "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "625"
   },
   {
     "id": "osmo1n22kz2zhwzl06ftd64heah7vahlythhsrj2388l0z95jlsjpkyuq0qd5dz",
-    "lp_token_id": "173",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "173"
   },
   {
     "id": "osmo1n34cvctdvs54y3mkmk0pmj5f47k38eecl509q68ml66x2xlxfgysu26f8u",
-    "lp_token_id": "130",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "130"
   },
   {
     "id": "osmo1n44k0kzvzqn3duscgzznh73p24je0vw38huugm5cg6k7fjren64s9a837a",
-    "lp_token_id": "836",
     "asset_ids": [
       "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
       "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "836"
   },
   {
     "id": "osmo1n8eyte6zq4njjcfjw3re4vhrgf9n32zstulurxg8k66dp7uk9leqjyeavk",
-    "lp_token_id": "168",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "168"
   },
   {
     "id": "osmo1na36haex62rq9y0rz34unlk8agh5kygug5eheelvhw3hxhmwwmgqppr5zx",
-    "lp_token_id": "287",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "287"
   },
   {
     "id": "osmo1nam3pd3u93sqxns28k5xu4vznnv5a654hh38fnwud5pakqqq04xs6upegq",
-    "lp_token_id": "541",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "541"
   },
   {
     "id": "osmo1namquuyzajapzsffw7vy28sfdwsjzk559vt0p6rzpkhzwplt0m3snd6ppr",
-    "lp_token_id": "379",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "379"
   },
   {
     "id": "osmo1nanwkuh98tjrft7v4js0p8efjp3w2h4jjmesprlzjdnfvzyuvcmscnuhr6",
-    "lp_token_id": "281",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "281"
   },
   {
     "id": "osmo1nefum67tu9gzamyzvsp960auxayp5ft3pkwey67h434nkytuys4svyml98",
-    "lp_token_id": "579",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "579"
   },
   {
     "id": "osmo1nfn4h33t30prnuyrhn20ntvgclzhc8x40mzkngc740r9r3sap4yqaf9c3a",
-    "lp_token_id": "360",
     "asset_ids": [
       "gamm/pool/359",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "360"
   },
   {
     "id": "osmo1ng6lckhx52kpr7ww9ynayuzzlsp5m6jcnkztysf03sncg9zz472ss3x370",
-    "lp_token_id": "626",
     "asset_ids": [
       "ibc/F867AE2112EFE646EC71A25CD2DFABB8927126AC1E19F1BBF0FF693A4ECA05DE",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "626"
   },
   {
     "id": "osmo1nggsx9rkkyyrg6pksejtpq9zea90yu6mjq6u5pwsmu53xweda4psp5jsfv",
-    "lp_token_id": "361",
     "asset_ids": [
       "gamm/pool/360",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "361"
   },
   {
     "id": "osmo1nh9vsmgqtdtrrrldfzxtjy3l444grmt7flrmyc265ey0arsng8dqqzfag3",
-    "lp_token_id": "879",
     "asset_ids": [
       "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "879"
   },
   {
     "id": "osmo1nk8ha9xldmqjn7adgz56tmu87e3yryuzj3upsk20kmy64vmg702squcxue",
-    "lp_token_id": "475",
     "asset_ids": [
       "gamm/pool/474",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "475"
   },
   {
     "id": "osmo1nkt8zu53tz64m9muw9jgaw2xfhxl3c6p8hkte57j46ctjdpduh6qgays4a",
-    "lp_token_id": "102",
     "asset_ids": [
       "gamm/pool/90",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "102"
   },
   {
     "id": "osmo1nmlwj8wfpq5r2dukds3lkg74t324y53j4eegk4h3u09hu5rn3kpqctntge",
-    "lp_token_id": "189",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "189"
   },
   {
     "id": "osmo1npz80ntx3vwkv3w9ryzc8g074hlykmw497ar0j7dqzk4yanjylqshan44d",
-    "lp_token_id": "274",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "274"
   },
   {
     "id": "osmo1nreqp8gx5nmej0ckrh7v2jy2p6j8pjv7xcyzrpylkstfamkm2slqxsvllj",
-    "lp_token_id": "661",
     "asset_ids": [
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "661"
   },
   {
     "id": "osmo1nspf22mwajwdka4zxk3k0vcn9xtqskur5we6u255q7hgcjhnj72qkdn45s",
-    "lp_token_id": "450",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "450"
   },
   {
     "id": "osmo1nukez7tx3w75sesfecus9tuedre25uhvs737t0g35uqzeaks5jusvvp5r4",
-    "lp_token_id": "464",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "464"
   },
   {
     "id": "osmo1nukyq8kzw4353yt8gvzjgfvvzar7h6skzkwptxkcrecjzfhxqdaqk4shck",
-    "lp_token_id": "123",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "123"
   },
   {
     "id": "osmo1nvjv09u5tcunewz468ad285z5dum9h4hvc0lcnsjvncq63umu8pq63czxa",
-    "lp_token_id": "755",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/7F1A862E98185A286F011DD093D8BD2FA1B7CD1A723EC5E6C59F76692F1728F7"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "755"
   },
   {
     "id": "osmo1nw8fdm6elm9h06zfxf5sltxjp0xw9cgcpzqzfqwpea5584xr0g7qhzzx2q",
-    "lp_token_id": "827",
     "asset_ids": [
       "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "827"
   },
   {
     "id": "osmo1nxm52c20twfrr44cdh5g4f7dufnuc7r60n5y9uqe27494qgw2qes2g4432",
-    "lp_token_id": "731",
     "asset_ids": [
       "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "731"
   },
   {
     "id": "osmo1nzky8dqcmzzf84hrwse3pggyq5kqe9njewn00fphaku4lgjw5gxsejdw0f",
-    "lp_token_id": "166",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "166"
   },
   {
     "id": "osmo1p0rpttlp8v2hy7m82l2t9p6545788f2ac3yksgrlycke2wr4mu0qdr7ytu",
-    "lp_token_id": "6",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "6"
   },
   {
     "id": "osmo1p352w3c2ms04cj6un55hnkwuw2fq748tgxjn57fujvp9pmx8mhnsr4jsgv",
-    "lp_token_id": "650",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "650"
   },
   {
     "id": "osmo1p4qpdv38znav3egx44yysvp5zwazsmw0p30vk8yxq43qraxspz0sdrq6td",
-    "lp_token_id": "178",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "178"
   },
   {
     "id": "osmo1p8amm7au5ajkuay8nrnwelwheazxqw23va9yq42ehx0s4reexu7s2jff2l",
-    "lp_token_id": "817",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/84502A75BCA4A5F68D464C00B3F610CE2585847D59B52E5FFB7C3C9D2DDCD3FE"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "817"
   },
   {
     "id": "osmo1p9mdkst9230ngdunv654l3trklnrpzlh9lr82fs4qes879l3n42stya63r",
-    "lp_token_id": "705",
     "asset_ids": [
       "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "705"
   },
   {
     "id": "osmo1p9pa7umdvry4u4338hgu4x5pkepnk9pcqddpg65zdj0k3a3ucjts85hj73",
-    "lp_token_id": "35",
     "asset_ids": [
       "uion",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "35"
   },
   {
     "id": "osmo1pa8d43s0t8hwdekx2uyq224tapyzxn60578ywzlkupkh60tyzhus2wcrez",
-    "lp_token_id": "188",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "188"
   },
   {
     "id": "osmo1pc849m5xe9wa7w9r4k2dv7pq958fm84a8t626ftufs8m5rs09guqxx8j3y",
-    "lp_token_id": "795",
     "asset_ids": [
       "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "795"
   },
   {
     "id": "osmo1pd4pfnj36p39q9zdpycjfms7zta3ugjjeyjxzmuhh28pqe70urxqje0k84",
-    "lp_token_id": "870",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "870"
   },
   {
     "id": "osmo1ped9637al0u0ck9gtmud27rxjkmhk2cxjt7lsqrtwd3pjzmm07jsxu8mvm",
-    "lp_token_id": "813",
     "asset_ids": [
       "ibc/A1AC7F9EE2F643A68E3A35BCEB22040120BEA4059773BB56985C76BDFEBC71D9",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "813"
   },
   {
     "id": "osmo1pemg6m8pd8xnz2gnnmh9w8ja3rhcq9ztlnwa34md545ttj46sfwsxyzy50",
-    "lp_token_id": "248",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "248"
   },
   {
     "id": "osmo1pf3vpzz9umucchpeklwtsc4xveql0m6xsh589ek8tn4er80v9wksya3e2d",
-    "lp_token_id": "257",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "257"
   },
   {
     "id": "osmo1pg8mzjdn3yxg4gf96axyw8gpn2ur6jxq5alctz7lmjkwk9n98neshpmtkj",
-    "lp_token_id": "866",
     "asset_ids": [
       "ibc/92B223EBFA74DB99BEA92B23DEAA6050734FEEAABB84689CB8E1AE8F9C9F9AF4",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "866"
   },
   {
     "id": "osmo1pjuess9ulvre83pyees8p688xglzl039nhgrtx8nv3j50uw8qhsqqma5jq",
-    "lp_token_id": "347",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "347"
   },
   {
     "id": "osmo1plswdqqd9nn7jy3s62vnjjmshwkk0us07shttqsmdph2gkgt6ejqmqef5c",
-    "lp_token_id": "45",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "45"
   },
   {
     "id": "osmo1pmhq2qy30wdlv4thqs9glsm38z06lp6syuh8nwa85aukw6tepmhq7eazwe",
-    "lp_token_id": "405",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "405"
   },
   {
     "id": "osmo1ppc37u39xsklmuew4vyggg34crggekqnuul32x67y32g65ekprhqwfxh56",
-    "lp_token_id": "428",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "428"
   },
   {
     "id": "osmo1prazp9zy7pk9ds5s66kj6uc50uvwsu9pmr6qwel3dn3juvjps3mqku4xwt",
-    "lp_token_id": "439",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "439"
   },
   {
     "id": "osmo1prgxk3tjsmrw230k266aeevjgmerceekj89ksjpjq3gt6wa3rmes36q0kt",
-    "lp_token_id": "656",
     "asset_ids": [
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "656"
   },
   {
     "id": "osmo1pw3kx94kn0vu6lj048vtk3vmzx7y7mde3zc2sjxull69mcg6zjyqft9qjv",
-    "lp_token_id": "136",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "136"
   },
   {
     "id": "osmo1py2nm36kk5dek5th97ljtdd509wl339zqslg89u8l9atchf9568sdlgu4k",
-    "lp_token_id": "249",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "249"
   },
   {
     "id": "osmo1pzdmgl6dnwnaers8ujawqet6fry3rxxkfwccrk0ypt8chx2prnasmlxc36",
-    "lp_token_id": "411",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "411"
   },
   {
     "id": "osmo1pzhmczzq7fl7rp72x8zrcm792ndp4r8z6pthe2rcw9vsudna4tmqdw3mmv",
-    "lp_token_id": "852",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/71055835C7639739EAE03AACD1324FE162DBA41D09F197CB72D966D014225B1C"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "852"
   },
   {
     "id": "osmo1pzhzluks9p6esj0kam002a6chhxefeca86jpntlz8aewyvje69xq986agq",
-    "lp_token_id": "647",
     "asset_ids": [
       "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "647"
   },
   {
     "id": "osmo1pzm7keu64vrwlz4cwscjpx70fnn8cuuqwmx3qcl9qef2ctx092dshnpg5q",
-    "lp_token_id": "466",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "466"
   },
   {
     "id": "osmo1q07hmk9ewecaa9mtnpz9uerq0tlfxj55yp2fg67lqy4xp704l5as56uq9e",
-    "lp_token_id": "759",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/E4FFAACCDB7D55CE2D257DF637C00158CB841F11D0013B2D03E31FF7800A2C58"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "759"
   },
   {
     "id": "osmo1q2ej0ns7n3xt3tk9m85r8rd672rnprevd2hmth2azfctfkzkpk2qqjeezx",
-    "lp_token_id": "311",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "311"
   },
   {
     "id": "osmo1q3f2z5ws7vyqrxpdswzh8ray0xwpawkr45wzc5232su0lf9j068q7wvp34",
-    "lp_token_id": "180",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "180"
   },
   {
     "id": "osmo1q479s6ll6l2csetyv6jqs823qe5cexzuzeemjjdv7ej8tk2xhetsngy2kk",
-    "lp_token_id": "838",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "838"
   },
   {
     "id": "osmo1q5xduzrk6v5n9jsn7nw9fqlnm6w06xkhc4p4w8gqxr9ujl08vlnq37eqdp",
-    "lp_token_id": "200",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "200"
   },
   {
     "id": "osmo1q6qdde6364m22pgvz3pe2yykze9cxjyjhutdlserkfahwaugdfps35p85a",
-    "lp_token_id": "558",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "558"
   },
   {
     "id": "osmo1q6qfznza2p9kcmnzywxj8w0ffkl6czfmwtrc97a6pdzdsc5xpyqswassc8",
-    "lp_token_id": "824",
     "asset_ids": [
       "ibc/7ABF696369EFB3387DF22B6A24204459FE5EFD010220E8E5618DC49DB877047B",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "824"
   },
   {
     "id": "osmo1q6wzn67t2fsg7sga6qj5skrafh6pd3pdtyss7jq35ukp8l86z45q42yueg",
-    "lp_token_id": "290",
     "asset_ids": [
       "ibc/CD942F878C80FBE9DEAB8F8E57F592C7252D06335F193635AF002ACBD69139CC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "290"
   },
   {
     "id": "osmo1q73hzfr0jfw84sx2rtuvr2v5xqve0jzz3qw6gq77gavxdh94c6nshw5erw",
-    "lp_token_id": "298",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "298"
   },
   {
     "id": "osmo1q7ul5yz2ma5mjj8vkf5njjz859wk4u90ley2emfx8th4xyx6fg7se0z4hn",
-    "lp_token_id": "832",
     "asset_ids": [
       "ibc/8E697BDABE97ACE8773C6DF7402B2D1D5104DD1EEABE12608E3469B7F64C15BA",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "832"
   },
   {
     "id": "osmo1q83j3062nnne65nsljaw0kwzsqam8ut7eheyzpr7ga56htsh20eqzr0vz6",
-    "lp_token_id": "186",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "186"
   },
   {
     "id": "osmo1q8uvftta2c9r25mqxd89q76vdcagwjsg7q9t6c787seamzmpcuwq2wn5uc",
-    "lp_token_id": "327",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "327"
   },
   {
     "id": "osmo1q9e2rxyu360hp69rg54up2k70sclp7uxl6mq79zrxkggquwkwfwqv9xgav",
-    "lp_token_id": "408",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "408"
   },
   {
     "id": "osmo1q9m4xr0rlnh7t4rsq3cmjsunvc9lzrl6d3ww309zjmcryxqzrkus8h7lys",
-    "lp_token_id": "182",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "182"
   },
   {
     "id": "osmo1qekmfz65ce08nee5c5caags2h24uhztjn9j6vr8uvnv4hcx44deq2xds6p",
-    "lp_token_id": "830",
     "asset_ids": [
       "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "830"
   },
   {
     "id": "osmo1qfu6489pfda4skcsv6defawyggetjdeer6n9ed60dn096ma5dxfsg3plhg",
-    "lp_token_id": "352",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "352"
   },
   {
     "id": "osmo1qg99g3wn2a477eumpml8wgxnhyhjj0zjwlefsfjgpdk9zcm6kxqsdt7e7y",
-    "lp_token_id": "607",
     "asset_ids": [
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "607"
   },
   {
     "id": "osmo1qhd0uc9sc7psufty2y0u6ch2zpchtrljshr6jukly0n98yll759sncp98w",
-    "lp_token_id": "325",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "325"
   },
   {
     "id": "osmo1qjfu245d9zn893y6c2z4rd689s0nyty4myvdmh6x39awag72n8uqgtcmea",
-    "lp_token_id": "336",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "336"
   },
   {
     "id": "osmo1qjujmew5s65g97stpuckas77f9hypy84vs9x8p0e7cypwv7jph9sgguu2u",
-    "lp_token_id": "386",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "386"
   },
   {
     "id": "osmo1qkwd25wehxz5m0ddgal6yc6a70ph552pnw7ptrj2h697jflpq6yshag46w",
-    "lp_token_id": "472",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "472"
   },
   {
     "id": "osmo1ql58ecue9v3qlwfa9zjc64rw2sw9cwrpct7j779ers2jcm4q4ggqrmpq6v",
-    "lp_token_id": "543",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "543"
   },
   {
     "id": "osmo1qlz6kfv2gyer5tfrlcn540atatq2xj0lmzzqgphguq5cm4rcscmqqvfggv",
-    "lp_token_id": "469",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "469"
   },
   {
     "id": "osmo1qm24s5jk9mz8wtc5luad8fsenrp5v5m7prjmfhunm0plcyg74u2qrsr325",
-    "lp_token_id": "15",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "15"
   },
   {
     "id": "osmo1qqff9yppkegxgnazg933cun78eaelxa9zp2mz5m94q9fds6s4k5qaz4a32",
-    "lp_token_id": "839",
     "asset_ids": [
       "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "839"
   },
   {
     "id": "osmo1qqtms0c5dfg4mlw4jgyj54tnr3cxznzrz2zutthxxgx4zz9559wsq0nlmw",
-    "lp_token_id": "840",
     "asset_ids": [
       "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "840"
   },
   {
     "id": "osmo1qtle736upg6t8nmra606axnvnm8fwvffugdfhsn2hs4f8mv7n2yqgvlwt2",
-    "lp_token_id": "486",
     "asset_ids": [
       "gamm/pool/464",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "486"
   },
   {
     "id": "osmo1qvjyyc95dwwua5rhvlxf2y55qm3uq5m85063qn3vrvsuq0u59wgqnlaeq0",
-    "lp_token_id": "196",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "196"
   },
   {
     "id": "osmo1qw2zv7uq5lav3gk0j7xjapa85w0q3s0s7zlv4dws2gey84vuew6skaqu0j",
-    "lp_token_id": "216",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "216"
   },
   {
     "id": "osmo1qxdyvvnhtumm58pmhjlhhhe0pc3ye5apnma6tm0mx2r250zlga3qmn0z9j",
-    "lp_token_id": "283",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "283"
   },
   {
     "id": "osmo1qxswx2sy9u0cpf9hrgqd29gjnudpjkpffkzjtplckjkkv7mjnh5s04vy0j",
-    "lp_token_id": "854",
     "asset_ids": [
       "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
       "ibc/D0E5BF2940FB58D9B283A339032DE88111407AAD7D94A7F1F3EB78874F8616D4"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "854"
   },
   {
     "id": "osmo1qyys2gt072ke0dvhqk2mkqclr4hw2ajmsvcrz45x4x5p53rsrn2sr8nq30",
-    "lp_token_id": "846",
     "asset_ids": [
       "ibc/71055835C7639739EAE03AACD1324FE162DBA41D09F197CB72D966D014225B1C",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "846"
   },
   {
     "id": "osmo1r52puhw7jqqx92h4r7eadpgnak5453yejda8p4de8t7whdychg2s4qtakx",
-    "lp_token_id": "232",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "232"
   },
   {
     "id": "osmo1r5gj8e5pachzmsl5jphyw3njfr28jfzmykcz0w750tptzkyrhv9sf360an",
-    "lp_token_id": "802",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "802"
   },
   {
     "id": "osmo1r5v05r30s0v75py3n3lhd7sq5cdgkaltles5rk0cmgndrdq7ktxqcn64y8",
-    "lp_token_id": "426",
     "asset_ids": [
       "uion",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "426"
   },
   {
     "id": "osmo1r6xjt4ykjudgvlpnulk3jvuacjxew2xjag8frez4wprxkyspq8lq7j2edq",
-    "lp_token_id": "676",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "676"
   },
   {
     "id": "osmo1r7m4vy9qfdpusvk02wyn3wln4amhz39sgvy2qyccjxq3a8drhwuss9feyu",
-    "lp_token_id": "324",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "324"
   },
   {
     "id": "osmo1r82whw6efky7yjk6rlruf4pxva2crqtezkt7s095wulqrea2w46qkxm9wd",
-    "lp_token_id": "419",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "419"
   },
   {
     "id": "osmo1r83hq5aynm6skjpxltxvrfk2ve4dn23mzczp5d2xcp9xth6skghqyn2zu8",
-    "lp_token_id": "638",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "638"
   },
   {
     "id": "osmo1r8ed7qcfkvpqggzf5ckhfxzswjpgdxvkg78t3f92rr3mvla942dqq0fvj3",
-    "lp_token_id": "312",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "312"
   },
   {
     "id": "osmo1rayrpuu7sravv2ug4gh8w0k769cmg2s7ykc6xen4777wm27l547qhcpzfk",
-    "lp_token_id": "901",
     "asset_ids": [
       "ibc/47CAF2DB8C016FAC960F33BC492FD8E454593B65CC59D70FA9D9F30424F9C32F",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "901"
   },
   {
     "id": "osmo1rcgcf8rx24qffmxv76xswwps8g3vcvcargf9zsq93uwlzgt3ymdq9errgw",
-    "lp_token_id": "727",
     "asset_ids": [
       "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "727"
   },
   {
     "id": "osmo1rclh8r9e0qtn284uusgqydgnjjv2d2w5v9e5ngrk0exzlua9x2ssnmtk48",
-    "lp_token_id": "583",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "583"
   },
   {
     "id": "osmo1re957uvznxe6jme4zmzm5d95lajz5an7mrdus85faakrj45qa57sshx5g9",
-    "lp_token_id": "155",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "155"
   },
   {
     "id": "osmo1replyw8a8pp2t78k9adu35zhg7l9npknka2teh58zyt6emkg3xusyt0xew",
-    "lp_token_id": "245",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "245"
   },
   {
     "id": "osmo1rk8tjedu75vr3s0usxulggkw5kfazcmv6gq72429nvdc468mf3wq67xw8g",
-    "lp_token_id": "342",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "342"
   },
   {
     "id": "osmo1rmhusclghxyvyxr9kq4nuum9pvsgplfpuvq0x5d0ufaaxrwkefqsardn6n",
-    "lp_token_id": "796",
     "asset_ids": [
       "ibc/E09ED39F390EC51FA9F3F69BEA08B5BBE6A48B3057B2B1C3467FAAE9E58B021B",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "796"
   },
   {
     "id": "osmo1rp8xap0z59k20fkt7078q8g4t37ee8reqpwt6afgglhe3h70hvls9xl5c4",
-    "lp_token_id": "885",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "885"
   },
   {
     "id": "osmo1rpu7k863l2pmdcw95452j487jxrh0mp77au489z3gjq7quhnk75st72zs4",
-    "lp_token_id": "765",
     "asset_ids": [
       "ibc/423967B46B1A51D78619085105B04FCFA14F7CBC0BE7539A316B2DCDFC7D8C07",
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "765"
   },
   {
     "id": "osmo1rq2qekdlt662cjr7zx5xknctju7zd4j8xhk7e0qcnsl4g2u0yr6qpej2sl",
-    "lp_token_id": "343",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "343"
   },
   {
     "id": "osmo1rrje5862udx9e0en3qve8539gvh33rfgfpzel9jxxvnjxxzmrnmqpc3vcz",
-    "lp_token_id": "645",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "645"
   },
   {
     "id": "osmo1rsr5pqt50eml482jhtg44mx9nc555wjd90vhz4hwkmrm7qngqx9sr3pvvp",
-    "lp_token_id": "763",
     "asset_ids": [
       "ibc/022A879A5301CBCACF96216C967805F15C33C615B74DC7236027C1BA1BF664FF",
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "763"
   },
   {
     "id": "osmo1ruqysu3pjzyv35w3fwk8mjprz8ludwc9xgexlvse40yqxd5hnmlqzlgjkm",
-    "lp_token_id": "752",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/F35C87A18804313088DAAF6FD430FCCCF1362BC3464D4FAD783C476F594C9CA7"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "752"
   },
   {
     "id": "osmo1rv4ercmn82tl55su3e79j2cvatgewx8qesqtgm3d9n7r6fy33esqektmlm",
-    "lp_token_id": "622",
     "asset_ids": [
       "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "622"
   },
   {
     "id": "osmo1rvlrxqytp0f6rw8k9g6j5y3t45l9v26l40y2rplh00a3ape2chesgq2dc7",
-    "lp_token_id": "377",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "377"
   },
   {
     "id": "osmo1rwswjnqfhkl8der73ac3q9ydcms8qkwcypksnu8pg2y5kf7enqjq8fas74",
-    "lp_token_id": "321",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "321"
   },
   {
     "id": "osmo1rxur0nsztn90mua2zv7ectqeht7ujzdfnfzwuny25da4k8vla4rsy8hls8",
-    "lp_token_id": "429",
     "asset_ids": [
       "gamm/pool/1",
       "gamm/pool/7"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "429"
   },
   {
     "id": "osmo1ryh98w99c3a26fjw09e4xd46jd00qfh2y9g38fk9zcd4ady5h0nqzpyvfx",
-    "lp_token_id": "165",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "165"
   },
   {
     "id": "osmo1rysdtqarh8y3yzlmpjwuaqvh3rhhqznqkex35wmhaxrvuqegvu3syuz3wa",
-    "lp_token_id": "646",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "646"
   },
   {
     "id": "osmo1rz76daxyz9vhf079ahgr6l76uah9xvhe65vu8dqyf5nq7674d3yss96x7w",
-    "lp_token_id": "530",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "530"
   },
   {
     "id": "osmo1rzsrh74px4ycnvwk936ycujp2q7ndhnvka7pt65pukvkvnpskfkqxf47ue",
-    "lp_token_id": "417",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "417"
   },
   {
     "id": "osmo1s2gwy72r2dnpk0dpfs0aftz7rahxsuglz30qkqdgzqsrpczyeexqay78uk",
-    "lp_token_id": "205",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "205"
   },
   {
     "id": "osmo1s3x4ey025k3ew7pamenlh89twqcd496rg0c9ye2ydnrxe6y68z8ss3g7az",
-    "lp_token_id": "706",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "706"
   },
   {
     "id": "osmo1s46juu2q7ets8tgqaytaaekfs5qu259tkex87ll068xsvfcf8uas6rkavc",
-    "lp_token_id": "598",
     "asset_ids": [
       "uion",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "598"
   },
   {
     "id": "osmo1s4eem3yk9de5xk8wr9gs9shc2905skd7h4e589cqs94pyrqem5jqn8y2ru",
-    "lp_token_id": "413",
     "asset_ids": [
       "gamm/pool/410",
       "gamm/pool/411"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "413"
   },
   {
     "id": "osmo1s666n6f6qhw2hcgkmwx3jxl7hz35cytrygmcvzcxxt84e8nrjfus4wyknj",
-    "lp_token_id": "739",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "739"
   },
   {
     "id": "osmo1s6nlndkuna63w5kk5npduwful69urrfvdlhn74awcan2dpx43xpsr4cxf9",
-    "lp_token_id": "527",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "527"
   },
   {
     "id": "osmo1s7p0al0sygrqumxlwhw0wfdazdasgew8wx0vspvhf7fwkfcxy03q3x7rcs",
-    "lp_token_id": "199",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "199"
   },
   {
     "id": "osmo1sf7twk9v5kkkredzk465wqk6s959ttuaf4683quu28q459e3jmlqkss6pa",
-    "lp_token_id": "556",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "556"
   },
   {
     "id": "osmo1sfqrusqfe0rfydt7aj8vwe59ujleu9zt6t7zrz58y0uv50sm7vpqvw2sdt",
-    "lp_token_id": "219",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "219"
   },
   {
     "id": "osmo1shzv0vcddhe0jh4wdh2xudrrw20uzu96ugsmyv29p5zscpk85snsmyjnjl",
-    "lp_token_id": "790",
     "asset_ids": [
       "ibc/7C781B4C2082CD62129A972D47486D78EC17155C299270E3C89348EA026BEAF8",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "790"
   },
   {
     "id": "osmo1sknzx8cw662aspm7f5xygfhuh9hkf76qqgqwshaqhmp9m920ahlqanwq25",
-    "lp_token_id": "36",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "36"
   },
   {
     "id": "osmo1skxw2mkpqnja6me7hmee5xu0l3h76a5jsahnwtk7tgeqszx0l33s6depu9",
-    "lp_token_id": "754",
     "asset_ids": [
       "ibc/27C09777C9F51B8AAE6BC15F92CFFDF2AB04067569A81D4938BA67EEC8D2E5D3",
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "754"
   },
   {
     "id": "osmo1sl6dla60tg44s0qk56sjvu6rhpuzfedd2xs3vm6es9v4q5smd7lqt0rgct",
-    "lp_token_id": "816",
     "asset_ids": [
       "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "816"
   },
   {
     "id": "osmo1snexrsplcnsstsmwp99jf3uua2f9pazcd0drgmmfr6kj22sdwm7scdkrdj",
-    "lp_token_id": "62",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "62"
   },
   {
     "id": "osmo1spsg7ka3mfknz2s8h6y8qg2azku322mfe3ryvluyhrygh6j4rr3s6ra4ca",
-    "lp_token_id": "161",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "161"
   },
   {
     "id": "osmo1sqan5vpspvyqtjj4spykrstq7ltgkvdsxuky5rurzzswejsdgd9qes5tjx",
-    "lp_token_id": "78",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "78"
   },
   {
     "id": "osmo1ssj7weswfdu3lz737evr5plqvgaqk28fl4akc085gghlxnu0qwvqdms4jc",
-    "lp_token_id": "222",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "222"
   },
   {
     "id": "osmo1stxalepejns0zm5rpq09jxwcg98r4a2m86kx9n598t32l079pwcsd2wg5n",
-    "lp_token_id": "197",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "197"
   },
   {
     "id": "osmo1svp9sxdq6qq4k2qpy8ldcf9368eejnawajcetpggpxkj5v5thvaswn32xf",
-    "lp_token_id": "414",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "414"
   },
   {
     "id": "osmo1szh2gzzsugx6e5vs7emkcrmcy87zg75jst8xemdp896v33u5f5eqt395ku",
-    "lp_token_id": "356",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "356"
   },
   {
     "id": "osmo1szvslwsxf3y2s4lt3c7e7mm92zgy44j8krruht5zzanmhrjwyc4qqpt5nz",
-    "lp_token_id": "621",
     "asset_ids": [
       "ibc/307E5C96C8F60D1CBEE269A9A86C0834E1DB06F2B3788AE4F716EDB97A48B97D",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "621"
   },
   {
     "id": "osmo1t0k2etaylj6w3tjs5wgn068hz4uyj7fpzs8707a4v02pj580mlrq9fyem2",
-    "lp_token_id": "738",
     "asset_ids": [
       "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "738"
   },
   {
     "id": "osmo1t0lgy5t88ctq2ur4xzjuk2rw6laxt434hsjn6shzwn7w0tph7z2s9p7qdc",
-    "lp_token_id": "819",
     "asset_ids": [
       "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "819"
   },
   {
     "id": "osmo1t2m0y54hrjmvs2zvxgy8005fjg4atqmveg9jafvzmqw64l42aawspdgj9z",
-    "lp_token_id": "328",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "328"
   },
   {
     "id": "osmo1t2qlvhu8766gmcgs7jnpyx5ey2hfje6uhjffgsn0rgzu3xx7cuzsl9wgt6",
-    "lp_token_id": "655",
     "asset_ids": [
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "655"
   },
   {
     "id": "osmo1t3de20l6jhz6gpx7v48upxzfkgu7d3r8nclkr5h7z53mvc7mfqyqcyqe25",
-    "lp_token_id": "440",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "440"
   },
   {
     "id": "osmo1t7zz28h30kjmd5rt0yg4gzd8g4ne0y6gpr5rf2zvsj6gs3fmcf8swfrmp8",
-    "lp_token_id": "394",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "394"
   },
   {
     "id": "osmo1t9hcnngffyvx3jagrr5wwetkdu3at3sf50a8jdfj7rwe7cyq8tks6t9cz0",
-    "lp_token_id": "382",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "382"
   },
   {
     "id": "osmo1taqxtna5e558fvstm2065n3zaej3ya2x3vv49a27uun80vduvk3ss4tscg",
-    "lp_token_id": "330",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "330"
   },
   {
     "id": "osmo1tf2uj9pdmkys6wzk2fwpcnp5x90lc9t5y8qw4ha2mms2nc5kkkesu3zj54",
-    "lp_token_id": "559",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "559"
   },
   {
     "id": "osmo1tg2k5rxex7zhzh3rcvmy6a2yfvw8446ezk7utz8j80vmkrpjve2qljc6hk",
-    "lp_token_id": "803",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "803"
   },
   {
     "id": "osmo1tgdxkfgc6k6fg9k8e3vpdkwxtwltx93ywfx959yn2e5ysxxpr7vsffd9jn",
-    "lp_token_id": "220",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "220"
   },
   {
     "id": "osmo1tgza0v4m0tlkgsew6jjup3zaqcv7qyx58gfzct8xyfx3d9vsv3mqetw8c7",
-    "lp_token_id": "185",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "185"
   },
   {
     "id": "osmo1thscstwxp87g0ygh7le3h92f9ff4sel9y9d2eysa25p43yf43rysk7jp93",
-    "lp_token_id": "604",
     "asset_ids": [
       "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "604"
   },
   {
     "id": "osmo1tl43tjmylclp37jduelnwrzeyuef2unxn9c04wrlakmgvzsnmgtqqet6za",
-    "lp_token_id": "628",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "628"
   },
   {
     "id": "osmo1trzwktd05mqzn8arhczsf7lwvmmfxmuducfvp3upzmlzs7jl38dscuprsg",
-    "lp_token_id": "637",
     "asset_ids": [
       "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "637"
   },
   {
     "id": "osmo1tusadtwjnzzyakm94t5gjqr4dlkdcp63hctlql6xvslvkf7kkdws5lfyxc",
-    "lp_token_id": "498",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "498"
   },
   {
     "id": "osmo1tuxr32k9pmshd5v2tuf89e2npc7j299cmpzscc74ec59xzkrr6fqmy2eda",
-    "lp_token_id": "822",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "822"
   },
   {
     "id": "osmo1tvfrcswx4c0dsma5z2nmuct34dresknmmaay0lrpsu0wsgh9q08qkv0zj2",
-    "lp_token_id": "612",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "612"
   },
   {
     "id": "osmo1tvv7j7c7hmantw8rkkkkhr2hx6kpckc5zkvnce30la6m048nckms0s5076",
-    "lp_token_id": "243",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "243"
   },
   {
     "id": "osmo1tx2ewuhrm0ypyuud04lslhwg5cwnn5ykxsqx49p9l2l94fn7tr2qw9um6j",
-    "lp_token_id": "318",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "318"
   },
   {
     "id": "osmo1txawpctjs6phpqsnkx2r5qud7yvekw93394anhuzz4dquy5jggssgqtn0l",
-    "lp_token_id": "42",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "42"
   },
   {
     "id": "osmo1ty9g3v2xpn70v7pw2jmzmy6npdsdw4e9yd9l5na9rs8qpjhnk89sawgrnw",
-    "lp_token_id": "599",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "599"
   },
   {
     "id": "osmo1tyjwq32pxv3xvpcdkkc8lp3gxkjdlll53grsjkqce3nsjctl328qpqfvj2",
-    "lp_token_id": "495",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "495"
   },
   {
     "id": "osmo1u05s34q3hk8mu3ypw6g5eqvfdvcllck8zualccz2p75lmdnmwgaszyg9ez",
-    "lp_token_id": "508",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "508"
   },
   {
     "id": "osmo1u0mjawl7cr9qjk5zfgmat5tlqgxgj5n999kal34kuu9k0mxrghqsm58fep",
-    "lp_token_id": "384",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "384"
   },
   {
     "id": "osmo1u0xmctf2dcz3qvmkhcp8prdq2xktnryyq6lshcccyr3jwfvpf9wq0rq3xy",
-    "lp_token_id": "157",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "157"
   },
   {
     "id": "osmo1u3402aty7hhz9zpsg4kkvcxs6skg6ly8lrrmky79tcuhccszk3vq59x0t2",
-    "lp_token_id": "260",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "260"
   },
   {
     "id": "osmo1u4nna8ml32n0u3fwcrfl0c3e7j8feaay0l5nzc2z850us2dkd9jqmvumll",
-    "lp_token_id": "86",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "86"
   },
   {
     "id": "osmo1u66wkjthdjxnavklpef7yzasdrvvqhckmhkqsw8uwlad3uaktr3qvny8k4",
-    "lp_token_id": "681",
     "asset_ids": [
       "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "681"
   },
   {
     "id": "osmo1u6wc5hkhg50kxdn9l8pye6zt6jvh5czeej86r4c6segzt0sw6wnsn7rj2x",
-    "lp_token_id": "280",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "280"
   },
   {
     "id": "osmo1u7uh9vvf85la2ukh60td0q07aq0mnvthxe7x0rutc0envm9865cqjesutw",
-    "lp_token_id": "736",
     "asset_ids": [
       "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "736"
   },
   {
     "id": "osmo1uc9j2thyq26jvktz4dsnya508dzr6ksjgl2w0lspsf2rdt64qu2qvgdz52",
-    "lp_token_id": "46",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "46"
   },
   {
     "id": "osmo1udj4gj4hx5l3k24qvn2cd08vmg7m6ewmxp65lxzfp2dq9xeqmv0s6kl8a7",
-    "lp_token_id": "366",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "366"
   },
   {
     "id": "osmo1ueg0m04nxj230juk08w9hlua8uupp3jgeclzllk98fzq592xly8q6zgg4w",
-    "lp_token_id": "465",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "465"
   },
   {
     "id": "osmo1ufuvzzlzu6qpre7hg2tkkm8st3qrx9g8ja4e9empma3kt9adqjcquklmqc",
-    "lp_token_id": "397",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "397"
   },
   {
     "id": "osmo1ugdp9q0nzcsmlllk9acvvuvt4h6g8fy0gspwgdtue06ya0vk4khqdka26t",
-    "lp_token_id": "258",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "258"
   },
   {
     "id": "osmo1uhpsqy52rs5dkwfpua5qulc4rcaw7y857zha0skzp3yxnd0k9k6ss44rjs",
-    "lp_token_id": "642",
     "asset_ids": [
       "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "642"
   },
   {
     "id": "osmo1uny6uzpdfqa9q2cea7ycnuwfr8s6c2zvyt6s7yh2rvvzt0zvhl6q6hdhdu",
-    "lp_token_id": "98",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "98"
   },
   {
     "id": "osmo1uppkz7d2r68qalz483ppa9w2z2lt0j35ext23vk0djtd9kh85g2qk66tlm",
-    "lp_token_id": "521",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "521"
   },
   {
     "id": "osmo1upzrcc4clr9cgttqqkfrt8yz73swd085edn8yfhtv65k2jansdlqnvnfyt",
-    "lp_token_id": "573",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "573"
   },
   {
     "id": "osmo1uqzdmre9vd0y9uzzm03umja3l9wmqdx3enl8fkfh9xa26yq7m77sx7xfkc",
-    "lp_token_id": "820",
     "asset_ids": [
       "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "820"
   },
   {
     "id": "osmo1utasxm8e2h7jermwv8mrv55nyphnpnkm2zrqzvn8hstx927s4q3sfkfprw",
-    "lp_token_id": "880",
     "asset_ids": [
       "ibc/19305E20681911F14D1FB275E538CDE524C3BF88CF9AE5D5F78F4D4DA05E85B2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "880"
   },
   {
     "id": "osmo1uvsrputqqa8g2dg3s9673w4r6yj8dclfzr4ctsk9jtgwvjwxjq7q297cdn",
-    "lp_token_id": "396",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "396"
   },
   {
     "id": "osmo1uxp60ju3h8ghmm2hae9adfulscrg2me5pr9zvl07lngmj0nr7lksqwfv32",
-    "lp_token_id": "784",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "784"
   },
   {
     "id": "osmo1uxqg4sr2yqvamc96n4kwkgna6nmmgtypfdn2gjhvwgymuunq3qlswyrdhg",
-    "lp_token_id": "725",
     "asset_ids": [
       "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "725"
   },
   {
     "id": "osmo1uyhjnu2l0qfxs3ltt2nuq6lx2fs8ff34684f0hw7sf557enrkd2ql6r2sl",
-    "lp_token_id": "239",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "239"
   },
   {
     "id": "osmo1uyhzfnjxp6a9gq3020f8d45ueszr5sj72p5cfry7hzg0zderhvzsscrkvx",
-    "lp_token_id": "878",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "878"
   },
   {
     "id": "osmo1v009a23dwz827gk4p23sf4tz0chyuwkht0ygerp2v09qhpmxw5eq52q9n7",
-    "lp_token_id": "286",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "286"
   },
   {
     "id": "osmo1v2982uaxxxmfyykkcusc2jlgrh43l6q646gdd27skr2smq8d8cwqksnw4j",
-    "lp_token_id": "902",
     "asset_ids": [
       "ibc/2FBAC4BF296D7844796844B35978E5899984BA5A6314B2DD8F83C215550010B3",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "902"
   },
   {
     "id": "osmo1v38v9n62pm4ktce0khdglyxzr3f8jdlahdux87q9m8x6uz4zfkesjv8wga",
-    "lp_token_id": "663",
     "asset_ids": [
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "663"
   },
   {
     "id": "osmo1v4gaqzdvmhdm4varxsd3qc385jser59vgpcxm8f5u9e9sjp58lzqlaw3kw",
-    "lp_token_id": "804",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "804"
   },
   {
     "id": "osmo1v4ulnkt7dj9903qvyeqz6d5u3rpjttcy6vzydt5gurqxunxyghgqw0u2d4",
-    "lp_token_id": "113",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "113"
   },
   {
     "id": "osmo1v5cueex2ajn35u8a3mr586vy9xf2tzl3n5ylghnwrc9ssnwwydnsk5gvm6",
-    "lp_token_id": "578",
     "asset_ids": [
       "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "578"
   },
   {
     "id": "osmo1v5eg7ch5gfj6aewdahuplj7ddhrlhq9cugp98lznnf542g4f9vgsv2lvxf",
-    "lp_token_id": "317",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "317"
   },
   {
     "id": "osmo1v6py2esnzl6pe6pg6mr42n37qrvcryavq3zjamwpa5csdayrgfts8dz4fx",
-    "lp_token_id": "170",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "170"
   },
   {
     "id": "osmo1v8289lc5hweg6qr3jhhsy3d4m2lf8663xz4fkwv8jcc5k3chgkwsxwky24",
-    "lp_token_id": "659",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "659"
   },
   {
     "id": "osmo1v8f030n78vpwrswjuppndv2h3p775g0q39znmew8tw6jv89fk5wsahrtk9",
-    "lp_token_id": "150",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "150"
   },
   {
     "id": "osmo1v9r9d4xk9j2r3m59hcnsy7037wu75ymyg6nc0em23rpwmp9nj3yqgz5wvw",
-    "lp_token_id": "778",
     "asset_ids": [
       "ibc/52C57FCA7D6854AA178E7A183DDBE4EF322B904B1D719FC485F6FFBC1F72A19E",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "778"
   },
   {
     "id": "osmo1val3zsn82xutf9tnadwxahva6cs9mscxkq7y9dhjpl5lvrqdp5xslvllw0",
-    "lp_token_id": "801",
     "asset_ids": [
       "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
       "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "801"
   },
   {
     "id": "osmo1vdlumhjnpdngk80dmuyq4vdngew4fscvlhq4tpgy8c8edswqapwse9987x",
-    "lp_token_id": "799",
     "asset_ids": [
       "ibc/161D7D62BAB3B9C39003334F1671208F43C06B643CC9EDBBE82B64793C857F1D",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "799"
   },
   {
     "id": "osmo1vedjqp8mzcr5yg8h0s75lg0l074nx8leqkj0efzvha8wpdus3nxq0myg32",
-    "lp_token_id": "101",
     "asset_ids": [
       "gamm/pool/10",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "101"
   },
   {
     "id": "osmo1vgmqyyu3gmnyr8w3g27uf5l02p76jz4gvjcwzrp40cjh55xht4qsrdmdsy",
-    "lp_token_id": "605",
     "asset_ids": [
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "605"
   },
   {
     "id": "osmo1vlqfs02w9l4ygp9wnkfpr54av4vdzea4czytvuccc5628pz7amzs2tftm6",
-    "lp_token_id": "893",
     "asset_ids": [
       "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
       "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "893"
   },
   {
     "id": "osmo1vmhq9xqcr702fspu9qmf22ggzu8fh4d374zs487068m4p5xh694sxgxza8",
-    "lp_token_id": "461",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "461"
   },
   {
     "id": "osmo1vnw5jmjusus6drlae4nv4l2dn2vg90lav77dvphj0r3gn9x2rh8qmz9ckh",
-    "lp_token_id": "369",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "369"
   },
   {
     "id": "osmo1vp0kxdq263kzawqmv394tjevw7useexp2hhh7835cjqjl28nkpmsum5nhn",
-    "lp_token_id": "473",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "473"
   },
   {
     "id": "osmo1vp9mwqrxt4dsyu4c0hzjpl79sw483wkqsfq8m7jrmjh9775ddn5snw8ccv",
-    "lp_token_id": "857",
     "asset_ids": [
       "ibc/23CA6C8D1AB2145DD13EB1E089A2E3F960DC298B468CCE034E19E5A78B61136E",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "857"
   },
   {
     "id": "osmo1vsadpr4k8xu6ply4yw084tjgyrqkeee99ktnjjjfus44pyzcs6mq5ml9xj",
-    "lp_token_id": "540",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "540"
   },
   {
     "id": "osmo1vtqgpkdd7taj8ssw4rlcd7ulu7wgmujfxlyaa3qkfztva07pm0sq2qkscy",
-    "lp_token_id": "911",
     "asset_ids": [
       "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "911"
   },
   {
     "id": "osmo1vx63kemxaxedvulz9xh45d9k0gc7udec35gy4my9f7tzywfeqljs52vdzf",
-    "lp_token_id": "898",
     "asset_ids": [
       "ibc/B1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "898"
   },
   {
     "id": "osmo1vyra2jgneztsn207a39dk5jhj7xu3ruh7hwuaq9jmmlf7averklq9lx3k4",
-    "lp_token_id": "460",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "460"
   },
   {
     "id": "osmo1vyz8a2xv27nj2t4xwm6h6rqpt6fhea08fsmg56tdlep7n3k3t2tsks5fxr",
-    "lp_token_id": "574",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "574"
   },
   {
     "id": "osmo1w3dsuh2hcp90vmhwrdxxftgm44edlcvn8xtzfvq2h457ma8hm00smpxet2",
-    "lp_token_id": "235",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "235"
   },
   {
     "id": "osmo1w3e7ywcnj6090nedg39p34mwthpuq25ly8d92kzg0pdx9kptlesswcj39s",
-    "lp_token_id": "916",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "916"
   },
   {
     "id": "osmo1w4w9gj02z3hv7qlry8mpju625qrevrtf2f2nmywu45j3j4mnahuskfrf38",
-    "lp_token_id": "90",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "90"
   },
   {
     "id": "osmo1w5awgnxgthpwdh4nl25ymdx78x8cnjepdh6ju7ep6gaq5up35l9qhzkfyz",
-    "lp_token_id": "594",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "594"
   },
   {
     "id": "osmo1w7na4s0suuchqfqsz0fyszu2udc68wgxsgk3vsrtvzdfyyfseevsufcx4e",
-    "lp_token_id": "276",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "276"
   },
   {
     "id": "osmo1w9rj85ugnk29uepdglrhuhusdx0wwh4ep5vks92apfryaeu9pq9q7yv3gm",
-    "lp_token_id": "288",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "288"
   },
   {
     "id": "osmo1wea46n3f86um4dp37t43pwpurcky9e7lz56tujrtcql9yx6sphtqee256z",
-    "lp_token_id": "529",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "529"
   },
   {
     "id": "osmo1wehlg2lrvqxjmy26ghkqdj4c653se5kr646z9rwwfflutj25dvnsn6ef3f",
-    "lp_token_id": "284",
     "asset_ids": [
       "gamm/pool/123",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "284"
   },
   {
     "id": "osmo1wfghlu9wguwrdrrv3su4fzkmsc80et9k2x796k6q4n0yvn2fx5wqe0mpve",
-    "lp_token_id": "742",
     "asset_ids": [
       "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "742"
   },
   {
     "id": "osmo1wh6azmp9dxraquxt2gyppgeyuvta2r3s3s72cx7xr6nprh8kgj4sl3qf0x",
-    "lp_token_id": "548",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "548"
   },
   {
     "id": "osmo1wjeftfc4708ly99x8mpty0faedwqmu6hw20v7dwxyma4vvn3u4jqmh9zh7",
-    "lp_token_id": "126",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "126"
   },
   {
     "id": "osmo1wjggh0jgm6mukp2rjcyas5w5eep20yqgxjcn9eqxh4rktcdku4aspnq4ka",
-    "lp_token_id": "137",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "137"
   },
   {
     "id": "osmo1wkspj354sp059377j67mk6uy48t7u2cm86609nq7xht47hj9mkzs39x3fd",
-    "lp_token_id": "152",
     "asset_ids": [
       "gamm/pool/1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "152"
   },
   {
     "id": "osmo1wlqxs0yh5m46hz5kaq2jmzc0vetrykej4zjm25kcpe9crxnvfxtqrnker2",
-    "lp_token_id": "714",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "714"
   },
   {
     "id": "osmo1wtd5nrx9f2uwu32z3njuhxtzxj4qcedrjlyrsm6q073yp84ryjgs5tgtq3",
-    "lp_token_id": "733",
     "asset_ids": [
       "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "733"
   },
   {
     "id": "osmo1wv6v6mgychqdmf9fj5esyrethnu86akn6gyqq7rlexacjjcht37qfsqjdl",
-    "lp_token_id": "698",
     "asset_ids": [
       "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "698"
   },
   {
     "id": "osmo1wxkx8kq5uvt4snu77ezhxclpecv95t3jyvagte8em9j6dk3jgczs66quh3",
-    "lp_token_id": "715",
     "asset_ids": [
       "ibc/2716E3F2E146664BEFA9217F1A03BFCEDBCD5178B3C71CACB1A0D7584451D219",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "715"
   },
   {
     "id": "osmo1wy5zsjq8mzyehg7g72hsf0v487a2h87sr30wzztjx9h0ct593zysl6444w",
-    "lp_token_id": "636",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "636"
   },
   {
     "id": "osmo1wyv2pa3xmrfgjgkd9s6v0e23dud2va6kgaaknyqm6kly6x228xvsh45uug",
-    "lp_token_id": "120",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "120"
   },
   {
     "id": "osmo1wyz6659ctwd28cq5nlw9a4jslm7nxydvg3uex2xmcl8y9fd49tjsfegg38",
-    "lp_token_id": "309",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "309"
   },
   {
     "id": "osmo1x0ptme5tp8r2qw8gsypg3qftfwfpt2hdk4jyvp7gryywmg5l9fsqvhs8fk",
-    "lp_token_id": "806",
     "asset_ids": [
       "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "806"
   },
   {
     "id": "osmo1x20esk0tjalpqjf6x8rz9plrlc8yam36c39lmqpm080dsyg6klhq4jdnvx",
-    "lp_token_id": "644",
     "asset_ids": [
       "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "644"
   },
   {
     "id": "osmo1x2cwskve25argave9s4392lwygg7j9fzxhxra97tvvpt80kvzxsswm0hqu",
-    "lp_token_id": "657",
     "asset_ids": [
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "657"
   },
   {
     "id": "osmo1x2wr6fllcwv9jmcwtq3lwjvuyutmcxf55q8a853jylah057lhl8scgqn06",
-    "lp_token_id": "690",
     "asset_ids": [
       "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "690"
   },
   {
     "id": "osmo1x5rh04vsyxx2u8enwpawhplmrhk7yrq82ulpj9wjcrt6j5y5n44q8vy2da",
-    "lp_token_id": "785",
     "asset_ids": [
       "ibc/5A7C219BA5F7582B99629BA3B2A01A61BFDA0F6FD1FE95B5366F7334C4BC0580",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "785"
   },
   {
     "id": "osmo1x6fpwjj6ur324atc4p2whc3rsdkaj2ecs4z5ckeu38eljv70mswqlmpqem",
-    "lp_token_id": "914",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "914"
   },
   {
     "id": "osmo1x6uvl8ef00hwl2ymgxfq40q9zjnykjw9u2w55466yl256lpqdpgqs9hpfg",
-    "lp_token_id": "63",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "63"
   },
   {
     "id": "osmo1x9g0qwks7t6u47cxnnqg6jyfaxczwk678eedr7z890n8dnwtx9fqvqwzkx",
-    "lp_token_id": "124",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "124"
   },
   {
     "id": "osmo1x9pjf7ehhdlfy035xy0t8rwp3dke6vhcdrtw2s35727ceh7ra7vslncd3q",
-    "lp_token_id": "721",
     "asset_ids": [
       "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
       "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "721"
   },
   {
     "id": "osmo1xct94me26df4k2fs6waecnvzca8dzv2jxl798tndqq3ync3tdkqskpn5cl",
-    "lp_token_id": "709",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "709"
   },
   {
     "id": "osmo1xe9d4uyaq5ek8u85kgvxusdadnx7u9k09cauv4f8gn9e7xr4xycq7rwn88",
-    "lp_token_id": "87",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "87"
   },
   {
     "id": "osmo1xf4n7h4fqt0qlc5gagfhu36n7jm05vrn8yhnf6kcxcjasf9u8eas585xt7",
-    "lp_token_id": "416",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "416"
   },
   {
     "id": "osmo1xfs2qqsx3vpy3nc2rna332afmk48sxpgh7cd6usvfrw0gcdcmz2qej4ywx",
-    "lp_token_id": "237",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "237"
   },
   {
     "id": "osmo1xhe34xslh74jyw8xl5p4auu5238zzhre7mcpd9kcxmfkrp5fuj9s4e6ldh",
-    "lp_token_id": "811",
     "asset_ids": [
       "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "811"
   },
   {
     "id": "osmo1xjd0l22txgpce4fh2kgjy7gmvhszzl05nzw7e7lc76qddxrywqpscj5pl8",
-    "lp_token_id": "54",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "54"
   },
   {
     "id": "osmo1xky9ttqjpqltad9y420x7ylnw5k8sh6ctnk57dvytvgaesywzccsnyptkl",
-    "lp_token_id": "764",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/C1CEF00F016FE89EA6E5B07DA895AACD91B0AAD69A991033D846B988AD4FB69D"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "764"
   },
   {
     "id": "osmo1xlq92gxx6a9zca4gjculx80gmpykh6lz2npustn27s7g7t2hcels964a7n",
-    "lp_token_id": "744",
     "asset_ids": [
       "ibc/BB6BCDB515050BAE97516111873CCD7BCF1FD0CCB723CC12F3C4F704D6C646CE",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "744"
   },
   {
     "id": "osmo1xp9gm8zw4fg7xrvu006eh7enpc0ywtsspv9ezzf7yqzpv2gpvd4qugqgvy",
-    "lp_token_id": "614",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "614"
   },
   {
     "id": "osmo1xr84lqj48rxlhk3w5weesczvl3tzemep6k5s968j6mmmvaml5e2qxhlngm",
-    "lp_token_id": "490",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "490"
   },
   {
     "id": "osmo1xslx5c73axa9t7xypphtc83zw6jvucwxcahfnfltc8fclqnuxz9s0833tw",
-    "lp_token_id": "633",
     "asset_ids": [
       "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "633"
   },
   {
     "id": "osmo1xsqe6aprxzmw4l7vzghjxxq2t3j504utx4aqpryy3tlerz7rmw7smsfnfl",
-    "lp_token_id": "372",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "372"
   },
   {
     "id": "osmo1xtresmp9jt2w7p40zj8rcvatc0lgwqj62elmerqd6n2pya03yyvszt0fng",
-    "lp_token_id": "363",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "363"
   },
   {
     "id": "osmo1xu8x23y94cjwexgxerr6pak0fprngxh4xwyw4stw6pny2ktw4qaq9k3xvw",
-    "lp_token_id": "780",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "780"
   },
   {
     "id": "osmo1xumj3tzy3f3cy0e98tj4plu3g9sq9rn86g0gzel6qk05stplwrpst2grm6",
-    "lp_token_id": "374",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "374"
   },
   {
     "id": "osmo1xuufuq55r4ukh6xgfkfkvhlgvgsy2z7wacchctvj9yllcc695lusvc3hml",
-    "lp_token_id": "900",
     "asset_ids": [
       "ibc/5E2DFDF1734137302129EA1C1BA21A580F96F778D4F021815EA4F6DB378DA1A4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "900"
   },
   {
     "id": "osmo1xv2t67l0x59r6gl4wpgx925qlgy38ua325jyugh0yah5jkzp0amsw0aqpc",
-    "lp_token_id": "378",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "378"
   },
   {
     "id": "osmo1xw730drgcts95umje5fwekx8dgpn4dg756d4a4y26jfhy6ekuu9q78qycc",
-    "lp_token_id": "704",
     "asset_ids": [
       "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "704"
   },
   {
     "id": "osmo1xxg0pnmyxj7xlvdvxrqdzrecaa2fquq97egpkf248t6kxuklsdjqazsyq0",
-    "lp_token_id": "850",
     "asset_ids": [
       "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "850"
   },
   {
     "id": "osmo1xzjr9a7t3k0y2498yh9cxmexy0vk6cwlx7jcvwvhlh6trs2t44zste5zhz",
-    "lp_token_id": "314",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "314"
   },
   {
     "id": "osmo1xzwgqxu9y7dhqq8ka33p9rs9ayej8cs742jn2akvuj0jkdvvuktqf4xdxv",
-    "lp_token_id": "68",
     "asset_ids": [
       "gamm/pool/1",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "68"
   },
   {
     "id": "osmo1y04x26mggspuwp8racsxukq2avuwk4q5frwyzm59szxy2x0s52sqq8men0",
-    "lp_token_id": "711",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "711"
   },
   {
     "id": "osmo1y09t7vkps2p7ppe2aqfuqhje2zkmnk4t72yagk30286p9zw8e68s7mylm8",
-    "lp_token_id": "338",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "338"
   },
   {
     "id": "osmo1y28qvpn23cuem32qt6jsrshmy5wj3ndn46lyh7p0dt5w8q0vxuwqfxhpzz",
-    "lp_token_id": "275",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "275"
   },
   {
     "id": "osmo1y3g6lwd5p72z5uxgm4z6wy7asyg53wg83np7mg3cz2wnf9zhl69q8shlnd",
-    "lp_token_id": "587",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "587"
   },
   {
     "id": "osmo1y3hutqnstzdx096nf47hw5s5pmu67cgzpz0gjh2f4cr39dw0uptstdjjln",
-    "lp_token_id": "519",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "519"
   },
   {
     "id": "osmo1y3jhypynwrdjyqu0y3t9qs6kpkuspysdcpatal25ll2792hkf2lsy9d9u8",
-    "lp_token_id": "588",
     "asset_ids": [
       "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "588"
   },
   {
     "id": "osmo1y3ptmx57hvu7au6s9r3fxq00856896unkdyqaump7vedag248l0qc03asg",
-    "lp_token_id": "481",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "481"
   },
   {
     "id": "osmo1y5dfzzdhyh9azqczjazk5v8vacf8we8f4gwlmyjc57s39jcgcp2s6d4l4k",
-    "lp_token_id": "80",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "80"
   },
   {
     "id": "osmo1y5wz4pl4xpwrgr9mpjfmfewfa5nfns4473s9zs29c7c5q8w7pskqccf39r",
-    "lp_token_id": "595",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "595"
   },
   {
     "id": "osmo1y6gvkz0qu93h7zgkrrhr6fqye5ny9ddpm9az2l5kjr0mmw9n48mqpmcnnv",
-    "lp_token_id": "571",
     "asset_ids": [
       "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "571"
   },
   {
     "id": "osmo1y820u9050hz23a48e7wzw5mnqftplvj205l0vaw3tx7g609l32zsxdyeam",
-    "lp_token_id": "504",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "504"
   },
   {
     "id": "osmo1ya0hny0hsc73q4tnn6wdswk777r9e5pxhswm3ej5f624zahxmzcs2ygthd",
-    "lp_token_id": "779",
     "asset_ids": [
       "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "779"
   },
   {
     "id": "osmo1ycedur3klym2dwlz0w0796zqmn7fdzn6fldwc6cuzqwarejcuq2qu8z96e",
-    "lp_token_id": "899",
     "asset_ids": [
       "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "899"
   },
   {
     "id": "osmo1yeu83fklh2vxjts7evnm8439rj326zwgqldaz4sr470pu29jr88qujz9hu",
-    "lp_token_id": "269",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "269"
   },
   {
     "id": "osmo1yfhmdj7akjtj8me0l3ttn3p475mdeuz032uzpl5n09q8evdzc7xsv6yj25",
-    "lp_token_id": "563",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "563"
   },
   {
     "id": "osmo1yfs3zurxezmggujt5ffxyzerx5ujjsuzm07y0dy8p69z3l9w3d5s9nyagx",
-    "lp_token_id": "894",
     "asset_ids": [
       "ibc/D3ADAF73F84CDF205BCB72C142FDAEEA2C612AB853CEE6D6C06F184FA38B1099",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "894"
   },
   {
     "id": "osmo1yggqusvjqscjy03ysdmjh5hxmt6tv20u5ufrsuy67ksnw2xqsvzql2j70s",
-    "lp_token_id": "562",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "562"
   },
   {
     "id": "osmo1yjpgrff07qx7q2tykqthtenyk7tmlnjy83097y00g20ncuxut8hsgwm4p9",
-    "lp_token_id": "717",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "ibc/AA1C80225BCA7B32ED1FC6ABF8B8E899BEB48ECDB4B417FD69873C6D715F97E7"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "717"
   },
   {
     "id": "osmo1yn7z42al3mafmztjayjduz42a8at3whyd279fkdsyumzar83x8mqvpw83x",
-    "lp_token_id": "631",
     "asset_ids": [
       "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "631"
   },
   {
     "id": "osmo1yqqtrljj2xcdldwgtwgjeqte69lf8wdyfcx99jffc669natgslcske6ku3",
-    "lp_token_id": "700",
     "asset_ids": [
       "ibc/00B6E60AD3D65CBEF5579AC8AF609527C0B57535B6E32D96C80A735344FD9DCC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "700"
   },
   {
     "id": "osmo1ysvqrdxtp489v8q03fun60nyr2v4p7p35dsf3g6cgln4avw6d4msdpldt2",
-    "lp_token_id": "278",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "278"
   },
   {
     "id": "osmo1yugu88lhymszf7plpnn9ez07a34w2fxne7j44zqfqycgu8xx8cyqxmq5w2",
-    "lp_token_id": "750",
     "asset_ids": [
       "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "750"
   },
   {
     "id": "osmo1yurhrjdwh4j3h5ck5tj08u9ht38qaxq4vu9ad7nn4jcf23lnfxvsclex5j",
-    "lp_token_id": "142",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "142"
   },
   {
     "id": "osmo1yuu7x52t2df6f0287md68q8l3u90h9jxjurcnxpskvve2de9krgqmm7mjm",
-    "lp_token_id": "693",
     "asset_ids": [
       "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "693"
   },
   {
     "id": "osmo1yv7jtrkt3t9t3mtsndxx7392azzmawyyy0k9qn97rv35dkluyp7qzyswmn",
-    "lp_token_id": "720",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "720"
   },
   {
     "id": "osmo1ywwh6qsau3fqc507puxqv22re0eqthuyk7xpfgxvdv62d53ydlasd0lpnp",
-    "lp_token_id": "335",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "335"
   },
   {
     "id": "osmo1yxs0cp0gdrc552u8whe293q8al4w6f5v2nl5cmdeecwx3p9m2p8qk7adjc",
-    "lp_token_id": "617",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "617"
   },
   {
     "id": "osmo1z0693astkr0t976z8fs22902qxnl8rhjw44uglll9qk07h7wpt6sy77yc7",
-    "lp_token_id": "511",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "511"
   },
   {
     "id": "osmo1z390kae9wyjw5lxy5hl4mfc52w6830eflury88mfjsjl9s5708cs5ckkde",
-    "lp_token_id": "333",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "333"
   },
   {
     "id": "osmo1z4ka2c5hzfpy8qkrefwd2pu7mqnfdxjrvqgch0h0llh269zcta9qxzsty4",
-    "lp_token_id": "468",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "468"
   },
   {
     "id": "osmo1z4tn4qh0dj89h5h3jyxprthh324vm88t7netqjeu6855hf7ttugqevfnew",
-    "lp_token_id": "526",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "526"
   },
   {
     "id": "osmo1z52y99kywzjjv9kf8498jkkva8n6g3epzeds6v9hth85rd90fcvq5zxp6w",
-    "lp_token_id": "210",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "210"
   },
   {
     "id": "osmo1z7pnmk64p2g8qpeu3j70uwv9eu77kj6qyk96mmxehc0lhm5lvmeq6ugylv",
-    "lp_token_id": "388",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "388"
   },
   {
     "id": "osmo1z86kzpdqmrdr6prp8dvj5n73w7t0fc54mx2gq7y30p6awyhun3kq4wxpaz",
-    "lp_token_id": "492",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "492"
   },
   {
     "id": "osmo1z9dqkuhkhuys9hcel25mtuw33awk0svp6afzg3d3j0vqft9cj9aspg97ce",
-    "lp_token_id": "316",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "316"
   },
   {
     "id": "osmo1zd2vqwlvpz4e9xrkvxvc0aa8cqsnwdvpgxulk7n449r6lr4adv3st6mzzf",
-    "lp_token_id": "639",
     "asset_ids": [
       "ibc/F867AE2112EFE646EC71A25CD2DFABB8927126AC1E19F1BBF0FF693A4ECA05DE",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "639"
   },
   {
     "id": "osmo1zd632nrrwh6r5wwqs0y6h5qslr3l3yh6kryxtg7zmrclqcrtwefqp0m097",
-    "lp_token_id": "776",
     "asset_ids": [
       "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "776"
   },
   {
     "id": "osmo1zddv3kuvxqulq09dcfur8etz3tax90vjuymtlzzk23ps39ew26cqm3gykf",
-    "lp_token_id": "233",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "233"
   },
   {
     "id": "osmo1zdp0cl67a25r25hslw3xzzt5mmd03ws04vevnthzklxzkg4xg35q8h8dnk",
-    "lp_token_id": "226",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "226"
   },
   {
     "id": "osmo1ze0t3al4zgndvjla36gp2khjkwwdzr2e4m8vl6fuzfllfrlr8mdq4wnmxt",
-    "lp_token_id": "745",
     "asset_ids": [
       "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "745"
   },
   {
     "id": "osmo1zffkpskd8vv643mwu59ujsgldfz0khlgcvsty8zv9y4t50azf6cqx0a3pp",
-    "lp_token_id": "615",
     "asset_ids": [
       "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "615"
   },
   {
     "id": "osmo1zfgxnef46xmdv6dgnwvem6dpuetr58hwpnwlvvxv0pgsdv8gj86qk22vcy",
-    "lp_token_id": "897",
     "asset_ids": [
       "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "897"
   },
   {
     "id": "osmo1zg4rlhp843nn3jk0uz2kvk4zzvp7wm6qpvlnuv7dnp4jlz9pmpws90duk8",
-    "lp_token_id": "82",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "82"
   },
   {
     "id": "osmo1zgnc6xvj607xmtpyu420h378cwgdnlwzhat9wjgsavgkjk5n3ckqx68328",
-    "lp_token_id": "608",
     "asset_ids": [
       "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "608"
   },
   {
     "id": "osmo1zka4v4c04jr74ludyls2lfzfttzx67qzd070xtnfq90yzyacgn9qv6vend",
-    "lp_token_id": "11",
     "asset_ids": [
       "uion",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "11"
   },
   {
     "id": "osmo1zml837f5en8x2fvvger70l76cmdahrdv5y6m9e6yk0scnddn5w0qj54m60",
-    "lp_token_id": "837",
     "asset_ids": [
       "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "837"
   },
   {
     "id": "osmo1zmxelh7k08hy085shm5y08mqeaqmahee7u77lpnf2h4eufnsyn6qucvfjy",
-    "lp_token_id": "43",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "43"
   },
   {
     "id": "osmo1zpjym32nr8qt8t8nm9nu2zr5hx90hferfv2jqpt824q9nz38k2vstj704t",
-    "lp_token_id": "250",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "250"
   },
   {
     "id": "osmo1zrm4msu7q238tlhkdyk2pu3px47z47n0tgwrlpf6c08f4ppmwycqfeas0n",
-    "lp_token_id": "96",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "96"
   },
   {
     "id": "osmo1zskwjdwjgxt8r3ukqgcn8z70qtzl5cswy03pkupvzvmwlvcjvtrs4fwrpx",
-    "lp_token_id": "462",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "462"
   },
   {
     "id": "osmo1ztfk57933fj6278dn9ja7w60nfq44mndludh2qx62e2tg9hc29lqm8avec",
-    "lp_token_id": "671",
     "asset_ids": [
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "671"
   },
   {
     "id": "osmo1ztk3sfcrdvv2lnmjzfad5qerkevp3y5ny8s3n5t8c94pxwu0putqw3dqtw",
-    "lp_token_id": "69",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "69"
   },
   {
     "id": "osmo1zvc24h5fd9a2gj7xs30fvp9wmf6jydf3w0updqu5hr6g9turnkzqqh00f4",
-    "lp_token_id": "190",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "190"
   },
   {
     "id": "osmo1zyjk6a4fapusydkauzph93h3c2ssngpfh3retatwaqw32lw20mhqcxu4xw",
-    "lp_token_id": "534",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "534"
   },
   {
     "id": "osmo1zzn7rddfytcjg26g3s97g2qck2nwz5upfth430fdmnnyph9vjxhqpytc3l",
-    "lp_token_id": "769",
     "asset_ids": [
       "ibc/1E09CB0F506ACF12FDE4683FB6B34DA62FB4BE122641E0D93AAF98A87675676C",
       "uosmo"
     ],
     "dex": "Osmosis",
-    "type": "balancerV1"
+    "type": "balancerV1",
+    "lp_token_id": "769"
   },
   {
     "id": "osmo16054sn8ug2njt8hnhzk5qy2zh7u8x6nmex3c02970dpmqfepz7hq434rlm",
-    "lp_token_id": "920",
     "asset_ids": [
       "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
       "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
     ],
     "dex": "Osmosis",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "920"
   },
   {
     "id": "osmo17m8tjws6ce8rqgghcfz09jgew9tcakp3qlw76pt86akerxk3t7rsgkn75e",
-    "lp_token_id": "873",
     "asset_ids": [
       "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
       "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4"
     ],
     "dex": "Osmosis",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "873"
   },
   {
     "id": "osmo17n9drfwd7sqa5rc7v7xwfv5ucfngg8nttu6j2plvxgvrrt2099qsq54urf",
-    "lp_token_id": "913",
     "asset_ids": [
       "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
       "ibc/C491E7582E94AE921F6A029790083CDE1106C28F3F6C4AD7F1340544C13EC372"
     ],
     "dex": "Osmosis",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "913"
   },
   {
     "id": "osmo1aqmdce4f8ymqcf7v0a8xcukt8xqga50zqcprta89e9p2fmscfzpscru5lr",
-    "lp_token_id": "886",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/CAA179E40F0266B0B29FB5EAA288FB9212E628822265D4141EBD1C47C3CBFCBC"
     ],
     "dex": "Osmosis",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "886"
   },
   {
     "id": "osmo1cxlrfu8r0v3cyqj78fuvlsmhjdgna0r7tum8cpd0g3x7w7pte8fsfvcs84",
-    "lp_token_id": "903",
     "asset_ids": [
       "ibc/46C83BB054E12E189882B5284542DB605D94C99827E367C9192CF0579CD5BC83",
       "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
     ],
     "dex": "Osmosis",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "903"
   },
   {
     "id": "osmo1d3dd4w06c2lyxqm7lf30st89esf4437f3tn42kpv9sh5zug5xdksnnp0nh",
-    "lp_token_id": "892",
     "asset_ids": [
       "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "892"
   },
   {
     "id": "osmo1ewsz7a8zefxq67h4205hlncpfm3np4mky34upu3sktc3llrj5rgqdutjgk",
-    "lp_token_id": "868",
     "asset_ids": [
       "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
     ],
     "dex": "Osmosis",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "868"
   },
   {
     "id": "osmo1hayyjltd3mjx6w8g7wtpu2zckk83ecxen2eux6c7tl42unfvnfysqg9myf",
-    "lp_token_id": "906",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "906"
   },
   {
     "id": "osmo1kxnekx4q8yem6wvp5t9ggqvhuxaqw7san00x5qdazp3fe597f8hsqft4nq",
-    "lp_token_id": "872",
     "asset_ids": [
       "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "872"
   },
   {
     "id": "osmo1r4r0ryw0pq2yhwcqwf8pg4w0fr764k3ztv9weuyqcn5hv0zxy67srvgfj2",
-    "lp_token_id": "884",
     "asset_ids": [
       "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
       "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
     ],
     "dex": "Osmosis",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "884"
   },
   {
     "id": "osmo1rdcx38vnf0tvx6x0xkel747m0rqkv5lg20lfww8gtdrydmu00pyqgefkm9",
-    "lp_token_id": "862",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "862"
   },
   {
     "id": "osmo1xfcjgr8l0e2pp3mx2qlcu5u4x0vt84cuzhwyytvmvhlnm5kjww8qudwh8y",
-    "lp_token_id": "863",
     "asset_ids": [
       "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
     ],
     "dex": "Osmosis",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "863"
   },
   {
     "id": "osmo1ylzwp5r95sqjmkjem3hu0ynslaxjd2tzv6udfhrlrtyhj4zerttq3343su",
-    "lp_token_id": "888",
     "asset_ids": [
       "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796",
       "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F"
     ],
     "dex": "Osmosis",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "888"
   }
 ]

--- a/osmosis/pool.json
+++ b/osmosis/pool.json
@@ -7,7 +7,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "722"
+    "lp_token_id": "gamm/pool/722"
   },
   {
     "id": "osmo104w884d9gw9s35ckru66ptl3uu3ss0u60xk7gplj8ky0xan6tfvsrfshe6",
@@ -17,7 +17,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "835"
+    "lp_token_id": "gamm/pool/835"
   },
   {
     "id": "osmo107cnz52uqdqzvwfvwcl4z55xqlj4rz78yv04a3tgqpkn3wrnkfxqq2ze39",
@@ -27,7 +27,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "487"
+    "lp_token_id": "gamm/pool/487"
   },
   {
     "id": "osmo108scuudnnhe70xuwa2etuyxffexexak6rflvsczj9n4fhrz92ajs9zudge",
@@ -37,7 +37,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "572"
+    "lp_token_id": "gamm/pool/572"
   },
   {
     "id": "osmo109uqkhlvees202dg6mkhn89actzyfvvlm9u7ym3zzytrp9gmhcvsawlssg",
@@ -47,7 +47,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "412"
+    "lp_token_id": "gamm/pool/412"
   },
   {
     "id": "osmo10ce9cnt6hk4jnghvdl5asdsc5rmjfswkk7u5jrfr5ecy5puvsdzs5x6rvc",
@@ -57,7 +57,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "515"
+    "lp_token_id": "gamm/pool/515"
   },
   {
     "id": "osmo10cm3vypuxkrvq4uznf4px5lv43ej99f6shushwtur3fpy6z69huq7gfce8",
@@ -67,7 +67,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "788"
+    "lp_token_id": "gamm/pool/788"
   },
   {
     "id": "osmo10d8ddsydag5xrnl2kacmkjtdxddstvz4jvraqqpf6ss2n7fy6lkqw4sx2f",
@@ -77,7 +77,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "560"
+    "lp_token_id": "gamm/pool/560"
   },
   {
     "id": "osmo10djas3dkuyvfzaxvgwjqp3aaf63wjrv23hx3pmk8pjaxc3f33k9ssrz8kf",
@@ -87,7 +87,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "482"
+    "lp_token_id": "gamm/pool/482"
   },
   {
     "id": "osmo10ecjz4nkzsr8rwmzmk7z6uwf6ux78wyctc98yphu0rc7cey9t5sstj4zyt",
@@ -97,7 +97,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "478"
+    "lp_token_id": "gamm/pool/478"
   },
   {
     "id": "osmo10g4gm8px3tfeft8y0w4yc7kyxv9p9dk40aplln59j0nxmmnjnjcqhpftcf",
@@ -107,17 +107,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "302"
+    "lp_token_id": "gamm/pool/302"
   },
   {
     "id": "osmo10g7srpl9gqhetplp6d2fr7l25ckjrtcsupk60984w8vf2zugcvjq6ashnq",
-    "asset_ids": [
-      "gamm/pool/102",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/102", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "103"
+    "lp_token_id": "gamm/pool/103"
   },
   {
     "id": "osmo10gyurv978mfwmfpd9e824kua3f2vca8626ky93aqndhqzqfmulds36ltrz",
@@ -127,7 +124,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "443"
+    "lp_token_id": "gamm/pool/443"
   },
   {
     "id": "osmo10j0kv8lfy5ym3wm8m0shte5p7zu5sjtj6a6s0zslp3suqrkaqyps3kfe06",
@@ -137,7 +134,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "707"
+    "lp_token_id": "gamm/pool/707"
   },
   {
     "id": "osmo10j25ze5tj5ryxz4jk79au6srhe62jsckk9dd6u5qt3326wv9gvnskn7tu9",
@@ -147,7 +144,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "500"
+    "lp_token_id": "gamm/pool/500"
   },
   {
     "id": "osmo10k2x02xa6acekt74fnw4sl6znfgv08k37zgkd0ej303uqc4t2s7sarhsr8",
@@ -157,7 +154,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "904"
+    "lp_token_id": "gamm/pool/904"
   },
   {
     "id": "osmo10kepynda48va573sjsn0ch6glf3e2qrs87ukpvd63ljdmkaflg3sjxf5r4",
@@ -167,7 +164,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "339"
+    "lp_token_id": "gamm/pool/339"
   },
   {
     "id": "osmo10r9v3xpzzd4752r0cvu50vacp8use9later59jcny07xz80gv6mq4yq70a",
@@ -177,7 +174,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "619"
+    "lp_token_id": "gamm/pool/619"
   },
   {
     "id": "osmo10rmhpg33dv9unqtw72jh67r8xdjmc07qe9zaef4jjycjyakl8q6sl76dhz",
@@ -187,17 +184,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "691"
+    "lp_token_id": "gamm/pool/691"
   },
   {
     "id": "osmo10sh5u7pl9dwh7ll8wfaahr0trkka4rv2k9amlj88s72k6v8paufs0qnz7p",
-    "asset_ids": [
-      "gamm/pool/222",
-      "gamm/pool/402"
-    ],
+    "asset_ids": ["gamm/pool/222", "gamm/pool/402"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "403"
+    "lp_token_id": "gamm/pool/403"
   },
   {
     "id": "osmo10tly0t6ppjaz0uhlskvlluzwwwswdc8tfy65mhhkwst6cfq07rdsxscmm9",
@@ -207,7 +201,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "349"
+    "lp_token_id": "gamm/pool/349"
   },
   {
     "id": "osmo10tx2zgul27naq2p5urn9kx7lygfr0zhsk3s42nh0dcfqyudq655sadlyxj",
@@ -217,17 +211,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "632"
+    "lp_token_id": "gamm/pool/632"
   },
   {
     "id": "osmo10uut208crprz36gpw3wwh50e6yuuq8jxf5yamdclg4vr84uw8cmqkunxkx",
-    "asset_ids": [
-      "gamm/pool/1",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/1", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "493"
+    "lp_token_id": "gamm/pool/493"
   },
   {
     "id": "osmo10v29rzxswcz2facklsfxg7a3ns2lu5vj9f0509ateum9u7ca33tqur69mk",
@@ -237,17 +228,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "277"
+    "lp_token_id": "gamm/pool/277"
   },
   {
     "id": "osmo10v35xj20k0jrfgs8p3lqt5gyga0wug3kkh4pq6xt3x4hqh5huvcssp04d3",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "255"
+    "lp_token_id": "gamm/pool/255"
   },
   {
     "id": "osmo10venxtvdglryxkdmvjr8wa6n3ugja40rewddlxtg0pr30vmkf47sllgslg",
@@ -257,7 +245,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "678"
+    "lp_token_id": "gamm/pool/678"
   },
   {
     "id": "osmo10xnwkjzqpdvgzxpz7eu5mcne5jc73c5h0xuhv9qmz0jsfyyxvr4qvhje97",
@@ -267,7 +255,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "777"
+    "lp_token_id": "gamm/pool/777"
   },
   {
     "id": "osmo10xphw0uxj2k7erakdajxxdwexu4qt0fwlu0xu3a26r76kthxjyxqal4wcf",
@@ -277,7 +265,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "677"
+    "lp_token_id": "gamm/pool/677"
   },
   {
     "id": "osmo10ya3d9gr2cmp268kdu8u5mna0pktqfxkt9ug54z9xrazpk3wpj0qz9zlcg",
@@ -287,7 +275,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "524"
+    "lp_token_id": "gamm/pool/524"
   },
   {
     "id": "osmo10yczu0hflmtny52ktkvfrrwj2cktkjn6yk9wsfyxsjf6n8pvwxfscmn4e5",
@@ -297,7 +285,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "144"
+    "lp_token_id": "gamm/pool/144"
   },
   {
     "id": "osmo120echqk9sfelg47lrultsc0em257582cxrp86epqhcz8gfqxf6fsluzp7z",
@@ -307,7 +295,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "849"
+    "lp_token_id": "gamm/pool/849"
   },
   {
     "id": "osmo1230t5url8jlyxp9czgjv7p93kkgka4uvr3syxlwum9zjk2gpn6cs4xcxgc",
@@ -317,7 +305,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "590"
+    "lp_token_id": "gamm/pool/590"
   },
   {
     "id": "osmo124h7edw5f98xzfgaxmxjpnu66hdt6cn58n4g3awa90cn3h5v6d8s45246p",
@@ -327,7 +315,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "447"
+    "lp_token_id": "gamm/pool/447"
   },
   {
     "id": "osmo124qc2hs5jgp2shrmtv2usxyrt52k447702pczyct0zqadlkkh2csvh5pzv",
@@ -337,7 +325,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "97"
+    "lp_token_id": "gamm/pool/97"
   },
   {
     "id": "osmo1265edur3evpvmmcter5a3lp93zlyc23wd9qp0vcu0xatn79a4q0qp24n2c",
@@ -347,7 +335,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "198"
+    "lp_token_id": "gamm/pool/198"
   },
   {
     "id": "osmo1272l80yvlqm4j6y5296fqhvy8ltgscsj2h4u76pumj2sy0ul82ns7hy0wu",
@@ -357,7 +345,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "127"
+    "lp_token_id": "gamm/pool/127"
   },
   {
     "id": "osmo128m3mqa0m6ex57nxkxkyczd3nsqns2p56wm5xu52p4jappg2jamq5jrlxe",
@@ -367,7 +355,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "265"
+    "lp_token_id": "gamm/pool/265"
   },
   {
     "id": "osmo12a8gxj8p07rn92zzjug6vq2a39hnqw92zhpmymxxs5avj327zslsszjqxr",
@@ -377,7 +365,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "229"
+    "lp_token_id": "gamm/pool/229"
   },
   {
     "id": "osmo12exa7m2esj4a9anudf0e2rpk5yynf049h585sm4zv7rqkjqun5cqs604sd",
@@ -387,7 +375,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "345"
+    "lp_token_id": "gamm/pool/345"
   },
   {
     "id": "osmo12fzg5z9xzw8yde57fj5w2rwqmxe6f4g3lgjdrjhhsqx8m43fqpgs7d8x8q",
@@ -397,7 +385,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "856"
+    "lp_token_id": "gamm/pool/856"
   },
   {
     "id": "osmo12h3748gmjdssn3pyxdtu9d6gl6wvlrem03y5e592h05f4kx6aa2ssp8jq7",
@@ -407,7 +395,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "422"
+    "lp_token_id": "gamm/pool/422"
   },
   {
     "id": "osmo12huxa5wnwskf8mnmr096yzwyrehm970782j95h25uuxrxxz8wdpq7udusr",
@@ -417,7 +405,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "303"
+    "lp_token_id": "gamm/pool/303"
   },
   {
     "id": "osmo12lzydwxr8xmyhrvg7kr0948zz4jnf4wjczwqrngppw4du85ustmqs5vpt6",
@@ -427,7 +415,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "263"
+    "lp_token_id": "gamm/pool/263"
   },
   {
     "id": "osmo12ng7y9c5lhyqgl2pxgap64de0fjynnwgtv3j5cme5c2ypmwezd2qwq982h",
@@ -437,7 +425,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "807"
+    "lp_token_id": "gamm/pool/807"
   },
   {
     "id": "osmo12nv2sf5qe5t93ly3fktdgrw5u9f5nn9cf8cakgt0pvhhqghvkrnqqhadah",
@@ -447,17 +435,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "805"
+    "lp_token_id": "gamm/pool/805"
   },
   {
     "id": "osmo12nxhn6pc44eguzf53y37nkpjqv80u3n0kxtuffyqrp0h0vkqccfqu2f7pk",
-    "asset_ids": [
-      "gamm/pool/1",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/1", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "393"
+    "lp_token_id": "gamm/pool/393"
   },
   {
     "id": "osmo12v9c78ctzvthgen8txmmqm06mjtdfu2gy3k68jtldxvssmwq6lrsn2fa8y",
@@ -467,17 +452,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "431"
+    "lp_token_id": "gamm/pool/431"
   },
   {
     "id": "osmo12vkrtnxwpkq7hnsnchs06ya7rv0vdpchxrgt7jktjm4kupzx8l2s6nfhny",
-    "asset_ids": [
-      "gamm/pool/41",
-      "gamm/pool/53"
-    ],
+    "asset_ids": ["gamm/pool/41", "gamm/pool/53"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "73"
+    "lp_token_id": "gamm/pool/73"
   },
   {
     "id": "osmo12y3z9khxjkhh7yk37c22kxjv5dl8ayxfa9s6fp0g2uekeuptmtmskvguh4",
@@ -487,7 +469,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "853"
+    "lp_token_id": "gamm/pool/853"
   },
   {
     "id": "osmo12zcj6ns9sa4twqn7xnjydcfwpedt3e90y4xg9gs7ught7fq98tcszvt5uq",
@@ -497,7 +479,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "891"
+    "lp_token_id": "gamm/pool/891"
   },
   {
     "id": "osmo12zlm0f4wrgvdks83gue66zs97hchhc2mf75xwgg5q89ev6hd45gs7hn0zt",
@@ -507,7 +489,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "773"
+    "lp_token_id": "gamm/pool/773"
   },
   {
     "id": "osmo132pj9lh5cujzql3q8umzk7zu7xyv8l9tplz3ejvra550p0ejwr0q4c3fgq",
@@ -517,7 +499,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "217"
+    "lp_token_id": "gamm/pool/217"
   },
   {
     "id": "osmo132qw6zaztxfnjj3a2e20adm3xwzjrycqwcc048x6wpv0w00dgl7qvlln2p",
@@ -527,7 +509,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "211"
+    "lp_token_id": "gamm/pool/211"
   },
   {
     "id": "osmo134hkyv9330wdk8jyaltskneqxcc3nndamy5020yn4l8s6987qd9se7042l",
@@ -537,7 +519,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "110"
+    "lp_token_id": "gamm/pool/110"
   },
   {
     "id": "osmo137n2magslhhhp77rt0qv2l4s4fksjncj2t8vd43sn9uwzeypqw9ql0enq2",
@@ -547,7 +529,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "23"
+    "lp_token_id": "gamm/pool/23"
   },
   {
     "id": "osmo139k7lc44flz23nxzjeermnrzw6faqvys6cjkywevsqaxut93awes9lclqv",
@@ -557,7 +539,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "224"
+    "lp_token_id": "gamm/pool/224"
   },
   {
     "id": "osmo13clkaupjee7n5df25v863kl2khxmcvkxk3cv9kwemz0rm77lur7qtg000v",
@@ -567,7 +549,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "531"
+    "lp_token_id": "gamm/pool/531"
   },
   {
     "id": "osmo13cslqv80p4uzx4cxjvpnrva68yac6z55yhafqau3k5vy6yw5027q2yx8ms",
@@ -577,7 +559,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "264"
+    "lp_token_id": "gamm/pool/264"
   },
   {
     "id": "osmo13dnatwj7l5vdksrh66zqkp6pmvfdtqc8vr6m543dav6x26q6wvyqe3nmv6",
@@ -587,7 +569,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "538"
+    "lp_token_id": "gamm/pool/538"
   },
   {
     "id": "osmo13dr6zv7tf2jzvdqza692av7ah77vzt2534luprlkuj6nfk42pcaqgzp7t4",
@@ -597,7 +579,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "273"
+    "lp_token_id": "gamm/pool/273"
   },
   {
     "id": "osmo13ejfnt55k897daggmc8z2kpahfufk3tvw4wq44k5y2kjt6tjjgaqm05kyd",
@@ -607,7 +589,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "793"
+    "lp_token_id": "gamm/pool/793"
   },
   {
     "id": "osmo13h85yg9msr3lr6leearsnsv5zt5hv8hv7k54gqtq2lrycn96mytqksgr48",
@@ -617,7 +599,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "457"
+    "lp_token_id": "gamm/pool/457"
   },
   {
     "id": "osmo13jr3p5p070h4pu7sxhtldag9899sev9pwx0r2vlvpkyravpxlqssnzsuq9",
@@ -627,7 +609,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "7"
+    "lp_token_id": "gamm/pool/7"
   },
   {
     "id": "osmo13k7fkdnkw6urxecxaevy9hq2vzzvxsl40jf3kcywudvkcx0xe0nqulj3yv",
@@ -637,7 +619,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "875"
+    "lp_token_id": "gamm/pool/875"
   },
   {
     "id": "osmo13kxnazqtly05g77xnqsqs95psld5dyspe5f5xa50n06tqqq79sys2ucevl",
@@ -647,7 +629,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "432"
+    "lp_token_id": "gamm/pool/432"
   },
   {
     "id": "osmo13l85na80w9vtscftf2054nzwsqc7k8ncd9fv6hl3gvtpxqv84jfs4gkh5m",
@@ -657,7 +639,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "831"
+    "lp_token_id": "gamm/pool/831"
   },
   {
     "id": "osmo13mczv44wvyqn6fys7f9mcv57d9fmg6e7yfkypaykp99amqfw7chq9wa5q9",
@@ -667,7 +649,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "34"
+    "lp_token_id": "gamm/pool/34"
   },
   {
     "id": "osmo13mj9ywzw3x8fpqxxnfdffuk6fgf4thv9jw78j8thu9k0uy32s92qa3an68",
@@ -677,7 +659,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "221"
+    "lp_token_id": "gamm/pool/221"
   },
   {
     "id": "osmo13mu0c55r8yt9mgycc7zx6jedxh73mf630xwpwvwfm7qf4q7k3edqu209ez",
@@ -687,7 +669,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "580"
+    "lp_token_id": "gamm/pool/580"
   },
   {
     "id": "osmo13n2p8v5w5knclf4yprk6hdrfqt3s94ynmjud7gf6djed8759qedsasl446",
@@ -697,7 +679,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "550"
+    "lp_token_id": "gamm/pool/550"
   },
   {
     "id": "osmo13nztwp3wht4k8zm6ztkczjqxyu74kvl8xjjfqssd7g2lwghzknhqn9gpek",
@@ -707,7 +689,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "332"
+    "lp_token_id": "gamm/pool/332"
   },
   {
     "id": "osmo13p8haggnllu9w0y6e0dsazcsezfywdcz4dqses8cxrnh0n0r393q05995g",
@@ -717,7 +699,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "544"
+    "lp_token_id": "gamm/pool/544"
   },
   {
     "id": "osmo13qvyfhzunrxulp7a0ekyn0vrl6yf26urnk8hedrnk7hn74acr49skjy00e",
@@ -727,7 +709,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "128"
+    "lp_token_id": "gamm/pool/128"
   },
   {
     "id": "osmo13refp99hxda7acm2rnn9nrejhh0d80ftjzxqulj7js884v3ckc3q02ssf6",
@@ -737,7 +719,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "334"
+    "lp_token_id": "gamm/pool/334"
   },
   {
     "id": "osmo13s0uss8gztzsrxqd08kvwmpt7d0k0tvzdfchdw0tr2suzvl3hm3s769ce5",
@@ -747,7 +729,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "241"
+    "lp_token_id": "gamm/pool/241"
   },
   {
     "id": "osmo13shtdrvcjzymxxe2s27k93l9xumkd4tjcmcv05pue2mfk20d66cs4r25lw",
@@ -757,7 +739,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "140"
+    "lp_token_id": "gamm/pool/140"
   },
   {
     "id": "osmo13tc9ntd0rnxumtlczqefzg5nk2kf6z7agmgj898sd3gl40dkccvqy06vkm",
@@ -767,7 +749,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "669"
+    "lp_token_id": "gamm/pool/669"
   },
   {
     "id": "osmo13tp73hg0skhenwrhp4sqg48a4e6459spyvnp7ptnz2galhpcz3lsalsh0w",
@@ -777,7 +759,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "910"
+    "lp_token_id": "gamm/pool/910"
   },
   {
     "id": "osmo13twh7y4pv6rdrxchtjeh7tav4qqujlwxxc9cdqpvruj9dh9xttrq8g5g9c",
@@ -787,17 +769,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "313"
+    "lp_token_id": "gamm/pool/313"
   },
   {
     "id": "osmo13u649up5fe79u2aq0d3rsl5x48lulu5yred75lcuw94dlugfxdqq39hz0s",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "320"
+    "lp_token_id": "gamm/pool/320"
   },
   {
     "id": "osmo13xtszjfnwjs5lxetjklspuuzg3tymnepu48p5sp38rhs458kc7yq9jxjf8",
@@ -807,7 +786,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "231"
+    "lp_token_id": "gamm/pool/231"
   },
   {
     "id": "osmo140c35lxmkmkzmxyh7293cmettfatdw090n0ttwzxxjwa3jraenwqqpczwd",
@@ -817,7 +796,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "712"
+    "lp_token_id": "gamm/pool/712"
   },
   {
     "id": "osmo140dhzccumruw0u38dt7qlj49ttvw2p5mwgcjqsqjuv443u2s5rgqll980k",
@@ -827,7 +806,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "187"
+    "lp_token_id": "gamm/pool/187"
   },
   {
     "id": "osmo140lcj9njcgennv4sk2qtffq0d29s7a9qpv2l30rccghfxfc44mvqphj5uv",
@@ -837,7 +816,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "401"
+    "lp_token_id": "gamm/pool/401"
   },
   {
     "id": "osmo142esjq2sxsju345f4germ3zqlc6j73f6tzzxpumkclzwxs9t5nuq5wuaal",
@@ -847,7 +826,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "577"
+    "lp_token_id": "gamm/pool/577"
   },
   {
     "id": "osmo143403qx9vwa0d0m6zzna2r0fw0xyefl4ey3jgtl4krk5qdzvwd9smnr936",
@@ -857,7 +836,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "496"
+    "lp_token_id": "gamm/pool/496"
   },
   {
     "id": "osmo146awk6s36fxfqa2hzp974lpmvry6cz20yp52ugrlw5c5983nqgjswz9ltt",
@@ -867,7 +846,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "479"
+    "lp_token_id": "gamm/pool/479"
   },
   {
     "id": "osmo1497udspu0fkv9hjv5kep7vglhg8nj986v4e6dz62dleen4m3a50s8evd6c",
@@ -877,7 +856,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "547"
+    "lp_token_id": "gamm/pool/547"
   },
   {
     "id": "osmo14azf94grg0qn67tkczejnt87t9yzt5ndg5h3pqc8zapz3hpg7whq5zzsyh",
@@ -887,7 +866,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "535"
+    "lp_token_id": "gamm/pool/535"
   },
   {
     "id": "osmo14cg7nxexxmuszptk6kghd7d73r7t6xrjfclcmk3qrc73wpjyxtesywq20q",
@@ -897,7 +876,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "674"
+    "lp_token_id": "gamm/pool/674"
   },
   {
     "id": "osmo14dxgrj6qc5t50aedyy9fz7wqvtnv9qjcus7ls6t4lcrt3ged388qsyuhte",
@@ -907,7 +886,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "266"
+    "lp_token_id": "gamm/pool/266"
   },
   {
     "id": "osmo14hxmap32awjzck43xeerxmvnyzvsrjrc7559jw97z23664vx4lyst3wly2",
@@ -917,7 +896,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "111"
+    "lp_token_id": "gamm/pool/111"
   },
   {
     "id": "osmo14jz33kmx87yv94x4hzh3ylrpt6kwkqvjlsaz06aus2equyjv9w3s5nw2kc",
@@ -927,7 +906,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "100"
+    "lp_token_id": "gamm/pool/100"
   },
   {
     "id": "osmo14klwpt49lrs76l24puae7jnct4430ufl9u42rdmz49vews0vu6zqrypt4c",
@@ -937,7 +916,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "692"
+    "lp_token_id": "gamm/pool/692"
   },
   {
     "id": "osmo14me6rlskklxu3rxmlzj27vhyecf8xfvvckwdn76fxkzqgdsy03jqj49ws0",
@@ -947,7 +926,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "244"
+    "lp_token_id": "gamm/pool/244"
   },
   {
     "id": "osmo14mwhxhggae403crueknyqshuqzge56w2q4lltmenzqwmt94ys6fqdjgv37",
@@ -957,7 +936,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "491"
+    "lp_token_id": "gamm/pool/491"
   },
   {
     "id": "osmo14nkh5n0e6r3qz78zcyygj3wv906qtsgqrm5nq3zwpx2zku2lvdqshfwyv3",
@@ -967,7 +946,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "485"
+    "lp_token_id": "gamm/pool/485"
   },
   {
     "id": "osmo14p3mvjdxg5skeh44atnvxvc3l0mf4jjt6uk62yk5nzv7q5dyf70qw6npt2",
@@ -977,7 +956,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "436"
+    "lp_token_id": "gamm/pool/436"
   },
   {
     "id": "osmo14pmk24h24cmpne8kzanagwe4f03wlqccwlm4spj4hyk7r0pxru9szmht2q",
@@ -987,7 +966,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "213"
+    "lp_token_id": "gamm/pool/213"
   },
   {
     "id": "osmo14ppp79wvq6xlg3tnwr86sgpqv36m4gs3uurrf8wlmgdx8cz9ly0sanpqjr",
@@ -997,7 +976,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "695"
+    "lp_token_id": "gamm/pool/695"
   },
   {
     "id": "osmo14q5n9efl2lf7txvkfveskzdt4l47n7lpj2lzs7yk8u6hmzerz5ysjg6qx8",
@@ -1007,7 +986,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "568"
+    "lp_token_id": "gamm/pool/568"
   },
   {
     "id": "osmo14slhuw6gtlsud3p2c79gy92qy72qcvjv6q6upwcrl95m8wyuepvsq9c29d",
@@ -1017,7 +996,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "576"
+    "lp_token_id": "gamm/pool/576"
   },
   {
     "id": "osmo14sxd3nugue3z44lh55cvn7uq8xzzzkgfknnuxtazr569jyymcqys2eykgs",
@@ -1027,7 +1006,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "391"
+    "lp_token_id": "gamm/pool/391"
   },
   {
     "id": "osmo14sy9cpm4adfrut88u4869ue2sz72rjjcq6hlsmf5uz97tkswvvnqnujj6t",
@@ -1037,7 +1016,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "881"
+    "lp_token_id": "gamm/pool/881"
   },
   {
     "id": "osmo14wp02k4djfx5yqvtr052lfytdmje05jm00even373h7cdydw78vsrjp52h",
@@ -1047,7 +1026,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "672"
+    "lp_token_id": "gamm/pool/672"
   },
   {
     "id": "osmo14xpkpdstm4xhwjsw3v8gs99f2xl949wcnxx8a8dvn0qq5460afkqcsxej3",
@@ -1057,7 +1036,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "163"
+    "lp_token_id": "gamm/pool/163"
   },
   {
     "id": "osmo14xt30a3pswr540lp55y7f9gfevmddv84takyjn2p28a27ayc85gs3p292f",
@@ -1067,7 +1046,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "730"
+    "lp_token_id": "gamm/pool/730"
   },
   {
     "id": "osmo14y9ejauxnuyr48eu8jterwyhnz4s94s5ywggzmhf3wmu73g28gcsenvnum",
@@ -1077,7 +1056,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "223"
+    "lp_token_id": "gamm/pool/223"
   },
   {
     "id": "osmo14ymxts36p4z2eef06qeeuqd5s0x7fmyhzs382qvnqxsv45zcqf7q0vztv0",
@@ -1087,17 +1066,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "762"
+    "lp_token_id": "gamm/pool/762"
   },
   {
     "id": "osmo1500hy75krs9e8t50aav6fahk8sxhajn9ctp40qwvvn8tcprkk6wszun4a5",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "2"
+    "lp_token_id": "gamm/pool/2"
   },
   {
     "id": "osmo150wfa0gum6sz5crkpvt9pztjf35dc8gvaufzrc40d6hr99wvyxlqcaddv9",
@@ -1107,7 +1083,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "581"
+    "lp_token_id": "gamm/pool/581"
   },
   {
     "id": "osmo153ezzm4uwy0dqh0mmxwgxu3mu0pknvgrsn4es3u5zrzhs57jc65qtsyl4c",
@@ -1117,7 +1093,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "523"
+    "lp_token_id": "gamm/pool/523"
   },
   {
     "id": "osmo154fszgu6aqqqtg0zff33leallf4rw3456s6spcsdmjf0u73jtd6suf32zx",
@@ -1127,7 +1103,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "282"
+    "lp_token_id": "gamm/pool/282"
   },
   {
     "id": "osmo155c60gtktr83uvnahsxc3q7gswmuwm7ukhxmz06jwl3yrjgd4k7s7k4wkr",
@@ -1137,7 +1113,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "350"
+    "lp_token_id": "gamm/pool/350"
   },
   {
     "id": "osmo155szru0rpgcjwlcgwtv3r35v4zdc0dkskpr4fwshqcm9r2974htsfujjuh",
@@ -1147,7 +1123,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "753"
+    "lp_token_id": "gamm/pool/753"
   },
   {
     "id": "osmo155tdryrz9lqtqtsyjuc2ughrryu6nncr8vr03hepdyqqsgesag6s6ggts0",
@@ -1157,7 +1133,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "557"
+    "lp_token_id": "gamm/pool/557"
   },
   {
     "id": "osmo157u4eawmj4ux5jth54aw9sfh3zsgvgncm20t9m9vc7er6vrkjnks9naflp",
@@ -1167,7 +1143,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "842"
+    "lp_token_id": "gamm/pool/842"
   },
   {
     "id": "osmo157yhlzsnqxvrne3wdpukh7uca40l9mak875u44f9asufvwkldzzs7tpaal",
@@ -1177,7 +1153,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "476"
+    "lp_token_id": "gamm/pool/476"
   },
   {
     "id": "osmo158s5v5kd2nzgrq0fse6tk60r70596e5p8qczj47pfqcqx9rc3l9s0q2v3h",
@@ -1187,7 +1163,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "143"
+    "lp_token_id": "gamm/pool/143"
   },
   {
     "id": "osmo159f0lecgvarm6a9snyqjnz9r32h72fwqq9q2s3py7we0v9mfp5vsx9w3ct",
@@ -1197,7 +1173,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "296"
+    "lp_token_id": "gamm/pool/296"
   },
   {
     "id": "osmo15d7sqmwy2snpxw2w776v0tthr328dzjvpvk7phssyuqszq4lr6xs5dcupr",
@@ -1207,7 +1183,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "917"
+    "lp_token_id": "gamm/pool/917"
   },
   {
     "id": "osmo15dz4u47sdmk4rq67k9v5n9fununc6j7y903azd3sm3yafd9wp68s9s4p5z",
@@ -1217,17 +1193,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "592"
+    "lp_token_id": "gamm/pool/592"
   },
   {
     "id": "osmo15e4a88d0vmd7ywh9e2ll8q447defplgamwza9ezay67z84cxmx7ssu8s6q",
-    "asset_ids": [
-      "gamm/pool/101",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/101", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "106"
+    "lp_token_id": "gamm/pool/106"
   },
   {
     "id": "osmo15e9w6y0g8z5as77g29azqwvp37dp96njn7h0vt5suz3un5vw95dsj4uurl",
@@ -1237,7 +1210,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "22"
+    "lp_token_id": "gamm/pool/22"
   },
   {
     "id": "osmo15eg4aq5fxdehdjv5zr385h4zmswamvw6pguqhykd3fs2jrgpgr0qqmlfqc",
@@ -1247,7 +1220,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "865"
+    "lp_token_id": "gamm/pool/865"
   },
   {
     "id": "osmo15h02q7rzpwn0gahklnek29naae4peg3j4rd5e4hcc264sm3mfugqaw6up7",
@@ -1257,7 +1230,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "665"
+    "lp_token_id": "gamm/pool/665"
   },
   {
     "id": "osmo15j2ttrqclc5j3fz53gps5n4p6eyw7qr3t2qsxna8ekjsahctgf4qe3v89q",
@@ -1267,7 +1240,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "353"
+    "lp_token_id": "gamm/pool/353"
   },
   {
     "id": "osmo15jt5g7jn3m2wem6an2n9m982hr6v2madrhjyt3vxrn00vew3xmmsnah0ct",
@@ -1277,7 +1250,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "552"
+    "lp_token_id": "gamm/pool/552"
   },
   {
     "id": "osmo15k82dwg2xkhm2una73jnq2ftan7c5rncul3fpyzyc9g3g6m0ae5skyswxd",
@@ -1287,7 +1260,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "751"
+    "lp_token_id": "gamm/pool/751"
   },
   {
     "id": "osmo15krawmktxe8rzzepj4wxzgeevns9xftpzwhw7uycdg43t2k7nsxq3n6xen",
@@ -1297,7 +1270,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "710"
+    "lp_token_id": "gamm/pool/710"
   },
   {
     "id": "osmo15mym9nr2g994zevcslnf8n96unwnsmqa8nzkef4lgavhjkgsy8gscuq3w9",
@@ -1307,7 +1280,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "371"
+    "lp_token_id": "gamm/pool/371"
   },
   {
     "id": "osmo15p62pdak6vsudduc82h09plethxq5m58k6x6t76y7fee3fgm0upq3x8553",
@@ -1317,7 +1290,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "770"
+    "lp_token_id": "gamm/pool/770"
   },
   {
     "id": "osmo15sg8553z787gk33z47yd8uvux72asllkcywnnplepe6c6lhurs5sfpy7a9",
@@ -1327,7 +1300,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "410"
+    "lp_token_id": "gamm/pool/410"
   },
   {
     "id": "osmo15t7afyxut7eugx0yn4quesujf5snv358g3ureyx46afpwhjrlaas5nl3zp",
@@ -1337,7 +1310,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "664"
+    "lp_token_id": "gamm/pool/664"
   },
   {
     "id": "osmo15u42rnfp5fr0qrdmnncptxvycwdxrdutwjv5v83t9y9yy7xq948qly3844",
@@ -1347,7 +1320,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "470"
+    "lp_token_id": "gamm/pool/470"
   },
   {
     "id": "osmo15u5e6evufc9gjd28n4z9rvhku8lfg3arpejm0gnzhzx05w9h7e7q8665jn",
@@ -1357,7 +1330,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "13"
+    "lp_token_id": "gamm/pool/13"
   },
   {
     "id": "osmo15upcqtt7tupfxdh4229vjwesgm7f3s5a66ke6dhfajxnkdmzm3pqu8y7hv",
@@ -1367,7 +1340,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "735"
+    "lp_token_id": "gamm/pool/735"
   },
   {
     "id": "osmo15v4mn84s9flhzpstkf9ql2mu0rnxh42pm8zhq47kh2fzs5zlwjsqaterkr",
@@ -1377,17 +1350,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "833"
+    "lp_token_id": "gamm/pool/833"
   },
   {
     "id": "osmo15v7xfk7qnm27r2kwsutegh3jt2ye7haadqlnt5xf89hkp29hx0cq4sgqr6",
-    "asset_ids": [
-      "gamm/pool/361",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/361", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "364"
+    "lp_token_id": "gamm/pool/364"
   },
   {
     "id": "osmo15vl4puljq9s6taqzmnsgd43gkz3ltp3hj4aexqj8x2ey4lxrrrks278cn4",
@@ -1397,7 +1367,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "640"
+    "lp_token_id": "gamm/pool/640"
   },
   {
     "id": "osmo15w6vtw48yqell0h4t3dyxhczp7dx0vl4f2xe3dgluyvznjdhhkgqnttcxy",
@@ -1407,7 +1377,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "726"
+    "lp_token_id": "gamm/pool/726"
   },
   {
     "id": "osmo15zzs8muh0lgnhdmzax35e90cskgulz7x566q6fpknguvdw95s0msen0l80",
@@ -1417,7 +1387,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "855"
+    "lp_token_id": "gamm/pool/855"
   },
   {
     "id": "osmo1605py4r32r73csszlqpz6n5t5sgax9gjjfnm68jnd7pv6qe4l54ql0w8ku",
@@ -1427,7 +1397,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "8"
+    "lp_token_id": "gamm/pool/8"
   },
   {
     "id": "osmo1620l9ewga9f6w3wyvfx5vhpuum3wwgz2haamn4t8lckfyzvnxd0q0chmeu",
@@ -1437,7 +1407,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "582"
+    "lp_token_id": "gamm/pool/582"
   },
   {
     "id": "osmo162yn5ntl2tuuyxxf3dmm3d76q56ch9zlka0v7852wxqd874q388s502qp2",
@@ -1447,7 +1417,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "685"
+    "lp_token_id": "gamm/pool/685"
   },
   {
     "id": "osmo163pdautlpkrj0au0s0nkqw8ln2r42gdkwjuf77c26h7crd44hj3suggfju",
@@ -1457,7 +1427,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "209"
+    "lp_token_id": "gamm/pool/209"
   },
   {
     "id": "osmo163sn2xvlaalva3td4hcjqmmrzzn4upu35qgdnnr4q0azp0t3v22qgfc8yz",
@@ -1467,7 +1437,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "420"
+    "lp_token_id": "gamm/pool/420"
   },
   {
     "id": "osmo163yhv8mj29c03zd7ktg2gwcpwjj6kcmdx933p3lfxdu66qsajt0skqkmvx",
@@ -1477,7 +1447,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "409"
+    "lp_token_id": "gamm/pool/409"
   },
   {
     "id": "osmo167a9n3f6t8v64pugrqnz88f7w8tlwaxfsgge4tm7jh4gvxrhstyqgyv5jw",
@@ -1487,7 +1457,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "536"
+    "lp_token_id": "gamm/pool/536"
   },
   {
     "id": "osmo167dnkr4k7ezmat3sq4nkdmwel54u7uh496n45djnu9xe82ad2w5s4qpg68",
@@ -1497,7 +1467,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "442"
+    "lp_token_id": "gamm/pool/442"
   },
   {
     "id": "osmo167dycqs0n3dxzfrwctg3p4hg7zxjjptr2p7nvkk9d23wu8spy4csdzvlsx",
@@ -1507,7 +1477,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "501"
+    "lp_token_id": "gamm/pool/501"
   },
   {
     "id": "osmo169wdlgu8tes3qm4un02gwvhxw78yphlf3mks30j3lkwek8j7vpgqcx2zzp",
@@ -1517,7 +1487,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "114"
+    "lp_token_id": "gamm/pool/114"
   },
   {
     "id": "osmo16a0su5csdrukz43z284agsqctfutps8eextnvrk3g2nhk2cxmlgsmfh4r8",
@@ -1527,7 +1497,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "112"
+    "lp_token_id": "gamm/pool/112"
   },
   {
     "id": "osmo16cl5fg34wtrnpvz9rcncm37nutywn0765ldkuw59gc68xrajzuwqd9jt88",
@@ -1537,7 +1507,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "616"
+    "lp_token_id": "gamm/pool/616"
   },
   {
     "id": "osmo16cr2suh8wxyd3rdj24s7qe4kr2lnjxmm0495j07tl06jclnwfa2qqs58qg",
@@ -1547,7 +1517,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "808"
+    "lp_token_id": "gamm/pool/808"
   },
   {
     "id": "osmo16d92nnsxj9nyc6j46k0pj6q0phhdu89nrz0y8657nn4el5fm3lwsut9e6k",
@@ -1557,7 +1527,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "630"
+    "lp_token_id": "gamm/pool/630"
   },
   {
     "id": "osmo16dafzdug0nreqs3h8g2rdtp5dr75ck9k2a9qzyvvgksn6cgukteqkafeu5",
@@ -1567,17 +1537,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "697"
+    "lp_token_id": "gamm/pool/697"
   },
   {
     "id": "osmo16dn4uk4xlqshzufy3f0as2pnvdpwqlwepp0m5qumwh2c4vgmp9jqaa0zsh",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "569"
+    "lp_token_id": "gamm/pool/569"
   },
   {
     "id": "osmo16h2dp9v34s7dy5f8ut708tf0pjj7772u8f8n77pxs3k5aj4rkg6sl85ehj",
@@ -1587,7 +1554,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "322"
+    "lp_token_id": "gamm/pool/322"
   },
   {
     "id": "osmo16h9xer73q9c4rpwvmxhqdcqc4r8q0ldrgme8f3q3ljntam6sarnsd5tnlf",
@@ -1597,7 +1564,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "456"
+    "lp_token_id": "gamm/pool/456"
   },
   {
     "id": "osmo16hrp33emfwydwnydry5k854ffeya64g6lgxj34ev27tl865msdxs7lpljf",
@@ -1607,7 +1574,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "783"
+    "lp_token_id": "gamm/pool/783"
   },
   {
     "id": "osmo16qetl32gwxnne8q46qsc4e65rtnx8z9w2dxqas66hllu6c2gty8q7fwz0k",
@@ -1617,17 +1584,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "821"
+    "lp_token_id": "gamm/pool/821"
   },
   {
     "id": "osmo16qzex7q0cpj3dflx79ycqvsujm0dt838lfjv9fjg80zna7jpn2ssn3cta4",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "395"
+    "lp_token_id": "gamm/pool/395"
   },
   {
     "id": "osmo16u8zapr7jvqv63hrnpfzfp4ys2g9ap69rxkdzpsasaa4qlwzx45sme0eus",
@@ -1637,7 +1601,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "438"
+    "lp_token_id": "gamm/pool/438"
   },
   {
     "id": "osmo16w7vk8sus35draftmhuac39vcvcpwcjttvjmee54vd0rx59xqp7s5t4flu",
@@ -1647,7 +1611,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "918"
+    "lp_token_id": "gamm/pool/918"
   },
   {
     "id": "osmo16x4qnfcefwaym3znv2waqh20rfgxpney2pxv4vvnv4p9y9n8ddaq68khcy",
@@ -1657,7 +1621,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "797"
+    "lp_token_id": "gamm/pool/797"
   },
   {
     "id": "osmo16zg36xlt7a84deeweraqtf64sw5pedh5c4cquqv0gy4e6498u52sdx2zj9",
@@ -1667,7 +1631,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "131"
+    "lp_token_id": "gamm/pool/131"
   },
   {
     "id": "osmo1702m29rngg2xjsd4mdl3xscfrgv3fy039hc6uvczq8rsfwdtnj0spp4yqx",
@@ -1677,7 +1641,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "728"
+    "lp_token_id": "gamm/pool/728"
   },
   {
     "id": "osmo1706zqq68yt0gsnq63j3wjn8egqvr5sqylxnjzalvskjqkv3v7xvshu3d36",
@@ -1687,7 +1651,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "433"
+    "lp_token_id": "gamm/pool/433"
   },
   {
     "id": "osmo170f2kcc7ud5mepllczl23jnwrpwt6q3fsrxv0mtwtt2tqydf5u4sx4nesp",
@@ -1697,7 +1661,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "424"
+    "lp_token_id": "gamm/pool/424"
   },
   {
     "id": "osmo1735wj90a09zr4a3pcujmpp85mkz05tu4ynm534eaqw9nl4zw2qkqtzjpw0",
@@ -1707,7 +1671,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "305"
+    "lp_token_id": "gamm/pool/305"
   },
   {
     "id": "osmo1752ysawy2adr7td9an30a8pkk8ngrvcq3tan08lvnar3s7f82y5s4dt8fs",
@@ -1717,7 +1681,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "907"
+    "lp_token_id": "gamm/pool/907"
   },
   {
     "id": "osmo175hpfs58xklq8aradgemnsufj5w27m4ymeelskntvhuvnwd9wkgqsw5lvd",
@@ -1727,7 +1691,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "134"
+    "lp_token_id": "gamm/pool/134"
   },
   {
     "id": "osmo177r65zqzqs50p8utgyltw2uldlxyq26v2klgyxy5440kha49vwaq6j9z8e",
@@ -1737,7 +1701,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "699"
+    "lp_token_id": "gamm/pool/699"
   },
   {
     "id": "osmo17atf6ld93djyxf0rehn8fcjka92enqy8jrcf7fc29xer4mafyv2qdz37dh",
@@ -1747,7 +1711,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "383"
+    "lp_token_id": "gamm/pool/383"
   },
   {
     "id": "osmo17dyt6827sq83px7gl7gsuzumlh0je00j0z9slcp08cxy8vn0ye0syrr2gh",
@@ -1757,7 +1721,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "696"
+    "lp_token_id": "gamm/pool/696"
   },
   {
     "id": "osmo17ehyaducl0pyznms988c7xcfd4w0n054klqr9fp4fmqzz05y9e2q9e3pvg",
@@ -1767,7 +1731,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "375"
+    "lp_token_id": "gamm/pool/375"
   },
   {
     "id": "osmo17ff0mxg5j6xtuh7ma623ejcntuzuvpewu9dyjk00wkadh75au3qs0gp8pv",
@@ -1777,7 +1741,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "18"
+    "lp_token_id": "gamm/pool/18"
   },
   {
     "id": "osmo17gykllhtf9q4hqdrtydgl7jgvyeqf3rsvdrwef4ct6pvfhsmyg0sp423x0",
@@ -1787,7 +1751,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "823"
+    "lp_token_id": "gamm/pool/823"
   },
   {
     "id": "osmo17h0ay5zhcllwgshem7r40a2wyx7a43w2ngfrrc7w2w60rrhdklws7u6zy6",
@@ -1797,7 +1761,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "768"
+    "lp_token_id": "gamm/pool/768"
   },
   {
     "id": "osmo17k408tt5xf9zz44qxf95q6f8m8tvkethvrwk93gwqgkfrlefkjms68dp7y",
@@ -1807,7 +1771,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "435"
+    "lp_token_id": "gamm/pool/435"
   },
   {
     "id": "osmo17kylujlrmyuxu0yvguv0gsxpvgvp44up8pvxvsyh36d0r9ww4pkq6c9zgp",
@@ -1817,7 +1781,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "212"
+    "lp_token_id": "gamm/pool/212"
   },
   {
     "id": "osmo17lmjln5dhd2c37npal49p2gfr2eqmrdv20h7g2u0rszg7jlqxu2sztwlgk",
@@ -1827,7 +1791,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "293"
+    "lp_token_id": "gamm/pool/293"
   },
   {
     "id": "osmo17n6nngjwheahmljdk0k56dh5dfnktn2r2f33sdaj4uwnrk00y4vs0jcc0f",
@@ -1837,7 +1801,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "525"
+    "lp_token_id": "gamm/pool/525"
   },
   {
     "id": "osmo17n6y5d9jqjvjk3yysnuszt9spuyqwcdz6uctuuf2m66906efj0ys333va9",
@@ -1847,7 +1811,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "160"
+    "lp_token_id": "gamm/pool/160"
   },
   {
     "id": "osmo17nsa8pa7cjeu2tj8v5mqen8cye3rrp2h69lzvepveruhvtmujkzq9uzjfw",
@@ -1857,7 +1821,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "549"
+    "lp_token_id": "gamm/pool/549"
   },
   {
     "id": "osmo17pk7pcuqxz2hn0j2rhqknzn4npujncpzdakpe9hclz5jr605023qcgc9ty",
@@ -1867,7 +1831,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "905"
+    "lp_token_id": "gamm/pool/905"
   },
   {
     "id": "osmo17rudnglqgrcnvn3am3xm02d94y4sa3l43ywkv3cp4je44p2ez5nq590lae",
@@ -1877,17 +1841,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "858"
+    "lp_token_id": "gamm/pool/858"
   },
   {
     "id": "osmo17rujtwmvk8vp3uqq6xxkymk83n3qethhejuar7ayhyuupcsw66mqmg4k28",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "344"
+    "lp_token_id": "gamm/pool/344"
   },
   {
     "id": "osmo17sk5nv9367kc5jgfmtf64c9esgf4sdeazd8fd5twrlhxqne3tgnqrp2qpz",
@@ -1897,7 +1858,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "613"
+    "lp_token_id": "gamm/pool/613"
   },
   {
     "id": "osmo17wpv2azveyr59utlztg6cm8ckzyyepklrrs4lswszn0u46s9rrgqpftypp",
@@ -1907,7 +1868,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "184"
+    "lp_token_id": "gamm/pool/184"
   },
   {
     "id": "osmo17yl0x8s78p9nhwgqtdjfeynfzaz25mnv2j8m75ev2jznv782958su68utl",
@@ -1917,7 +1878,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "181"
+    "lp_token_id": "gamm/pool/181"
   },
   {
     "id": "osmo17z485xwwqknnxfcs73w4nxu0ndp4n8jf6ylj730cph4a6p47hawqrg65wr",
@@ -1927,7 +1888,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "270"
+    "lp_token_id": "gamm/pool/270"
   },
   {
     "id": "osmo18503q8ndu9smzuwqm9nlgw4l6373d430xp32yv4gclug6t27qy6qz7dyku",
@@ -1937,7 +1898,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "449"
+    "lp_token_id": "gamm/pool/449"
   },
   {
     "id": "osmo185d7wu8622egqk0hgzpp48nmaeg3fvlc4pglg2zqrgdtcjenr3hstpyagv",
@@ -1947,7 +1908,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "425"
+    "lp_token_id": "gamm/pool/425"
   },
   {
     "id": "osmo185uac6gnxaa7aa9pqxgktpuqhe6ve3jkfa8wl8dcx3p3zmymzkyszj4k6j",
@@ -1957,7 +1918,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "890"
+    "lp_token_id": "gamm/pool/890"
   },
   {
     "id": "osmo1860equ7v4tjdcmr2vtka5kr3mzuh3ekzpcez77y7pd25972wl52q5rk9hd",
@@ -1967,7 +1928,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "351"
+    "lp_token_id": "gamm/pool/351"
   },
   {
     "id": "osmo18864qdsyavwstv9r7kcrtzhnuk5zcevex4gmftk0vkaqczew5sjscf7xmp",
@@ -1977,7 +1938,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "262"
+    "lp_token_id": "gamm/pool/262"
   },
   {
     "id": "osmo18984gjmrtrj8tzz5mlx04lqusrmjpdx28ty8h4zgf3yw7lr9r53s3ruz0e",
@@ -1987,7 +1948,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "782"
+    "lp_token_id": "gamm/pool/782"
   },
   {
     "id": "osmo189lml9kvhv8qac8eewhj3kuvz2zpy47fqlv0ahs3gtymejfty7yqqvdyk3",
@@ -1997,7 +1958,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "454"
+    "lp_token_id": "gamm/pool/454"
   },
   {
     "id": "osmo18ahq029ylafhmmf25wqu6lvpz6nz4nf533sv6hlqht6d49p23ehszdp5gh",
@@ -2007,7 +1968,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "38"
+    "lp_token_id": "gamm/pool/38"
   },
   {
     "id": "osmo18c87zv90lqd59tl6u068dqcs9x80rfwwjs5wr0vrj7shay429ntq05psnd",
@@ -2017,7 +1978,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "448"
+    "lp_token_id": "gamm/pool/448"
   },
   {
     "id": "osmo18dpk6wfldlfzkk2tdas2tztcth26v39tt7sc2t30drzrex6mlnqqa3hd78",
@@ -2027,7 +1988,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "757"
+    "lp_token_id": "gamm/pool/757"
   },
   {
     "id": "osmo18et08xm2dag9ppkdcs7epza2dvt423kxpdnr4vc670cm7d8jh22qukx7ls",
@@ -2037,7 +1998,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "488"
+    "lp_token_id": "gamm/pool/488"
   },
   {
     "id": "osmo18f2zqvulx7wfzg95eh864jw7neqhz23sk8g9lffys3l4jnlttleq5r5kl9",
@@ -2047,7 +2008,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "203"
+    "lp_token_id": "gamm/pool/203"
   },
   {
     "id": "osmo18fdae3yzc2ycw27gzftx0czkpszzrsflw8cyqe99ku3c9aj7lfcq3tjzyt",
@@ -2057,7 +2018,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "869"
+    "lp_token_id": "gamm/pool/869"
   },
   {
     "id": "osmo18ggsma2ef28tlyey053sxv7d3ka45lzpf7zm8mr47duezgghswrq9trxet",
@@ -2067,7 +2028,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "915"
+    "lp_token_id": "gamm/pool/915"
   },
   {
     "id": "osmo18gt77cjyv6xe2gqjp9k6ct0fk2usv67q6jjjeagdttsy8qks78ysfq82fu",
@@ -2077,7 +2038,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "747"
+    "lp_token_id": "gamm/pool/747"
   },
   {
     "id": "osmo18hd0dfzfwdmlz22qp6dqfd06xryqdaug9y2qwafhkp4znc0rqz5q5ms2wr",
@@ -2087,7 +2048,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "555"
+    "lp_token_id": "gamm/pool/555"
   },
   {
     "id": "osmo18jxduxdcesftwkx8uh2lqrjl6teky87t8rpv9wd704929hpe73cq44xcwy",
@@ -2097,7 +2058,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "798"
+    "lp_token_id": "gamm/pool/798"
   },
   {
     "id": "osmo18ltnsk33a45827l42v89wws3u2evagpfua7v57nnhslnggxkqkgq4qjmcf",
@@ -2107,7 +2068,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "20"
+    "lp_token_id": "gamm/pool/20"
   },
   {
     "id": "osmo18lw3t03dmyv6975kzjgacezvaafflz5aepmqrqqc8y494gwwwpmq9vm7p8",
@@ -2117,7 +2078,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "586"
+    "lp_token_id": "gamm/pool/586"
   },
   {
     "id": "osmo18p7qaaevs9kzsyuzmva969s4klx4xjxtn93cccpypfkhl3mqpcrqlwvu3j",
@@ -2127,7 +2088,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "772"
+    "lp_token_id": "gamm/pool/772"
   },
   {
     "id": "osmo18pr2rasc9428jwr6t8hf4m50fgd35am4s6lr45yae0slmfzqukgq20jmsw",
@@ -2137,7 +2098,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "122"
+    "lp_token_id": "gamm/pool/122"
   },
   {
     "id": "osmo18rqwcrvsfyy9s2tlfvmchclxf2cfw2hqvrjvkuljcrhq2vpg4suse8h6tj",
@@ -2147,7 +2108,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "620"
+    "lp_token_id": "gamm/pool/620"
   },
   {
     "id": "osmo18svklenrqknkccu7fyh9lunj4ruw6dfx7kfmmv79s0v6sud2ht9qan8ddk",
@@ -2157,7 +2118,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "387"
+    "lp_token_id": "gamm/pool/387"
   },
   {
     "id": "osmo18taz6el39wzs87vn594z5q39mm8psf4v57jyjpx52dg46ac4mg2sxrj5hy",
@@ -2167,7 +2128,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "800"
+    "lp_token_id": "gamm/pool/800"
   },
   {
     "id": "osmo18vt7x9yuda579ssr668avfe8mlngrf255fx3re23340twmh3ujyqsfr3h8",
@@ -2177,7 +2138,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "474"
+    "lp_token_id": "gamm/pool/474"
   },
   {
     "id": "osmo18yxeq5kpup4k47vhjgu8j4y8d82sna7sdtjlz7hkuphnqtsmh8asc9vgca",
@@ -2187,7 +2148,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "29"
+    "lp_token_id": "gamm/pool/29"
   },
   {
     "id": "osmo1937gh7cem2tn09r7c4uh7zgjvgjyxlffa677rv7zmspphu9dxwyqs6pw8k",
@@ -2197,7 +2158,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "668"
+    "lp_token_id": "gamm/pool/668"
   },
   {
     "id": "osmo193lusv4u9c7xuz7ct6wmcyq0c5evayu4x78pdhvp8ewa4huh6a9s4tt3lp",
@@ -2207,7 +2168,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "688"
+    "lp_token_id": "gamm/pool/688"
   },
   {
     "id": "osmo195dw0uzghljwwt3577352xu5gfmy3zrngfa545hdnfy2dd45acrsnsca44",
@@ -2217,7 +2178,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "683"
+    "lp_token_id": "gamm/pool/683"
   },
   {
     "id": "osmo195vm9cpsdntewfe7l83yx2w28hkfvx33lyu454gvfrr6f5m7gcas420nk8",
@@ -2227,17 +2188,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "732"
+    "lp_token_id": "gamm/pool/732"
   },
   {
     "id": "osmo196w6qg0r3cfy9rx00390wkfdj9krd93uaed3nlht5uhqfh2avcyq3aldku",
-    "asset_ids": [
-      "gamm/pool/1",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/1", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "392"
+    "lp_token_id": "gamm/pool/392"
   },
   {
     "id": "osmo1973kthujxy3xq49dj29t6q90uxj0s8epkg0tan82j2fnzm7ez6usuas27z",
@@ -2247,7 +2205,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "215"
+    "lp_token_id": "gamm/pool/215"
   },
   {
     "id": "osmo19a5l88sxfdjxtm0d7x777g0g7679m0uusepaytqy0wlnnzut83wswvvezu",
@@ -2257,7 +2215,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "179"
+    "lp_token_id": "gamm/pool/179"
   },
   {
     "id": "osmo19a6nnvczjpnjzt3wgrf4h02yej62wpvnq9cayph7ec5klhds487s9kazwf",
@@ -2267,7 +2225,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "666"
+    "lp_token_id": "gamm/pool/666"
   },
   {
     "id": "osmo19apu4h3aqlzhtpd0suftzctxnctwqd0lpzpueus3tughvcfdv4gsnzqxu4",
@@ -2277,7 +2235,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "156"
+    "lp_token_id": "gamm/pool/156"
   },
   {
     "id": "osmo19ecrtx598f0yyg2chk82gtsuzst2jfr6tkmevnwn8538lysws7sqnsg8q2",
@@ -2287,7 +2245,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "565"
+    "lp_token_id": "gamm/pool/565"
   },
   {
     "id": "osmo19eq5d9ng00ttwlsh9j9fs6t898lqltt9ah4ph039a3hznrz3hrns7rxy40",
@@ -2297,17 +2255,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "306"
+    "lp_token_id": "gamm/pool/306"
   },
   {
     "id": "osmo19esg8fulwzufjjarprfpu4mz06zjpkmk7p0wydcw5q900lp2k3mq7afv7m",
-    "asset_ids": [
-      "gamm/pool/502",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/502", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "503"
+    "lp_token_id": "gamm/pool/503"
   },
   {
     "id": "osmo19ffd2uz59gf0w594hpwxjgzrkt3c2vd70gzw6lhdtsz07hl2m7sqfky68k",
@@ -2317,7 +2272,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "254"
+    "lp_token_id": "gamm/pool/254"
   },
   {
     "id": "osmo19fm8jtzyw8ujsnsqm5rznudn8fhhkykjh4ra8rvx9lsfslw2pc2sp36h3r",
@@ -2327,7 +2282,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "9"
+    "lp_token_id": "gamm/pool/9"
   },
   {
     "id": "osmo19g97e0xshdd4xefn39wwquftq3g9u0a7jk8wcety6fgv58cpsx5sdjnvre",
@@ -2337,7 +2292,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "516"
+    "lp_token_id": "gamm/pool/516"
   },
   {
     "id": "osmo19gffpaavnhhzryktpskz7782ttt5qfs4cqfmhyuygc3cxytljfcqyggf5t",
@@ -2347,7 +2302,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "859"
+    "lp_token_id": "gamm/pool/859"
   },
   {
     "id": "osmo19hcj893wcz2cwk7jkzgvqxlwqqp7cl2v66f2e2l68hy4wezuegmqdcuk0e",
@@ -2357,7 +2312,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "654"
+    "lp_token_id": "gamm/pool/654"
   },
   {
     "id": "osmo19hp7h8xhg8r3z8wv0hf3hw95n09q5vxtfefeha97kuwflttq926qe8xs83",
@@ -2367,7 +2322,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "267"
+    "lp_token_id": "gamm/pool/267"
   },
   {
     "id": "osmo19jeyxdr0maeeh9uedgaemyghd8jgfcucv59mjnw867vhwkysf7fsqf2yxk",
@@ -2377,7 +2332,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "756"
+    "lp_token_id": "gamm/pool/756"
   },
   {
     "id": "osmo19jglnr7dv7ppezmk5v6sk3drydxc97nda2wxujzjmh8ef33lq0tstn9y4k",
@@ -2387,7 +2342,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "834"
+    "lp_token_id": "gamm/pool/834"
   },
   {
     "id": "osmo19kdw6jce9eclvydnl8656z569ygjj060pehg9z8xq2p3ffyger6s6dj7tk",
@@ -2397,7 +2352,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "451"
+    "lp_token_id": "gamm/pool/451"
   },
   {
     "id": "osmo19mzey7tczk8fz5r2u2qnrmt6wlpgfh8k2wcnt20k2rhmspsv6h6s9t9327",
@@ -2407,7 +2362,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "415"
+    "lp_token_id": "gamm/pool/415"
   },
   {
     "id": "osmo19ntgdh5wuu9zeh6svqc7x9h8zv6w7u4p7sxn2t980p7ct8st3s5sc8u9yy",
@@ -2417,7 +2372,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "307"
+    "lp_token_id": "gamm/pool/307"
   },
   {
     "id": "osmo19qawwfrlkz9upglmpqj6akgz9ap7v2mnd05pxzgmxw3ywz58wnvqtet2mg",
@@ -2427,7 +2382,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "627"
+    "lp_token_id": "gamm/pool/627"
   },
   {
     "id": "osmo19rrapg60r2f6s2h534n8d2tflv6kwed443jguxrvg2lf7pyggmmqq6mu8d",
@@ -2437,7 +2392,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "370"
+    "lp_token_id": "gamm/pool/370"
   },
   {
     "id": "osmo19sp2fqdyr4p8mwn0206jk9ps06ewpavxxxz07zpseyphuy9uwmgspv87l4",
@@ -2447,7 +2402,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "228"
+    "lp_token_id": "gamm/pool/228"
   },
   {
     "id": "osmo19xaz97zcvcmp5q3ur3g4fqe6mlhz7k2dqd8w639yzk3greh6afws2wjlt3",
@@ -2457,7 +2412,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "618"
+    "lp_token_id": "gamm/pool/618"
   },
   {
     "id": "osmo19yat2nwf4h3d667xgyvtr2pg05nsxy2y8z408pnf8ypmkrqwyruqnnn4hz",
@@ -2467,7 +2422,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "118"
+    "lp_token_id": "gamm/pool/118"
   },
   {
     "id": "osmo19zg3tz4q5t3x6d2hdmwfkud4d3l3x8r4szr6clvlssw277y3g35srvkczc",
@@ -2477,17 +2432,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "597"
+    "lp_token_id": "gamm/pool/597"
   },
   {
     "id": "osmo1a0ev3jr6fts7y09as95pryn59hzwfkaletpusfzctejjy0wqa47sxqgy3a",
-    "asset_ids": [
-      "gamm/pool/356",
-      "gamm/pool/357"
-    ],
+    "asset_ids": ["gamm/pool/356", "gamm/pool/357"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "358"
+    "lp_token_id": "gamm/pool/358"
   },
   {
     "id": "osmo1a482ur89qhmuv07gmnt93jnmqww3ae3mdj4pd5hh4uje7zk57wys258nqn",
@@ -2497,7 +2449,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "252"
+    "lp_token_id": "gamm/pool/252"
   },
   {
     "id": "osmo1a6rvlkd2jw32mjf2pt78fte7f2hqu7gvr0yqsqek2c7anftrunkqqq798z",
@@ -2507,7 +2459,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "26"
+    "lp_token_id": "gamm/pool/26"
   },
   {
     "id": "osmo1a86mk698pzmwsv28pcs5f4hvl22eexc3krc4k03j27fgkeqtaftqgnvlq3",
@@ -2517,7 +2469,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "365"
+    "lp_token_id": "gamm/pool/365"
   },
   {
     "id": "osmo1aaaa5xedavww3s9j48zpfjy4tcqll26wpr6fkt8wys3ufzlwv89qc6f8t8",
@@ -2527,7 +2479,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "603"
+    "lp_token_id": "gamm/pool/603"
   },
   {
     "id": "osmo1aav62u4pls035r93uuy4h2dckl06hc2atpsdzm8947qvlc34pprs3edc28",
@@ -2537,7 +2489,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "400"
+    "lp_token_id": "gamm/pool/400"
   },
   {
     "id": "osmo1aavgx9ta75dchrwjf46z086pcjr44t4qkvz0c7walmvf5j3lxqnsulxsfw",
@@ -2547,7 +2499,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "532"
+    "lp_token_id": "gamm/pool/532"
   },
   {
     "id": "osmo1adqhma2hfrqr04uy4t4lmu3rft2k7rjj3j7xyye0v3tg09urg0xqcm28q5",
@@ -2557,17 +2509,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "567"
+    "lp_token_id": "gamm/pool/567"
   },
   {
     "id": "osmo1adzv0qftyywfavf06uqh0lutcqz5nz5favasq58rkvnu4l3zvs7shy9kxu",
-    "asset_ids": [
-      "gamm/pool/364",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/364", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "367"
+    "lp_token_id": "gamm/pool/367"
   },
   {
     "id": "osmo1ag2w5l8av9msvzhks4vyd920r9lzaesekes6yg3vykp9fch5n22sk6er50",
@@ -2577,7 +2526,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "812"
+    "lp_token_id": "gamm/pool/812"
   },
   {
     "id": "osmo1ah0sdvddcp3jjgfsyd960gud26l4dwz5gkqtx0qw42sv7kpsakhqyv257p",
@@ -2587,7 +2536,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "471"
+    "lp_token_id": "gamm/pool/471"
   },
   {
     "id": "osmo1ajghgy4ltm4ghn5smlrr29egrk3mq72642jsq8hqqet4cnwv4kssm9mrw8",
@@ -2597,7 +2546,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "91"
+    "lp_token_id": "gamm/pool/91"
   },
   {
     "id": "osmo1ak0lwxqlp70chxtt2fd4kr0ywhuk2fr6ncsjr884psu7h8m59vuqm6p42n",
@@ -2607,7 +2556,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "641"
+    "lp_token_id": "gamm/pool/641"
   },
   {
     "id": "osmo1amh63u7vgtrak5rmetdjrl67jhl6rate05r792ywyxzp5jt6eq7sx5uphr",
@@ -2617,17 +2566,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "585"
+    "lp_token_id": "gamm/pool/585"
   },
   {
     "id": "osmo1ang9dlvxrc0n835xyxvwf66mj0mm0sznyqwtu03kdd2dmhg40hlqnq36up",
-    "asset_ids": [
-      "gamm/pool/1",
-      "gamm/pool/8"
-    ],
+    "asset_ids": ["gamm/pool/1", "gamm/pool/8"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "246"
+    "lp_token_id": "gamm/pool/246"
   },
   {
     "id": "osmo1avdp69rp58an6hysjh5n6g9w0wx73sytfxcg3qjynnxcar5t5qfqxukm2s",
@@ -2637,7 +2583,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "673"
+    "lp_token_id": "gamm/pool/673"
   },
   {
     "id": "osmo1avm2f4fegrla4wcxft7ct3rksnuxvjl3mhv9gljg2e0c2swvlmqsaxy3xv",
@@ -2647,7 +2593,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "37"
+    "lp_token_id": "gamm/pool/37"
   },
   {
     "id": "osmo1awdgj7l3rjq2hmevgxuha99w39600fek27vsun4rztvy7s5h6n8sklwc8d",
@@ -2657,7 +2603,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "477"
+    "lp_token_id": "gamm/pool/477"
   },
   {
     "id": "osmo1ayjsj697r8ne5pnda82s96hdjvu5svp7ucjj3ekzlj886epq78cs2e48n3",
@@ -2667,7 +2613,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "789"
+    "lp_token_id": "gamm/pool/789"
   },
   {
     "id": "osmo1c0l0m8tvta5qdr5cutfnydw2h6r6qpzxtwtk8e7677v2h7es3tfsgv986d",
@@ -2677,7 +2623,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "826"
+    "lp_token_id": "gamm/pool/826"
   },
   {
     "id": "osmo1c0utzzgn56dhacxt2rzf8mvgkql54xnu78fhpnxqnx6hld9hue0qe79a7c",
@@ -2687,7 +2633,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "83"
+    "lp_token_id": "gamm/pool/83"
   },
   {
     "id": "osmo1c2agkt3smeangnelsxqqr97fm6kd0s7erqsgcuvc3nu06yr63qnqcz22mj",
@@ -2697,7 +2643,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "606"
+    "lp_token_id": "gamm/pool/606"
   },
   {
     "id": "osmo1c3vwd6kvev6499jg6tseszqky6p69mwdg5n66j060hvytxd6hjrsvzxk6u",
@@ -2707,7 +2653,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "445"
+    "lp_token_id": "gamm/pool/445"
   },
   {
     "id": "osmo1c4xsza76pfcauuqadpa3gq6mj6zjzjx4upm8p9388jp7tk52qars6p8e30",
@@ -2717,7 +2663,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "238"
+    "lp_token_id": "gamm/pool/238"
   },
   {
     "id": "osmo1c59p7ddraqwrtxe0camylyhra9s6w35qtywuaavravzx6us3cpsqn3dgn3",
@@ -2727,7 +2673,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "133"
+    "lp_token_id": "gamm/pool/133"
   },
   {
     "id": "osmo1c89mqqr6p979nl0jheysulp84zzpg84ujq5r0dzsmn7xl6aj38pq5fvwdw",
@@ -2737,17 +2683,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "883"
+    "lp_token_id": "gamm/pool/883"
   },
   {
     "id": "osmo1c8gdt3cquepqadv6ys2m9ht8eys40c2ws46ntwm7zknr2hwcsuhsly32ft",
-    "asset_ids": [
-      "gamm/pool/13",
-      "gamm/pool/5"
-    ],
+    "asset_ids": ["gamm/pool/13", "gamm/pool/5"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "81"
+    "lp_token_id": "gamm/pool/81"
   },
   {
     "id": "osmo1c9gj5nwxhuh2gz7wwg4r8e8tw8v7ggy9lh2hu7kkdgh0t450754qh9cpvd",
@@ -2757,7 +2700,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "3"
+    "lp_token_id": "gamm/pool/3"
   },
   {
     "id": "osmo1c9x2kvqge4r2z5rf7p64sg0fvdmjsklxcexmmre2amxsqjxeex2qrlmr3h",
@@ -2767,7 +2710,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "208"
+    "lp_token_id": "gamm/pool/208"
   },
   {
     "id": "osmo1cafjr2f6uek4jc7g0sgxwxnssu3uq2c5uvlzkg2mwkg6jdwu6a9sa7qg4m",
@@ -2777,7 +2720,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "716"
+    "lp_token_id": "gamm/pool/716"
   },
   {
     "id": "osmo1ccfjmcfe09k0f6fdcfdgkc52c52l2c0jywfc57sn5qd22texqr3qla0e5m",
@@ -2787,7 +2730,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "787"
+    "lp_token_id": "gamm/pool/787"
   },
   {
     "id": "osmo1ccjfm7gpa37mc9zwq553p0ttzq3ga5g6jzarz37lcq4qlnsdcxhsghcv3y",
@@ -2797,7 +2740,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "810"
+    "lp_token_id": "gamm/pool/810"
   },
   {
     "id": "osmo1cdtygs9r2lf9smh79j9l883wfxearsweevfqrrehfh7up3xw4nxqrsjwlw",
@@ -2807,7 +2750,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "373"
+    "lp_token_id": "gamm/pool/373"
   },
   {
     "id": "osmo1cf892ucxz0g5y9tlakunhn6hlgk40w0s6fy6hcjzsqnmx4u77xcqjafnfd",
@@ -2817,7 +2760,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "791"
+    "lp_token_id": "gamm/pool/791"
   },
   {
     "id": "osmo1cgr0zcfetq39yc3zhex2eaw2unczcw90m6qn7msw45r6qae9k0xqputy2m",
@@ -2827,17 +2770,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "737"
+    "lp_token_id": "gamm/pool/737"
   },
   {
     "id": "osmo1cgw34ya7ndpmplgv5wyec4mz7hq3crc64uqq02qv6zk9vxun2rksk8fcja",
-    "asset_ids": [
-      "gamm/pool/73",
-      "gamm/pool/74"
-    ],
+    "asset_ids": ["gamm/pool/73", "gamm/pool/74"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "75"
+    "lp_token_id": "gamm/pool/75"
   },
   {
     "id": "osmo1cj8dxdkgugvj0dysm79zha8mgkn9r7x9yg9n4cmdmqv9ucjkv2dsj5evg5",
@@ -2847,7 +2787,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "533"
+    "lp_token_id": "gamm/pool/533"
   },
   {
     "id": "osmo1csvn07y2n36dy3glfvdxeke80sxrhp8xwtjfds8nhvjullkqzpmq4zzh2s",
@@ -2857,7 +2797,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "337"
+    "lp_token_id": "gamm/pool/337"
   },
   {
     "id": "osmo1cu6nmf563q57u4lc7v9t23sytz25t5cya0f060227vwsy6u0cpaquldl5e",
@@ -2867,7 +2807,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "376"
+    "lp_token_id": "gamm/pool/376"
   },
   {
     "id": "osmo1cu9q2r5r09uct7ykpepyttk64hf30aygjn0ky567qrky5nthl56spqtnxz",
@@ -2877,7 +2817,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "593"
+    "lp_token_id": "gamm/pool/593"
   },
   {
     "id": "osmo1cwauwz0e490vkszxhrfhmawjsaw8ulac8fr03wccssn4eqswdxpsn2ycxj",
@@ -2887,7 +2827,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "294"
+    "lp_token_id": "gamm/pool/294"
   },
   {
     "id": "osmo1cxfkytmxzs55c00anuftly389mzg3gzvncfm8s4u9zeulhj8hsfq87snws",
@@ -2897,7 +2837,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "95"
+    "lp_token_id": "gamm/pool/95"
   },
   {
     "id": "osmo1cyjmqv92kx6trjjjsmemj3hvs9qg5jsrhscmq5km05hpkdsv62zqwpnggf",
@@ -2907,7 +2847,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "740"
+    "lp_token_id": "gamm/pool/740"
   },
   {
     "id": "osmo1cyllu6l6dw88t2wlk5ex4femwvj8nh249uff5uzzt2409aw0gy7su6lq2h",
@@ -2917,7 +2857,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "85"
+    "lp_token_id": "gamm/pool/85"
   },
   {
     "id": "osmo1czqlvqjdlm2raj6t65nansxt5zlv8ny04fn66gcm9llgl24axmksd2px7e",
@@ -2927,7 +2867,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "882"
+    "lp_token_id": "gamm/pool/882"
   },
   {
     "id": "osmo1czvns32qxxcyckqdfn02j7taflphz5dxawc6ksg7j5h58nlnen2sh8xxyj",
@@ -2937,7 +2877,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "138"
+    "lp_token_id": "gamm/pool/138"
   },
   {
     "id": "osmo1czyl3pef9apzjzwn949jk4lsfcql2mg66xxrmlvcukt2x3q0y03s7v06d3",
@@ -2947,7 +2887,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "271"
+    "lp_token_id": "gamm/pool/271"
   },
   {
     "id": "osmo1d0elgsavwgez5xf0fdan3krzfjm5jkdtcgxzlvunu4jndycs8u8qzs5h33",
@@ -2957,7 +2897,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "19"
+    "lp_token_id": "gamm/pool/19"
   },
   {
     "id": "osmo1d338zex4aayp5r6r4rtrvclcwdx4x0jqnpy0qzyszn700hk9n75snwxtsf",
@@ -2967,7 +2907,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "125"
+    "lp_token_id": "gamm/pool/125"
   },
   {
     "id": "osmo1d3nk4hhy929kyqnrxf874xvdey46szrw4mxk3n8v26kzck6a8r2s677wyq",
@@ -2977,7 +2917,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "240"
+    "lp_token_id": "gamm/pool/240"
   },
   {
     "id": "osmo1d4t6lpc8glprq3nfg49u4887hv8jhxvllsey27mvpu7qf4pawkjsplh3pn",
@@ -2987,7 +2927,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "354"
+    "lp_token_id": "gamm/pool/354"
   },
   {
     "id": "osmo1d6h0xq4vsgpay9n77yrzuaqyvs96x83c0wrrffr92pkcxnuk6lsqff43ne",
@@ -2997,7 +2937,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "452"
+    "lp_token_id": "gamm/pool/452"
   },
   {
     "id": "osmo1d735wcpt6x0w4ynqe874lr7ch9laufgas0dr2nfs6e4zzlurlf9q5st28n",
@@ -3007,7 +2947,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "781"
+    "lp_token_id": "gamm/pool/781"
   },
   {
     "id": "osmo1d7khqcglglgvkkj8jwt62mw0h7ak9y7de5js9zccn9kgtmx0j2qsm56cev",
@@ -3017,7 +2957,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "551"
+    "lp_token_id": "gamm/pool/551"
   },
   {
     "id": "osmo1d7tu6pz4nx5e4yzj2keu6ftvr9u5p22u2vu5t6ts8syqt0e3reesqnpun0",
@@ -3027,7 +2967,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "319"
+    "lp_token_id": "gamm/pool/319"
   },
   {
     "id": "osmo1d9y4rs70crz90a49fa3khad0dxy6yg7ezgdzlvuvjrujwvaspawqjut7t4",
@@ -3037,7 +2977,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "818"
+    "lp_token_id": "gamm/pool/818"
   },
   {
     "id": "osmo1dal655pjhghjfnlaxppj6kacgdrr50xf47dsheeanwaxzya2dm5qfmljhe",
@@ -3047,17 +2987,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "191"
+    "lp_token_id": "gamm/pool/191"
   },
   {
     "id": "osmo1daztxlwd90kqt7yw7mvakhp9kjd34g250dywutq06nvlze2u6uhsuk26xw",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "194"
+    "lp_token_id": "gamm/pool/194"
   },
   {
     "id": "osmo1dcvgttz6jwepg3gchu097aa2vxjgp3g5gm0t0p7z20lyclu7y0rqmc232t",
@@ -3067,7 +3004,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "652"
+    "lp_token_id": "gamm/pool/652"
   },
   {
     "id": "osmo1def45s6km7yvg37czsyxdalscd63w9k2v6yynskcgq3l6slm4tps2kvurk",
@@ -3077,7 +3014,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "404"
+    "lp_token_id": "gamm/pool/404"
   },
   {
     "id": "osmo1dejxnyjlhkfr8vjh9j47vjl9j9cvs3jk6aql6nvmxyyv547mumgqtcfc5w",
@@ -3087,7 +3024,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "329"
+    "lp_token_id": "gamm/pool/329"
   },
   {
     "id": "osmo1dgnr0ajw2p2wxh05lv8s8znts6rpz3n2rcepng368tzr5h4pzm7swkyfru",
@@ -3097,7 +3034,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "748"
+    "lp_token_id": "gamm/pool/748"
   },
   {
     "id": "osmo1dgnsyv3zj9uhen85ttf0heulkzcjj7nn27jw00hzpzp0ecfwx82slyu0ta",
@@ -3107,7 +3044,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "406"
+    "lp_token_id": "gamm/pool/406"
   },
   {
     "id": "osmo1dgrkc9rt7653dyvkepwk25tqjfnkel0alywgwl35p9jtjw4a92gq7f7mnz",
@@ -3117,7 +3054,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "159"
+    "lp_token_id": "gamm/pool/159"
   },
   {
     "id": "osmo1dh38ppn36hhdl365atjw4anr3d4faxzc6j0tassym738k276rx4q2rqkrs",
@@ -3127,7 +3064,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "814"
+    "lp_token_id": "gamm/pool/814"
   },
   {
     "id": "osmo1dj7rqa2r8psqp36asc4r6j20v8u62zjpqqwt8khxe24t5dzwssns3aph35",
@@ -3137,7 +3074,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "499"
+    "lp_token_id": "gamm/pool/499"
   },
   {
     "id": "osmo1djnm5mvg2s9p0appalcypxcjd7cd0xw6564k96r8dylgva3vmfnq0ca434",
@@ -3147,7 +3084,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "145"
+    "lp_token_id": "gamm/pool/145"
   },
   {
     "id": "osmo1dlahvz8g205z94g4xpxfxa77wmm5kn0janhs34ft22yxyljuyfaspawg0m",
@@ -3157,7 +3094,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "279"
+    "lp_token_id": "gamm/pool/279"
   },
   {
     "id": "osmo1dq3745uz8j2qd5fq2wtyvz9xzr5587awdnpn08272946dmn5pq5qjknyr9",
@@ -3167,7 +3104,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "520"
+    "lp_token_id": "gamm/pool/520"
   },
   {
     "id": "osmo1dsdccxrhra2pndxay08s7vajz72kr5vxqayalv7xt4gntey2xkmqa8u2x9",
@@ -3177,7 +3114,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "680"
+    "lp_token_id": "gamm/pool/680"
   },
   {
     "id": "osmo1dssdhlzawzthqsg60a5zms6xtx4tsktfzswal4qsxgugaad6j6wsxd6yk3",
@@ -3187,7 +3124,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "385"
+    "lp_token_id": "gamm/pool/385"
   },
   {
     "id": "osmo1dt25gt7wgeh9l66adztvyl9x2l94mane2zdkrp29e4y7s3484qcsgv24y5",
@@ -3197,7 +3134,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "129"
+    "lp_token_id": "gamm/pool/129"
   },
   {
     "id": "osmo1dt568undkrrlullpzz0c27548vjdrhnsxwhygxrdtacv2dns2ryqa28jhs",
@@ -3207,7 +3144,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "24"
+    "lp_token_id": "gamm/pool/24"
   },
   {
     "id": "osmo1dtlq83lwessktl65gxz6u8ufqc9lz0knh6nnw3rwklgla6jumrfq5a3clp",
@@ -3217,7 +3154,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "546"
+    "lp_token_id": "gamm/pool/546"
   },
   {
     "id": "osmo1du947dpr6v3nlcwu8a2x2qtzkqm6z2nay7dqkzj8fgcqmull6mvq8wum5e",
@@ -3227,7 +3164,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "167"
+    "lp_token_id": "gamm/pool/167"
   },
   {
     "id": "osmo1dufw6sdwhp6cxuxh8kfg9t50erne08t9sl37a6jeyswpknufftws5w7w8y",
@@ -3237,7 +3174,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "629"
+    "lp_token_id": "gamm/pool/629"
   },
   {
     "id": "osmo1dyvjg5eyr58e73fpnw3z6c7wz2h0wvarmpmvq0c60vawm8e6q70q44v94n",
@@ -3247,7 +3184,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "147"
+    "lp_token_id": "gamm/pool/147"
   },
   {
     "id": "osmo1dzwru0m7m0klhxqj84hd3vhhltk07r6try7pj7s3qy47nqq43g0s6fsy2n",
@@ -3257,7 +3194,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "214"
+    "lp_token_id": "gamm/pool/214"
   },
   {
     "id": "osmo1e0m28qylp9k0s4l6quk2skv9g3w0p8qvu8aqmxuf2n6tt7ctkuyqrw5d48",
@@ -3267,7 +3204,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "761"
+    "lp_token_id": "gamm/pool/761"
   },
   {
     "id": "osmo1e5xkxxpszq9t08yuu828rjzrmj5gvpwnf9ywv74ryz4frsyr0zlqyx76xf",
@@ -3277,7 +3214,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "766"
+    "lp_token_id": "gamm/pool/766"
   },
   {
     "id": "osmo1e63smvqcnxpgxuvhrknfapmyvjy98csgm7z6xr6zjnkwmjf7zeaqsc66vn",
@@ -3287,7 +3224,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "236"
+    "lp_token_id": "gamm/pool/236"
   },
   {
     "id": "osmo1e6szkqkkt3g6u7ukjpdz493mkvm9njknrxpe4vcfahl4dlx358msqgnrxz",
@@ -3297,7 +3234,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "292"
+    "lp_token_id": "gamm/pool/292"
   },
   {
     "id": "osmo1e92udnupts46czvcwtjcpgyvjhjv3grpjg43p60d8el8r24td3zqt8gfv0",
@@ -3307,7 +3244,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "792"
+    "lp_token_id": "gamm/pool/792"
   },
   {
     "id": "osmo1e9s595ml68g99m9vtat2jl66v65ravl7wlu3usj7mu3arz56flpssletl2",
@@ -3317,7 +3254,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "689"
+    "lp_token_id": "gamm/pool/689"
   },
   {
     "id": "osmo1ea5ymws7tufhg7v72wjwp3qskngmnpl729uc9h4anusfasmg48tqwje94x",
@@ -3327,7 +3264,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "825"
+    "lp_token_id": "gamm/pool/825"
   },
   {
     "id": "osmo1ecljlcqy3z4tfrr7rql0tmr83mh3qfjdzmpgwad9zm6q908k347qhc23ht",
@@ -3337,7 +3274,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "192"
+    "lp_token_id": "gamm/pool/192"
   },
   {
     "id": "osmo1edal9l38mgcm2hj27hgz0mcqapkp9yla3pgtusxap824hwqvfttq00m4wy",
@@ -3347,7 +3284,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "59"
+    "lp_token_id": "gamm/pool/59"
   },
   {
     "id": "osmo1efnu25xj2cp6th0jacx9e7qn6zlwnceq24v74pz0wn9gxtlc8pvsqn0l0v",
@@ -3357,7 +3294,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "421"
+    "lp_token_id": "gamm/pool/421"
   },
   {
     "id": "osmo1eft30ela0axavl9xa3plmv00ah005vkhyexsm0rc0cmfkz8jujjsaqq56h",
@@ -3367,7 +3304,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "326"
+    "lp_token_id": "gamm/pool/326"
   },
   {
     "id": "osmo1eg26w7fg3hdzjxyxv5x846ekjmw0rdewlxlp6rf20efursfurh7q78cyu2",
@@ -3377,7 +3314,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "758"
+    "lp_token_id": "gamm/pool/758"
   },
   {
     "id": "osmo1egng4w6ht85nhy5038hfs5xvx6ddg0l6mqslaxnudqssq5jm4y2qrh2han",
@@ -3387,7 +3324,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "539"
+    "lp_token_id": "gamm/pool/539"
   },
   {
     "id": "osmo1ehnfys6czdccwsg4twezh3w37a6zxgaa6ud0s0mn0c6yuqnj6dkq6jx9u5",
@@ -3397,7 +3334,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "119"
+    "lp_token_id": "gamm/pool/119"
   },
   {
     "id": "osmo1ejaswj8lcyh0zgnes8zt45e0w7tqm4mrxr74sfwgpdh72shp58ms4fdqsk",
@@ -3407,17 +3344,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "611"
+    "lp_token_id": "gamm/pool/611"
   },
   {
     "id": "osmo1ejcrrmfxaphd6nf270r34467u2a407mewhq5g5cz6hdhzqs7nnxsvpthf9",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "380"
+    "lp_token_id": "gamm/pool/380"
   },
   {
     "id": "osmo1ejm5jcfnsvcw5zxvc5h2k5d2yppww7tk9jt7hnqh9upaudckp8cqjn2578",
@@ -3427,7 +3361,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "105"
+    "lp_token_id": "gamm/pool/105"
   },
   {
     "id": "osmo1ekrucs08jgx45nf5d6rtkd2px4m60v9hwa4l2mj9frkvv908mwvsqz7z96",
@@ -3437,7 +3371,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "390"
+    "lp_token_id": "gamm/pool/390"
   },
   {
     "id": "osmo1eljhrrff3eklwl6t6lv8znt8pyej5k9k54cvr3gyakqmr6xldt7qu2vhgl",
@@ -3447,7 +3381,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "434"
+    "lp_token_id": "gamm/pool/434"
   },
   {
     "id": "osmo1emy3l3y30eqv25kfrwcs54whga4smrzvf39rl8km45rupcjz7uaqcmxtup",
@@ -3457,7 +3391,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "609"
+    "lp_token_id": "gamm/pool/609"
   },
   {
     "id": "osmo1ep9jw2xkuu3mhdqstgpeqw2tr2txw7aulx5cx0lar2lc3pw0huzs6j5ty5",
@@ -3467,7 +3401,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "141"
+    "lp_token_id": "gamm/pool/141"
   },
   {
     "id": "osmo1ephgyd57rw7mzf0p5gdjjezt2j442jpzdezvkjdvpke703fyy06qtstsmk",
@@ -3477,7 +3411,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "771"
+    "lp_token_id": "gamm/pool/771"
   },
   {
     "id": "osmo1exr9ekmy6ucvp8f8mqzu8qetxzsgzuz4d4h28y70ftwqwfcfvgqq2ywwh9",
@@ -3487,7 +3421,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "340"
+    "lp_token_id": "gamm/pool/340"
   },
   {
     "id": "osmo1ey4fm0hsg5h0el6c4duhkmu8ujgp0ndv0u04jpnkg696lsx6kytscdw7tp",
@@ -3497,7 +3431,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "310"
+    "lp_token_id": "gamm/pool/310"
   },
   {
     "id": "osmo1f2tlf4lnhzsrh9pyu9y3u6wju2nlqzummm3zs70jerk2s7a0fq4qfq9epf",
@@ -3507,7 +3441,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "510"
+    "lp_token_id": "gamm/pool/510"
   },
   {
     "id": "osmo1f33v0n0kn6vtu7vkxuf2rm9dxncnwuga5825tzupc3t9umsgt0rsl6u29e",
@@ -3517,7 +3451,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "151"
+    "lp_token_id": "gamm/pool/151"
   },
   {
     "id": "osmo1f4lp47dxu7w2ykr5dpgd8yeylx94xg5xv4cfmrcsfu4v77tqv73s3y3cmp",
@@ -3527,7 +3461,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "253"
+    "lp_token_id": "gamm/pool/253"
   },
   {
     "id": "osmo1f5fse04elu35trhlkf9dq4crgjay6pfh2nnmgx88acj7xmcarnvqgvq45v",
@@ -3537,7 +3471,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "600"
+    "lp_token_id": "gamm/pool/600"
   },
   {
     "id": "osmo1f602n58fsvphaledcyyxeczukyee0dnum08psrqrl894s3cc57zq6jyvyq",
@@ -3547,7 +3481,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "12"
+    "lp_token_id": "gamm/pool/12"
   },
   {
     "id": "osmo1f7cj0tc02qqwaps8d98s3pnwfyudsvfj9w4zmdmxdrp9gw0sh27spf7yyl",
@@ -3557,7 +3491,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "164"
+    "lp_token_id": "gamm/pool/164"
   },
   {
     "id": "osmo1f7rg0se3mhuwkjuzwdys2j64f4ktk5pz9lmf2cas5xu84urf5ulqy2qmpc",
@@ -3567,7 +3501,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "234"
+    "lp_token_id": "gamm/pool/234"
   },
   {
     "id": "osmo1f7vufh36kuhn8gtjhzzm98h22w6830zww86zwx8f6f47cz76r5yqvg67p5",
@@ -3577,7 +3511,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "158"
+    "lp_token_id": "gamm/pool/158"
   },
   {
     "id": "osmo1f7x8t6zv4tdmu2txgztqc9jwfa0kmx2jpgcmah69njaxc6h5gszsp8884g",
@@ -3587,7 +3521,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "561"
+    "lp_token_id": "gamm/pool/561"
   },
   {
     "id": "osmo1f95y595e89tucsuqrzdpgvtetyc8mzswdrqp4rrt8v8dexa2t4nquuee0m",
@@ -3597,7 +3531,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "682"
+    "lp_token_id": "gamm/pool/682"
   },
   {
     "id": "osmo1f9862pvm6htudctzex2c67ezkkp5z4lt07h76kdjl7gayez95eus2ekuhs",
@@ -3607,7 +3541,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "115"
+    "lp_token_id": "gamm/pool/115"
   },
   {
     "id": "osmo1fcl04ma3dhc080jscyzkgf65u2ctv9v67ec03an3cff0gnfqkllqqkufhx",
@@ -3617,7 +3551,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "21"
+    "lp_token_id": "gamm/pool/21"
   },
   {
     "id": "osmo1fg5xzrgah8mr6uqcgfjv5m0l9n2ce0ptye4sraavt3me3uh7yfeqy755dg",
@@ -3627,7 +3561,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "489"
+    "lp_token_id": "gamm/pool/489"
   },
   {
     "id": "osmo1fharjyp6vl6xx67f59jn2mrc0p6vl5lf32zpweuyevdhpusv5uysamun60",
@@ -3637,7 +3571,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "480"
+    "lp_token_id": "gamm/pool/480"
   },
   {
     "id": "osmo1fjjqzp80dgpq2lr0jzzyc9x05eeu6th36lc9r24x3m26af0vm5tsdzkt00",
@@ -3647,7 +3581,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "723"
+    "lp_token_id": "gamm/pool/723"
   },
   {
     "id": "osmo1fjrk6zk2st8uzgzedh8rx9rt8gk7rmxmstr8923v0xsqn2gjafmqr99vc5",
@@ -3657,7 +3591,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "502"
+    "lp_token_id": "gamm/pool/502"
   },
   {
     "id": "osmo1fksasqaynht6wz2nhzyjnc6ef0d5caevyt9uqczhclfuzd8kyycqpl4g5j",
@@ -3667,7 +3601,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "686"
+    "lp_token_id": "gamm/pool/686"
   },
   {
     "id": "osmo1fmz4zaaj377th482zzrvc5d9rx7hpreyhfprvum9hd2vyedg0trquug78j",
@@ -3677,7 +3611,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "528"
+    "lp_token_id": "gamm/pool/528"
   },
   {
     "id": "osmo1fpv2vn8xz4arzvwjqc52eh085rc4ktnsdwmpg3tum0rvgyf2hfqqw035mc",
@@ -3687,7 +3621,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "169"
+    "lp_token_id": "gamm/pool/169"
   },
   {
     "id": "osmo1fpzttww633v3jqz7vkf9csjcvjlmfl7rq3654uf0j6seq0p4h4esrjmuxw",
@@ -3697,7 +3631,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "602"
+    "lp_token_id": "gamm/pool/602"
   },
   {
     "id": "osmo1fqu4s8f5dha4tgf3swet43jlmeutxeynmm265mv2m8awauy6cvfstu4xyg",
@@ -3707,7 +3641,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "121"
+    "lp_token_id": "gamm/pool/121"
   },
   {
     "id": "osmo1frnc03evn4vnyrcvqqv85304rgegj3g44xj8vpdktmuaqwaqxtasefugr5",
@@ -3717,7 +3651,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "648"
+    "lp_token_id": "gamm/pool/648"
   },
   {
     "id": "osmo1fwexzng4wjqvga4avsvmqs6ay09yv80g4w6wrn9um05d95vsqw6saqxjgm",
@@ -3727,7 +3661,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "441"
+    "lp_token_id": "gamm/pool/441"
   },
   {
     "id": "osmo1fyav6ky62qrtu5hu6hv6jrx2mu058gvke6ncqyke6ns5mjgvtj5sv52acw",
@@ -3737,7 +3671,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "864"
+    "lp_token_id": "gamm/pool/864"
   },
   {
     "id": "osmo1fyxn5dnns58s2k0r8h3tf3llj6drwxn2lxqh7gv92hpy4953ka8qx6hey5",
@@ -3747,7 +3681,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "518"
+    "lp_token_id": "gamm/pool/518"
   },
   {
     "id": "osmo1g0c2n00paxpku0t4psy50kz385htrv50yk5szm6z57c0rzpd6qesjhwxwh",
@@ -3757,7 +3691,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "724"
+    "lp_token_id": "gamm/pool/724"
   },
   {
     "id": "osmo1g0e2en7r0juxqx2mmp9gc6nxtx9xfrsll5swvccsskywrfd7utjsmkt4l7",
@@ -3767,7 +3701,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "896"
+    "lp_token_id": "gamm/pool/896"
   },
   {
     "id": "osmo1g0jmvyrlmed35fd42rfu8emhn8mndyknn7rmx26943nt8jcz70rsd5su83",
@@ -3777,7 +3711,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "463"
+    "lp_token_id": "gamm/pool/463"
   },
   {
     "id": "osmo1g2y3ptjh8rndpsq6r2cty94nl777fugke3z2rq37ac3uldtfagcsspp8xt",
@@ -3787,7 +3721,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "829"
+    "lp_token_id": "gamm/pool/829"
   },
   {
     "id": "osmo1g4u4df420klg8xnkuhezz065p7e4q6emwagx3ctd9qv3gcl32h7sfygnlq",
@@ -3797,7 +3731,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "651"
+    "lp_token_id": "gamm/pool/651"
   },
   {
     "id": "osmo1g7jq4a7hw9n65tdv9mn28gckr7zqrzp0czvlxa0gqftrmtw28c5qc82aan",
@@ -3807,7 +3741,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "743"
+    "lp_token_id": "gamm/pool/743"
   },
   {
     "id": "osmo1g96kuarfld3nfeenuvdke2ec6584qvhrpx8eq0qxntk5llgzdlesk20neg",
@@ -3817,7 +3751,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "225"
+    "lp_token_id": "gamm/pool/225"
   },
   {
     "id": "osmo1gaern4gnnuu05dlzfr9ax5hl9hwt6tcymklv3vy4cs0tz8kkqqnqlxesce",
@@ -3827,7 +3761,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "60"
+    "lp_token_id": "gamm/pool/60"
   },
   {
     "id": "osmo1gdfp7xyv7j7wm7v0z42rqcaumf8emz3c9whfzmhmu6qauu6xfdts9t5dcm",
@@ -3837,7 +3771,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "889"
+    "lp_token_id": "gamm/pool/889"
   },
   {
     "id": "osmo1gesjuqekz3pyuuz0fg7j2ctckeqkltn8h225ce0fd93fckd9sksshu4wzn",
@@ -3847,7 +3781,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "566"
+    "lp_token_id": "gamm/pool/566"
   },
   {
     "id": "osmo1gf86c7l352dk4zcgruldykckr99jn86khvjy2efcvevewrjkv3msxur0kp",
@@ -3857,7 +3791,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "514"
+    "lp_token_id": "gamm/pool/514"
   },
   {
     "id": "osmo1gfzdnqyy95cgvjl3vkr7vs3ra9f06xu7mu0w4ldxj6rqszkhvnts0vs24p",
@@ -3867,7 +3801,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "39"
+    "lp_token_id": "gamm/pool/39"
   },
   {
     "id": "osmo1ghy3kl2fvyzag0q68zwmve4afl26avtt4sn80um6gw7zqx7p35ns83cch8",
@@ -3877,7 +3811,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "537"
+    "lp_token_id": "gamm/pool/537"
   },
   {
     "id": "osmo1gjfqv5vtwnm99dwac9v9ug4l9msyq9wejnatnvj35ex25ak2nrssh3pat9",
@@ -3887,7 +3821,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "268"
+    "lp_token_id": "gamm/pool/268"
   },
   {
     "id": "osmo1gkq0x059rrnv6egs8snzy7m80zrz3uygtu3khxr3llgnljm2wjpqmeqlz4",
@@ -3897,7 +3831,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "703"
+    "lp_token_id": "gamm/pool/703"
   },
   {
     "id": "osmo1glc2ym96m3tsncmulludzhksuahvk09rwyjlm7t20dewlwk8vzxs529ngm",
@@ -3907,7 +3841,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "381"
+    "lp_token_id": "gamm/pool/381"
   },
   {
     "id": "osmo1glls893n6fdgw2nrx5kl6l940qrxpvd3k5qlf3udu0r5zhgc6dqqs98en8",
@@ -3917,7 +3851,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "204"
+    "lp_token_id": "gamm/pool/204"
   },
   {
     "id": "osmo1gms9szd899acpscedg46za5zjmut2yalkgnr6x2ekw7q3l6ppqvs0h3lu0",
@@ -3927,7 +3861,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "459"
+    "lp_token_id": "gamm/pool/459"
   },
   {
     "id": "osmo1gnq7pvafrxq0yg74ph5r7vxl6dh6rsp5yncrq5gd4sr6vtjppndqsd3jjl",
@@ -3937,7 +3871,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "670"
+    "lp_token_id": "gamm/pool/670"
   },
   {
     "id": "osmo1gr45uf6rm02778wdwlhkdxt3c94fr6eqtk6284fpr804r24nrersnasvtx",
@@ -3947,7 +3881,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "684"
+    "lp_token_id": "gamm/pool/684"
   },
   {
     "id": "osmo1grw4dy9teaam0u2jywd9sw49max4ua9vj6hgsvjnr3jva8cr3husxrc3g0",
@@ -3957,7 +3891,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "175"
+    "lp_token_id": "gamm/pool/175"
   },
   {
     "id": "osmo1grzll8mqv9c0tkwe0secf225mpxnrx86fffnnlz4ffhwkqsr3gaswfa52j",
@@ -3967,7 +3901,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "719"
+    "lp_token_id": "gamm/pool/719"
   },
   {
     "id": "osmo1grzzz4rwj8l06wuf83dwhhhss39zv3302edgpa3tx6s6g45etsrqjjrz3v",
@@ -3977,7 +3911,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "70"
+    "lp_token_id": "gamm/pool/70"
   },
   {
     "id": "osmo1gs0czr9thyy0fgneenmj5swnew73gk5xktr352qggxlhhm5uwkpq77sgns",
@@ -3987,7 +3921,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "741"
+    "lp_token_id": "gamm/pool/741"
   },
   {
     "id": "osmo1gtc9dqfscgnlrw73yalnan4v2fwy2hz5447sqgclx68yz46us3xs38v2eh",
@@ -3997,7 +3931,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "522"
+    "lp_token_id": "gamm/pool/522"
   },
   {
     "id": "osmo1gtxfvhhvx8n5xvytrrp48qgu5vflpr0qm5e5c4p3zqwd4mr4u0uq6wv5d4",
@@ -4007,7 +3941,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "570"
+    "lp_token_id": "gamm/pool/570"
   },
   {
     "id": "osmo1gvcvxl68u9rgwgfctxkfuhmyqxqzn3lrxw9cn5qg3q5er27ex65q6vlpuh",
@@ -4017,7 +3951,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "289"
+    "lp_token_id": "gamm/pool/289"
   },
   {
     "id": "osmo1gwzs6qa626az6nhqcg93uxa8mfcfcc4mm7xecctwqaelfl70jewsgtkfh5",
@@ -4027,7 +3961,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "348"
+    "lp_token_id": "gamm/pool/348"
   },
   {
     "id": "osmo1gxdq040aa9qk9d5uvtlt00uwhaskslthdq9k2kpkwm430u4cnyqsj7ml7k",
@@ -4037,17 +3971,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "79"
+    "lp_token_id": "gamm/pool/79"
   },
   {
     "id": "osmo1gy7usssxrzsepfpn9z07456cqqmumtmn5mw3wgc5jpmwt2ha8qdqwxy09x",
-    "asset_ids": [
-      "gamm/pool/1",
-      "gamm/pool/73"
-    ],
+    "asset_ids": ["gamm/pool/1", "gamm/pool/73"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "74"
+    "lp_token_id": "gamm/pool/74"
   },
   {
     "id": "osmo1h5hz4uttwlnvvn4xf0r0sr89v6rgtv399le6y0ksv458jvg9vm2q8nyvdh",
@@ -4057,7 +3988,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "919"
+    "lp_token_id": "gamm/pool/919"
   },
   {
     "id": "osmo1h6tps4e40h66y5xunmgazkd4kvpcl26367ue3ta4ukjzw4j5j7tqxqqxh0",
@@ -4067,7 +3998,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "172"
+    "lp_token_id": "gamm/pool/172"
   },
   {
     "id": "osmo1h7yfu7x4qsv2urnkl4kzydgxegdfyjdry5ee4xzj98jwz0uh07rqdkmprr",
@@ -4077,7 +4008,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "497"
+    "lp_token_id": "gamm/pool/497"
   },
   {
     "id": "osmo1haqvxq0ykcxa5wjzpvpdpu96jdss0v0du7hfly595rhlamtzlmzq9a748l",
@@ -4087,7 +4018,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "99"
+    "lp_token_id": "gamm/pool/99"
   },
   {
     "id": "osmo1hcpnvyer3r93x2ux72w0347plas3vzs0f886lwa4thhdqth04jcqkc0k3c",
@@ -4097,7 +4028,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "467"
+    "lp_token_id": "gamm/pool/467"
   },
   {
     "id": "osmo1hdsvaxe9898kryxy2zlljtazl5dur9qxhph9q0qnrcqylyf9j9gq6peqep",
@@ -4107,7 +4038,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "427"
+    "lp_token_id": "gamm/pool/427"
   },
   {
     "id": "osmo1hecg2sghe8y69el3r9s0ysvlgqrwhg626lwujq5wzh0hah8zsqgspe678n",
@@ -4117,7 +4048,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "16"
+    "lp_token_id": "gamm/pool/16"
   },
   {
     "id": "osmo1hedgxlrrcls3aefh83vhqq4aema6yglhu24w8x67nulyc7655ghsdfvv60",
@@ -4127,7 +4058,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "653"
+    "lp_token_id": "gamm/pool/653"
   },
   {
     "id": "osmo1hek3fwgtlxgjvsgplhsucpz7w7q9vlp6mjm5m0c84na0x2y9y43qynrs6g",
@@ -4137,7 +4068,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "285"
+    "lp_token_id": "gamm/pool/285"
   },
   {
     "id": "osmo1hg0eeayprkg6a66fqs07sncy09rw6tae9k6g7ryrjk0k4nypfjwqrl6wy4",
@@ -4147,7 +4078,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "746"
+    "lp_token_id": "gamm/pool/746"
   },
   {
     "id": "osmo1hg2963kvsu2arwx69hcqmsl2ms4x5pjw9x7w43lvspn5tgz4aqksk0sk5c",
@@ -4157,17 +4088,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "58"
+    "lp_token_id": "gamm/pool/58"
   },
   {
     "id": "osmo1hgxsqpxghfw7pwwl8jwxzy04cyll8nhf6ejnxpx3wvkszkq6rznqap0yuc",
-    "asset_ids": [
-      "gamm/pool/503",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/503", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "505"
+    "lp_token_id": "gamm/pool/505"
   },
   {
     "id": "osmo1hhrh0atndq75k3wws0jp8z4q4sdr5hs2u629wk2l35yuu92mah3sfa06ns",
@@ -4177,7 +4105,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "148"
+    "lp_token_id": "gamm/pool/148"
   },
   {
     "id": "osmo1hjffj5jr5z53gepl9754vl5z8vxahz6r6yq0kaj2kppxrcrzu7lqvuzgqx",
@@ -4187,7 +4115,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "146"
+    "lp_token_id": "gamm/pool/146"
   },
   {
     "id": "osmo1hjkkjcc88t8mf2h4n2rzdxtdpmscv53ek33vs48jxk5x0d2uf9hs59teze",
@@ -4197,7 +4125,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "72"
+    "lp_token_id": "gamm/pool/72"
   },
   {
     "id": "osmo1hl0s405ggpxp8z5svx4myy23s4vsxm2n0040xcug59gx0cmdhqwq5t7x0y",
@@ -4207,7 +4135,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "304"
+    "lp_token_id": "gamm/pool/304"
   },
   {
     "id": "osmo1hlxc9ypgx9pfnrt8vacsyw8d0hj32n8vymg2u7aaxar2f6aulpeq2t095k",
@@ -4217,7 +4145,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "662"
+    "lp_token_id": "gamm/pool/662"
   },
   {
     "id": "osmo1hpfr8caa9swnqj2wapqwjfakqkfvdq70uvjv37pdst3xunsde2hqkz0na4",
@@ -4227,7 +4155,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "28"
+    "lp_token_id": "gamm/pool/28"
   },
   {
     "id": "osmo1hpgavxcjzhzrfj6y36ut7klat093w9wq9rdk399gmr8u3s96uqmsmqx9zn",
@@ -4237,7 +4165,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "554"
+    "lp_token_id": "gamm/pool/554"
   },
   {
     "id": "osmo1hs78pxgz4v0tmqs4gau9zpdsaeu4jumkr2r7qy0v40uqnws26ussyxt7ga",
@@ -4247,7 +4175,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "506"
+    "lp_token_id": "gamm/pool/506"
   },
   {
     "id": "osmo1hvm4qlmmpy60ed3ex4zfdlpwmurex6uunudfu0rjh6w87tvtawsq3aj6v5",
@@ -4257,7 +4185,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "346"
+    "lp_token_id": "gamm/pool/346"
   },
   {
     "id": "osmo1hxddxnuw6whdd4e8kwln9xeaws45kz7cuwe5asd05ws7xnltgjwszmq7np",
@@ -4267,7 +4195,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "247"
+    "lp_token_id": "gamm/pool/247"
   },
   {
     "id": "osmo1hz6eyl2u990ge6nq7c3uq8fnlx2ghedkervym8s9psnqjcj44wxqlewm4v",
@@ -4277,7 +4205,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "775"
+    "lp_token_id": "gamm/pool/775"
   },
   {
     "id": "osmo1j4ak6hul4x2m93rqnnjpxx7x6zml435zmv7y7wet0adr3sfw8crsnhd3cl",
@@ -4287,7 +4215,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "713"
+    "lp_token_id": "gamm/pool/713"
   },
   {
     "id": "osmo1j4j7kxkmu6kdenrx9ky50k9x86s36mcaqxukr8sjtl2rwp9vkwfqljjd3r",
@@ -4297,7 +4225,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "701"
+    "lp_token_id": "gamm/pool/701"
   },
   {
     "id": "osmo1j4xmzkea5t8s077t0s39vs5psp6f6dacpjswn64ln2v4pncwxg3qjs30zl",
@@ -4307,7 +4235,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "93"
+    "lp_token_id": "gamm/pool/93"
   },
   {
     "id": "osmo1j5l9ysw5xv0uqz9uh7mcg0l5rlerqm695ec9kkg2t8rp600zv47q82eqwa",
@@ -4317,7 +4245,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "5"
+    "lp_token_id": "gamm/pool/5"
   },
   {
     "id": "osmo1j5ywgvensu0uez4te9ql2eslg4qt96evhpldwd7j8h2mr66c8s7scvx4w8",
@@ -4327,7 +4255,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "623"
+    "lp_token_id": "gamm/pool/623"
   },
   {
     "id": "osmo1j6vmgahwmxgcpra7dudw570g44cntyvx9pz3k83ny8z0qgytq8aqmf8j0s",
@@ -4337,7 +4265,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "634"
+    "lp_token_id": "gamm/pool/634"
   },
   {
     "id": "osmo1j8cp3mdc9jq7vmgf0hpr8uz6e3at6uctwtzhn6qlm7g3shvzavwqg4qxyr",
@@ -4347,7 +4275,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "251"
+    "lp_token_id": "gamm/pool/251"
   },
   {
     "id": "osmo1jaemtd5g8h2dwegte0h3r76xt7uahrj4tdmdyypl5ptlswhnfves5cvs3v",
@@ -4357,7 +4285,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "227"
+    "lp_token_id": "gamm/pool/227"
   },
   {
     "id": "osmo1jajfyerkktqn6qfyxefeg078lfrdpkl87gsyhy925nwc6hysrtzq7zx9g4",
@@ -4367,7 +4295,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "407"
+    "lp_token_id": "gamm/pool/407"
   },
   {
     "id": "osmo1jaldjtc7ksfldxgg604zyspyd94p8kn6tleaarcdwl8wakul6w7sy50gam",
@@ -4377,7 +4305,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "139"
+    "lp_token_id": "gamm/pool/139"
   },
   {
     "id": "osmo1jatt233sux9mxjuqmtmaavucvatj23m2v6nyh3rel60qpjegkduqewylk7",
@@ -4387,7 +4315,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "912"
+    "lp_token_id": "gamm/pool/912"
   },
   {
     "id": "osmo1jeku67d5x534pn4l3ules7yye2s6kkj92hmn0lyldwnv5xv6cq3qjujw5y",
@@ -4397,7 +4325,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "512"
+    "lp_token_id": "gamm/pool/512"
   },
   {
     "id": "osmo1jm5tyuxars5j84jdeeqkp0zpyfk2ea84x7fec8jq03x00708f3qqwr3f57",
@@ -4407,7 +4335,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "66"
+    "lp_token_id": "gamm/pool/66"
   },
   {
     "id": "osmo1jn6lsmjf2qcgqyj6zzl9llunm3u38x3dh3dggyx043ysxy6jjwssq3h7ha",
@@ -4417,7 +4345,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "162"
+    "lp_token_id": "gamm/pool/162"
   },
   {
     "id": "osmo1jn8pdd9kez2n7422vg8qvwn7angtz2v8gjwkff3glprxypr25v0qp7zwkt",
@@ -4427,7 +4355,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "610"
+    "lp_token_id": "gamm/pool/610"
   },
   {
     "id": "osmo1jqvyxwgq5eujwp58ef2hgaf0xsn6vh0w9at77adyjj3uafrv8r7qjpks4h",
@@ -4437,7 +4365,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "847"
+    "lp_token_id": "gamm/pool/847"
   },
   {
     "id": "osmo1js8gkwluk3uux73v9u83f0egh7862sezq2f80l2c9eetylr9meqq698nvz",
@@ -4447,7 +4375,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "84"
+    "lp_token_id": "gamm/pool/84"
   },
   {
     "id": "osmo1jsfqrh9y0mjvrh09u82ja7az4fsyew64gn2pfg98c8969zg5zmhq2njffj",
@@ -4457,7 +4385,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "786"
+    "lp_token_id": "gamm/pool/786"
   },
   {
     "id": "osmo1jsr3q3yw5pt3gtnsdsr0c6hx23f83cpv6st6ze3pplthwrc67j8sjge00h",
@@ -4467,7 +4395,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "815"
+    "lp_token_id": "gamm/pool/815"
   },
   {
     "id": "osmo1jtzkz2383cegga8pzq7azm7tp3lcutep95urpvuqxz3x85sfpw7ssaqpc5",
@@ -4477,7 +4405,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "596"
+    "lp_token_id": "gamm/pool/596"
   },
   {
     "id": "osmo1jve7zc9y29kl8jalu0aaz8v38y2vpjucdk7thg79ektq4t7aswcsa6w45d",
@@ -4487,7 +4415,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "193"
+    "lp_token_id": "gamm/pool/193"
   },
   {
     "id": "osmo1jz730xfzjnkp2zaasvqg9e3smv2a4f8qvrm6p8cs83m2srkr56hs4wtm3w",
@@ -4497,17 +4425,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "749"
+    "lp_token_id": "gamm/pool/749"
   },
   {
     "id": "osmo1k33jzr6syz8fs9jlsjerwum53ctu9nzkfdr3uy58ddt2tpsnsw0sl8ff3s",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "135"
+    "lp_token_id": "gamm/pool/135"
   },
   {
     "id": "osmo1k3hmk0dyeu7m0jx6w0ltufvh76kjk0zscthmk0u86u3y95dy4xhqmqgeww",
@@ -4517,17 +4442,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "483"
+    "lp_token_id": "gamm/pool/483"
   },
   {
     "id": "osmo1k4gj3utpx0s3pmtq7shmyhdq2dp605e03hcprvzvec7jq2ge2u7s4r0wp4",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "545"
+    "lp_token_id": "gamm/pool/545"
   },
   {
     "id": "osmo1k4nr7aguzj733ch3kdpl4834ex5uep84gcvtnumj2ekgrh4xlfssslwlpd",
@@ -4537,7 +4459,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "767"
+    "lp_token_id": "gamm/pool/767"
   },
   {
     "id": "osmo1k5s6tga7smv266aftu7l4trqsdqg3slgq5kj2q02dppdxlw7pjvsxjzjrk",
@@ -4547,7 +4469,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "368"
+    "lp_token_id": "gamm/pool/368"
   },
   {
     "id": "osmo1k6mv2aefssjt0jq8gwvccwaa0xsv7m0dxl5kzqay47pepy6e8kqq3rage2",
@@ -4557,7 +4479,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "718"
+    "lp_token_id": "gamm/pool/718"
   },
   {
     "id": "osmo1k804l4hsemvreuguf96rnv8f8rmgmr2fm0nuy7z9s7je7j63dktqgamzc3",
@@ -4567,7 +4489,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "841"
+    "lp_token_id": "gamm/pool/841"
   },
   {
     "id": "osmo1k9a068d7990a52fncvt70magqvzsfkeg9a6qnqehv20qwwdqfrdqux5s24",
@@ -4577,7 +4499,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "89"
+    "lp_token_id": "gamm/pool/89"
   },
   {
     "id": "osmo1kaekqycnekvhhstysh7e9wwkl0w79wt9pr7vusmqfqkfcqgqac7s2fc6dj",
@@ -4587,7 +4509,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "845"
+    "lp_token_id": "gamm/pool/845"
   },
   {
     "id": "osmo1kavqnurym4exfwyz85j68mkggacegptpkvpv08d3g6q9vavhw94qvj756k",
@@ -4597,17 +4519,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "848"
+    "lp_token_id": "gamm/pool/848"
   },
   {
     "id": "osmo1kchnwg6y2y4r2nyjartp9q3ss4ysjkx9gzgxwdtg6624g6natn3seyj0f4",
-    "asset_ids": [
-      "gamm/pool/222",
-      "gamm/pool/323"
-    ],
+    "asset_ids": ["gamm/pool/222", "gamm/pool/323"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "402"
+    "lp_token_id": "gamm/pool/402"
   },
   {
     "id": "osmo1kcra3rvreavuzm94jfwl6pd4kysppvdn0g72d2d846qrg0gaaz2scsukt6",
@@ -4617,7 +4536,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "174"
+    "lp_token_id": "gamm/pool/174"
   },
   {
     "id": "osmo1kdnj8qjhya69n2yj820mzt9wjunjekkyu5ewwn7l5ppyn6qhu9zqzj8fk8",
@@ -4627,7 +4546,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "694"
+    "lp_token_id": "gamm/pool/694"
   },
   {
     "id": "osmo1ked4s6v8a5fnr7wshk3825c4dc44hth4aln264ygjxqw9ck4ry6qg6ysxy",
@@ -4637,7 +4556,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "509"
+    "lp_token_id": "gamm/pool/509"
   },
   {
     "id": "osmo1kg2ga83a9g5rhv5xu2m24q8rnqjv5vr6257cc2ny5x5737ttkg4sjh2zm9",
@@ -4647,7 +4566,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "667"
+    "lp_token_id": "gamm/pool/667"
   },
   {
     "id": "osmo1kgg8uct2yut6etpprx2sdfn2fq7890jez9jd5arunsgg734mv68st55v0w",
@@ -4657,7 +4576,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "230"
+    "lp_token_id": "gamm/pool/230"
   },
   {
     "id": "osmo1kljure6uz60xec9ecmq7sldzgz2x8n2r8snxgvuwla4rn7kpvjzsjczqqx",
@@ -4667,7 +4586,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "760"
+    "lp_token_id": "gamm/pool/760"
   },
   {
     "id": "osmo1knufp26cx4y9p4eecgra5z4deu6hek0hh9let2gwjns2g3tzue0qt4xzsf",
@@ -4677,7 +4596,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "458"
+    "lp_token_id": "gamm/pool/458"
   },
   {
     "id": "osmo1kp5sa9gkqwtcksupd30hdez9mfx4ak65c7m99yqj4pk599tlfh5q96u2e4",
@@ -4687,7 +4606,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "453"
+    "lp_token_id": "gamm/pool/453"
   },
   {
     "id": "osmo1kpf2xfutvfqfum9aj2juvjcjcxzp7k3le389v6ql6lurzcq0hausa6uyx8",
@@ -4697,7 +4616,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "14"
+    "lp_token_id": "gamm/pool/14"
   },
   {
     "id": "osmo1kqmrg9qyqfgkys9q892m8st5mkesez8vpnegppecex0ylqqp8h8sedeu4q",
@@ -4707,7 +4626,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "660"
+    "lp_token_id": "gamm/pool/660"
   },
   {
     "id": "osmo1krp38zzc3zz5as9ndqkyskhkzv6x9e30ckcq5g4lcsu5wpwcqy0sa3dea2",
@@ -4717,7 +4636,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "10"
+    "lp_token_id": "gamm/pool/10"
   },
   {
     "id": "osmo1kskty9u0uvqrn89p4ultt4m2se2jjkrt404d20zgqftdch5t4k6qmysqvn",
@@ -4727,7 +4646,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "649"
+    "lp_token_id": "gamm/pool/649"
   },
   {
     "id": "osmo1ku38urrhfsz29778kcwr7zaesfcv86js2alyy58t6dnzh8nnf73qpwkwtw",
@@ -4737,7 +4656,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "564"
+    "lp_token_id": "gamm/pool/564"
   },
   {
     "id": "osmo1ku7t6f3pcl3e9kfzlzrp5jwktsl7vqu4dym7fzvn2gsj47qp9e5se820kn",
@@ -4747,7 +4666,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "256"
+    "lp_token_id": "gamm/pool/256"
   },
   {
     "id": "osmo1kuceh0se3p3f6xf7ca5yh5ud33my9rzk9jyjh0hk5ufvh02vvn8slg06wy",
@@ -4757,7 +4676,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "206"
+    "lp_token_id": "gamm/pool/206"
   },
   {
     "id": "osmo1kuecnt3tye9q23d5ytw6xmfp70w7gz4te6sjs42ptep9utrx5v4q5uuj9u",
@@ -4767,7 +4686,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "446"
+    "lp_token_id": "gamm/pool/446"
   },
   {
     "id": "osmo1kxlcgxrc2lqn7hmks2ukld6a8f0fdfm0dwstut2uragrugkryyvq7eyxmv",
@@ -4777,7 +4696,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "794"
+    "lp_token_id": "gamm/pool/794"
   },
   {
     "id": "osmo1kyrc9u2g4f44empz8achjdxzkftprxhx56p28ft02lkaucvztyqsrlsrd3",
@@ -4787,7 +4706,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "259"
+    "lp_token_id": "gamm/pool/259"
   },
   {
     "id": "osmo1kyw5a3cuukhc63r7pry549fdzt2wtn9w6fesz70q6lg25rzlas3s0el87c",
@@ -4797,7 +4716,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "921"
+    "lp_token_id": "gamm/pool/921"
   },
   {
     "id": "osmo1kze098t3xxs3w6mfhxkdeehrktjd49582g8vtgfh5cke2jfh2hhsqqjvgx",
@@ -4807,7 +4726,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "88"
+    "lp_token_id": "gamm/pool/88"
   },
   {
     "id": "osmo1l0s5xy5nm9qwdn72nux9dyck9k52l4mg907ghrxc0lw8rn6vxuaseq3t9f",
@@ -4817,7 +4736,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "207"
+    "lp_token_id": "gamm/pool/207"
   },
   {
     "id": "osmo1l265e7cug3tk3eugex8hpq2adk5drdecxzp6lsytn6dls6jpjkssvp9zqe",
@@ -4827,7 +4746,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "584"
+    "lp_token_id": "gamm/pool/584"
   },
   {
     "id": "osmo1l2a4nmtjuv8mfucrenpujyn9j04vl3gmrsyq0vaj5f8e6apmavvqhtje00",
@@ -4837,7 +4756,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "860"
+    "lp_token_id": "gamm/pool/860"
   },
   {
     "id": "osmo1l2sd4j9yq6hz0q039hnjydx6zj2lptu34f846yg5jutgu0r7juvszgk2xy",
@@ -4847,7 +4766,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "261"
+    "lp_token_id": "gamm/pool/261"
   },
   {
     "id": "osmo1l45a67tujfxl99qt39a09cqf9ep0vtqyn8xnuua66yvjtc7e8lvsua2hjn",
@@ -4857,17 +4776,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "17"
+    "lp_token_id": "gamm/pool/17"
   },
   {
     "id": "osmo1l5ehe7cqgf5fplxegqaukwygaz8g2h62yhdt06te6uem30l2j9mswf6qct",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "50"
+    "lp_token_id": "gamm/pool/50"
   },
   {
     "id": "osmo1l7vu8utujujfy0j2xrhcfzcz27q85j29vxxyjx4w7lnxzsevjfwq69qxrq",
@@ -4877,7 +4793,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "513"
+    "lp_token_id": "gamm/pool/513"
   },
   {
     "id": "osmo1l87xgwa4j9ntqfuz440pw5xgsw27y227rddfz2knekfk59k0satqj9as7f",
@@ -4887,17 +4803,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "575"
+    "lp_token_id": "gamm/pool/575"
   },
   {
     "id": "osmo1lahkpd2rxat3huy3kqkphvugruzxm3d5n0jxve6c8xzmkcvgfw9qjdnkhf",
-    "asset_ids": [
-      "gamm/pool/104",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/104", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "107"
+    "lp_token_id": "gamm/pool/107"
   },
   {
     "id": "osmo1lc77pdqlnj3s7typ0nvq7xxt79gmtec7mvazdsw8c2ffy4j9hjrs6crft0",
@@ -4907,7 +4820,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "624"
+    "lp_token_id": "gamm/pool/624"
   },
   {
     "id": "osmo1leu9xn7ecn7wq58kz949827zspj7xzf98200mukzctgnrpsqwsfscnwc7s",
@@ -4917,7 +4830,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "658"
+    "lp_token_id": "gamm/pool/658"
   },
   {
     "id": "osmo1lg3y6n2qc382ukpl8y6hfxlk6lprw3aye47zsld7xpnktfhvxneqxjf4f7",
@@ -4927,7 +4840,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "774"
+    "lp_token_id": "gamm/pool/774"
   },
   {
     "id": "osmo1lh3kh39lzupfnupjsl5vda29utlzkaz2673hepw2cdck8rqm3arssz7skt",
@@ -4937,7 +4850,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "589"
+    "lp_token_id": "gamm/pool/589"
   },
   {
     "id": "osmo1lherhrcrxe9yev22rjda9auagvr9nupncmtn4yajs48kvfe42t2sq83s4w",
@@ -4947,7 +4860,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "909"
+    "lp_token_id": "gamm/pool/909"
   },
   {
     "id": "osmo1lhg9ec0lmn0wec4tsxwk7kwqd5px203vwvh7wth5wls4jeu2hjlqxn7gte",
@@ -4957,7 +4870,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "734"
+    "lp_token_id": "gamm/pool/734"
   },
   {
     "id": "osmo1lkam7g0tg3r9uaq0y7tgzax5934zaevuhe70evqxaaga7n9wqgasqeale8",
@@ -4967,17 +4880,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "687"
+    "lp_token_id": "gamm/pool/687"
   },
   {
     "id": "osmo1lmk3mgsj2ajp4s34jzfsqscz60nfys4rlsg5u8k03a9420ggyh2qldlmzq",
-    "asset_ids": [
-      "gamm/pool/38",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/38", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "61"
+    "lp_token_id": "gamm/pool/61"
   },
   {
     "id": "osmo1lu9gpwx7n5phng70yap748t48ws5p82rher9hvkqqvpczj0f9rwqc3rmy5",
@@ -4987,7 +4897,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "430"
+    "lp_token_id": "gamm/pool/430"
   },
   {
     "id": "osmo1lughuhtdk7fj9n9pzx7hu5ulrcg6g84mk5j3aezgw86f4vae79qqw5wzd4",
@@ -4997,7 +4907,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "389"
+    "lp_token_id": "gamm/pool/389"
   },
   {
     "id": "osmo1lv9ju9nuzr4vgazyma7l8hsw0zcafwwm77vvdjm79mku6ydpq4mskdpsd2",
@@ -5007,7 +4917,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "291"
+    "lp_token_id": "gamm/pool/291"
   },
   {
     "id": "osmo1ly2shj6fznqwqskswmpwmrkqxdsavhmlmkr92wg3hcqqxnn2y5vsrkhc6u",
@@ -5017,7 +4927,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "601"
+    "lp_token_id": "gamm/pool/601"
   },
   {
     "id": "osmo1lzwv0glchfcw0fpwzdwfdsepmvluv6z6eh4qunxdml33sj06q3yq7xwtde",
@@ -5027,7 +4937,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "4"
+    "lp_token_id": "gamm/pool/4"
   },
   {
     "id": "osmo1m0qkljyn3a0sm2m9sgj6485frrmxnqpetc0lqstun5nzqj28fctqkt2qeh",
@@ -5037,7 +4947,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "843"
+    "lp_token_id": "gamm/pool/843"
   },
   {
     "id": "osmo1m0yntqzum06tc7ztw34sn646clwf32p7x2cfymaf8jx0cyf3jvlqfe5d6x",
@@ -5047,7 +4957,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "183"
+    "lp_token_id": "gamm/pool/183"
   },
   {
     "id": "osmo1m28rqxevywfn76c4lf5vws64shd0hxvxyvzazzswlj5n7q48pxrqvlgry5",
@@ -5057,7 +4967,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "643"
+    "lp_token_id": "gamm/pool/643"
   },
   {
     "id": "osmo1m3690pyfyadnny62ylj44xdlhzen7dluzmlrwwayzmnmm8deqy6sd86xla",
@@ -5067,7 +4977,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "517"
+    "lp_token_id": "gamm/pool/517"
   },
   {
     "id": "osmo1m3lgd2ekfvtde7suplqwgz0c38dfw0rcrnds86876680u0ud8sfqkg63dx",
@@ -5077,7 +4987,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "729"
+    "lp_token_id": "gamm/pool/729"
   },
   {
     "id": "osmo1m4qg2yg542hp38yrdnp7wxhpm8j3agu78sg7f6lz0dzpmk4t4cysy9x5mj",
@@ -5087,7 +4997,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "177"
+    "lp_token_id": "gamm/pool/177"
   },
   {
     "id": "osmo1m728dvj3vg684xgcv3skek3ylzjxryu5v0qyyl9jv3zz7vkga9fq7jpkck",
@@ -5097,7 +5007,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "308"
+    "lp_token_id": "gamm/pool/308"
   },
   {
     "id": "osmo1m80fnqvvsd83we8gnh998re55jq8cq2mdkccclqmuqw8xpm69agsm8ffd6",
@@ -5107,7 +5017,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "553"
+    "lp_token_id": "gamm/pool/553"
   },
   {
     "id": "osmo1masvawn2hnrddygr7czdkhjgnnuf86qgf657u4jpm4xg3qz53nkq0hkjy7",
@@ -5117,7 +5027,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "355"
+    "lp_token_id": "gamm/pool/355"
   },
   {
     "id": "osmo1maw9j25fppqf3c2l4ufxxhn7leu58ke2c5lm9r8ehm60fnzgpzfsu8jzhk",
@@ -5127,17 +5037,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "32"
+    "lp_token_id": "gamm/pool/32"
   },
   {
     "id": "osmo1mdqhf078cs0qe7gfcv9rdw0yzvzf0wejvyrlx8hyzcpsfn2zgpyq7l9ly6",
-    "asset_ids": [
-      "gamm/pool/108",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/108", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "153"
+    "lp_token_id": "gamm/pool/153"
   },
   {
     "id": "osmo1mel7yxyqx2n39zrw8eqrxv8gjltvlchqaycjz6gg0x8qgs7zhe9sc5gavj",
@@ -5147,7 +5054,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "507"
+    "lp_token_id": "gamm/pool/507"
   },
   {
     "id": "osmo1mh2eclfdnq5e9pz8ejyz7q245nry7p0q4u6t6xj363xw9uxt0uqqf26dzm",
@@ -5157,7 +5064,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "300"
+    "lp_token_id": "gamm/pool/300"
   },
   {
     "id": "osmo1mhnddjymtcxxn9mj9en37ufnf9s9tfg0rzgy24y7f06d7t5v340sdhlfen",
@@ -5167,7 +5074,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "171"
+    "lp_token_id": "gamm/pool/171"
   },
   {
     "id": "osmo1mrlrvqret269x5aqvkycy0fnu4jz3fqqf6tqflptygpewn264jpsw8kega",
@@ -5177,7 +5084,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "195"
+    "lp_token_id": "gamm/pool/195"
   },
   {
     "id": "osmo1mrltfv8y3jf4v3ggw0hnjjxzmwmq749rsjgvgvjuk0ezzs4hycfskm6c6a",
@@ -5187,7 +5094,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "301"
+    "lp_token_id": "gamm/pool/301"
   },
   {
     "id": "osmo1mtarz7hmt5m0h7muks3pdnwfmwqps9nndrrq6xrz5rhdsl6s3cwssm4vv3",
@@ -5197,7 +5104,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "867"
+    "lp_token_id": "gamm/pool/867"
   },
   {
     "id": "osmo1mtn55pzt3huxrskm986s89e465u3kvln9uum5deeza27f0vtmucs9ysvr6",
@@ -5207,7 +5114,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "542"
+    "lp_token_id": "gamm/pool/542"
   },
   {
     "id": "osmo1mvpqp7xujzf7c5jyamxg3u23zflz6ye0vnalx94khkyf4fp4m7aq96z76w",
@@ -5217,7 +5124,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "844"
+    "lp_token_id": "gamm/pool/844"
   },
   {
     "id": "osmo1mw0ac6rwlp5r8wapwk3zs6g29h8fcscxqakdzw9emkne6c8wjp9q0t3v8t",
@@ -5227,7 +5134,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "1"
+    "lp_token_id": "gamm/pool/1"
   },
   {
     "id": "osmo1mxcjnczrsd9ge4pkczpt9e84rntk08h27ez0d36yaxumsk2smdys3vsucj",
@@ -5237,7 +5144,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "625"
+    "lp_token_id": "gamm/pool/625"
   },
   {
     "id": "osmo1n22kz2zhwzl06ftd64heah7vahlythhsrj2388l0z95jlsjpkyuq0qd5dz",
@@ -5247,7 +5154,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "173"
+    "lp_token_id": "gamm/pool/173"
   },
   {
     "id": "osmo1n34cvctdvs54y3mkmk0pmj5f47k38eecl509q68ml66x2xlxfgysu26f8u",
@@ -5257,7 +5164,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "130"
+    "lp_token_id": "gamm/pool/130"
   },
   {
     "id": "osmo1n44k0kzvzqn3duscgzznh73p24je0vw38huugm5cg6k7fjren64s9a837a",
@@ -5267,7 +5174,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "836"
+    "lp_token_id": "gamm/pool/836"
   },
   {
     "id": "osmo1n8eyte6zq4njjcfjw3re4vhrgf9n32zstulurxg8k66dp7uk9leqjyeavk",
@@ -5277,7 +5184,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "168"
+    "lp_token_id": "gamm/pool/168"
   },
   {
     "id": "osmo1na36haex62rq9y0rz34unlk8agh5kygug5eheelvhw3hxhmwwmgqppr5zx",
@@ -5287,7 +5194,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "287"
+    "lp_token_id": "gamm/pool/287"
   },
   {
     "id": "osmo1nam3pd3u93sqxns28k5xu4vznnv5a654hh38fnwud5pakqqq04xs6upegq",
@@ -5297,7 +5204,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "541"
+    "lp_token_id": "gamm/pool/541"
   },
   {
     "id": "osmo1namquuyzajapzsffw7vy28sfdwsjzk559vt0p6rzpkhzwplt0m3snd6ppr",
@@ -5307,7 +5214,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "379"
+    "lp_token_id": "gamm/pool/379"
   },
   {
     "id": "osmo1nanwkuh98tjrft7v4js0p8efjp3w2h4jjmesprlzjdnfvzyuvcmscnuhr6",
@@ -5317,7 +5224,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "281"
+    "lp_token_id": "gamm/pool/281"
   },
   {
     "id": "osmo1nefum67tu9gzamyzvsp960auxayp5ft3pkwey67h434nkytuys4svyml98",
@@ -5327,17 +5234,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "579"
+    "lp_token_id": "gamm/pool/579"
   },
   {
     "id": "osmo1nfn4h33t30prnuyrhn20ntvgclzhc8x40mzkngc740r9r3sap4yqaf9c3a",
-    "asset_ids": [
-      "gamm/pool/359",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/359", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "360"
+    "lp_token_id": "gamm/pool/360"
   },
   {
     "id": "osmo1ng6lckhx52kpr7ww9ynayuzzlsp5m6jcnkztysf03sncg9zz472ss3x370",
@@ -5347,7 +5251,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "626"
+    "lp_token_id": "gamm/pool/626"
   },
   {
     "id": "osmo1nggsx9rkkyyrg6pksejtpq9zea90yu6mjq6u5pwsmu53xweda4psp5jsfv",
@@ -5357,7 +5261,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "361"
+    "lp_token_id": "gamm/pool/361"
   },
   {
     "id": "osmo1nh9vsmgqtdtrrrldfzxtjy3l444grmt7flrmyc265ey0arsng8dqqzfag3",
@@ -5367,17 +5271,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "879"
+    "lp_token_id": "gamm/pool/879"
   },
   {
     "id": "osmo1nk8ha9xldmqjn7adgz56tmu87e3yryuzj3upsk20kmy64vmg702squcxue",
-    "asset_ids": [
-      "gamm/pool/474",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/474", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "475"
+    "lp_token_id": "gamm/pool/475"
   },
   {
     "id": "osmo1nkt8zu53tz64m9muw9jgaw2xfhxl3c6p8hkte57j46ctjdpduh6qgays4a",
@@ -5387,7 +5288,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "102"
+    "lp_token_id": "gamm/pool/102"
   },
   {
     "id": "osmo1nmlwj8wfpq5r2dukds3lkg74t324y53j4eegk4h3u09hu5rn3kpqctntge",
@@ -5397,7 +5298,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "189"
+    "lp_token_id": "gamm/pool/189"
   },
   {
     "id": "osmo1npz80ntx3vwkv3w9ryzc8g074hlykmw497ar0j7dqzk4yanjylqshan44d",
@@ -5407,7 +5308,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "274"
+    "lp_token_id": "gamm/pool/274"
   },
   {
     "id": "osmo1nreqp8gx5nmej0ckrh7v2jy2p6j8pjv7xcyzrpylkstfamkm2slqxsvllj",
@@ -5417,7 +5318,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "661"
+    "lp_token_id": "gamm/pool/661"
   },
   {
     "id": "osmo1nspf22mwajwdka4zxk3k0vcn9xtqskur5we6u255q7hgcjhnj72qkdn45s",
@@ -5427,7 +5328,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "450"
+    "lp_token_id": "gamm/pool/450"
   },
   {
     "id": "osmo1nukez7tx3w75sesfecus9tuedre25uhvs737t0g35uqzeaks5jusvvp5r4",
@@ -5437,7 +5338,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "464"
+    "lp_token_id": "gamm/pool/464"
   },
   {
     "id": "osmo1nukyq8kzw4353yt8gvzjgfvvzar7h6skzkwptxkcrecjzfhxqdaqk4shck",
@@ -5447,7 +5348,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "123"
+    "lp_token_id": "gamm/pool/123"
   },
   {
     "id": "osmo1nvjv09u5tcunewz468ad285z5dum9h4hvc0lcnsjvncq63umu8pq63czxa",
@@ -5457,7 +5358,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "755"
+    "lp_token_id": "gamm/pool/755"
   },
   {
     "id": "osmo1nw8fdm6elm9h06zfxf5sltxjp0xw9cgcpzqzfqwpea5584xr0g7qhzzx2q",
@@ -5467,7 +5368,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "827"
+    "lp_token_id": "gamm/pool/827"
   },
   {
     "id": "osmo1nxm52c20twfrr44cdh5g4f7dufnuc7r60n5y9uqe27494qgw2qes2g4432",
@@ -5477,7 +5378,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "731"
+    "lp_token_id": "gamm/pool/731"
   },
   {
     "id": "osmo1nzky8dqcmzzf84hrwse3pggyq5kqe9njewn00fphaku4lgjw5gxsejdw0f",
@@ -5487,7 +5388,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "166"
+    "lp_token_id": "gamm/pool/166"
   },
   {
     "id": "osmo1p0rpttlp8v2hy7m82l2t9p6545788f2ac3yksgrlycke2wr4mu0qdr7ytu",
@@ -5497,7 +5398,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "6"
+    "lp_token_id": "gamm/pool/6"
   },
   {
     "id": "osmo1p352w3c2ms04cj6un55hnkwuw2fq748tgxjn57fujvp9pmx8mhnsr4jsgv",
@@ -5507,7 +5408,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "650"
+    "lp_token_id": "gamm/pool/650"
   },
   {
     "id": "osmo1p4qpdv38znav3egx44yysvp5zwazsmw0p30vk8yxq43qraxspz0sdrq6td",
@@ -5517,7 +5418,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "178"
+    "lp_token_id": "gamm/pool/178"
   },
   {
     "id": "osmo1p8amm7au5ajkuay8nrnwelwheazxqw23va9yq42ehx0s4reexu7s2jff2l",
@@ -5527,7 +5428,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "817"
+    "lp_token_id": "gamm/pool/817"
   },
   {
     "id": "osmo1p9mdkst9230ngdunv654l3trklnrpzlh9lr82fs4qes879l3n42stya63r",
@@ -5537,17 +5438,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "705"
+    "lp_token_id": "gamm/pool/705"
   },
   {
     "id": "osmo1p9pa7umdvry4u4338hgu4x5pkepnk9pcqddpg65zdj0k3a3ucjts85hj73",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "35"
+    "lp_token_id": "gamm/pool/35"
   },
   {
     "id": "osmo1pa8d43s0t8hwdekx2uyq224tapyzxn60578ywzlkupkh60tyzhus2wcrez",
@@ -5557,7 +5455,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "188"
+    "lp_token_id": "gamm/pool/188"
   },
   {
     "id": "osmo1pc849m5xe9wa7w9r4k2dv7pq958fm84a8t626ftufs8m5rs09guqxx8j3y",
@@ -5567,7 +5465,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "795"
+    "lp_token_id": "gamm/pool/795"
   },
   {
     "id": "osmo1pd4pfnj36p39q9zdpycjfms7zta3ugjjeyjxzmuhh28pqe70urxqje0k84",
@@ -5577,7 +5475,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "870"
+    "lp_token_id": "gamm/pool/870"
   },
   {
     "id": "osmo1ped9637al0u0ck9gtmud27rxjkmhk2cxjt7lsqrtwd3pjzmm07jsxu8mvm",
@@ -5587,7 +5485,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "813"
+    "lp_token_id": "gamm/pool/813"
   },
   {
     "id": "osmo1pemg6m8pd8xnz2gnnmh9w8ja3rhcq9ztlnwa34md545ttj46sfwsxyzy50",
@@ -5597,7 +5495,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "248"
+    "lp_token_id": "gamm/pool/248"
   },
   {
     "id": "osmo1pf3vpzz9umucchpeklwtsc4xveql0m6xsh589ek8tn4er80v9wksya3e2d",
@@ -5607,7 +5505,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "257"
+    "lp_token_id": "gamm/pool/257"
   },
   {
     "id": "osmo1pg8mzjdn3yxg4gf96axyw8gpn2ur6jxq5alctz7lmjkwk9n98neshpmtkj",
@@ -5617,7 +5515,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "866"
+    "lp_token_id": "gamm/pool/866"
   },
   {
     "id": "osmo1pjuess9ulvre83pyees8p688xglzl039nhgrtx8nv3j50uw8qhsqqma5jq",
@@ -5627,7 +5525,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "347"
+    "lp_token_id": "gamm/pool/347"
   },
   {
     "id": "osmo1plswdqqd9nn7jy3s62vnjjmshwkk0us07shttqsmdph2gkgt6ejqmqef5c",
@@ -5637,7 +5535,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "45"
+    "lp_token_id": "gamm/pool/45"
   },
   {
     "id": "osmo1pmhq2qy30wdlv4thqs9glsm38z06lp6syuh8nwa85aukw6tepmhq7eazwe",
@@ -5647,7 +5545,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "405"
+    "lp_token_id": "gamm/pool/405"
   },
   {
     "id": "osmo1ppc37u39xsklmuew4vyggg34crggekqnuul32x67y32g65ekprhqwfxh56",
@@ -5657,7 +5555,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "428"
+    "lp_token_id": "gamm/pool/428"
   },
   {
     "id": "osmo1prazp9zy7pk9ds5s66kj6uc50uvwsu9pmr6qwel3dn3juvjps3mqku4xwt",
@@ -5667,7 +5565,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "439"
+    "lp_token_id": "gamm/pool/439"
   },
   {
     "id": "osmo1prgxk3tjsmrw230k266aeevjgmerceekj89ksjpjq3gt6wa3rmes36q0kt",
@@ -5677,7 +5575,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "656"
+    "lp_token_id": "gamm/pool/656"
   },
   {
     "id": "osmo1pw3kx94kn0vu6lj048vtk3vmzx7y7mde3zc2sjxull69mcg6zjyqft9qjv",
@@ -5687,7 +5585,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "136"
+    "lp_token_id": "gamm/pool/136"
   },
   {
     "id": "osmo1py2nm36kk5dek5th97ljtdd509wl339zqslg89u8l9atchf9568sdlgu4k",
@@ -5697,7 +5595,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "249"
+    "lp_token_id": "gamm/pool/249"
   },
   {
     "id": "osmo1pzdmgl6dnwnaers8ujawqet6fry3rxxkfwccrk0ypt8chx2prnasmlxc36",
@@ -5707,7 +5605,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "411"
+    "lp_token_id": "gamm/pool/411"
   },
   {
     "id": "osmo1pzhmczzq7fl7rp72x8zrcm792ndp4r8z6pthe2rcw9vsudna4tmqdw3mmv",
@@ -5717,7 +5615,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "852"
+    "lp_token_id": "gamm/pool/852"
   },
   {
     "id": "osmo1pzhzluks9p6esj0kam002a6chhxefeca86jpntlz8aewyvje69xq986agq",
@@ -5727,7 +5625,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "647"
+    "lp_token_id": "gamm/pool/647"
   },
   {
     "id": "osmo1pzm7keu64vrwlz4cwscjpx70fnn8cuuqwmx3qcl9qef2ctx092dshnpg5q",
@@ -5737,7 +5635,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "466"
+    "lp_token_id": "gamm/pool/466"
   },
   {
     "id": "osmo1q07hmk9ewecaa9mtnpz9uerq0tlfxj55yp2fg67lqy4xp704l5as56uq9e",
@@ -5747,7 +5645,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "759"
+    "lp_token_id": "gamm/pool/759"
   },
   {
     "id": "osmo1q2ej0ns7n3xt3tk9m85r8rd672rnprevd2hmth2azfctfkzkpk2qqjeezx",
@@ -5757,7 +5655,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "311"
+    "lp_token_id": "gamm/pool/311"
   },
   {
     "id": "osmo1q3f2z5ws7vyqrxpdswzh8ray0xwpawkr45wzc5232su0lf9j068q7wvp34",
@@ -5767,7 +5665,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "180"
+    "lp_token_id": "gamm/pool/180"
   },
   {
     "id": "osmo1q479s6ll6l2csetyv6jqs823qe5cexzuzeemjjdv7ej8tk2xhetsngy2kk",
@@ -5777,7 +5675,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "838"
+    "lp_token_id": "gamm/pool/838"
   },
   {
     "id": "osmo1q5xduzrk6v5n9jsn7nw9fqlnm6w06xkhc4p4w8gqxr9ujl08vlnq37eqdp",
@@ -5787,7 +5685,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "200"
+    "lp_token_id": "gamm/pool/200"
   },
   {
     "id": "osmo1q6qdde6364m22pgvz3pe2yykze9cxjyjhutdlserkfahwaugdfps35p85a",
@@ -5797,7 +5695,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "558"
+    "lp_token_id": "gamm/pool/558"
   },
   {
     "id": "osmo1q6qfznza2p9kcmnzywxj8w0ffkl6czfmwtrc97a6pdzdsc5xpyqswassc8",
@@ -5807,7 +5705,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "824"
+    "lp_token_id": "gamm/pool/824"
   },
   {
     "id": "osmo1q6wzn67t2fsg7sga6qj5skrafh6pd3pdtyss7jq35ukp8l86z45q42yueg",
@@ -5817,7 +5715,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "290"
+    "lp_token_id": "gamm/pool/290"
   },
   {
     "id": "osmo1q73hzfr0jfw84sx2rtuvr2v5xqve0jzz3qw6gq77gavxdh94c6nshw5erw",
@@ -5827,7 +5725,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "298"
+    "lp_token_id": "gamm/pool/298"
   },
   {
     "id": "osmo1q7ul5yz2ma5mjj8vkf5njjz859wk4u90ley2emfx8th4xyx6fg7se0z4hn",
@@ -5837,7 +5735,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "832"
+    "lp_token_id": "gamm/pool/832"
   },
   {
     "id": "osmo1q83j3062nnne65nsljaw0kwzsqam8ut7eheyzpr7ga56htsh20eqzr0vz6",
@@ -5847,7 +5745,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "186"
+    "lp_token_id": "gamm/pool/186"
   },
   {
     "id": "osmo1q8uvftta2c9r25mqxd89q76vdcagwjsg7q9t6c787seamzmpcuwq2wn5uc",
@@ -5857,7 +5755,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "327"
+    "lp_token_id": "gamm/pool/327"
   },
   {
     "id": "osmo1q9e2rxyu360hp69rg54up2k70sclp7uxl6mq79zrxkggquwkwfwqv9xgav",
@@ -5867,7 +5765,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "408"
+    "lp_token_id": "gamm/pool/408"
   },
   {
     "id": "osmo1q9m4xr0rlnh7t4rsq3cmjsunvc9lzrl6d3ww309zjmcryxqzrkus8h7lys",
@@ -5877,7 +5775,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "182"
+    "lp_token_id": "gamm/pool/182"
   },
   {
     "id": "osmo1qekmfz65ce08nee5c5caags2h24uhztjn9j6vr8uvnv4hcx44deq2xds6p",
@@ -5887,7 +5785,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "830"
+    "lp_token_id": "gamm/pool/830"
   },
   {
     "id": "osmo1qfu6489pfda4skcsv6defawyggetjdeer6n9ed60dn096ma5dxfsg3plhg",
@@ -5897,7 +5795,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "352"
+    "lp_token_id": "gamm/pool/352"
   },
   {
     "id": "osmo1qg99g3wn2a477eumpml8wgxnhyhjj0zjwlefsfjgpdk9zcm6kxqsdt7e7y",
@@ -5907,7 +5805,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "607"
+    "lp_token_id": "gamm/pool/607"
   },
   {
     "id": "osmo1qhd0uc9sc7psufty2y0u6ch2zpchtrljshr6jukly0n98yll759sncp98w",
@@ -5917,7 +5815,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "325"
+    "lp_token_id": "gamm/pool/325"
   },
   {
     "id": "osmo1qjfu245d9zn893y6c2z4rd689s0nyty4myvdmh6x39awag72n8uqgtcmea",
@@ -5927,7 +5825,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "336"
+    "lp_token_id": "gamm/pool/336"
   },
   {
     "id": "osmo1qjujmew5s65g97stpuckas77f9hypy84vs9x8p0e7cypwv7jph9sgguu2u",
@@ -5937,7 +5835,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "386"
+    "lp_token_id": "gamm/pool/386"
   },
   {
     "id": "osmo1qkwd25wehxz5m0ddgal6yc6a70ph552pnw7ptrj2h697jflpq6yshag46w",
@@ -5947,7 +5845,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "472"
+    "lp_token_id": "gamm/pool/472"
   },
   {
     "id": "osmo1ql58ecue9v3qlwfa9zjc64rw2sw9cwrpct7j779ers2jcm4q4ggqrmpq6v",
@@ -5957,7 +5855,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "543"
+    "lp_token_id": "gamm/pool/543"
   },
   {
     "id": "osmo1qlz6kfv2gyer5tfrlcn540atatq2xj0lmzzqgphguq5cm4rcscmqqvfggv",
@@ -5967,7 +5865,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "469"
+    "lp_token_id": "gamm/pool/469"
   },
   {
     "id": "osmo1qm24s5jk9mz8wtc5luad8fsenrp5v5m7prjmfhunm0plcyg74u2qrsr325",
@@ -5977,7 +5875,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "15"
+    "lp_token_id": "gamm/pool/15"
   },
   {
     "id": "osmo1qqff9yppkegxgnazg933cun78eaelxa9zp2mz5m94q9fds6s4k5qaz4a32",
@@ -5987,7 +5885,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "839"
+    "lp_token_id": "gamm/pool/839"
   },
   {
     "id": "osmo1qqtms0c5dfg4mlw4jgyj54tnr3cxznzrz2zutthxxgx4zz9559wsq0nlmw",
@@ -5997,17 +5895,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "840"
+    "lp_token_id": "gamm/pool/840"
   },
   {
     "id": "osmo1qtle736upg6t8nmra606axnvnm8fwvffugdfhsn2hs4f8mv7n2yqgvlwt2",
-    "asset_ids": [
-      "gamm/pool/464",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/464", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "486"
+    "lp_token_id": "gamm/pool/486"
   },
   {
     "id": "osmo1qvjyyc95dwwua5rhvlxf2y55qm3uq5m85063qn3vrvsuq0u59wgqnlaeq0",
@@ -6017,7 +5912,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "196"
+    "lp_token_id": "gamm/pool/196"
   },
   {
     "id": "osmo1qw2zv7uq5lav3gk0j7xjapa85w0q3s0s7zlv4dws2gey84vuew6skaqu0j",
@@ -6027,7 +5922,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "216"
+    "lp_token_id": "gamm/pool/216"
   },
   {
     "id": "osmo1qxdyvvnhtumm58pmhjlhhhe0pc3ye5apnma6tm0mx2r250zlga3qmn0z9j",
@@ -6037,7 +5932,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "283"
+    "lp_token_id": "gamm/pool/283"
   },
   {
     "id": "osmo1qxswx2sy9u0cpf9hrgqd29gjnudpjkpffkzjtplckjkkv7mjnh5s04vy0j",
@@ -6047,7 +5942,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "854"
+    "lp_token_id": "gamm/pool/854"
   },
   {
     "id": "osmo1qyys2gt072ke0dvhqk2mkqclr4hw2ajmsvcrz45x4x5p53rsrn2sr8nq30",
@@ -6057,7 +5952,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "846"
+    "lp_token_id": "gamm/pool/846"
   },
   {
     "id": "osmo1r52puhw7jqqx92h4r7eadpgnak5453yejda8p4de8t7whdychg2s4qtakx",
@@ -6067,7 +5962,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "232"
+    "lp_token_id": "gamm/pool/232"
   },
   {
     "id": "osmo1r5gj8e5pachzmsl5jphyw3njfr28jfzmykcz0w750tptzkyrhv9sf360an",
@@ -6077,17 +5972,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "802"
+    "lp_token_id": "gamm/pool/802"
   },
   {
     "id": "osmo1r5v05r30s0v75py3n3lhd7sq5cdgkaltles5rk0cmgndrdq7ktxqcn64y8",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "426"
+    "lp_token_id": "gamm/pool/426"
   },
   {
     "id": "osmo1r6xjt4ykjudgvlpnulk3jvuacjxew2xjag8frez4wprxkyspq8lq7j2edq",
@@ -6097,7 +5989,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "676"
+    "lp_token_id": "gamm/pool/676"
   },
   {
     "id": "osmo1r7m4vy9qfdpusvk02wyn3wln4amhz39sgvy2qyccjxq3a8drhwuss9feyu",
@@ -6107,7 +5999,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "324"
+    "lp_token_id": "gamm/pool/324"
   },
   {
     "id": "osmo1r82whw6efky7yjk6rlruf4pxva2crqtezkt7s095wulqrea2w46qkxm9wd",
@@ -6117,7 +6009,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "419"
+    "lp_token_id": "gamm/pool/419"
   },
   {
     "id": "osmo1r83hq5aynm6skjpxltxvrfk2ve4dn23mzczp5d2xcp9xth6skghqyn2zu8",
@@ -6127,7 +6019,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "638"
+    "lp_token_id": "gamm/pool/638"
   },
   {
     "id": "osmo1r8ed7qcfkvpqggzf5ckhfxzswjpgdxvkg78t3f92rr3mvla942dqq0fvj3",
@@ -6137,7 +6029,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "312"
+    "lp_token_id": "gamm/pool/312"
   },
   {
     "id": "osmo1rayrpuu7sravv2ug4gh8w0k769cmg2s7ykc6xen4777wm27l547qhcpzfk",
@@ -6147,7 +6039,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "901"
+    "lp_token_id": "gamm/pool/901"
   },
   {
     "id": "osmo1rcgcf8rx24qffmxv76xswwps8g3vcvcargf9zsq93uwlzgt3ymdq9errgw",
@@ -6157,7 +6049,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "727"
+    "lp_token_id": "gamm/pool/727"
   },
   {
     "id": "osmo1rclh8r9e0qtn284uusgqydgnjjv2d2w5v9e5ngrk0exzlua9x2ssnmtk48",
@@ -6167,7 +6059,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "583"
+    "lp_token_id": "gamm/pool/583"
   },
   {
     "id": "osmo1re957uvznxe6jme4zmzm5d95lajz5an7mrdus85faakrj45qa57sshx5g9",
@@ -6177,7 +6069,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "155"
+    "lp_token_id": "gamm/pool/155"
   },
   {
     "id": "osmo1replyw8a8pp2t78k9adu35zhg7l9npknka2teh58zyt6emkg3xusyt0xew",
@@ -6187,7 +6079,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "245"
+    "lp_token_id": "gamm/pool/245"
   },
   {
     "id": "osmo1rk8tjedu75vr3s0usxulggkw5kfazcmv6gq72429nvdc468mf3wq67xw8g",
@@ -6197,7 +6089,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "342"
+    "lp_token_id": "gamm/pool/342"
   },
   {
     "id": "osmo1rmhusclghxyvyxr9kq4nuum9pvsgplfpuvq0x5d0ufaaxrwkefqsardn6n",
@@ -6207,7 +6099,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "796"
+    "lp_token_id": "gamm/pool/796"
   },
   {
     "id": "osmo1rp8xap0z59k20fkt7078q8g4t37ee8reqpwt6afgglhe3h70hvls9xl5c4",
@@ -6217,7 +6109,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "885"
+    "lp_token_id": "gamm/pool/885"
   },
   {
     "id": "osmo1rpu7k863l2pmdcw95452j487jxrh0mp77au489z3gjq7quhnk75st72zs4",
@@ -6227,7 +6119,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "765"
+    "lp_token_id": "gamm/pool/765"
   },
   {
     "id": "osmo1rq2qekdlt662cjr7zx5xknctju7zd4j8xhk7e0qcnsl4g2u0yr6qpej2sl",
@@ -6237,7 +6129,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "343"
+    "lp_token_id": "gamm/pool/343"
   },
   {
     "id": "osmo1rrje5862udx9e0en3qve8539gvh33rfgfpzel9jxxvnjxxzmrnmqpc3vcz",
@@ -6247,7 +6139,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "645"
+    "lp_token_id": "gamm/pool/645"
   },
   {
     "id": "osmo1rsr5pqt50eml482jhtg44mx9nc555wjd90vhz4hwkmrm7qngqx9sr3pvvp",
@@ -6257,7 +6149,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "763"
+    "lp_token_id": "gamm/pool/763"
   },
   {
     "id": "osmo1ruqysu3pjzyv35w3fwk8mjprz8ludwc9xgexlvse40yqxd5hnmlqzlgjkm",
@@ -6267,7 +6159,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "752"
+    "lp_token_id": "gamm/pool/752"
   },
   {
     "id": "osmo1rv4ercmn82tl55su3e79j2cvatgewx8qesqtgm3d9n7r6fy33esqektmlm",
@@ -6277,7 +6169,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "622"
+    "lp_token_id": "gamm/pool/622"
   },
   {
     "id": "osmo1rvlrxqytp0f6rw8k9g6j5y3t45l9v26l40y2rplh00a3ape2chesgq2dc7",
@@ -6287,7 +6179,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "377"
+    "lp_token_id": "gamm/pool/377"
   },
   {
     "id": "osmo1rwswjnqfhkl8der73ac3q9ydcms8qkwcypksnu8pg2y5kf7enqjq8fas74",
@@ -6297,17 +6189,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "321"
+    "lp_token_id": "gamm/pool/321"
   },
   {
     "id": "osmo1rxur0nsztn90mua2zv7ectqeht7ujzdfnfzwuny25da4k8vla4rsy8hls8",
-    "asset_ids": [
-      "gamm/pool/1",
-      "gamm/pool/7"
-    ],
+    "asset_ids": ["gamm/pool/1", "gamm/pool/7"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "429"
+    "lp_token_id": "gamm/pool/429"
   },
   {
     "id": "osmo1ryh98w99c3a26fjw09e4xd46jd00qfh2y9g38fk9zcd4ady5h0nqzpyvfx",
@@ -6317,7 +6206,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "165"
+    "lp_token_id": "gamm/pool/165"
   },
   {
     "id": "osmo1rysdtqarh8y3yzlmpjwuaqvh3rhhqznqkex35wmhaxrvuqegvu3syuz3wa",
@@ -6327,7 +6216,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "646"
+    "lp_token_id": "gamm/pool/646"
   },
   {
     "id": "osmo1rz76daxyz9vhf079ahgr6l76uah9xvhe65vu8dqyf5nq7674d3yss96x7w",
@@ -6337,7 +6226,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "530"
+    "lp_token_id": "gamm/pool/530"
   },
   {
     "id": "osmo1rzsrh74px4ycnvwk936ycujp2q7ndhnvka7pt65pukvkvnpskfkqxf47ue",
@@ -6347,7 +6236,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "417"
+    "lp_token_id": "gamm/pool/417"
   },
   {
     "id": "osmo1s2gwy72r2dnpk0dpfs0aftz7rahxsuglz30qkqdgzqsrpczyeexqay78uk",
@@ -6357,7 +6246,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "205"
+    "lp_token_id": "gamm/pool/205"
   },
   {
     "id": "osmo1s3x4ey025k3ew7pamenlh89twqcd496rg0c9ye2ydnrxe6y68z8ss3g7az",
@@ -6367,27 +6256,21 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "706"
+    "lp_token_id": "gamm/pool/706"
   },
   {
     "id": "osmo1s46juu2q7ets8tgqaytaaekfs5qu259tkex87ll068xsvfcf8uas6rkavc",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "598"
+    "lp_token_id": "gamm/pool/598"
   },
   {
     "id": "osmo1s4eem3yk9de5xk8wr9gs9shc2905skd7h4e589cqs94pyrqem5jqn8y2ru",
-    "asset_ids": [
-      "gamm/pool/410",
-      "gamm/pool/411"
-    ],
+    "asset_ids": ["gamm/pool/410", "gamm/pool/411"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "413"
+    "lp_token_id": "gamm/pool/413"
   },
   {
     "id": "osmo1s666n6f6qhw2hcgkmwx3jxl7hz35cytrygmcvzcxxt84e8nrjfus4wyknj",
@@ -6397,7 +6280,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "739"
+    "lp_token_id": "gamm/pool/739"
   },
   {
     "id": "osmo1s6nlndkuna63w5kk5npduwful69urrfvdlhn74awcan2dpx43xpsr4cxf9",
@@ -6407,7 +6290,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "527"
+    "lp_token_id": "gamm/pool/527"
   },
   {
     "id": "osmo1s7p0al0sygrqumxlwhw0wfdazdasgew8wx0vspvhf7fwkfcxy03q3x7rcs",
@@ -6417,7 +6300,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "199"
+    "lp_token_id": "gamm/pool/199"
   },
   {
     "id": "osmo1sf7twk9v5kkkredzk465wqk6s959ttuaf4683quu28q459e3jmlqkss6pa",
@@ -6427,7 +6310,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "556"
+    "lp_token_id": "gamm/pool/556"
   },
   {
     "id": "osmo1sfqrusqfe0rfydt7aj8vwe59ujleu9zt6t7zrz58y0uv50sm7vpqvw2sdt",
@@ -6437,7 +6320,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "219"
+    "lp_token_id": "gamm/pool/219"
   },
   {
     "id": "osmo1shzv0vcddhe0jh4wdh2xudrrw20uzu96ugsmyv29p5zscpk85snsmyjnjl",
@@ -6447,7 +6330,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "790"
+    "lp_token_id": "gamm/pool/790"
   },
   {
     "id": "osmo1sknzx8cw662aspm7f5xygfhuh9hkf76qqgqwshaqhmp9m920ahlqanwq25",
@@ -6457,7 +6340,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "36"
+    "lp_token_id": "gamm/pool/36"
   },
   {
     "id": "osmo1skxw2mkpqnja6me7hmee5xu0l3h76a5jsahnwtk7tgeqszx0l33s6depu9",
@@ -6467,7 +6350,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "754"
+    "lp_token_id": "gamm/pool/754"
   },
   {
     "id": "osmo1sl6dla60tg44s0qk56sjvu6rhpuzfedd2xs3vm6es9v4q5smd7lqt0rgct",
@@ -6477,7 +6360,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "816"
+    "lp_token_id": "gamm/pool/816"
   },
   {
     "id": "osmo1snexrsplcnsstsmwp99jf3uua2f9pazcd0drgmmfr6kj22sdwm7scdkrdj",
@@ -6487,7 +6370,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "62"
+    "lp_token_id": "gamm/pool/62"
   },
   {
     "id": "osmo1spsg7ka3mfknz2s8h6y8qg2azku322mfe3ryvluyhrygh6j4rr3s6ra4ca",
@@ -6497,7 +6380,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "161"
+    "lp_token_id": "gamm/pool/161"
   },
   {
     "id": "osmo1sqan5vpspvyqtjj4spykrstq7ltgkvdsxuky5rurzzswejsdgd9qes5tjx",
@@ -6507,7 +6390,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "78"
+    "lp_token_id": "gamm/pool/78"
   },
   {
     "id": "osmo1ssj7weswfdu3lz737evr5plqvgaqk28fl4akc085gghlxnu0qwvqdms4jc",
@@ -6517,7 +6400,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "222"
+    "lp_token_id": "gamm/pool/222"
   },
   {
     "id": "osmo1stxalepejns0zm5rpq09jxwcg98r4a2m86kx9n598t32l079pwcsd2wg5n",
@@ -6527,7 +6410,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "197"
+    "lp_token_id": "gamm/pool/197"
   },
   {
     "id": "osmo1svp9sxdq6qq4k2qpy8ldcf9368eejnawajcetpggpxkj5v5thvaswn32xf",
@@ -6537,7 +6420,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "414"
+    "lp_token_id": "gamm/pool/414"
   },
   {
     "id": "osmo1szh2gzzsugx6e5vs7emkcrmcy87zg75jst8xemdp896v33u5f5eqt395ku",
@@ -6547,7 +6430,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "356"
+    "lp_token_id": "gamm/pool/356"
   },
   {
     "id": "osmo1szvslwsxf3y2s4lt3c7e7mm92zgy44j8krruht5zzanmhrjwyc4qqpt5nz",
@@ -6557,7 +6440,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "621"
+    "lp_token_id": "gamm/pool/621"
   },
   {
     "id": "osmo1t0k2etaylj6w3tjs5wgn068hz4uyj7fpzs8707a4v02pj580mlrq9fyem2",
@@ -6567,7 +6450,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "738"
+    "lp_token_id": "gamm/pool/738"
   },
   {
     "id": "osmo1t0lgy5t88ctq2ur4xzjuk2rw6laxt434hsjn6shzwn7w0tph7z2s9p7qdc",
@@ -6577,7 +6460,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "819"
+    "lp_token_id": "gamm/pool/819"
   },
   {
     "id": "osmo1t2m0y54hrjmvs2zvxgy8005fjg4atqmveg9jafvzmqw64l42aawspdgj9z",
@@ -6587,7 +6470,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "328"
+    "lp_token_id": "gamm/pool/328"
   },
   {
     "id": "osmo1t2qlvhu8766gmcgs7jnpyx5ey2hfje6uhjffgsn0rgzu3xx7cuzsl9wgt6",
@@ -6597,7 +6480,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "655"
+    "lp_token_id": "gamm/pool/655"
   },
   {
     "id": "osmo1t3de20l6jhz6gpx7v48upxzfkgu7d3r8nclkr5h7z53mvc7mfqyqcyqe25",
@@ -6607,7 +6490,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "440"
+    "lp_token_id": "gamm/pool/440"
   },
   {
     "id": "osmo1t7zz28h30kjmd5rt0yg4gzd8g4ne0y6gpr5rf2zvsj6gs3fmcf8swfrmp8",
@@ -6617,7 +6500,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "394"
+    "lp_token_id": "gamm/pool/394"
   },
   {
     "id": "osmo1t9hcnngffyvx3jagrr5wwetkdu3at3sf50a8jdfj7rwe7cyq8tks6t9cz0",
@@ -6627,7 +6510,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "382"
+    "lp_token_id": "gamm/pool/382"
   },
   {
     "id": "osmo1taqxtna5e558fvstm2065n3zaej3ya2x3vv49a27uun80vduvk3ss4tscg",
@@ -6637,7 +6520,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "330"
+    "lp_token_id": "gamm/pool/330"
   },
   {
     "id": "osmo1tf2uj9pdmkys6wzk2fwpcnp5x90lc9t5y8qw4ha2mms2nc5kkkesu3zj54",
@@ -6647,7 +6530,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "559"
+    "lp_token_id": "gamm/pool/559"
   },
   {
     "id": "osmo1tg2k5rxex7zhzh3rcvmy6a2yfvw8446ezk7utz8j80vmkrpjve2qljc6hk",
@@ -6657,7 +6540,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "803"
+    "lp_token_id": "gamm/pool/803"
   },
   {
     "id": "osmo1tgdxkfgc6k6fg9k8e3vpdkwxtwltx93ywfx959yn2e5ysxxpr7vsffd9jn",
@@ -6667,7 +6550,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "220"
+    "lp_token_id": "gamm/pool/220"
   },
   {
     "id": "osmo1tgza0v4m0tlkgsew6jjup3zaqcv7qyx58gfzct8xyfx3d9vsv3mqetw8c7",
@@ -6677,7 +6560,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "185"
+    "lp_token_id": "gamm/pool/185"
   },
   {
     "id": "osmo1thscstwxp87g0ygh7le3h92f9ff4sel9y9d2eysa25p43yf43rysk7jp93",
@@ -6687,7 +6570,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "604"
+    "lp_token_id": "gamm/pool/604"
   },
   {
     "id": "osmo1tl43tjmylclp37jduelnwrzeyuef2unxn9c04wrlakmgvzsnmgtqqet6za",
@@ -6697,7 +6580,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "628"
+    "lp_token_id": "gamm/pool/628"
   },
   {
     "id": "osmo1trzwktd05mqzn8arhczsf7lwvmmfxmuducfvp3upzmlzs7jl38dscuprsg",
@@ -6707,7 +6590,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "637"
+    "lp_token_id": "gamm/pool/637"
   },
   {
     "id": "osmo1tusadtwjnzzyakm94t5gjqr4dlkdcp63hctlql6xvslvkf7kkdws5lfyxc",
@@ -6717,7 +6600,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "498"
+    "lp_token_id": "gamm/pool/498"
   },
   {
     "id": "osmo1tuxr32k9pmshd5v2tuf89e2npc7j299cmpzscc74ec59xzkrr6fqmy2eda",
@@ -6727,7 +6610,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "822"
+    "lp_token_id": "gamm/pool/822"
   },
   {
     "id": "osmo1tvfrcswx4c0dsma5z2nmuct34dresknmmaay0lrpsu0wsgh9q08qkv0zj2",
@@ -6737,7 +6620,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "612"
+    "lp_token_id": "gamm/pool/612"
   },
   {
     "id": "osmo1tvv7j7c7hmantw8rkkkkhr2hx6kpckc5zkvnce30la6m048nckms0s5076",
@@ -6747,7 +6630,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "243"
+    "lp_token_id": "gamm/pool/243"
   },
   {
     "id": "osmo1tx2ewuhrm0ypyuud04lslhwg5cwnn5ykxsqx49p9l2l94fn7tr2qw9um6j",
@@ -6757,7 +6640,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "318"
+    "lp_token_id": "gamm/pool/318"
   },
   {
     "id": "osmo1txawpctjs6phpqsnkx2r5qud7yvekw93394anhuzz4dquy5jggssgqtn0l",
@@ -6767,7 +6650,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "42"
+    "lp_token_id": "gamm/pool/42"
   },
   {
     "id": "osmo1ty9g3v2xpn70v7pw2jmzmy6npdsdw4e9yd9l5na9rs8qpjhnk89sawgrnw",
@@ -6777,7 +6660,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "599"
+    "lp_token_id": "gamm/pool/599"
   },
   {
     "id": "osmo1tyjwq32pxv3xvpcdkkc8lp3gxkjdlll53grsjkqce3nsjctl328qpqfvj2",
@@ -6787,7 +6670,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "495"
+    "lp_token_id": "gamm/pool/495"
   },
   {
     "id": "osmo1u05s34q3hk8mu3ypw6g5eqvfdvcllck8zualccz2p75lmdnmwgaszyg9ez",
@@ -6797,7 +6680,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "508"
+    "lp_token_id": "gamm/pool/508"
   },
   {
     "id": "osmo1u0mjawl7cr9qjk5zfgmat5tlqgxgj5n999kal34kuu9k0mxrghqsm58fep",
@@ -6807,7 +6690,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "384"
+    "lp_token_id": "gamm/pool/384"
   },
   {
     "id": "osmo1u0xmctf2dcz3qvmkhcp8prdq2xktnryyq6lshcccyr3jwfvpf9wq0rq3xy",
@@ -6817,7 +6700,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "157"
+    "lp_token_id": "gamm/pool/157"
   },
   {
     "id": "osmo1u3402aty7hhz9zpsg4kkvcxs6skg6ly8lrrmky79tcuhccszk3vq59x0t2",
@@ -6827,7 +6710,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "260"
+    "lp_token_id": "gamm/pool/260"
   },
   {
     "id": "osmo1u4nna8ml32n0u3fwcrfl0c3e7j8feaay0l5nzc2z850us2dkd9jqmvumll",
@@ -6837,7 +6720,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "86"
+    "lp_token_id": "gamm/pool/86"
   },
   {
     "id": "osmo1u66wkjthdjxnavklpef7yzasdrvvqhckmhkqsw8uwlad3uaktr3qvny8k4",
@@ -6847,7 +6730,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "681"
+    "lp_token_id": "gamm/pool/681"
   },
   {
     "id": "osmo1u6wc5hkhg50kxdn9l8pye6zt6jvh5czeej86r4c6segzt0sw6wnsn7rj2x",
@@ -6857,7 +6740,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "280"
+    "lp_token_id": "gamm/pool/280"
   },
   {
     "id": "osmo1u7uh9vvf85la2ukh60td0q07aq0mnvthxe7x0rutc0envm9865cqjesutw",
@@ -6867,7 +6750,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "736"
+    "lp_token_id": "gamm/pool/736"
   },
   {
     "id": "osmo1uc9j2thyq26jvktz4dsnya508dzr6ksjgl2w0lspsf2rdt64qu2qvgdz52",
@@ -6877,7 +6760,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "46"
+    "lp_token_id": "gamm/pool/46"
   },
   {
     "id": "osmo1udj4gj4hx5l3k24qvn2cd08vmg7m6ewmxp65lxzfp2dq9xeqmv0s6kl8a7",
@@ -6887,7 +6770,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "366"
+    "lp_token_id": "gamm/pool/366"
   },
   {
     "id": "osmo1ueg0m04nxj230juk08w9hlua8uupp3jgeclzllk98fzq592xly8q6zgg4w",
@@ -6897,7 +6780,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "465"
+    "lp_token_id": "gamm/pool/465"
   },
   {
     "id": "osmo1ufuvzzlzu6qpre7hg2tkkm8st3qrx9g8ja4e9empma3kt9adqjcquklmqc",
@@ -6907,7 +6790,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "397"
+    "lp_token_id": "gamm/pool/397"
   },
   {
     "id": "osmo1ugdp9q0nzcsmlllk9acvvuvt4h6g8fy0gspwgdtue06ya0vk4khqdka26t",
@@ -6917,7 +6800,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "258"
+    "lp_token_id": "gamm/pool/258"
   },
   {
     "id": "osmo1uhpsqy52rs5dkwfpua5qulc4rcaw7y857zha0skzp3yxnd0k9k6ss44rjs",
@@ -6927,7 +6810,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "642"
+    "lp_token_id": "gamm/pool/642"
   },
   {
     "id": "osmo1uny6uzpdfqa9q2cea7ycnuwfr8s6c2zvyt6s7yh2rvvzt0zvhl6q6hdhdu",
@@ -6937,7 +6820,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "98"
+    "lp_token_id": "gamm/pool/98"
   },
   {
     "id": "osmo1uppkz7d2r68qalz483ppa9w2z2lt0j35ext23vk0djtd9kh85g2qk66tlm",
@@ -6947,7 +6830,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "521"
+    "lp_token_id": "gamm/pool/521"
   },
   {
     "id": "osmo1upzrcc4clr9cgttqqkfrt8yz73swd085edn8yfhtv65k2jansdlqnvnfyt",
@@ -6957,7 +6840,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "573"
+    "lp_token_id": "gamm/pool/573"
   },
   {
     "id": "osmo1uqzdmre9vd0y9uzzm03umja3l9wmqdx3enl8fkfh9xa26yq7m77sx7xfkc",
@@ -6967,7 +6850,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "820"
+    "lp_token_id": "gamm/pool/820"
   },
   {
     "id": "osmo1utasxm8e2h7jermwv8mrv55nyphnpnkm2zrqzvn8hstx927s4q3sfkfprw",
@@ -6977,7 +6860,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "880"
+    "lp_token_id": "gamm/pool/880"
   },
   {
     "id": "osmo1uvsrputqqa8g2dg3s9673w4r6yj8dclfzr4ctsk9jtgwvjwxjq7q297cdn",
@@ -6987,7 +6870,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "396"
+    "lp_token_id": "gamm/pool/396"
   },
   {
     "id": "osmo1uxp60ju3h8ghmm2hae9adfulscrg2me5pr9zvl07lngmj0nr7lksqwfv32",
@@ -6997,7 +6880,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "784"
+    "lp_token_id": "gamm/pool/784"
   },
   {
     "id": "osmo1uxqg4sr2yqvamc96n4kwkgna6nmmgtypfdn2gjhvwgymuunq3qlswyrdhg",
@@ -7007,7 +6890,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "725"
+    "lp_token_id": "gamm/pool/725"
   },
   {
     "id": "osmo1uyhjnu2l0qfxs3ltt2nuq6lx2fs8ff34684f0hw7sf557enrkd2ql6r2sl",
@@ -7017,7 +6900,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "239"
+    "lp_token_id": "gamm/pool/239"
   },
   {
     "id": "osmo1uyhzfnjxp6a9gq3020f8d45ueszr5sj72p5cfry7hzg0zderhvzsscrkvx",
@@ -7027,7 +6910,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "878"
+    "lp_token_id": "gamm/pool/878"
   },
   {
     "id": "osmo1v009a23dwz827gk4p23sf4tz0chyuwkht0ygerp2v09qhpmxw5eq52q9n7",
@@ -7037,7 +6920,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "286"
+    "lp_token_id": "gamm/pool/286"
   },
   {
     "id": "osmo1v2982uaxxxmfyykkcusc2jlgrh43l6q646gdd27skr2smq8d8cwqksnw4j",
@@ -7047,7 +6930,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "902"
+    "lp_token_id": "gamm/pool/902"
   },
   {
     "id": "osmo1v38v9n62pm4ktce0khdglyxzr3f8jdlahdux87q9m8x6uz4zfkesjv8wga",
@@ -7057,7 +6940,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "663"
+    "lp_token_id": "gamm/pool/663"
   },
   {
     "id": "osmo1v4gaqzdvmhdm4varxsd3qc385jser59vgpcxm8f5u9e9sjp58lzqlaw3kw",
@@ -7067,7 +6950,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "804"
+    "lp_token_id": "gamm/pool/804"
   },
   {
     "id": "osmo1v4ulnkt7dj9903qvyeqz6d5u3rpjttcy6vzydt5gurqxunxyghgqw0u2d4",
@@ -7077,7 +6960,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "113"
+    "lp_token_id": "gamm/pool/113"
   },
   {
     "id": "osmo1v5cueex2ajn35u8a3mr586vy9xf2tzl3n5ylghnwrc9ssnwwydnsk5gvm6",
@@ -7087,7 +6970,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "578"
+    "lp_token_id": "gamm/pool/578"
   },
   {
     "id": "osmo1v5eg7ch5gfj6aewdahuplj7ddhrlhq9cugp98lznnf542g4f9vgsv2lvxf",
@@ -7097,7 +6980,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "317"
+    "lp_token_id": "gamm/pool/317"
   },
   {
     "id": "osmo1v6py2esnzl6pe6pg6mr42n37qrvcryavq3zjamwpa5csdayrgfts8dz4fx",
@@ -7107,7 +6990,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "170"
+    "lp_token_id": "gamm/pool/170"
   },
   {
     "id": "osmo1v8289lc5hweg6qr3jhhsy3d4m2lf8663xz4fkwv8jcc5k3chgkwsxwky24",
@@ -7117,7 +7000,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "659"
+    "lp_token_id": "gamm/pool/659"
   },
   {
     "id": "osmo1v8f030n78vpwrswjuppndv2h3p775g0q39znmew8tw6jv89fk5wsahrtk9",
@@ -7127,7 +7010,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "150"
+    "lp_token_id": "gamm/pool/150"
   },
   {
     "id": "osmo1v9r9d4xk9j2r3m59hcnsy7037wu75ymyg6nc0em23rpwmp9nj3yqgz5wvw",
@@ -7137,7 +7020,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "778"
+    "lp_token_id": "gamm/pool/778"
   },
   {
     "id": "osmo1val3zsn82xutf9tnadwxahva6cs9mscxkq7y9dhjpl5lvrqdp5xslvllw0",
@@ -7147,7 +7030,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "801"
+    "lp_token_id": "gamm/pool/801"
   },
   {
     "id": "osmo1vdlumhjnpdngk80dmuyq4vdngew4fscvlhq4tpgy8c8edswqapwse9987x",
@@ -7157,17 +7040,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "799"
+    "lp_token_id": "gamm/pool/799"
   },
   {
     "id": "osmo1vedjqp8mzcr5yg8h0s75lg0l074nx8leqkj0efzvha8wpdus3nxq0myg32",
-    "asset_ids": [
-      "gamm/pool/10",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/10", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "101"
+    "lp_token_id": "gamm/pool/101"
   },
   {
     "id": "osmo1vgmqyyu3gmnyr8w3g27uf5l02p76jz4gvjcwzrp40cjh55xht4qsrdmdsy",
@@ -7177,7 +7057,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "605"
+    "lp_token_id": "gamm/pool/605"
   },
   {
     "id": "osmo1vlqfs02w9l4ygp9wnkfpr54av4vdzea4czytvuccc5628pz7amzs2tftm6",
@@ -7187,7 +7067,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "893"
+    "lp_token_id": "gamm/pool/893"
   },
   {
     "id": "osmo1vmhq9xqcr702fspu9qmf22ggzu8fh4d374zs487068m4p5xh694sxgxza8",
@@ -7197,7 +7077,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "461"
+    "lp_token_id": "gamm/pool/461"
   },
   {
     "id": "osmo1vnw5jmjusus6drlae4nv4l2dn2vg90lav77dvphj0r3gn9x2rh8qmz9ckh",
@@ -7207,7 +7087,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "369"
+    "lp_token_id": "gamm/pool/369"
   },
   {
     "id": "osmo1vp0kxdq263kzawqmv394tjevw7useexp2hhh7835cjqjl28nkpmsum5nhn",
@@ -7217,7 +7097,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "473"
+    "lp_token_id": "gamm/pool/473"
   },
   {
     "id": "osmo1vp9mwqrxt4dsyu4c0hzjpl79sw483wkqsfq8m7jrmjh9775ddn5snw8ccv",
@@ -7227,7 +7107,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "857"
+    "lp_token_id": "gamm/pool/857"
   },
   {
     "id": "osmo1vsadpr4k8xu6ply4yw084tjgyrqkeee99ktnjjjfus44pyzcs6mq5ml9xj",
@@ -7237,7 +7117,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "540"
+    "lp_token_id": "gamm/pool/540"
   },
   {
     "id": "osmo1vtqgpkdd7taj8ssw4rlcd7ulu7wgmujfxlyaa3qkfztva07pm0sq2qkscy",
@@ -7247,7 +7127,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "911"
+    "lp_token_id": "gamm/pool/911"
   },
   {
     "id": "osmo1vx63kemxaxedvulz9xh45d9k0gc7udec35gy4my9f7tzywfeqljs52vdzf",
@@ -7257,7 +7137,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "898"
+    "lp_token_id": "gamm/pool/898"
   },
   {
     "id": "osmo1vyra2jgneztsn207a39dk5jhj7xu3ruh7hwuaq9jmmlf7averklq9lx3k4",
@@ -7267,7 +7147,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "460"
+    "lp_token_id": "gamm/pool/460"
   },
   {
     "id": "osmo1vyz8a2xv27nj2t4xwm6h6rqpt6fhea08fsmg56tdlep7n3k3t2tsks5fxr",
@@ -7277,7 +7157,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "574"
+    "lp_token_id": "gamm/pool/574"
   },
   {
     "id": "osmo1w3dsuh2hcp90vmhwrdxxftgm44edlcvn8xtzfvq2h457ma8hm00smpxet2",
@@ -7287,7 +7167,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "235"
+    "lp_token_id": "gamm/pool/235"
   },
   {
     "id": "osmo1w3e7ywcnj6090nedg39p34mwthpuq25ly8d92kzg0pdx9kptlesswcj39s",
@@ -7297,7 +7177,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "916"
+    "lp_token_id": "gamm/pool/916"
   },
   {
     "id": "osmo1w4w9gj02z3hv7qlry8mpju625qrevrtf2f2nmywu45j3j4mnahuskfrf38",
@@ -7307,7 +7187,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "90"
+    "lp_token_id": "gamm/pool/90"
   },
   {
     "id": "osmo1w5awgnxgthpwdh4nl25ymdx78x8cnjepdh6ju7ep6gaq5up35l9qhzkfyz",
@@ -7317,7 +7197,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "594"
+    "lp_token_id": "gamm/pool/594"
   },
   {
     "id": "osmo1w7na4s0suuchqfqsz0fyszu2udc68wgxsgk3vsrtvzdfyyfseevsufcx4e",
@@ -7327,7 +7207,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "276"
+    "lp_token_id": "gamm/pool/276"
   },
   {
     "id": "osmo1w9rj85ugnk29uepdglrhuhusdx0wwh4ep5vks92apfryaeu9pq9q7yv3gm",
@@ -7337,7 +7217,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "288"
+    "lp_token_id": "gamm/pool/288"
   },
   {
     "id": "osmo1wea46n3f86um4dp37t43pwpurcky9e7lz56tujrtcql9yx6sphtqee256z",
@@ -7347,17 +7227,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "529"
+    "lp_token_id": "gamm/pool/529"
   },
   {
     "id": "osmo1wehlg2lrvqxjmy26ghkqdj4c653se5kr646z9rwwfflutj25dvnsn6ef3f",
-    "asset_ids": [
-      "gamm/pool/123",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/123", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "284"
+    "lp_token_id": "gamm/pool/284"
   },
   {
     "id": "osmo1wfghlu9wguwrdrrv3su4fzkmsc80et9k2x796k6q4n0yvn2fx5wqe0mpve",
@@ -7367,7 +7244,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "742"
+    "lp_token_id": "gamm/pool/742"
   },
   {
     "id": "osmo1wh6azmp9dxraquxt2gyppgeyuvta2r3s3s72cx7xr6nprh8kgj4sl3qf0x",
@@ -7377,7 +7254,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "548"
+    "lp_token_id": "gamm/pool/548"
   },
   {
     "id": "osmo1wjeftfc4708ly99x8mpty0faedwqmu6hw20v7dwxyma4vvn3u4jqmh9zh7",
@@ -7387,7 +7264,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "126"
+    "lp_token_id": "gamm/pool/126"
   },
   {
     "id": "osmo1wjggh0jgm6mukp2rjcyas5w5eep20yqgxjcn9eqxh4rktcdku4aspnq4ka",
@@ -7397,17 +7274,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "137"
+    "lp_token_id": "gamm/pool/137"
   },
   {
     "id": "osmo1wkspj354sp059377j67mk6uy48t7u2cm86609nq7xht47hj9mkzs39x3fd",
-    "asset_ids": [
-      "gamm/pool/1",
-      "uosmo"
-    ],
+    "asset_ids": ["gamm/pool/1", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "152"
+    "lp_token_id": "gamm/pool/152"
   },
   {
     "id": "osmo1wlqxs0yh5m46hz5kaq2jmzc0vetrykej4zjm25kcpe9crxnvfxtqrnker2",
@@ -7417,7 +7291,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "714"
+    "lp_token_id": "gamm/pool/714"
   },
   {
     "id": "osmo1wtd5nrx9f2uwu32z3njuhxtzxj4qcedrjlyrsm6q073yp84ryjgs5tgtq3",
@@ -7427,7 +7301,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "733"
+    "lp_token_id": "gamm/pool/733"
   },
   {
     "id": "osmo1wv6v6mgychqdmf9fj5esyrethnu86akn6gyqq7rlexacjjcht37qfsqjdl",
@@ -7437,7 +7311,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "698"
+    "lp_token_id": "gamm/pool/698"
   },
   {
     "id": "osmo1wxkx8kq5uvt4snu77ezhxclpecv95t3jyvagte8em9j6dk3jgczs66quh3",
@@ -7447,7 +7321,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "715"
+    "lp_token_id": "gamm/pool/715"
   },
   {
     "id": "osmo1wy5zsjq8mzyehg7g72hsf0v487a2h87sr30wzztjx9h0ct593zysl6444w",
@@ -7457,7 +7331,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "636"
+    "lp_token_id": "gamm/pool/636"
   },
   {
     "id": "osmo1wyv2pa3xmrfgjgkd9s6v0e23dud2va6kgaaknyqm6kly6x228xvsh45uug",
@@ -7467,7 +7341,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "120"
+    "lp_token_id": "gamm/pool/120"
   },
   {
     "id": "osmo1wyz6659ctwd28cq5nlw9a4jslm7nxydvg3uex2xmcl8y9fd49tjsfegg38",
@@ -7477,7 +7351,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "309"
+    "lp_token_id": "gamm/pool/309"
   },
   {
     "id": "osmo1x0ptme5tp8r2qw8gsypg3qftfwfpt2hdk4jyvp7gryywmg5l9fsqvhs8fk",
@@ -7487,7 +7361,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "806"
+    "lp_token_id": "gamm/pool/806"
   },
   {
     "id": "osmo1x20esk0tjalpqjf6x8rz9plrlc8yam36c39lmqpm080dsyg6klhq4jdnvx",
@@ -7497,7 +7371,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "644"
+    "lp_token_id": "gamm/pool/644"
   },
   {
     "id": "osmo1x2cwskve25argave9s4392lwygg7j9fzxhxra97tvvpt80kvzxsswm0hqu",
@@ -7507,7 +7381,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "657"
+    "lp_token_id": "gamm/pool/657"
   },
   {
     "id": "osmo1x2wr6fllcwv9jmcwtq3lwjvuyutmcxf55q8a853jylah057lhl8scgqn06",
@@ -7517,7 +7391,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "690"
+    "lp_token_id": "gamm/pool/690"
   },
   {
     "id": "osmo1x5rh04vsyxx2u8enwpawhplmrhk7yrq82ulpj9wjcrt6j5y5n44q8vy2da",
@@ -7527,7 +7401,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "785"
+    "lp_token_id": "gamm/pool/785"
   },
   {
     "id": "osmo1x6fpwjj6ur324atc4p2whc3rsdkaj2ecs4z5ckeu38eljv70mswqlmpqem",
@@ -7537,7 +7411,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "914"
+    "lp_token_id": "gamm/pool/914"
   },
   {
     "id": "osmo1x6uvl8ef00hwl2ymgxfq40q9zjnykjw9u2w55466yl256lpqdpgqs9hpfg",
@@ -7547,7 +7421,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "63"
+    "lp_token_id": "gamm/pool/63"
   },
   {
     "id": "osmo1x9g0qwks7t6u47cxnnqg6jyfaxczwk678eedr7z890n8dnwtx9fqvqwzkx",
@@ -7557,7 +7431,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "124"
+    "lp_token_id": "gamm/pool/124"
   },
   {
     "id": "osmo1x9pjf7ehhdlfy035xy0t8rwp3dke6vhcdrtw2s35727ceh7ra7vslncd3q",
@@ -7567,7 +7441,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "721"
+    "lp_token_id": "gamm/pool/721"
   },
   {
     "id": "osmo1xct94me26df4k2fs6waecnvzca8dzv2jxl798tndqq3ync3tdkqskpn5cl",
@@ -7577,7 +7451,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "709"
+    "lp_token_id": "gamm/pool/709"
   },
   {
     "id": "osmo1xe9d4uyaq5ek8u85kgvxusdadnx7u9k09cauv4f8gn9e7xr4xycq7rwn88",
@@ -7587,7 +7461,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "87"
+    "lp_token_id": "gamm/pool/87"
   },
   {
     "id": "osmo1xf4n7h4fqt0qlc5gagfhu36n7jm05vrn8yhnf6kcxcjasf9u8eas585xt7",
@@ -7597,7 +7471,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "416"
+    "lp_token_id": "gamm/pool/416"
   },
   {
     "id": "osmo1xfs2qqsx3vpy3nc2rna332afmk48sxpgh7cd6usvfrw0gcdcmz2qej4ywx",
@@ -7607,7 +7481,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "237"
+    "lp_token_id": "gamm/pool/237"
   },
   {
     "id": "osmo1xhe34xslh74jyw8xl5p4auu5238zzhre7mcpd9kcxmfkrp5fuj9s4e6ldh",
@@ -7617,7 +7491,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "811"
+    "lp_token_id": "gamm/pool/811"
   },
   {
     "id": "osmo1xjd0l22txgpce4fh2kgjy7gmvhszzl05nzw7e7lc76qddxrywqpscj5pl8",
@@ -7627,7 +7501,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "54"
+    "lp_token_id": "gamm/pool/54"
   },
   {
     "id": "osmo1xky9ttqjpqltad9y420x7ylnw5k8sh6ctnk57dvytvgaesywzccsnyptkl",
@@ -7637,7 +7511,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "764"
+    "lp_token_id": "gamm/pool/764"
   },
   {
     "id": "osmo1xlq92gxx6a9zca4gjculx80gmpykh6lz2npustn27s7g7t2hcels964a7n",
@@ -7647,7 +7521,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "744"
+    "lp_token_id": "gamm/pool/744"
   },
   {
     "id": "osmo1xp9gm8zw4fg7xrvu006eh7enpc0ywtsspv9ezzf7yqzpv2gpvd4qugqgvy",
@@ -7657,7 +7531,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "614"
+    "lp_token_id": "gamm/pool/614"
   },
   {
     "id": "osmo1xr84lqj48rxlhk3w5weesczvl3tzemep6k5s968j6mmmvaml5e2qxhlngm",
@@ -7667,7 +7541,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "490"
+    "lp_token_id": "gamm/pool/490"
   },
   {
     "id": "osmo1xslx5c73axa9t7xypphtc83zw6jvucwxcahfnfltc8fclqnuxz9s0833tw",
@@ -7677,7 +7551,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "633"
+    "lp_token_id": "gamm/pool/633"
   },
   {
     "id": "osmo1xsqe6aprxzmw4l7vzghjxxq2t3j504utx4aqpryy3tlerz7rmw7smsfnfl",
@@ -7687,7 +7561,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "372"
+    "lp_token_id": "gamm/pool/372"
   },
   {
     "id": "osmo1xtresmp9jt2w7p40zj8rcvatc0lgwqj62elmerqd6n2pya03yyvszt0fng",
@@ -7697,7 +7571,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "363"
+    "lp_token_id": "gamm/pool/363"
   },
   {
     "id": "osmo1xu8x23y94cjwexgxerr6pak0fprngxh4xwyw4stw6pny2ktw4qaq9k3xvw",
@@ -7707,7 +7581,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "780"
+    "lp_token_id": "gamm/pool/780"
   },
   {
     "id": "osmo1xumj3tzy3f3cy0e98tj4plu3g9sq9rn86g0gzel6qk05stplwrpst2grm6",
@@ -7717,7 +7591,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "374"
+    "lp_token_id": "gamm/pool/374"
   },
   {
     "id": "osmo1xuufuq55r4ukh6xgfkfkvhlgvgsy2z7wacchctvj9yllcc695lusvc3hml",
@@ -7727,7 +7601,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "900"
+    "lp_token_id": "gamm/pool/900"
   },
   {
     "id": "osmo1xv2t67l0x59r6gl4wpgx925qlgy38ua325jyugh0yah5jkzp0amsw0aqpc",
@@ -7737,7 +7611,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "378"
+    "lp_token_id": "gamm/pool/378"
   },
   {
     "id": "osmo1xw730drgcts95umje5fwekx8dgpn4dg756d4a4y26jfhy6ekuu9q78qycc",
@@ -7747,7 +7621,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "704"
+    "lp_token_id": "gamm/pool/704"
   },
   {
     "id": "osmo1xxg0pnmyxj7xlvdvxrqdzrecaa2fquq97egpkf248t6kxuklsdjqazsyq0",
@@ -7757,7 +7631,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "850"
+    "lp_token_id": "gamm/pool/850"
   },
   {
     "id": "osmo1xzjr9a7t3k0y2498yh9cxmexy0vk6cwlx7jcvwvhlh6trs2t44zste5zhz",
@@ -7767,7 +7641,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "314"
+    "lp_token_id": "gamm/pool/314"
   },
   {
     "id": "osmo1xzwgqxu9y7dhqq8ka33p9rs9ayej8cs742jn2akvuj0jkdvvuktqf4xdxv",
@@ -7777,7 +7651,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "68"
+    "lp_token_id": "gamm/pool/68"
   },
   {
     "id": "osmo1y04x26mggspuwp8racsxukq2avuwk4q5frwyzm59szxy2x0s52sqq8men0",
@@ -7787,7 +7661,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "711"
+    "lp_token_id": "gamm/pool/711"
   },
   {
     "id": "osmo1y09t7vkps2p7ppe2aqfuqhje2zkmnk4t72yagk30286p9zw8e68s7mylm8",
@@ -7797,7 +7671,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "338"
+    "lp_token_id": "gamm/pool/338"
   },
   {
     "id": "osmo1y28qvpn23cuem32qt6jsrshmy5wj3ndn46lyh7p0dt5w8q0vxuwqfxhpzz",
@@ -7807,7 +7681,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "275"
+    "lp_token_id": "gamm/pool/275"
   },
   {
     "id": "osmo1y3g6lwd5p72z5uxgm4z6wy7asyg53wg83np7mg3cz2wnf9zhl69q8shlnd",
@@ -7817,7 +7691,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "587"
+    "lp_token_id": "gamm/pool/587"
   },
   {
     "id": "osmo1y3hutqnstzdx096nf47hw5s5pmu67cgzpz0gjh2f4cr39dw0uptstdjjln",
@@ -7827,7 +7701,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "519"
+    "lp_token_id": "gamm/pool/519"
   },
   {
     "id": "osmo1y3jhypynwrdjyqu0y3t9qs6kpkuspysdcpatal25ll2792hkf2lsy9d9u8",
@@ -7837,7 +7711,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "588"
+    "lp_token_id": "gamm/pool/588"
   },
   {
     "id": "osmo1y3ptmx57hvu7au6s9r3fxq00856896unkdyqaump7vedag248l0qc03asg",
@@ -7847,7 +7721,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "481"
+    "lp_token_id": "gamm/pool/481"
   },
   {
     "id": "osmo1y5dfzzdhyh9azqczjazk5v8vacf8we8f4gwlmyjc57s39jcgcp2s6d4l4k",
@@ -7857,7 +7731,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "80"
+    "lp_token_id": "gamm/pool/80"
   },
   {
     "id": "osmo1y5wz4pl4xpwrgr9mpjfmfewfa5nfns4473s9zs29c7c5q8w7pskqccf39r",
@@ -7867,7 +7741,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "595"
+    "lp_token_id": "gamm/pool/595"
   },
   {
     "id": "osmo1y6gvkz0qu93h7zgkrrhr6fqye5ny9ddpm9az2l5kjr0mmw9n48mqpmcnnv",
@@ -7877,7 +7751,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "571"
+    "lp_token_id": "gamm/pool/571"
   },
   {
     "id": "osmo1y820u9050hz23a48e7wzw5mnqftplvj205l0vaw3tx7g609l32zsxdyeam",
@@ -7887,7 +7761,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "504"
+    "lp_token_id": "gamm/pool/504"
   },
   {
     "id": "osmo1ya0hny0hsc73q4tnn6wdswk777r9e5pxhswm3ej5f624zahxmzcs2ygthd",
@@ -7897,7 +7771,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "779"
+    "lp_token_id": "gamm/pool/779"
   },
   {
     "id": "osmo1ycedur3klym2dwlz0w0796zqmn7fdzn6fldwc6cuzqwarejcuq2qu8z96e",
@@ -7907,7 +7781,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "899"
+    "lp_token_id": "gamm/pool/899"
   },
   {
     "id": "osmo1yeu83fklh2vxjts7evnm8439rj326zwgqldaz4sr470pu29jr88qujz9hu",
@@ -7917,7 +7791,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "269"
+    "lp_token_id": "gamm/pool/269"
   },
   {
     "id": "osmo1yfhmdj7akjtj8me0l3ttn3p475mdeuz032uzpl5n09q8evdzc7xsv6yj25",
@@ -7927,7 +7801,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "563"
+    "lp_token_id": "gamm/pool/563"
   },
   {
     "id": "osmo1yfs3zurxezmggujt5ffxyzerx5ujjsuzm07y0dy8p69z3l9w3d5s9nyagx",
@@ -7937,7 +7811,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "894"
+    "lp_token_id": "gamm/pool/894"
   },
   {
     "id": "osmo1yggqusvjqscjy03ysdmjh5hxmt6tv20u5ufrsuy67ksnw2xqsvzql2j70s",
@@ -7947,7 +7821,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "562"
+    "lp_token_id": "gamm/pool/562"
   },
   {
     "id": "osmo1yjpgrff07qx7q2tykqthtenyk7tmlnjy83097y00g20ncuxut8hsgwm4p9",
@@ -7957,7 +7831,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "717"
+    "lp_token_id": "gamm/pool/717"
   },
   {
     "id": "osmo1yn7z42al3mafmztjayjduz42a8at3whyd279fkdsyumzar83x8mqvpw83x",
@@ -7967,7 +7841,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "631"
+    "lp_token_id": "gamm/pool/631"
   },
   {
     "id": "osmo1yqqtrljj2xcdldwgtwgjeqte69lf8wdyfcx99jffc669natgslcske6ku3",
@@ -7977,7 +7851,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "700"
+    "lp_token_id": "gamm/pool/700"
   },
   {
     "id": "osmo1ysvqrdxtp489v8q03fun60nyr2v4p7p35dsf3g6cgln4avw6d4msdpldt2",
@@ -7987,7 +7861,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "278"
+    "lp_token_id": "gamm/pool/278"
   },
   {
     "id": "osmo1yugu88lhymszf7plpnn9ez07a34w2fxne7j44zqfqycgu8xx8cyqxmq5w2",
@@ -7997,7 +7871,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "750"
+    "lp_token_id": "gamm/pool/750"
   },
   {
     "id": "osmo1yurhrjdwh4j3h5ck5tj08u9ht38qaxq4vu9ad7nn4jcf23lnfxvsclex5j",
@@ -8007,7 +7881,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "142"
+    "lp_token_id": "gamm/pool/142"
   },
   {
     "id": "osmo1yuu7x52t2df6f0287md68q8l3u90h9jxjurcnxpskvve2de9krgqmm7mjm",
@@ -8017,7 +7891,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "693"
+    "lp_token_id": "gamm/pool/693"
   },
   {
     "id": "osmo1yv7jtrkt3t9t3mtsndxx7392azzmawyyy0k9qn97rv35dkluyp7qzyswmn",
@@ -8027,7 +7901,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "720"
+    "lp_token_id": "gamm/pool/720"
   },
   {
     "id": "osmo1ywwh6qsau3fqc507puxqv22re0eqthuyk7xpfgxvdv62d53ydlasd0lpnp",
@@ -8037,7 +7911,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "335"
+    "lp_token_id": "gamm/pool/335"
   },
   {
     "id": "osmo1yxs0cp0gdrc552u8whe293q8al4w6f5v2nl5cmdeecwx3p9m2p8qk7adjc",
@@ -8047,7 +7921,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "617"
+    "lp_token_id": "gamm/pool/617"
   },
   {
     "id": "osmo1z0693astkr0t976z8fs22902qxnl8rhjw44uglll9qk07h7wpt6sy77yc7",
@@ -8057,7 +7931,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "511"
+    "lp_token_id": "gamm/pool/511"
   },
   {
     "id": "osmo1z390kae9wyjw5lxy5hl4mfc52w6830eflury88mfjsjl9s5708cs5ckkde",
@@ -8067,7 +7941,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "333"
+    "lp_token_id": "gamm/pool/333"
   },
   {
     "id": "osmo1z4ka2c5hzfpy8qkrefwd2pu7mqnfdxjrvqgch0h0llh269zcta9qxzsty4",
@@ -8077,7 +7951,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "468"
+    "lp_token_id": "gamm/pool/468"
   },
   {
     "id": "osmo1z4tn4qh0dj89h5h3jyxprthh324vm88t7netqjeu6855hf7ttugqevfnew",
@@ -8087,7 +7961,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "526"
+    "lp_token_id": "gamm/pool/526"
   },
   {
     "id": "osmo1z52y99kywzjjv9kf8498jkkva8n6g3epzeds6v9hth85rd90fcvq5zxp6w",
@@ -8097,7 +7971,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "210"
+    "lp_token_id": "gamm/pool/210"
   },
   {
     "id": "osmo1z7pnmk64p2g8qpeu3j70uwv9eu77kj6qyk96mmxehc0lhm5lvmeq6ugylv",
@@ -8107,7 +7981,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "388"
+    "lp_token_id": "gamm/pool/388"
   },
   {
     "id": "osmo1z86kzpdqmrdr6prp8dvj5n73w7t0fc54mx2gq7y30p6awyhun3kq4wxpaz",
@@ -8117,7 +7991,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "492"
+    "lp_token_id": "gamm/pool/492"
   },
   {
     "id": "osmo1z9dqkuhkhuys9hcel25mtuw33awk0svp6afzg3d3j0vqft9cj9aspg97ce",
@@ -8127,7 +8001,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "316"
+    "lp_token_id": "gamm/pool/316"
   },
   {
     "id": "osmo1zd2vqwlvpz4e9xrkvxvc0aa8cqsnwdvpgxulk7n449r6lr4adv3st6mzzf",
@@ -8137,7 +8011,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "639"
+    "lp_token_id": "gamm/pool/639"
   },
   {
     "id": "osmo1zd632nrrwh6r5wwqs0y6h5qslr3l3yh6kryxtg7zmrclqcrtwefqp0m097",
@@ -8147,7 +8021,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "776"
+    "lp_token_id": "gamm/pool/776"
   },
   {
     "id": "osmo1zddv3kuvxqulq09dcfur8etz3tax90vjuymtlzzk23ps39ew26cqm3gykf",
@@ -8157,7 +8031,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "233"
+    "lp_token_id": "gamm/pool/233"
   },
   {
     "id": "osmo1zdp0cl67a25r25hslw3xzzt5mmd03ws04vevnthzklxzkg4xg35q8h8dnk",
@@ -8167,7 +8041,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "226"
+    "lp_token_id": "gamm/pool/226"
   },
   {
     "id": "osmo1ze0t3al4zgndvjla36gp2khjkwwdzr2e4m8vl6fuzfllfrlr8mdq4wnmxt",
@@ -8177,7 +8051,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "745"
+    "lp_token_id": "gamm/pool/745"
   },
   {
     "id": "osmo1zffkpskd8vv643mwu59ujsgldfz0khlgcvsty8zv9y4t50azf6cqx0a3pp",
@@ -8187,7 +8061,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "615"
+    "lp_token_id": "gamm/pool/615"
   },
   {
     "id": "osmo1zfgxnef46xmdv6dgnwvem6dpuetr58hwpnwlvvxv0pgsdv8gj86qk22vcy",
@@ -8197,7 +8071,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "897"
+    "lp_token_id": "gamm/pool/897"
   },
   {
     "id": "osmo1zg4rlhp843nn3jk0uz2kvk4zzvp7wm6qpvlnuv7dnp4jlz9pmpws90duk8",
@@ -8207,7 +8081,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "82"
+    "lp_token_id": "gamm/pool/82"
   },
   {
     "id": "osmo1zgnc6xvj607xmtpyu420h378cwgdnlwzhat9wjgsavgkjk5n3ckqx68328",
@@ -8217,17 +8091,14 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "608"
+    "lp_token_id": "gamm/pool/608"
   },
   {
     "id": "osmo1zka4v4c04jr74ludyls2lfzfttzx67qzd070xtnfq90yzyacgn9qv6vend",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "11"
+    "lp_token_id": "gamm/pool/11"
   },
   {
     "id": "osmo1zml837f5en8x2fvvger70l76cmdahrdv5y6m9e6yk0scnddn5w0qj54m60",
@@ -8237,7 +8108,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "837"
+    "lp_token_id": "gamm/pool/837"
   },
   {
     "id": "osmo1zmxelh7k08hy085shm5y08mqeaqmahee7u77lpnf2h4eufnsyn6qucvfjy",
@@ -8247,7 +8118,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "43"
+    "lp_token_id": "gamm/pool/43"
   },
   {
     "id": "osmo1zpjym32nr8qt8t8nm9nu2zr5hx90hferfv2jqpt824q9nz38k2vstj704t",
@@ -8257,7 +8128,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "250"
+    "lp_token_id": "gamm/pool/250"
   },
   {
     "id": "osmo1zrm4msu7q238tlhkdyk2pu3px47z47n0tgwrlpf6c08f4ppmwycqfeas0n",
@@ -8267,7 +8138,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "96"
+    "lp_token_id": "gamm/pool/96"
   },
   {
     "id": "osmo1zskwjdwjgxt8r3ukqgcn8z70qtzl5cswy03pkupvzvmwlvcjvtrs4fwrpx",
@@ -8277,7 +8148,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "462"
+    "lp_token_id": "gamm/pool/462"
   },
   {
     "id": "osmo1ztfk57933fj6278dn9ja7w60nfq44mndludh2qx62e2tg9hc29lqm8avec",
@@ -8287,7 +8158,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "671"
+    "lp_token_id": "gamm/pool/671"
   },
   {
     "id": "osmo1ztk3sfcrdvv2lnmjzfad5qerkevp3y5ny8s3n5t8c94pxwu0putqw3dqtw",
@@ -8297,7 +8168,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "69"
+    "lp_token_id": "gamm/pool/69"
   },
   {
     "id": "osmo1zvc24h5fd9a2gj7xs30fvp9wmf6jydf3w0updqu5hr6g9turnkzqqh00f4",
@@ -8307,7 +8178,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "190"
+    "lp_token_id": "gamm/pool/190"
   },
   {
     "id": "osmo1zyjk6a4fapusydkauzph93h3c2ssngpfh3retatwaqw32lw20mhqcxu4xw",
@@ -8317,7 +8188,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "534"
+    "lp_token_id": "gamm/pool/534"
   },
   {
     "id": "osmo1zzn7rddfytcjg26g3s97g2qck2nwz5upfth430fdmnnyph9vjxhqpytc3l",
@@ -8327,7 +8198,7 @@
     ],
     "dex": "Osmosis",
     "type": "balancerV1",
-    "lp_token_id": "769"
+    "lp_token_id": "gamm/pool/769"
   },
   {
     "id": "osmo16054sn8ug2njt8hnhzk5qy2zh7u8x6nmex3c02970dpmqfepz7hq434rlm",
@@ -8337,7 +8208,7 @@
     ],
     "dex": "Osmosis",
     "type": "stable",
-    "lp_token_id": "920"
+    "lp_token_id": "gamm/pool/920"
   },
   {
     "id": "osmo17m8tjws6ce8rqgghcfz09jgew9tcakp3qlw76pt86akerxk3t7rsgkn75e",
@@ -8347,7 +8218,7 @@
     ],
     "dex": "Osmosis",
     "type": "stable",
-    "lp_token_id": "873"
+    "lp_token_id": "gamm/pool/873"
   },
   {
     "id": "osmo17n9drfwd7sqa5rc7v7xwfv5ucfngg8nttu6j2plvxgvrrt2099qsq54urf",
@@ -8357,7 +8228,7 @@
     ],
     "dex": "Osmosis",
     "type": "stable",
-    "lp_token_id": "913"
+    "lp_token_id": "gamm/pool/913"
   },
   {
     "id": "osmo1aqmdce4f8ymqcf7v0a8xcukt8xqga50zqcprta89e9p2fmscfzpscru5lr",
@@ -8367,7 +8238,7 @@
     ],
     "dex": "Osmosis",
     "type": "stable",
-    "lp_token_id": "886"
+    "lp_token_id": "gamm/pool/886"
   },
   {
     "id": "osmo1cxlrfu8r0v3cyqj78fuvlsmhjdgna0r7tum8cpd0g3x7w7pte8fsfvcs84",
@@ -8377,7 +8248,7 @@
     ],
     "dex": "Osmosis",
     "type": "stable",
-    "lp_token_id": "903"
+    "lp_token_id": "gamm/pool/903"
   },
   {
     "id": "osmo1d3dd4w06c2lyxqm7lf30st89esf4437f3tn42kpv9sh5zug5xdksnnp0nh",
@@ -8387,7 +8258,7 @@
     ],
     "dex": "Osmosis",
     "type": "stable",
-    "lp_token_id": "892"
+    "lp_token_id": "gamm/pool/892"
   },
   {
     "id": "osmo1ewsz7a8zefxq67h4205hlncpfm3np4mky34upu3sktc3llrj5rgqdutjgk",
@@ -8397,7 +8268,7 @@
     ],
     "dex": "Osmosis",
     "type": "stable",
-    "lp_token_id": "868"
+    "lp_token_id": "gamm/pool/868"
   },
   {
     "id": "osmo1hayyjltd3mjx6w8g7wtpu2zckk83ecxen2eux6c7tl42unfvnfysqg9myf",
@@ -8407,7 +8278,7 @@
     ],
     "dex": "Osmosis",
     "type": "stable",
-    "lp_token_id": "906"
+    "lp_token_id": "gamm/pool/906"
   },
   {
     "id": "osmo1kxnekx4q8yem6wvp5t9ggqvhuxaqw7san00x5qdazp3fe597f8hsqft4nq",
@@ -8417,7 +8288,7 @@
     ],
     "dex": "Osmosis",
     "type": "stable",
-    "lp_token_id": "872"
+    "lp_token_id": "gamm/pool/872"
   },
   {
     "id": "osmo1r4r0ryw0pq2yhwcqwf8pg4w0fr764k3ztv9weuyqcn5hv0zxy67srvgfj2",
@@ -8427,7 +8298,7 @@
     ],
     "dex": "Osmosis",
     "type": "stable",
-    "lp_token_id": "884"
+    "lp_token_id": "gamm/pool/884"
   },
   {
     "id": "osmo1rdcx38vnf0tvx6x0xkel747m0rqkv5lg20lfww8gtdrydmu00pyqgefkm9",
@@ -8437,7 +8308,7 @@
     ],
     "dex": "Osmosis",
     "type": "stable",
-    "lp_token_id": "862"
+    "lp_token_id": "gamm/pool/862"
   },
   {
     "id": "osmo1xfcjgr8l0e2pp3mx2qlcu5u4x0vt84cuzhwyytvmvhlnm5kjww8qudwh8y",
@@ -8447,7 +8318,7 @@
     ],
     "dex": "Osmosis",
     "type": "stable",
-    "lp_token_id": "863"
+    "lp_token_id": "gamm/pool/863"
   },
   {
     "id": "osmo1ylzwp5r95sqjmkjem3hu0ynslaxjd2tzv6udfhrlrtyhj4zerttq3343su",
@@ -8457,6 +8328,6 @@
     ],
     "dex": "Osmosis",
     "type": "stable",
-    "lp_token_id": "888"
+    "lp_token_id": "gamm/pool/888"
   }
 ]

--- a/osmosis/pool.json
+++ b/osmosis/pool.json
@@ -111,7 +111,10 @@
   },
   {
     "id": "osmo10g7srpl9gqhetplp6d2fr7l25ckjrtcsupk60984w8vf2zugcvjq6ashnq",
-    "asset_ids": ["gamm/pool/102", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/102",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/103"
@@ -188,7 +191,10 @@
   },
   {
     "id": "osmo10sh5u7pl9dwh7ll8wfaahr0trkka4rv2k9amlj88s72k6v8paufs0qnz7p",
-    "asset_ids": ["gamm/pool/222", "gamm/pool/402"],
+    "asset_ids": [
+      "gamm/pool/222",
+      "gamm/pool/402"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/403"
@@ -215,7 +221,10 @@
   },
   {
     "id": "osmo10uut208crprz36gpw3wwh50e6yuuq8jxf5yamdclg4vr84uw8cmqkunxkx",
-    "asset_ids": ["gamm/pool/1", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/1",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/493"
@@ -232,7 +241,10 @@
   },
   {
     "id": "osmo10v35xj20k0jrfgs8p3lqt5gyga0wug3kkh4pq6xt3x4hqh5huvcssp04d3",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/255"
@@ -439,7 +451,10 @@
   },
   {
     "id": "osmo12nxhn6pc44eguzf53y37nkpjqv80u3n0kxtuffyqrp0h0vkqccfqu2f7pk",
-    "asset_ids": ["gamm/pool/1", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/1",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/393"
@@ -456,7 +471,10 @@
   },
   {
     "id": "osmo12vkrtnxwpkq7hnsnchs06ya7rv0vdpchxrgt7jktjm4kupzx8l2s6nfhny",
-    "asset_ids": ["gamm/pool/41", "gamm/pool/53"],
+    "asset_ids": [
+      "gamm/pool/41",
+      "gamm/pool/53"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/73"
@@ -773,7 +791,10 @@
   },
   {
     "id": "osmo13u649up5fe79u2aq0d3rsl5x48lulu5yred75lcuw94dlugfxdqq39hz0s",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/320"
@@ -1070,7 +1091,10 @@
   },
   {
     "id": "osmo1500hy75krs9e8t50aav6fahk8sxhajn9ctp40qwvvn8tcprkk6wszun4a5",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/2"
@@ -1197,7 +1221,10 @@
   },
   {
     "id": "osmo15e4a88d0vmd7ywh9e2ll8q447defplgamwza9ezay67z84cxmx7ssu8s6q",
-    "asset_ids": ["gamm/pool/101", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/101",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/106"
@@ -1354,7 +1381,10 @@
   },
   {
     "id": "osmo15v7xfk7qnm27r2kwsutegh3jt2ye7haadqlnt5xf89hkp29hx0cq4sgqr6",
-    "asset_ids": ["gamm/pool/361", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/361",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/364"
@@ -1541,7 +1571,10 @@
   },
   {
     "id": "osmo16dn4uk4xlqshzufy3f0as2pnvdpwqlwepp0m5qumwh2c4vgmp9jqaa0zsh",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/569"
@@ -1588,7 +1621,10 @@
   },
   {
     "id": "osmo16qzex7q0cpj3dflx79ycqvsujm0dt838lfjv9fjg80zna7jpn2ssn3cta4",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/395"
@@ -1845,7 +1881,10 @@
   },
   {
     "id": "osmo17rujtwmvk8vp3uqq6xxkymk83n3qethhejuar7ayhyuupcsw66mqmg4k28",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/344"
@@ -2192,7 +2231,10 @@
   },
   {
     "id": "osmo196w6qg0r3cfy9rx00390wkfdj9krd93uaed3nlht5uhqfh2avcyq3aldku",
-    "asset_ids": ["gamm/pool/1", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/1",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/392"
@@ -2259,7 +2301,10 @@
   },
   {
     "id": "osmo19esg8fulwzufjjarprfpu4mz06zjpkmk7p0wydcw5q900lp2k3mq7afv7m",
-    "asset_ids": ["gamm/pool/502", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/502",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/503"
@@ -2436,7 +2481,10 @@
   },
   {
     "id": "osmo1a0ev3jr6fts7y09as95pryn59hzwfkaletpusfzctejjy0wqa47sxqgy3a",
-    "asset_ids": ["gamm/pool/356", "gamm/pool/357"],
+    "asset_ids": [
+      "gamm/pool/356",
+      "gamm/pool/357"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/358"
@@ -2513,7 +2561,10 @@
   },
   {
     "id": "osmo1adzv0qftyywfavf06uqh0lutcqz5nz5favasq58rkvnu4l3zvs7shy9kxu",
-    "asset_ids": ["gamm/pool/364", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/364",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/367"
@@ -2570,7 +2621,10 @@
   },
   {
     "id": "osmo1ang9dlvxrc0n835xyxvwf66mj0mm0sznyqwtu03kdd2dmhg40hlqnq36up",
-    "asset_ids": ["gamm/pool/1", "gamm/pool/8"],
+    "asset_ids": [
+      "gamm/pool/1",
+      "gamm/pool/8"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/246"
@@ -2687,7 +2741,10 @@
   },
   {
     "id": "osmo1c8gdt3cquepqadv6ys2m9ht8eys40c2ws46ntwm7zknr2hwcsuhsly32ft",
-    "asset_ids": ["gamm/pool/13", "gamm/pool/5"],
+    "asset_ids": [
+      "gamm/pool/13",
+      "gamm/pool/5"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/81"
@@ -2774,7 +2831,10 @@
   },
   {
     "id": "osmo1cgw34ya7ndpmplgv5wyec4mz7hq3crc64uqq02qv6zk9vxun2rksk8fcja",
-    "asset_ids": ["gamm/pool/73", "gamm/pool/74"],
+    "asset_ids": [
+      "gamm/pool/73",
+      "gamm/pool/74"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/75"
@@ -2991,7 +3051,10 @@
   },
   {
     "id": "osmo1daztxlwd90kqt7yw7mvakhp9kjd34g250dywutq06nvlze2u6uhsuk26xw",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/194"
@@ -3348,7 +3411,10 @@
   },
   {
     "id": "osmo1ejcrrmfxaphd6nf270r34467u2a407mewhq5g5cz6hdhzqs7nnxsvpthf9",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/380"
@@ -3975,7 +4041,10 @@
   },
   {
     "id": "osmo1gy7usssxrzsepfpn9z07456cqqmumtmn5mw3wgc5jpmwt2ha8qdqwxy09x",
-    "asset_ids": ["gamm/pool/1", "gamm/pool/73"],
+    "asset_ids": [
+      "gamm/pool/1",
+      "gamm/pool/73"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/74"
@@ -4092,7 +4161,10 @@
   },
   {
     "id": "osmo1hgxsqpxghfw7pwwl8jwxzy04cyll8nhf6ejnxpx3wvkszkq6rznqap0yuc",
-    "asset_ids": ["gamm/pool/503", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/503",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/505"
@@ -4429,7 +4501,10 @@
   },
   {
     "id": "osmo1k33jzr6syz8fs9jlsjerwum53ctu9nzkfdr3uy58ddt2tpsnsw0sl8ff3s",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/135"
@@ -4446,7 +4521,10 @@
   },
   {
     "id": "osmo1k4gj3utpx0s3pmtq7shmyhdq2dp605e03hcprvzvec7jq2ge2u7s4r0wp4",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/545"
@@ -4523,7 +4601,10 @@
   },
   {
     "id": "osmo1kchnwg6y2y4r2nyjartp9q3ss4ysjkx9gzgxwdtg6624g6natn3seyj0f4",
-    "asset_ids": ["gamm/pool/222", "gamm/pool/323"],
+    "asset_ids": [
+      "gamm/pool/222",
+      "gamm/pool/323"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/402"
@@ -4780,7 +4861,10 @@
   },
   {
     "id": "osmo1l5ehe7cqgf5fplxegqaukwygaz8g2h62yhdt06te6uem30l2j9mswf6qct",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/50"
@@ -4807,7 +4891,10 @@
   },
   {
     "id": "osmo1lahkpd2rxat3huy3kqkphvugruzxm3d5n0jxve6c8xzmkcvgfw9qjdnkhf",
-    "asset_ids": ["gamm/pool/104", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/104",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/107"
@@ -4884,7 +4971,10 @@
   },
   {
     "id": "osmo1lmk3mgsj2ajp4s34jzfsqscz60nfys4rlsg5u8k03a9420ggyh2qldlmzq",
-    "asset_ids": ["gamm/pool/38", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/38",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/61"
@@ -5041,7 +5131,10 @@
   },
   {
     "id": "osmo1mdqhf078cs0qe7gfcv9rdw0yzvzf0wejvyrlx8hyzcpsfn2zgpyq7l9ly6",
-    "asset_ids": ["gamm/pool/108", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/108",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/153"
@@ -5238,7 +5331,10 @@
   },
   {
     "id": "osmo1nfn4h33t30prnuyrhn20ntvgclzhc8x40mzkngc740r9r3sap4yqaf9c3a",
-    "asset_ids": ["gamm/pool/359", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/359",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/360"
@@ -5275,7 +5371,10 @@
   },
   {
     "id": "osmo1nk8ha9xldmqjn7adgz56tmu87e3yryuzj3upsk20kmy64vmg702squcxue",
-    "asset_ids": ["gamm/pool/474", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/474",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/475"
@@ -5442,7 +5541,10 @@
   },
   {
     "id": "osmo1p9pa7umdvry4u4338hgu4x5pkepnk9pcqddpg65zdj0k3a3ucjts85hj73",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/35"
@@ -5899,7 +6001,10 @@
   },
   {
     "id": "osmo1qtle736upg6t8nmra606axnvnm8fwvffugdfhsn2hs4f8mv7n2yqgvlwt2",
-    "asset_ids": ["gamm/pool/464", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/464",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/486"
@@ -5976,7 +6081,10 @@
   },
   {
     "id": "osmo1r5v05r30s0v75py3n3lhd7sq5cdgkaltles5rk0cmgndrdq7ktxqcn64y8",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/426"
@@ -6193,7 +6301,10 @@
   },
   {
     "id": "osmo1rxur0nsztn90mua2zv7ectqeht7ujzdfnfzwuny25da4k8vla4rsy8hls8",
-    "asset_ids": ["gamm/pool/1", "gamm/pool/7"],
+    "asset_ids": [
+      "gamm/pool/1",
+      "gamm/pool/7"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/429"
@@ -6260,14 +6371,20 @@
   },
   {
     "id": "osmo1s46juu2q7ets8tgqaytaaekfs5qu259tkex87ll068xsvfcf8uas6rkavc",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/598"
   },
   {
     "id": "osmo1s4eem3yk9de5xk8wr9gs9shc2905skd7h4e589cqs94pyrqem5jqn8y2ru",
-    "asset_ids": ["gamm/pool/410", "gamm/pool/411"],
+    "asset_ids": [
+      "gamm/pool/410",
+      "gamm/pool/411"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/413"
@@ -7044,7 +7161,10 @@
   },
   {
     "id": "osmo1vedjqp8mzcr5yg8h0s75lg0l074nx8leqkj0efzvha8wpdus3nxq0myg32",
-    "asset_ids": ["gamm/pool/10", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/10",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/101"
@@ -7231,7 +7351,10 @@
   },
   {
     "id": "osmo1wehlg2lrvqxjmy26ghkqdj4c653se5kr646z9rwwfflutj25dvnsn6ef3f",
-    "asset_ids": ["gamm/pool/123", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/123",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/284"
@@ -7278,7 +7401,10 @@
   },
   {
     "id": "osmo1wkspj354sp059377j67mk6uy48t7u2cm86609nq7xht47hj9mkzs39x3fd",
-    "asset_ids": ["gamm/pool/1", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/1",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/152"
@@ -8095,7 +8221,10 @@
   },
   {
     "id": "osmo1zka4v4c04jr74ludyls2lfzfttzx67qzd070xtnfq90yzyacgn9qv6vend",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1",
     "lp_token_id": "gamm/pool/11"

--- a/osmosis/pool.json
+++ b/osmosis/pool.json
@@ -1,0 +1,8452 @@
+[
+  {
+    "id": "osmo102ryca72c5ktx2ruzt8ag6mvtczdqeuvm82l09vd5uq597e7hn7sqgw28l",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo104w884d9gw9s35ckru66ptl3uu3ss0u60xk7gplj8ky0xan6tfvsrfshe6",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
+      "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo107cnz52uqdqzvwfvwcl4z55xqlj4rz78yv04a3tgqpkn3wrnkfxqq2ze39",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo108scuudnnhe70xuwa2etuyxffexexak6rflvsczj9n4fhrz92ajs9zudge",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo109uqkhlvees202dg6mkhn89actzyfvvlm9u7ym3zzytrp9gmhcvsawlssg",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10ce9cnt6hk4jnghvdl5asdsc5rmjfswkk7u5jrfr5ecy5puvsdzs5x6rvc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10cm3vypuxkrvq4uznf4px5lv43ej99f6shushwtur3fpy6z69huq7gfce8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/FFA652599C77E853F017193E36B5AB2D4D9AFC4B54721A74904F80C9236BF3B7",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10d8ddsydag5xrnl2kacmkjtdxddstvz4jvraqqpf6ss2n7fy6lkqw4sx2f",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10djas3dkuyvfzaxvgwjqp3aaf63wjrv23hx3pmk8pjaxc3f33k9ssrz8kf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10ecjz4nkzsr8rwmzmk7z6uwf6ux78wyctc98yphu0rc7cey9t5sstj4zyt",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10g4gm8px3tfeft8y0w4yc7kyxv9p9dk40aplln59j0nxmmnjnjcqhpftcf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10g7srpl9gqhetplp6d2fr7l25ckjrtcsupk60984w8vf2zugcvjq6ashnq",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/102",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10gyurv978mfwmfpd9e824kua3f2vca8626ky93aqndhqzqfmulds36ltrz",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10j0kv8lfy5ym3wm8m0shte5p7zu5sjtj6a6s0zslp3suqrkaqyps3kfe06",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
+      "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10j25ze5tj5ryxz4jk79au6srhe62jsckk9dd6u5qt3326wv9gvnskn7tu9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10k2x02xa6acekt74fnw4sl6znfgv08k37zgkd0ej303uqc4t2s7sarhsr8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+      "ibc/BE95D1E09F5A44FC5409F4E0F52750DF2A868D865BC91F3C3EE3C83235789D18"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10kepynda48va573sjsn0ch6glf3e2qrs87ukpvd63ljdmkaflg3sjxf5r4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10r9v3xpzzd4752r0cvu50vacp8use9later59jcny07xz80gv6mq4yq70a",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10rmhpg33dv9unqtw72jh67r8xdjmc07qe9zaef4jjycjyakl8q6sl76dhz",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/DB9755CB6FE55192948AE074D18FA815E1429D3D374D5BDA8D89623C6CF235C3",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10sh5u7pl9dwh7ll8wfaahr0trkka4rv2k9amlj88s72k6v8paufs0qnz7p",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/222",
+      "gamm/pool/402"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10tly0t6ppjaz0uhlskvlluzwwwswdc8tfy65mhhkwst6cfq07rdsxscmm9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10tx2zgul27naq2p5urn9kx7lygfr0zhsk3s42nh0dcfqyudq655sadlyxj",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10uut208crprz36gpw3wwh50e6yuuq8jxf5yamdclg4vr84uw8cmqkunxkx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10v29rzxswcz2facklsfxg7a3ns2lu5vj9f0509ateum9u7ca33tqur69mk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10v35xj20k0jrfgs8p3lqt5gyga0wug3kkh4pq6xt3x4hqh5huvcssp04d3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10venxtvdglryxkdmvjr8wa6n3ugja40rewddlxtg0pr30vmkf47sllgslg",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10xnwkjzqpdvgzxpz7eu5mcne5jc73c5h0xuhv9qmz0jsfyyxvr4qvhje97",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10xphw0uxj2k7erakdajxxdwexu4qt0fwlu0xu3a26r76kthxjyxqal4wcf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/DB9755CB6FE55192948AE074D18FA815E1429D3D374D5BDA8D89623C6CF235C3",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10ya3d9gr2cmp268kdu8u5mna0pktqfxkt9ug54z9xrazpk3wpj0qz9zlcg",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo10yczu0hflmtny52ktkvfrrwj2cktkjn6yk9wsfyxsjf6n8pvwxfscmn4e5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo120echqk9sfelg47lrultsc0em257582cxrp86epqhcz8gfqxf6fsluzp7z",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1230t5url8jlyxp9czgjv7p93kkgka4uvr3syxlwum9zjk2gpn6cs4xcxgc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo124h7edw5f98xzfgaxmxjpnu66hdt6cn58n4g3awa90cn3h5v6d8s45246p",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo124qc2hs5jgp2shrmtv2usxyrt52k447702pczyct0zqadlkkh2csvh5pzv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1265edur3evpvmmcter5a3lp93zlyc23wd9qp0vcu0xatn79a4q0qp24n2c",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1272l80yvlqm4j6y5296fqhvy8ltgscsj2h4u76pumj2sy0ul82ns7hy0wu",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo128m3mqa0m6ex57nxkxkyczd3nsqns2p56wm5xu52p4jappg2jamq5jrlxe",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo12a8gxj8p07rn92zzjug6vq2a39hnqw92zhpmymxxs5avj327zslsszjqxr",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo12exa7m2esj4a9anudf0e2rpk5yynf049h585sm4zv7rqkjqun5cqs604sd",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo12fzg5z9xzw8yde57fj5w2rwqmxe6f4g3lgjdrjhhsqx8m43fqpgs7d8x8q",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/C822645522FC3EECF817609AA38C24B64D04F5C267A23BCCF8F2E3BC5755FA88",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo12h3748gmjdssn3pyxdtu9d6gl6wvlrem03y5e592h05f4kx6aa2ssp8jq7",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo12huxa5wnwskf8mnmr096yzwyrehm970782j95h25uuxrxxz8wdpq7udusr",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo12lzydwxr8xmyhrvg7kr0948zz4jnf4wjczwqrngppw4du85ustmqs5vpt6",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo12ng7y9c5lhyqgl2pxgap64de0fjynnwgtv3j5cme5c2ypmwezd2qwq982h",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo12nv2sf5qe5t93ly3fktdgrw5u9f5nn9cf8cakgt0pvhhqghvkrnqqhadah",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0CD46223FEABD2AEAAAF1F057D01E63BCA79B7D4BD6B68F1EB973A987344695D",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo12nxhn6pc44eguzf53y37nkpjqv80u3n0kxtuffyqrp0h0vkqccfqu2f7pk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo12v9c78ctzvthgen8txmmqm06mjtdfu2gy3k68jtldxvssmwq6lrsn2fa8y",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo12vkrtnxwpkq7hnsnchs06ya7rv0vdpchxrgt7jktjm4kupzx8l2s6nfhny",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/41",
+      "gamm/pool/53"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo12y3z9khxjkhh7yk37c22kxjv5dl8ayxfa9s6fp0g2uekeuptmtmskvguh4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9A8A93D04917A149C8AC7C16D3DA8F470D59E8D867499C4DA97450E1D7363213",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo12zcj6ns9sa4twqn7xnjydcfwpedt3e90y4xg9gs7ught7fq98tcszvt5uq",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo12zlm0f4wrgvdks83gue66zs97hchhc2mf75xwgg5q89ev6hd45gs7hn0zt",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo132pj9lh5cujzql3q8umzk7zu7xyv8l9tplz3ejvra550p0ejwr0q4c3fgq",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo132qw6zaztxfnjj3a2e20adm3xwzjrycqwcc048x6wpv0w00dgl7qvlln2p",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo134hkyv9330wdk8jyaltskneqxcc3nndamy5020yn4l8s6987qd9se7042l",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo137n2magslhhhp77rt0qv2l4s4fksjncj2t8vd43sn9uwzeypqw9ql0enq2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo139k7lc44flz23nxzjeermnrzw6faqvys6cjkywevsqaxut93awes9lclqv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13clkaupjee7n5df25v863kl2khxmcvkxk3cv9kwemz0rm77lur7qtg000v",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13cslqv80p4uzx4cxjvpnrva68yac6z55yhafqau3k5vy6yw5027q2yx8ms",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13dnatwj7l5vdksrh66zqkp6pmvfdtqc8vr6m543dav6x26q6wvyqe3nmv6",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13dr6zv7tf2jzvdqza692av7ah77vzt2534luprlkuj6nfk42pcaqgzp7t4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13ejfnt55k897daggmc8z2kpahfufk3tvw4wq44k5y2kjt6tjjgaqm05kyd",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13h85yg9msr3lr6leearsnsv5zt5hv8hv7k54gqtq2lrycn96mytqksgr48",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13jr3p5p070h4pu7sxhtldag9899sev9pwx0r2vlvpkyravpxlqssnzsuq9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13k7fkdnkw6urxecxaevy9hq2vzzvxsl40jf3kcywudvkcx0xe0nqulj3yv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13kxnazqtly05g77xnqsqs95psld5dyspe5f5xa50n06tqqq79sys2ucevl",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13l85na80w9vtscftf2054nzwsqc7k8ncd9fv6hl3gvtpxqv84jfs4gkh5m",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13mczv44wvyqn6fys7f9mcv57d9fmg6e7yfkypaykp99amqfw7chq9wa5q9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13mj9ywzw3x8fpqxxnfdffuk6fgf4thv9jw78j8thu9k0uy32s92qa3an68",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13mu0c55r8yt9mgycc7zx6jedxh73mf630xwpwvwfm7qf4q7k3edqu209ez",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13n2p8v5w5knclf4yprk6hdrfqt3s94ynmjud7gf6djed8759qedsasl446",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13nztwp3wht4k8zm6ztkczjqxyu74kvl8xjjfqssd7g2lwghzknhqn9gpek",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13p8haggnllu9w0y6e0dsazcsezfywdcz4dqses8cxrnh0n0r393q05995g",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13qvyfhzunrxulp7a0ekyn0vrl6yf26urnk8hedrnk7hn74acr49skjy00e",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13refp99hxda7acm2rnn9nrejhh0d80ftjzxqulj7js884v3ckc3q02ssf6",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13s0uss8gztzsrxqd08kvwmpt7d0k0tvzdfchdw0tr2suzvl3hm3s769ce5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13shtdrvcjzymxxe2s27k93l9xumkd4tjcmcv05pue2mfk20d66cs4r25lw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13tc9ntd0rnxumtlczqefzg5nk2kf6z7agmgj898sd3gl40dkccvqy06vkm",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/6BDB4C8CCD45033F9604E4B93ED395008A753E01EECD6992E7D1EA23D9D3B788",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13tp73hg0skhenwrhp4sqg48a4e6459spyvnp7ptnz2galhpcz3lsalsh0w",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13twh7y4pv6rdrxchtjeh7tav4qqujlwxxc9cdqpvruj9dh9xttrq8g5g9c",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13u649up5fe79u2aq0d3rsl5x48lulu5yred75lcuw94dlugfxdqq39hz0s",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo13xtszjfnwjs5lxetjklspuuzg3tymnepu48p5sp38rhs458kc7yq9jxjf8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo140c35lxmkmkzmxyh7293cmettfatdw090n0ttwzxxjwa3jraenwqqpczwd",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo140dhzccumruw0u38dt7qlj49ttvw2p5mwgcjqsqjuv443u2s5rgqll980k",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo140lcj9njcgennv4sk2qtffq0d29s7a9qpv2l30rccghfxfc44mvqphj5uv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo142esjq2sxsju345f4germ3zqlc6j73f6tzzxpumkclzwxs9t5nuq5wuaal",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo143403qx9vwa0d0m6zzna2r0fw0xyefl4ey3jgtl4krk5qdzvwd9smnr936",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo146awk6s36fxfqa2hzp974lpmvry6cz20yp52ugrlw5c5983nqgjswz9ltt",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1497udspu0fkv9hjv5kep7vglhg8nj986v4e6dz62dleen4m3a50s8evd6c",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14azf94grg0qn67tkczejnt87t9yzt5ndg5h3pqc8zapz3hpg7whq5zzsyh",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14cg7nxexxmuszptk6kghd7d73r7t6xrjfclcmk3qrc73wpjyxtesywq20q",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14dxgrj6qc5t50aedyy9fz7wqvtnv9qjcus7ls6t4lcrt3ged388qsyuhte",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14hxmap32awjzck43xeerxmvnyzvsrjrc7559jw97z23664vx4lyst3wly2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14jz33kmx87yv94x4hzh3ylrpt6kwkqvjlsaz06aus2equyjv9w3s5nw2kc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14klwpt49lrs76l24puae7jnct4430ufl9u42rdmz49vews0vu6zqrypt4c",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14me6rlskklxu3rxmlzj27vhyecf8xfvvckwdn76fxkzqgdsy03jqj49ws0",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14mwhxhggae403crueknyqshuqzge56w2q4lltmenzqwmt94ys6fqdjgv37",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14nkh5n0e6r3qz78zcyygj3wv906qtsgqrm5nq3zwpx2zku2lvdqshfwyv3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14p3mvjdxg5skeh44atnvxvc3l0mf4jjt6uk62yk5nzv7q5dyf70qw6npt2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14pmk24h24cmpne8kzanagwe4f03wlqccwlm4spj4hyk7r0pxru9szmht2q",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14ppp79wvq6xlg3tnwr86sgpqv36m4gs3uurrf8wlmgdx8cz9ly0sanpqjr",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52E12CF5CA2BB903D84F5298B4BFD725D66CAB95E09AA4FC75B2904CA5485FEB",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14q5n9efl2lf7txvkfveskzdt4l47n7lpj2lzs7yk8u6hmzerz5ysjg6qx8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14slhuw6gtlsud3p2c79gy92qy72qcvjv6q6upwcrl95m8wyuepvsq9c29d",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14sxd3nugue3z44lh55cvn7uq8xzzzkgfknnuxtazr569jyymcqys2eykgs",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14sy9cpm4adfrut88u4869ue2sz72rjjcq6hlsmf5uz97tkswvvnqnujj6t",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14wp02k4djfx5yqvtr052lfytdmje05jm00even373h7cdydw78vsrjp52h",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14xpkpdstm4xhwjsw3v8gs99f2xl949wcnxx8a8dvn0qq5460afkqcsxej3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14xt30a3pswr540lp55y7f9gfevmddv84takyjn2p28a27ayc85gs3p292f",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/57AA1A70A4BC9769C525EBF6386F7A21536E04A79D62E1981EFCEF9428EBB205",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14y9ejauxnuyr48eu8jterwyhnz4s94s5ywggzmhf3wmu73g28gcsenvnum",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo14ymxts36p4z2eef06qeeuqd5s0x7fmyhzs382qvnqxsv45zcqf7q0vztv0",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+      "ibc/6A6174468758D207DD2D880363BF699C6568A29E87651337AEDAFD9E69EA7E58"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1500hy75krs9e8t50aav6fahk8sxhajn9ctp40qwvvn8tcprkk6wszun4a5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo150wfa0gum6sz5crkpvt9pztjf35dc8gvaufzrc40d6hr99wvyxlqcaddv9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/204A582244FC241613DBB50B04D1D454116C58C4AF7866C186AA0D6EEAD42780",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo153ezzm4uwy0dqh0mmxwgxu3mu0pknvgrsn4es3u5zrzhs57jc65qtsyl4c",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo154fszgu6aqqqtg0zff33leallf4rw3456s6spcsdmjf0u73jtd6suf32zx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo155c60gtktr83uvnahsxc3q7gswmuwm7ukhxmz06jwl3yrjgd4k7s7k4wkr",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo155szru0rpgcjwlcgwtv3r35v4zdc0dkskpr4fwshqcm9r2974htsfujjuh",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+      "ibc/B4DED8861763C7674BD726FFFE5CAB09BDC3CC706E77C82E46EFEDCF9DB3B495"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo155tdryrz9lqtqtsyjuc2ughrryu6nncr8vr03hepdyqqsgesag6s6ggts0",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo157u4eawmj4ux5jth54aw9sfh3zsgvgncm20t9m9vc7er6vrkjnks9naflp",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
+      "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo157yhlzsnqxvrne3wdpukh7uca40l9mak875u44f9asufvwkldzzs7tpaal",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo158s5v5kd2nzgrq0fse6tk60r70596e5p8qczj47pfqcqx9rc3l9s0q2v3h",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo159f0lecgvarm6a9snyqjnz9r32h72fwqq9q2s3py7we0v9mfp5vsx9w3ct",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15d7sqmwy2snpxw2w776v0tthr328dzjvpvk7phssyuqszq4lr6xs5dcupr",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15dz4u47sdmk4rq67k9v5n9fununc6j7y903azd3sm3yafd9wp68s9s4p5z",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15e4a88d0vmd7ywh9e2ll8q447defplgamwza9ezay67z84cxmx7ssu8s6q",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/101",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15e9w6y0g8z5as77g29azqwvp37dp96njn7h0vt5suz3un5vw95dsj4uurl",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15eg4aq5fxdehdjv5zr385h4zmswamvw6pguqhykd3fs2jrgpgr0qqmlfqc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/92B223EBFA74DB99BEA92B23DEAA6050734FEEAABB84689CB8E1AE8F9C9F9AF4",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15h02q7rzpwn0gahklnek29naae4peg3j4rd5e4hcc264sm3mfugqaw6up7",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15j2ttrqclc5j3fz53gps5n4p6eyw7qr3t2qsxna8ekjsahctgf4qe3v89q",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15jt5g7jn3m2wem6an2n9m982hr6v2madrhjyt3vxrn00vew3xmmsnah0ct",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15k82dwg2xkhm2una73jnq2ftan7c5rncul3fpyzyc9g3g6m0ae5skyswxd",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+      "ibc/7ABF696369EFB3387DF22B6A24204459FE5EFD010220E8E5618DC49DB877047B"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15krawmktxe8rzzepj4wxzgeevns9xftpzwhw7uycdg43t2k7nsxq3n6xen",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15mym9nr2g994zevcslnf8n96unwnsmqa8nzkef4lgavhjkgsy8gscuq3w9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15p62pdak6vsudduc82h09plethxq5m58k6x6t76y7fee3fgm0upq3x8553",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15sg8553z787gk33z47yd8uvux72asllkcywnnplepe6c6lhurs5sfpy7a9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15t7afyxut7eugx0yn4quesujf5snv358g3ureyx46afpwhjrlaas5nl3zp",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15u42rnfp5fr0qrdmnncptxvycwdxrdutwjv5v83t9y9yy7xq948qly3844",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15u5e6evufc9gjd28n4z9rvhku8lfg3arpejm0gnzhzx05w9h7e7q8665jn",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15upcqtt7tupfxdh4229vjwesgm7f3s5a66ke6dhfajxnkdmzm3pqu8y7hv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15v4mn84s9flhzpstkf9ql2mu0rnxh42pm8zhq47kh2fzs5zlwjsqaterkr",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15v7xfk7qnm27r2kwsutegh3jt2ye7haadqlnt5xf89hkp29hx0cq4sgqr6",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/361",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15vl4puljq9s6taqzmnsgd43gkz3ltp3hj4aexqj8x2ey4lxrrrks278cn4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15w6vtw48yqell0h4t3dyxhczp7dx0vl4f2xe3dgluyvznjdhhkgqnttcxy",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo15zzs8muh0lgnhdmzax35e90cskgulz7x566q6fpknguvdw95s0msen0l80",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
+      "ibc/71055835C7639739EAE03AACD1324FE162DBA41D09F197CB72D966D014225B1C"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1605py4r32r73csszlqpz6n5t5sgax9gjjfnm68jnd7pv6qe4l54ql0w8ku",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1620l9ewga9f6w3wyvfx5vhpuum3wwgz2haamn4t8lckfyzvnxd0q0chmeu",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/204A582244FC241613DBB50B04D1D454116C58C4AF7866C186AA0D6EEAD42780",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo162yn5ntl2tuuyxxf3dmm3d76q56ch9zlka0v7852wxqd874q388s502qp2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo163pdautlpkrj0au0s0nkqw8ln2r42gdkwjuf77c26h7crd44hj3suggfju",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo163sn2xvlaalva3td4hcjqmmrzzn4upu35qgdnnr4q0azp0t3v22qgfc8yz",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo163yhv8mj29c03zd7ktg2gwcpwjj6kcmdx933p3lfxdu66qsajt0skqkmvx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo167a9n3f6t8v64pugrqnz88f7w8tlwaxfsgge4tm7jh4gvxrhstyqgyv5jw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo167dnkr4k7ezmat3sq4nkdmwel54u7uh496n45djnu9xe82ad2w5s4qpg68",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo167dycqs0n3dxzfrwctg3p4hg7zxjjptr2p7nvkk9d23wu8spy4csdzvlsx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo169wdlgu8tes3qm4un02gwvhxw78yphlf3mks30j3lkwek8j7vpgqcx2zzp",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/1",
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo16a0su5csdrukz43z284agsqctfutps8eextnvrk3g2nhk2cxmlgsmfh4r8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo16cl5fg34wtrnpvz9rcncm37nutywn0765ldkuw59gc68xrajzuwqd9jt88",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo16cr2suh8wxyd3rdj24s7qe4kr2lnjxmm0495j07tl06jclnwfa2qqs58qg",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/18A676A074F73B9B42DA4F9DFC8E5AEF334C9A6636DDEC8D34682F52F1DECDF6",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo16d92nnsxj9nyc6j46k0pj6q0phhdu89nrz0y8657nn4el5fm3lwsut9e6k",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo16dafzdug0nreqs3h8g2rdtp5dr75ck9k2a9qzyvvgksn6cgukteqkafeu5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo16dn4uk4xlqshzufy3f0as2pnvdpwqlwepp0m5qumwh2c4vgmp9jqaa0zsh",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo16h2dp9v34s7dy5f8ut708tf0pjj7772u8f8n77pxs3k5aj4rkg6sl85ehj",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo16h9xer73q9c4rpwvmxhqdcqc4r8q0ldrgme8f3q3ljntam6sarnsd5tnlf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo16hrp33emfwydwnydry5k854ffeya64g6lgxj34ev27tl865msdxs7lpljf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo16qetl32gwxnne8q46qsc4e65rtnx8z9w2dxqas66hllu6c2gty8q7fwz0k",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo16qzex7q0cpj3dflx79ycqvsujm0dt838lfjv9fjg80zna7jpn2ssn3cta4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo16u8zapr7jvqv63hrnpfzfp4ys2g9ap69rxkdzpsasaa4qlwzx45sme0eus",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo16w7vk8sus35draftmhuac39vcvcpwcjttvjmee54vd0rx59xqp7s5t4flu",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo16x4qnfcefwaym3znv2waqh20rfgxpney2pxv4vvnv4p9y9n8ddaq68khcy",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
+      "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo16zg36xlt7a84deeweraqtf64sw5pedh5c4cquqv0gy4e6498u52sdx2zj9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1702m29rngg2xjsd4mdl3xscfrgv3fy039hc6uvczq8rsfwdtnj0spp4yqx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1706zqq68yt0gsnq63j3wjn8egqvr5sqylxnjzalvskjqkv3v7xvshu3d36",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo170f2kcc7ud5mepllczl23jnwrpwt6q3fsrxv0mtwtt2tqydf5u4sx4nesp",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1735wj90a09zr4a3pcujmpp85mkz05tu4ynm534eaqw9nl4zw2qkqtzjpw0",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1752ysawy2adr7td9an30a8pkk8ngrvcq3tan08lvnar3s7f82y5s4dt8fs",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo175hpfs58xklq8aradgemnsufj5w27m4ymeelskntvhuvnwd9wkgqsw5lvd",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo177r65zqzqs50p8utgyltw2uldlxyq26v2klgyxy5440kha49vwaq6j9z8e",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/00B6E60AD3D65CBEF5579AC8AF609527C0B57535B6E32D96C80A735344FD9DCC",
+      "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17atf6ld93djyxf0rehn8fcjka92enqy8jrcf7fc29xer4mafyv2qdz37dh",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17dyt6827sq83px7gl7gsuzumlh0je00j0z9slcp08cxy8vn0ye0syrr2gh",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17ehyaducl0pyznms988c7xcfd4w0n054klqr9fp4fmqzz05y9e2q9e3pvg",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17ff0mxg5j6xtuh7ma623ejcntuzuvpewu9dyjk00wkadh75au3qs0gp8pv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17gykllhtf9q4hqdrtydgl7jgvyeqf3rsvdrwef4ct6pvfhsmyg0sp423x0",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17h0ay5zhcllwgshem7r40a2wyx7a43w2ngfrrc7w2w60rrhdklws7u6zy6",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+      "ibc/B3FB7128CE957DE1ADB687A919AA0786C77C62FB1280C07CDD78AEA032D56853"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17k408tt5xf9zz44qxf95q6f8m8tvkethvrwk93gwqgkfrlefkjms68dp7y",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17kylujlrmyuxu0yvguv0gsxpvgvp44up8pvxvsyh36d0r9ww4pkq6c9zgp",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17lmjln5dhd2c37npal49p2gfr2eqmrdv20h7g2u0rszg7jlqxu2sztwlgk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/CD942F878C80FBE9DEAB8F8E57F592C7252D06335F193635AF002ACBD69139CC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17n6nngjwheahmljdk0k56dh5dfnktn2r2f33sdaj4uwnrk00y4vs0jcc0f",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17n6y5d9jqjvjk3yysnuszt9spuyqwcdz6uctuuf2m66906efj0ys333va9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17nsa8pa7cjeu2tj8v5mqen8cye3rrp2h69lzvepveruhvtmujkzq9uzjfw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17pk7pcuqxz2hn0j2rhqknzn4npujncpzdakpe9hclz5jr605023qcgc9ty",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17rudnglqgrcnvn3am3xm02d94y4sa3l43ywkv3cp4je44p2ez5nq590lae",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17rujtwmvk8vp3uqq6xxkymk83n3qethhejuar7ayhyuupcsw66mqmg4k28",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17sk5nv9367kc5jgfmtf64c9esgf4sdeazd8fd5twrlhxqne3tgnqrp2qpz",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17wpv2azveyr59utlztg6cm8ckzyyepklrrs4lswszn0u46s9rrgqpftypp",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17yl0x8s78p9nhwgqtdjfeynfzaz25mnv2j8m75ev2jznv782958su68utl",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo17z485xwwqknnxfcs73w4nxu0ndp4n8jf6ylj730cph4a6p47hawqrg65wr",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18503q8ndu9smzuwqm9nlgw4l6373d430xp32yv4gclug6t27qy6qz7dyku",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo185d7wu8622egqk0hgzpp48nmaeg3fvlc4pglg2zqrgdtcjenr3hstpyagv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo185uac6gnxaa7aa9pqxgktpuqhe6ve3jkfa8wl8dcx3p3zmymzkyszj4k6j",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1860equ7v4tjdcmr2vtka5kr3mzuh3ekzpcez77y7pd25972wl52q5rk9hd",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18864qdsyavwstv9r7kcrtzhnuk5zcevex4gmftk0vkaqczew5sjscf7xmp",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18984gjmrtrj8tzz5mlx04lqusrmjpdx28ty8h4zgf3yw7lr9r53s3ruz0e",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo189lml9kvhv8qac8eewhj3kuvz2zpy47fqlv0ahs3gtymejfty7yqqvdyk3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18ahq029ylafhmmf25wqu6lvpz6nz4nf533sv6hlqht6d49p23ehszdp5gh",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18c87zv90lqd59tl6u068dqcs9x80rfwwjs5wr0vrj7shay429ntq05psnd",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18dpk6wfldlfzkk2tdas2tztcth26v39tt7sc2t30drzrex6mlnqqa3hd78",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/051A38BBEF92B9D8293AFBE1FA293E704359E9CB28297A0FD5DBA3E9CCEE9AB1",
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18et08xm2dag9ppkdcs7epza2dvt423kxpdnr4vc670cm7d8jh22qukx7ls",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18f2zqvulx7wfzg95eh864jw7neqhz23sk8g9lffys3l4jnlttleq5r5kl9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18fdae3yzc2ycw27gzftx0czkpszzrsflw8cyqe99ku3c9aj7lfcq3tjzyt",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18ggsma2ef28tlyey053sxv7d3ka45lzpf7zm8mr47duezgghswrq9trxet",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18gt77cjyv6xe2gqjp9k6ct0fk2usv67q6jjjeagdttsy8qks78ysfq82fu",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18hd0dfzfwdmlz22qp6dqfd06xryqdaug9y2qwafhkp4znc0rqz5q5ms2wr",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18jxduxdcesftwkx8uh2lqrjl6teky87t8rpv9wd704929hpe73cq44xcwy",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18ltnsk33a45827l42v89wws3u2evagpfua7v57nnhslnggxkqkgq4qjmcf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18lw3t03dmyv6975kzjgacezvaafflz5aepmqrqqc8y494gwwwpmq9vm7p8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18p7qaaevs9kzsyuzmva969s4klx4xjxtn93cccpypfkhl3mqpcrqlwvu3j",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
+      "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18pr2rasc9428jwr6t8hf4m50fgd35am4s6lr45yae0slmfzqukgq20jmsw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18rqwcrvsfyy9s2tlfvmchclxf2cfw2hqvrjvkuljcrhq2vpg4suse8h6tj",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/307E5C96C8F60D1CBEE269A9A86C0834E1DB06F2B3788AE4F716EDB97A48B97D",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18svklenrqknkccu7fyh9lunj4ruw6dfx7kfmmv79s0v6sud2ht9qan8ddk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18taz6el39wzs87vn594z5q39mm8psf4v57jyjpx52dg46ac4mg2sxrj5hy",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18vt7x9yuda579ssr668avfe8mlngrf255fx3re23340twmh3ujyqsfr3h8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo18yxeq5kpup4k47vhjgu8j4y8d82sna7sdtjlz7hkuphnqtsmh8asc9vgca",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1937gh7cem2tn09r7c4uh7zgjvgjyxlffa677rv7zmspphu9dxwyqs6pw8k",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo193lusv4u9c7xuz7ct6wmcyq0c5evayu4x78pdhvp8ewa4huh6a9s4tt3lp",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+      "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo195dw0uzghljwwt3577352xu5gfmy3zrngfa545hdnfy2dd45acrsnsca44",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo195vm9cpsdntewfe7l83yx2w28hkfvx33lyu454gvfrr6f5m7gcas420nk8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/F16FDC11A7662B86BC0B9CE61871CBACF7C20606F95E86260FD38915184B75B4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo196w6qg0r3cfy9rx00390wkfdj9krd93uaed3nlht5uhqfh2avcyq3aldku",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1973kthujxy3xq49dj29t6q90uxj0s8epkg0tan82j2fnzm7ez6usuas27z",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19a5l88sxfdjxtm0d7x777g0g7679m0uusepaytqy0wlnnzut83wswvvezu",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19a6nnvczjpnjzt3wgrf4h02yej62wpvnq9cayph7ec5klhds487s9kazwf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19apu4h3aqlzhtpd0suftzctxnctwqd0lpzpueus3tughvcfdv4gsnzqxu4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19ecrtx598f0yyg2chk82gtsuzst2jfr6tkmevnwn8538lysws7sqnsg8q2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19eq5d9ng00ttwlsh9j9fs6t898lqltt9ah4ph039a3hznrz3hrns7rxy40",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19esg8fulwzufjjarprfpu4mz06zjpkmk7p0wydcw5q900lp2k3mq7afv7m",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/502",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19ffd2uz59gf0w594hpwxjgzrkt3c2vd70gzw6lhdtsz07hl2m7sqfky68k",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19fm8jtzyw8ujsnsqm5rznudn8fhhkykjh4ra8rvx9lsfslw2pc2sp36h3r",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19g97e0xshdd4xefn39wwquftq3g9u0a7jk8wcety6fgv58cpsx5sdjnvre",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19gffpaavnhhzryktpskz7782ttt5qfs4cqfmhyuygc3cxytljfcqyggf5t",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19hcj893wcz2cwk7jkzgvqxlwqqp7cl2v66f2e2l68hy4wezuegmqdcuk0e",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/6F4EFBEAF2659742F33499C9B4D272CFD824DD785156DF4C5C453F95CEF27D98",
+      "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19hp7h8xhg8r3z8wv0hf3hw95n09q5vxtfefeha97kuwflttq926qe8xs83",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19jeyxdr0maeeh9uedgaemyghd8jgfcucv59mjnw867vhwkysf7fsqf2yxk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+      "ibc/56C276FC136E239449DCE664292DBEEF5795C4EF4B5B35DB98BD1C0948274867"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19jglnr7dv7ppezmk5v6sk3drydxc97nda2wxujzjmh8ef33lq0tstn9y4k",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
+      "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19kdw6jce9eclvydnl8656z569ygjj060pehg9z8xq2p3ffyger6s6dj7tk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19mzey7tczk8fz5r2u2qnrmt6wlpgfh8k2wcnt20k2rhmspsv6h6s9t9327",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19ntgdh5wuu9zeh6svqc7x9h8zv6w7u4p7sxn2t980p7ct8st3s5sc8u9yy",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19qawwfrlkz9upglmpqj6akgz9ap7v2mnd05pxzgmxw3ywz58wnvqtet2mg",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19rrapg60r2f6s2h534n8d2tflv6kwed443jguxrvg2lf7pyggmmqq6mu8d",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19sp2fqdyr4p8mwn0206jk9ps06ewpavxxxz07zpseyphuy9uwmgspv87l4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19xaz97zcvcmp5q3ur3g4fqe6mlhz7k2dqd8w639yzk3greh6afws2wjlt3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19yat2nwf4h3d667xgyvtr2pg05nsxy2y8z408pnf8ypmkrqwyruqnnn4hz",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo19zg3tz4q5t3x6d2hdmwfkud4d3l3x8r4szr6clvlssw277y3g35srvkczc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1a0ev3jr6fts7y09as95pryn59hzwfkaletpusfzctejjy0wqa47sxqgy3a",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/356",
+      "gamm/pool/357"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1a482ur89qhmuv07gmnt93jnmqww3ae3mdj4pd5hh4uje7zk57wys258nqn",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1a6rvlkd2jw32mjf2pt78fte7f2hqu7gvr0yqsqek2c7anftrunkqqq798z",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1a86mk698pzmwsv28pcs5f4hvl22eexc3krc4k03j27fgkeqtaftqgnvlq3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1aaaa5xedavww3s9j48zpfjy4tcqll26wpr6fkt8wys3ufzlwv89qc6f8t8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1aav62u4pls035r93uuy4h2dckl06hc2atpsdzm8947qvlc34pprs3edc28",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1aavgx9ta75dchrwjf46z086pcjr44t4qkvz0c7walmvf5j3lxqnsulxsfw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1adqhma2hfrqr04uy4t4lmu3rft2k7rjj3j7xyye0v3tg09urg0xqcm28q5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1adzv0qftyywfavf06uqh0lutcqz5nz5favasq58rkvnu4l3zvs7shy9kxu",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/364",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ag2w5l8av9msvzhks4vyd920r9lzaesekes6yg3vykp9fch5n22sk6er50",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ah0sdvddcp3jjgfsyd960gud26l4dwz5gkqtx0qw42sv7kpsakhqyv257p",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ajghgy4ltm4ghn5smlrr29egrk3mq72642jsq8hqqet4cnwv4kssm9mrw8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ak0lwxqlp70chxtt2fd4kr0ywhuk2fr6ncsjr884psu7h8m59vuqm6p42n",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1amh63u7vgtrak5rmetdjrl67jhl6rate05r792ywyxzp5jt6eq7sx5uphr",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ang9dlvxrc0n835xyxvwf66mj0mm0sznyqwtu03kdd2dmhg40hlqnq36up",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/1",
+      "gamm/pool/8"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1avdp69rp58an6hysjh5n6g9w0wx73sytfxcg3qjynnxcar5t5qfqxukm2s",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1avm2f4fegrla4wcxft7ct3rksnuxvjl3mhv9gljg2e0c2swvlmqsaxy3xv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1awdgj7l3rjq2hmevgxuha99w39600fek27vsun4rztvy7s5h6n8sklwc8d",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ayjsj697r8ne5pnda82s96hdjvu5svp7ucjj3ekzlj886epq78cs2e48n3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1c0l0m8tvta5qdr5cutfnydw2h6r6qpzxtwtk8e7677v2h7es3tfsgv986d",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1c0utzzgn56dhacxt2rzf8mvgkql54xnu78fhpnxqnx6hld9hue0qe79a7c",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1c2agkt3smeangnelsxqqr97fm6kd0s7erqsgcuvc3nu06yr63qnqcz22mj",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1c3vwd6kvev6499jg6tseszqky6p69mwdg5n66j060hvytxd6hjrsvzxk6u",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1c4xsza76pfcauuqadpa3gq6mj6zjzjx4upm8p9388jp7tk52qars6p8e30",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1c59p7ddraqwrtxe0camylyhra9s6w35qtywuaavravzx6us3cpsqn3dgn3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1c89mqqr6p979nl0jheysulp84zzpg84ujq5r0dzsmn7xl6aj38pq5fvwdw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1c8gdt3cquepqadv6ys2m9ht8eys40c2ws46ntwm7zknr2hwcsuhsly32ft",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/13",
+      "gamm/pool/5"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1c9gj5nwxhuh2gz7wwg4r8e8tw8v7ggy9lh2hu7kkdgh0t450754qh9cpvd",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1c9x2kvqge4r2z5rf7p64sg0fvdmjsklxcexmmre2amxsqjxeex2qrlmr3h",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1cafjr2f6uek4jc7g0sgxwxnssu3uq2c5uvlzkg2mwkg6jdwu6a9sa7qg4m",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
+      "ibc/AA1C80225BCA7B32ED1FC6ABF8B8E899BEB48ECDB4B417FD69873C6D715F97E7"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ccfjmcfe09k0f6fdcfdgkc52c52l2c0jywfc57sn5qd22texqr3qla0e5m",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9B6FBABA36BB4A3BF127AE5E96B572A5197FD9F3111D895D8919B07BC290764A",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ccjfm7gpa37mc9zwq553p0ttzq3ga5g6jzarz37lcq4qlnsdcxhsghcv3y",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5DD1F95ED336014D00CE2520977EC71566D282F9749170ADC83A392E0EA7426A",
+      "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1cdtygs9r2lf9smh79j9l883wfxearsweevfqrrehfh7up3xw4nxqrsjwlw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1cf892ucxz0g5y9tlakunhn6hlgk40w0s6fy6hcjzsqnmx4u77xcqjafnfd",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1cgr0zcfetq39yc3zhex2eaw2unczcw90m6qn7msw45r6qae9k0xqputy2m",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1cgw34ya7ndpmplgv5wyec4mz7hq3crc64uqq02qv6zk9vxun2rksk8fcja",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/73",
+      "gamm/pool/74"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1cj8dxdkgugvj0dysm79zha8mgkn9r7x9yg9n4cmdmqv9ucjkv2dsj5evg5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1csvn07y2n36dy3glfvdxeke80sxrhp8xwtjfds8nhvjullkqzpmq4zzh2s",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1cu6nmf563q57u4lc7v9t23sytz25t5cya0f060227vwsy6u0cpaquldl5e",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1cu9q2r5r09uct7ykpepyttk64hf30aygjn0ky567qrky5nthl56spqtnxz",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1cwauwz0e490vkszxhrfhmawjsaw8ulac8fr03wccssn4eqswdxpsn2ycxj",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1cxfkytmxzs55c00anuftly389mzg3gzvncfm8s4u9zeulhj8hsfq87snws",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1cyjmqv92kx6trjjjsmemj3hvs9qg5jsrhscmq5km05hpkdsv62zqwpnggf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1cyllu6l6dw88t2wlk5ex4femwvj8nh249uff5uzzt2409aw0gy7su6lq2h",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1czqlvqjdlm2raj6t65nansxt5zlv8ny04fn66gcm9llgl24axmksd2px7e",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1czvns32qxxcyckqdfn02j7taflphz5dxawc6ksg7j5h58nlnen2sh8xxyj",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1czyl3pef9apzjzwn949jk4lsfcql2mg66xxrmlvcukt2x3q0y03s7v06d3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1d0elgsavwgez5xf0fdan3krzfjm5jkdtcgxzlvunu4jndycs8u8qzs5h33",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1d338zex4aayp5r6r4rtrvclcwdx4x0jqnpy0qzyszn700hk9n75snwxtsf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1d3nk4hhy929kyqnrxf874xvdey46szrw4mxk3n8v26kzck6a8r2s677wyq",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1d4t6lpc8glprq3nfg49u4887hv8jhxvllsey27mvpu7qf4pawkjsplh3pn",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/A91B70554A510310B2A068979C8E7A9B433EF689E82A9321922D8A1B845B95F5",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1d6h0xq4vsgpay9n77yrzuaqyvs96x83c0wrrffr92pkcxnuk6lsqff43ne",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1d735wcpt6x0w4ynqe874lr7ch9laufgas0dr2nfs6e4zzlurlf9q5st28n",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1d7khqcglglgvkkj8jwt62mw0h7ak9y7de5js9zccn9kgtmx0j2qsm56cev",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1d7tu6pz4nx5e4yzj2keu6ftvr9u5p22u2vu5t6ts8syqt0e3reesqnpun0",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1d9y4rs70crz90a49fa3khad0dxy6yg7ezgdzlvuvjrujwvaspawqjut7t4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dal655pjhghjfnlaxppj6kacgdrr50xf47dsheeanwaxzya2dm5qfmljhe",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1daztxlwd90kqt7yw7mvakhp9kjd34g250dywutq06nvlze2u6uhsuk26xw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dcvgttz6jwepg3gchu097aa2vxjgp3g5gm0t0p7z20lyclu7y0rqmc232t",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1def45s6km7yvg37czsyxdalscd63w9k2v6yynskcgq3l6slm4tps2kvurk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dejxnyjlhkfr8vjh9j47vjl9j9cvs3jk6aql6nvmxyyv547mumgqtcfc5w",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dgnr0ajw2p2wxh05lv8s8znts6rpz3n2rcepng368tzr5h4pzm7swkyfru",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dgnsyv3zj9uhen85ttf0heulkzcjj7nn27jw00hzpzp0ecfwx82slyu0ta",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dgrkc9rt7653dyvkepwk25tqjfnkel0alywgwl35p9jtjw4a92gq7f7mnz",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dh38ppn36hhdl365atjw4anr3d4faxzc6j0tassym738k276rx4q2rqkrs",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
+      "ibc/E09ED39F390EC51FA9F3F69BEA08B5BBE6A48B3057B2B1C3467FAAE9E58B021B"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dj7rqa2r8psqp36asc4r6j20v8u62zjpqqwt8khxe24t5dzwssns3aph35",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1djnm5mvg2s9p0appalcypxcjd7cd0xw6564k96r8dylgva3vmfnq0ca434",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dlahvz8g205z94g4xpxfxa77wmm5kn0janhs34ft22yxyljuyfaspawg0m",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dq3745uz8j2qd5fq2wtyvz9xzr5587awdnpn08272946dmn5pq5qjknyr9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dsdccxrhra2pndxay08s7vajz72kr5vxqayalv7xt4gntey2xkmqa8u2x9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dssdhlzawzthqsg60a5zms6xtx4tsktfzswal4qsxgugaad6j6wsxd6yk3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dt25gt7wgeh9l66adztvyl9x2l94mane2zdkrp29e4y7s3484qcsgv24y5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dt568undkrrlullpzz0c27548vjdrhnsxwhygxrdtacv2dns2ryqa28jhs",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dtlq83lwessktl65gxz6u8ufqc9lz0knh6nnw3rwklgla6jumrfq5a3clp",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1du947dpr6v3nlcwu8a2x2qtzkqm6z2nay7dqkzj8fgcqmull6mvq8wum5e",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dufw6sdwhp6cxuxh8kfg9t50erne08t9sl37a6jeyswpknufftws5w7w8y",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dyvjg5eyr58e73fpnw3z6c7wz2h0wvarmpmvq0c60vawm8e6q70q44v94n",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1dzwru0m7m0klhxqj84hd3vhhltk07r6try7pj7s3qy47nqq43g0s6fsy2n",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1e0m28qylp9k0s4l6quk2skv9g3w0p8qvu8aqmxuf2n6tt7ctkuyqrw5d48",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+      "ibc/8A07D4BD40E0F44ECFDF360F7EA7008B288926FB87C54489FE54DB81A5340E0C"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1e5xkxxpszq9t08yuu828rjzrmj5gvpwnf9ywv74ryz4frsyr0zlqyx76xf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DE9A32D603EE05E9B8619DF24D90FD518C932AE0B5B3209A986B7262DBADE2A",
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1e63smvqcnxpgxuvhrknfapmyvjy98csgm7z6xr6zjnkwmjf7zeaqsc66vn",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1e6szkqkkt3g6u7ukjpdz493mkvm9njknrxpe4vcfahl4dlx358msqgnrxz",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1e92udnupts46czvcwtjcpgyvjhjv3grpjg43p60d8el8r24td3zqt8gfv0",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/C78F65E1648A3DFE0BAEB6C4CDA69CC2A75437F1793C0E6386DFDA26393790AE",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1e9s595ml68g99m9vtat2jl66v65ravl7wlu3usj7mu3arz56flpssletl2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+      "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ea5ymws7tufhg7v72wjwp3qskngmnpl729uc9h4anusfasmg48tqwje94x",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ecljlcqy3z4tfrr7rql0tmr83mh3qfjdzmpgwad9zm6q908k347qhc23ht",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1edal9l38mgcm2hj27hgz0mcqapkp9yla3pgtusxap824hwqvfttq00m4wy",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1efnu25xj2cp6th0jacx9e7qn6zlwnceq24v74pz0wn9gxtlc8pvsqn0l0v",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/420",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1eft30ela0axavl9xa3plmv00ah005vkhyexsm0rc0cmfkz8jujjsaqq56h",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1eg26w7fg3hdzjxyxv5x846ekjmw0rdewlxlp6rf20efursfurh7q78cyu2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+      "ibc/B797E4F42CD33C50511B341E50C5CC0E8EF0D93B1E1247ABAA071583B8619202"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1egng4w6ht85nhy5038hfs5xvx6ddg0l6mqslaxnudqssq5jm4y2qrh2han",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ehnfys6czdccwsg4twezh3w37a6zxgaa6ud0s0mn0c6yuqnj6dkq6jx9u5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ejaswj8lcyh0zgnes8zt45e0w7tqm4mrxr74sfwgpdh72shp58ms4fdqsk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ejcrrmfxaphd6nf270r34467u2a407mewhq5g5cz6hdhzqs7nnxsvpthf9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ejm5jcfnsvcw5zxvc5h2k5d2yppww7tk9jt7hnqh9upaudckp8cqjn2578",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ekrucs08jgx45nf5d6rtkd2px4m60v9hwa4l2mj9frkvv908mwvsqz7z96",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1eljhrrff3eklwl6t6lv8znt8pyej5k9k54cvr3gyakqmr6xldt7qu2vhgl",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1emy3l3y30eqv25kfrwcs54whga4smrzvf39rl8km45rupcjz7uaqcmxtup",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ep9jw2xkuu3mhdqstgpeqw2tr2txw7aulx5cx0lar2lc3pw0huzs6j5ty5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ephgyd57rw7mzf0p5gdjjezt2j442jpzdezvkjdvpke703fyy06qtstsmk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/AA1C80225BCA7B32ED1FC6ABF8B8E899BEB48ECDB4B417FD69873C6D715F97E7"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1exr9ekmy6ucvp8f8mqzu8qetxzsgzuz4d4h28y70ftwqwfcfvgqq2ywwh9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ey4fm0hsg5h0el6c4duhkmu8ujgp0ndv0u04jpnkg696lsx6kytscdw7tp",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1f2tlf4lnhzsrh9pyu9y3u6wju2nlqzummm3zs70jerk2s7a0fq4qfq9epf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1f33v0n0kn6vtu7vkxuf2rm9dxncnwuga5825tzupc3t9umsgt0rsl6u29e",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1f4lp47dxu7w2ykr5dpgd8yeylx94xg5xv4cfmrcsfu4v77tqv73s3y3cmp",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1f5fse04elu35trhlkf9dq4crgjay6pfh2nnmgx88acj7xmcarnvqgvq45v",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/EA3E1640F9B1532AB129A571203A0B9F789A7F14BB66E350DCBFA18E1A1931F0"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1f602n58fsvphaledcyyxeczukyee0dnum08psrqrl894s3cc57zq6jyvyq",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1f7cj0tc02qqwaps8d98s3pnwfyudsvfj9w4zmdmxdrp9gw0sh27spf7yyl",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1f7rg0se3mhuwkjuzwdys2j64f4ktk5pz9lmf2cas5xu84urf5ulqy2qmpc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1f7vufh36kuhn8gtjhzzm98h22w6830zww86zwx8f6f47cz76r5yqvg67p5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1f7x8t6zv4tdmu2txgztqc9jwfa0kmx2jpgcmah69njaxc6h5gszsp8884g",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1f95y595e89tucsuqrzdpgvtetyc8mzswdrqp4rrt8v8dexa2t4nquuee0m",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1f9862pvm6htudctzex2c67ezkkp5z4lt07h76kdjl7gayez95eus2ekuhs",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1fcl04ma3dhc080jscyzkgf65u2ctv9v67ec03an3cff0gnfqkllqqkufhx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1fg5xzrgah8mr6uqcgfjv5m0l9n2ce0ptye4sraavt3me3uh7yfeqy755dg",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1fharjyp6vl6xx67f59jn2mrc0p6vl5lf32zpweuyevdhpusv5uysamun60",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1fjjqzp80dgpq2lr0jzzyc9x05eeu6th36lc9r24x3m26af0vm5tsdzkt00",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1fjrk6zk2st8uzgzedh8rx9rt8gk7rmxmstr8923v0xsqn2gjafmqr99vc5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1fksasqaynht6wz2nhzyjnc6ef0d5caevyt9uqczhclfuzd8kyycqpl4g5j",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1fmz4zaaj377th482zzrvc5d9rx7hpreyhfprvum9hd2vyedg0trquug78j",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1fpv2vn8xz4arzvwjqc52eh085rc4ktnsdwmpg3tum0rvgyf2hfqqw035mc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1fpzttww633v3jqz7vkf9csjcvjlmfl7rq3654uf0j6seq0p4h4esrjmuxw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1fqu4s8f5dha4tgf3swet43jlmeutxeynmm265mv2m8awauy6cvfstu4xyg",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1frnc03evn4vnyrcvqqv85304rgegj3g44xj8vpdktmuaqwaqxtasefugr5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/8061A06D3BD4D52C4A28FFECF7150D370393AF0BA661C3776C54FF32836C3961",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1fwexzng4wjqvga4avsvmqs6ay09yv80g4w6wrn9um05d95vsqw6saqxjgm",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1fyav6ky62qrtu5hu6hv6jrx2mu058gvke6ncqyke6ns5mjgvtj5sv52acw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/92B223EBFA74DB99BEA92B23DEAA6050734FEEAABB84689CB8E1AE8F9C9F9AF4",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1fyxn5dnns58s2k0r8h3tf3llj6drwxn2lxqh7gv92hpy4953ka8qx6hey5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1g0c2n00paxpku0t4psy50kz385htrv50yk5szm6z57c0rzpd6qesjhwxwh",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1g0e2en7r0juxqx2mmp9gc6nxtx9xfrsll5swvccsskywrfd7utjsmkt4l7",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
+      "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1g0jmvyrlmed35fd42rfu8emhn8mndyknn7rmx26943nt8jcz70rsd5su83",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1g2y3ptjh8rndpsq6r2cty94nl777fugke3z2rq37ac3uldtfagcsspp8xt",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1g4u4df420klg8xnkuhezz065p7e4q6emwagx3ctd9qv3gcl32h7sfygnlq",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/8FEFAE6AECF6E2A255585617F781F35A8D5709A545A804482A261C0C9548A9D3",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1g7jq4a7hw9n65tdv9mn28gckr7zqrzp0czvlxa0gqftrmtw28c5qc82aan",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1g96kuarfld3nfeenuvdke2ec6584qvhrpx8eq0qxntk5llgzdlesk20neg",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1gaern4gnnuu05dlzfr9ax5hl9hwt6tcymklv3vy4cs0tz8kkqqnqlxesce",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1gdfp7xyv7j7wm7v0z42rqcaumf8emz3c9whfzmhmu6qauu6xfdts9t5dcm",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1gesjuqekz3pyuuz0fg7j2ctckeqkltn8h225ce0fd93fckd9sksshu4wzn",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1gf86c7l352dk4zcgruldykckr99jn86khvjy2efcvevewrjkv3msxur0kp",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1gfzdnqyy95cgvjl3vkr7vs3ra9f06xu7mu0w4ldxj6rqszkhvnts0vs24p",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ghy3kl2fvyzag0q68zwmve4afl26avtt4sn80um6gw7zqx7p35ns83cch8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1gjfqv5vtwnm99dwac9v9ug4l9msyq9wejnatnvj35ex25ak2nrssh3pat9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1gkq0x059rrnv6egs8snzy7m80zrz3uygtu3khxr3llgnljm2wjpqmeqlz4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1glc2ym96m3tsncmulludzhksuahvk09rwyjlm7t20dewlwk8vzxs529ngm",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1glls893n6fdgw2nrx5kl6l940qrxpvd3k5qlf3udu0r5zhgc6dqqs98en8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1gms9szd899acpscedg46za5zjmut2yalkgnr6x2ekw7q3l6ppqvs0h3lu0",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1gnq7pvafrxq0yg74ph5r7vxl6dh6rsp5yncrq5gd4sr6vtjppndqsd3jjl",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1gr45uf6rm02778wdwlhkdxt3c94fr6eqtk6284fpr804r24nrersnasvtx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+      "ibc/CD20AC50CE57F1CF2EA680D7D47733DA9213641D2D116C5806A880F508609A7A"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1grw4dy9teaam0u2jywd9sw49max4ua9vj6hgsvjnr3jva8cr3husxrc3g0",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1grzll8mqv9c0tkwe0secf225mpxnrx86fffnnlz4ffhwkqsr3gaswfa52j",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1grzzz4rwj8l06wuf83dwhhhss39zv3302edgpa3tx6s6g45etsrqjjrz3v",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1gs0czr9thyy0fgneenmj5swnew73gk5xktr352qggxlhhm5uwkpq77sgns",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1gtc9dqfscgnlrw73yalnan4v2fwy2hz5447sqgclx68yz46us3xs38v2eh",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1gtxfvhhvx8n5xvytrrp48qgu5vflpr0qm5e5c4p3zqwd4mr4u0uq6wv5d4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1gvcvxl68u9rgwgfctxkfuhmyqxqzn3lrxw9cn5qg3q5er27ex65q6vlpuh",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1gwzs6qa626az6nhqcg93uxa8mfcfcc4mm7xecctwqaelfl70jewsgtkfh5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1gxdq040aa9qk9d5uvtlt00uwhaskslthdq9k2kpkwm430u4cnyqsj7ml7k",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1gy7usssxrzsepfpn9z07456cqqmumtmn5mw3wgc5jpmwt2ha8qdqwxy09x",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/1",
+      "gamm/pool/73"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1h5hz4uttwlnvvn4xf0r0sr89v6rgtv399le6y0ksv458jvg9vm2q8nyvdh",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
+      "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1h6tps4e40h66y5xunmgazkd4kvpcl26367ue3ta4ukjzw4j5j7tqxqqxh0",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1h7yfu7x4qsv2urnkl4kzydgxegdfyjdry5ee4xzj98jwz0uh07rqdkmprr",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1haqvxq0ykcxa5wjzpvpdpu96jdss0v0du7hfly595rhlamtzlmzq9a748l",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hcpnvyer3r93x2ux72w0347plas3vzs0f886lwa4thhdqth04jcqkc0k3c",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hdsvaxe9898kryxy2zlljtazl5dur9qxhph9q0qnrcqylyf9j9gq6peqep",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hecg2sghe8y69el3r9s0ysvlgqrwhg626lwujq5wzh0hah8zsqgspe678n",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hedgxlrrcls3aefh83vhqq4aema6yglhu24w8x67nulyc7655ghsdfvv60",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hek3fwgtlxgjvsgplhsucpz7w7q9vlp6mjm5m0c84na0x2y9y43qynrs6g",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hg0eeayprkg6a66fqs07sncy09rw6tae9k6g7ryrjk0k4nypfjwqrl6wy4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hg2963kvsu2arwx69hcqmsl2ms4x5pjw9x7w43lvspn5tgz4aqksk0sk5c",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hgxsqpxghfw7pwwl8jwxzy04cyll8nhf6ejnxpx3wvkszkq6rznqap0yuc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/503",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hhrh0atndq75k3wws0jp8z4q4sdr5hs2u629wk2l35yuu92mah3sfa06ns",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hjffj5jr5z53gepl9754vl5z8vxahz6r6yq0kaj2kppxrcrzu7lqvuzgqx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hjkkjcc88t8mf2h4n2rzdxtdpmscv53ek33vs48jxk5x0d2uf9hs59teze",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hl0s405ggpxp8z5svx4myy23s4vsxm2n0040xcug59gx0cmdhqwq5t7x0y",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hlxc9ypgx9pfnrt8vacsyw8d0hj32n8vymg2u7aaxar2f6aulpeq2t095k",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hpfr8caa9swnqj2wapqwjfakqkfvdq70uvjv37pdst3xunsde2hqkz0na4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hpgavxcjzhzrfj6y36ut7klat093w9wq9rdk399gmr8u3s96uqmsmqx9zn",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hs78pxgz4v0tmqs4gau9zpdsaeu4jumkr2r7qy0v40uqnws26ussyxt7ga",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hvm4qlmmpy60ed3ex4zfdlpwmurex6uunudfu0rjh6w87tvtawsq3aj6v5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hxddxnuw6whdd4e8kwln9xeaws45kz7cuwe5asd05ws7xnltgjwszmq7np",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1hz6eyl2u990ge6nq7c3uq8fnlx2ghedkervym8s9psnqjcj44wxqlewm4v",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1j4ak6hul4x2m93rqnnjpxx7x6zml435zmv7y7wet0adr3sfw8crsnhd3cl",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1j4j7kxkmu6kdenrx9ky50k9x86s36mcaqxukr8sjtl2rwp9vkwfqljjd3r",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/67C89B8B0A70C08F093C909A4DD996DD10E0494C87E28FD9A551697BF173D4CA",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1j4xmzkea5t8s077t0s39vs5psp6f6dacpjswn64ln2v4pncwxg3qjs30zl",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1j5l9ysw5xv0uqz9uh7mcg0l5rlerqm695ec9kkg2t8rp600zv47q82eqwa",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1j5ywgvensu0uez4te9ql2eslg4qt96evhpldwd7j8h2mr66c8s7scvx4w8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1j6vmgahwmxgcpra7dudw570g44cntyvx9pz3k83ny8z0qgytq8aqmf8j0s",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1j8cp3mdc9jq7vmgf0hpr8uz6e3at6uctwtzhn6qlm7g3shvzavwqg4qxyr",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1jaemtd5g8h2dwegte0h3r76xt7uahrj4tdmdyypl5ptlswhnfves5cvs3v",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1jajfyerkktqn6qfyxefeg078lfrdpkl87gsyhy925nwc6hysrtzq7zx9g4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1jaldjtc7ksfldxgg604zyspyd94p8kn6tleaarcdwl8wakul6w7sy50gam",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1jatt233sux9mxjuqmtmaavucvatj23m2v6nyh3rel60qpjegkduqewylk7",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
+      "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1jeku67d5x534pn4l3ules7yye2s6kkj92hmn0lyldwnv5xv6cq3qjujw5y",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1jm5tyuxars5j84jdeeqkp0zpyfk2ea84x7fec8jq03x00708f3qqwr3f57",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1jn6lsmjf2qcgqyj6zzl9llunm3u38x3dh3dggyx043ysxy6jjwssq3h7ha",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1jn8pdd9kez2n7422vg8qvwn7angtz2v8gjwkff3glprxypr25v0qp7zwkt",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+      "ibc/EA3E1640F9B1532AB129A571203A0B9F789A7F14BB66E350DCBFA18E1A1931F0"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1jqvyxwgq5eujwp58ef2hgaf0xsn6vh0w9at77adyjj3uafrv8r7qjpks4h",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
+      "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1js8gkwluk3uux73v9u83f0egh7862sezq2f80l2c9eetylr9meqq698nvz",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1jsfqrh9y0mjvrh09u82ja7az4fsyew64gn2pfg98c8969zg5zmhq2njffj",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5A7C219BA5F7582B99629BA3B2A01A61BFDA0F6FD1FE95B5366F7334C4BC0580",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1jsr3q3yw5pt3gtnsdsr0c6hx23f83cpv6st6ze3pplthwrc67j8sjge00h",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1jtzkz2383cegga8pzq7azm7tp3lcutep95urpvuqxz3x85sfpw7ssaqpc5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1jve7zc9y29kl8jalu0aaz8v38y2vpjucdk7thg79ektq4t7aswcsa6w45d",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1jz730xfzjnkp2zaasvqg9e3smv2a4f8qvrm6p8cs83m2srkr56hs4wtm3w",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1k33jzr6syz8fs9jlsjerwum53ctu9nzkfdr3uy58ddt2tpsnsw0sl8ff3s",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1k3hmk0dyeu7m0jx6w0ltufvh76kjk0zscthmk0u86u3y95dy4xhqmqgeww",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1k4gj3utpx0s3pmtq7shmyhdq2dp605e03hcprvzvec7jq2ge2u7s4r0wp4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1k4nr7aguzj733ch3kdpl4834ex5uep84gcvtnumj2ekgrh4xlfssslwlpd",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/239A507997222805E441956EBE8087D7E2D05D6535C6D4C75EF8DCF83B3DE1A1",
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1k5s6tga7smv266aftu7l4trqsdqg3slgq5kj2q02dppdxlw7pjvsxjzjrk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1k6mv2aefssjt0jq8gwvccwaa0xsv7m0dxl5kzqay47pepy6e8kqq3rage2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0CB9DB3441D0D50F35699DEE22B9C965487E83FB2D9F483D1CC5CA34E856C484",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1k804l4hsemvreuguf96rnv8f8rmgmr2fm0nuy7z9s7je7j63dktqgamzc3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1k9a068d7990a52fncvt70magqvzsfkeg9a6qnqehv20qwwdqfrdqux5s24",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1kaekqycnekvhhstysh7e9wwkl0w79wt9pr7vusmqfqkfcqgqac7s2fc6dj",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/A6383B6CF5EA23E067666C06BC34E2A96869927BD9744DC0C1643E589C710AA3",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1kavqnurym4exfwyz85j68mkggacegptpkvpv08d3g6q9vavhw94qvj756k",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1kchnwg6y2y4r2nyjartp9q3ss4ysjkx9gzgxwdtg6624g6natn3seyj0f4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/222",
+      "gamm/pool/323"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1kcra3rvreavuzm94jfwl6pd4kysppvdn0g72d2d846qrg0gaaz2scsukt6",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1kdnj8qjhya69n2yj820mzt9wjunjekkyu5ewwn7l5ppyn6qhu9zqzj8fk8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ked4s6v8a5fnr7wshk3825c4dc44hth4aln264ygjxqw9ck4ry6qg6ysxy",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1kg2ga83a9g5rhv5xu2m24q8rnqjv5vr6257cc2ny5x5737ttkg4sjh2zm9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1kgg8uct2yut6etpprx2sdfn2fq7890jez9jd5arunsgg734mv68st55v0w",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1kljure6uz60xec9ecmq7sldzgz2x8n2r8snxgvuwla4rn7kpvjzsjczqqx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+      "ibc/C9864D1B9623F703C75BBF72B7FF8A7317E1535C96538D21467A4311246DC3B5"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1knufp26cx4y9p4eecgra5z4deu6hek0hh9let2gwjns2g3tzue0qt4xzsf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1kp5sa9gkqwtcksupd30hdez9mfx4ak65c7m99yqj4pk599tlfh5q96u2e4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1kpf2xfutvfqfum9aj2juvjcjcxzp7k3le389v6ql6lurzcq0hausa6uyx8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1kqmrg9qyqfgkys9q892m8st5mkesez8vpnegppecex0ylqqp8h8sedeu4q",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "ibc/F6B691D5F7126579DDC87357B09D653B47FDCE0A3383FF33C8D8B544FE29A8A6"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1krp38zzc3zz5as9ndqkyskhkzv6x9e30ckcq5g4lcsu5wpwcqy0sa3dea2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1kskty9u0uvqrn89p4ultt4m2se2jjkrt404d20zgqftdch5t4k6qmysqvn",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/F6B691D5F7126579DDC87357B09D653B47FDCE0A3383FF33C8D8B544FE29A8A6",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ku38urrhfsz29778kcwr7zaesfcv86js2alyy58t6dnzh8nnf73qpwkwtw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ku7t6f3pcl3e9kfzlzrp5jwktsl7vqu4dym7fzvn2gsj47qp9e5se820kn",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1kuceh0se3p3f6xf7ca5yh5ud33my9rzk9jyjh0hk5ufvh02vvn8slg06wy",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1kuecnt3tye9q23d5ytw6xmfp70w7gz4te6sjs42ptep9utrx5v4q5uuj9u",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1kxlcgxrc2lqn7hmks2ukld6a8f0fdfm0dwstut2uragrugkryyvq7eyxmv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1kyrc9u2g4f44empz8achjdxzkftprxhx56p28ft02lkaucvztyqsrlsrd3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1kze098t3xxs3w6mfhxkdeehrktjd49582g8vtgfh5cke2jfh2hhsqqjvgx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1l0s5xy5nm9qwdn72nux9dyck9k52l4mg907ghrxc0lw8rn6vxuaseq3t9f",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1l265e7cug3tk3eugex8hpq2adk5drdecxzp6lsytn6dls6jpjkssvp9zqe",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1l2a4nmtjuv8mfucrenpujyn9j04vl3gmrsyq0vaj5f8e6apmavvqhtje00",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1l2sd4j9yq6hz0q039hnjydx6zj2lptu34f846yg5jutgu0r7juvszgk2xy",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1l45a67tujfxl99qt39a09cqf9ep0vtqyn8xnuua66yvjtc7e8lvsua2hjn",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1l5ehe7cqgf5fplxegqaukwygaz8g2h62yhdt06te6uem30l2j9mswf6qct",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1l7vu8utujujfy0j2xrhcfzcz27q85j29vxxyjx4w7lnxzsevjfwq69qxrq",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1l87xgwa4j9ntqfuz440pw5xgsw27y227rddfz2knekfk59k0satqj9as7f",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1lahkpd2rxat3huy3kqkphvugruzxm3d5n0jxve6c8xzmkcvgfw9qjdnkhf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/104",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1lc77pdqlnj3s7typ0nvq7xxt79gmtec7mvazdsw8c2ffy4j9hjrs6crft0",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1leu9xn7ecn7wq58kz949827zspj7xzf98200mukzctgnrpsqwsfscnwc7s",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
+      "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1lg3y6n2qc382ukpl8y6hfxlk6lprw3aye47zsld7xpnktfhvxneqxjf4f7",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1lh3kh39lzupfnupjsl5vda29utlzkaz2673hepw2cdck8rqm3arssz7skt",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+      "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1lherhrcrxe9yev22rjda9auagvr9nupncmtn4yajs48kvfe42t2sq83s4w",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+      "ibc/D38BB3DD46864694F009AF01DA5A815B3A875F8CC52FF5679BFFCC35DC7451D5"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1lhg9ec0lmn0wec4tsxwk7kwqd5px203vwvh7wth5wls4jeu2hjlqxn7gte",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1lkam7g0tg3r9uaq0y7tgzax5934zaevuhe70evqxaaga7n9wqgasqeale8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+      "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1lmk3mgsj2ajp4s34jzfsqscz60nfys4rlsg5u8k03a9420ggyh2qldlmzq",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/38",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1lu9gpwx7n5phng70yap748t48ws5p82rher9hvkqqvpczj0f9rwqc3rmy5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1lughuhtdk7fj9n9pzx7hu5ulrcg6g84mk5j3aezgw86f4vae79qqw5wzd4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1lv9ju9nuzr4vgazyma7l8hsw0zcafwwm77vvdjm79mku6ydpq4mskdpsd2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/CD942F878C80FBE9DEAB8F8E57F592C7252D06335F193635AF002ACBD69139CC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ly2shj6fznqwqskswmpwmrkqxdsavhmlmkr92wg3hcqqxnn2y5vsrkhc6u",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/EA3E1640F9B1532AB129A571203A0B9F789A7F14BB66E350DCBFA18E1A1931F0",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1lzwv0glchfcw0fpwzdwfdsepmvluv6z6eh4qunxdml33sj06q3yq7xwtde",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1m0qkljyn3a0sm2m9sgj6485frrmxnqpetc0lqstun5nzqj28fctqkt2qeh",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/CAA179E40F0266B0B29FB5EAA288FB9212E628822265D4141EBD1C47C3CBFCBC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1m0yntqzum06tc7ztw34sn646clwf32p7x2cfymaf8jx0cyf3jvlqfe5d6x",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1m28rqxevywfn76c4lf5vws64shd0hxvxyvzazzswlj5n7q48pxrqvlgry5",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1m3690pyfyadnny62ylj44xdlhzen7dluzmlrwwayzmnmm8deqy6sd86xla",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1m3lgd2ekfvtde7suplqwgz0c38dfw0rcrnds86876680u0ud8sfqkg63dx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/2716E3F2E146664BEFA9217F1A03BFCEDBCD5178B3C71CACB1A0D7584451D219",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1m4qg2yg542hp38yrdnp7wxhpm8j3agu78sg7f6lz0dzpmk4t4cysy9x5mj",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1m728dvj3vg684xgcv3skek3ylzjxryu5v0qyyl9jv3zz7vkga9fq7jpkck",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1m80fnqvvsd83we8gnh998re55jq8cq2mdkccclqmuqw8xpm69agsm8ffd6",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1masvawn2hnrddygr7czdkhjgnnuf86qgf657u4jpm4xg3qz53nkq0hkjy7",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1maw9j25fppqf3c2l4ufxxhn7leu58ke2c5lm9r8ehm60fnzgpzfsu8jzhk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1mdqhf078cs0qe7gfcv9rdw0yzvzf0wejvyrlx8hyzcpsfn2zgpyq7l9ly6",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/108",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1mel7yxyqx2n39zrw8eqrxv8gjltvlchqaycjz6gg0x8qgs7zhe9sc5gavj",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1mh2eclfdnq5e9pz8ejyz7q245nry7p0q4u6t6xj363xw9uxt0uqqf26dzm",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1mhnddjymtcxxn9mj9en37ufnf9s9tfg0rzgy24y7f06d7t5v340sdhlfen",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1mrlrvqret269x5aqvkycy0fnu4jz3fqqf6tqflptygpewn264jpsw8kega",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1mrltfv8y3jf4v3ggw0hnjjxzmwmq749rsjgvgvjuk0ezzs4hycfskm6c6a",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1mtarz7hmt5m0h7muks3pdnwfmwqps9nndrrq6xrz5rhdsl6s3cwssm4vv3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/D3B574938631B0A1BA704879020C696E514CFADAA7643CDE4BD5EB010BDE327B"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1mtn55pzt3huxrskm986s89e465u3kvln9uum5deeza27f0vtmucs9ysvr6",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1mvpqp7xujzf7c5jyamxg3u23zflz6ye0vnalx94khkyf4fp4m7aq96z76w",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1mw0ac6rwlp5r8wapwk3zs6g29h8fcscxqakdzw9emkne6c8wjp9q0t3v8t",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1mxcjnczrsd9ge4pkczpt9e84rntk08h27ez0d36yaxumsk2smdys3vsucj",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1n22kz2zhwzl06ftd64heah7vahlythhsrj2388l0z95jlsjpkyuq0qd5dz",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1n34cvctdvs54y3mkmk0pmj5f47k38eecl509q68ml66x2xlxfgysu26f8u",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1n44k0kzvzqn3duscgzznh73p24je0vw38huugm5cg6k7fjren64s9a837a",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
+      "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1n8eyte6zq4njjcfjw3re4vhrgf9n32zstulurxg8k66dp7uk9leqjyeavk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1na36haex62rq9y0rz34unlk8agh5kygug5eheelvhw3hxhmwwmgqppr5zx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1nam3pd3u93sqxns28k5xu4vznnv5a654hh38fnwud5pakqqq04xs6upegq",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1namquuyzajapzsffw7vy28sfdwsjzk559vt0p6rzpkhzwplt0m3snd6ppr",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1nanwkuh98tjrft7v4js0p8efjp3w2h4jjmesprlzjdnfvzyuvcmscnuhr6",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1nefum67tu9gzamyzvsp960auxayp5ft3pkwey67h434nkytuys4svyml98",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1nfn4h33t30prnuyrhn20ntvgclzhc8x40mzkngc740r9r3sap4yqaf9c3a",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/359",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ng6lckhx52kpr7ww9ynayuzzlsp5m6jcnkztysf03sncg9zz472ss3x370",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/F867AE2112EFE646EC71A25CD2DFABB8927126AC1E19F1BBF0FF693A4ECA05DE",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1nggsx9rkkyyrg6pksejtpq9zea90yu6mjq6u5pwsmu53xweda4psp5jsfv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/360",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1nh9vsmgqtdtrrrldfzxtjy3l444grmt7flrmyc265ey0arsng8dqqzfag3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1nk8ha9xldmqjn7adgz56tmu87e3yryuzj3upsk20kmy64vmg702squcxue",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/474",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1nkt8zu53tz64m9muw9jgaw2xfhxl3c6p8hkte57j46ctjdpduh6qgays4a",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/90",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1nmlwj8wfpq5r2dukds3lkg74t324y53j4eegk4h3u09hu5rn3kpqctntge",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1npz80ntx3vwkv3w9ryzc8g074hlykmw497ar0j7dqzk4yanjylqshan44d",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1nreqp8gx5nmej0ckrh7v2jy2p6j8pjv7xcyzrpylkstfamkm2slqxsvllj",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1nspf22mwajwdka4zxk3k0vcn9xtqskur5we6u255q7hgcjhnj72qkdn45s",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1nukez7tx3w75sesfecus9tuedre25uhvs737t0g35uqzeaks5jusvvp5r4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1nukyq8kzw4353yt8gvzjgfvvzar7h6skzkwptxkcrecjzfhxqdaqk4shck",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1nvjv09u5tcunewz468ad285z5dum9h4hvc0lcnsjvncq63umu8pq63czxa",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+      "ibc/7F1A862E98185A286F011DD093D8BD2FA1B7CD1A723EC5E6C59F76692F1728F7"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1nw8fdm6elm9h06zfxf5sltxjp0xw9cgcpzqzfqwpea5584xr0g7qhzzx2q",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1nxm52c20twfrr44cdh5g4f7dufnuc7r60n5y9uqe27494qgw2qes2g4432",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1nzky8dqcmzzf84hrwse3pggyq5kqe9njewn00fphaku4lgjw5gxsejdw0f",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1p0rpttlp8v2hy7m82l2t9p6545788f2ac3yksgrlycke2wr4mu0qdr7ytu",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1p352w3c2ms04cj6un55hnkwuw2fq748tgxjn57fujvp9pmx8mhnsr4jsgv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+      "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1p4qpdv38znav3egx44yysvp5zwazsmw0p30vk8yxq43qraxspz0sdrq6td",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1p8amm7au5ajkuay8nrnwelwheazxqw23va9yq42ehx0s4reexu7s2jff2l",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "ibc/84502A75BCA4A5F68D464C00B3F610CE2585847D59B52E5FFB7C3C9D2DDCD3FE"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1p9mdkst9230ngdunv654l3trklnrpzlh9lr82fs4qes879l3n42stya63r",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1p9pa7umdvry4u4338hgu4x5pkepnk9pcqddpg65zdj0k3a3ucjts85hj73",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1pa8d43s0t8hwdekx2uyq224tapyzxn60578ywzlkupkh60tyzhus2wcrez",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1pc849m5xe9wa7w9r4k2dv7pq958fm84a8t626ftufs8m5rs09guqxx8j3y",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1pd4pfnj36p39q9zdpycjfms7zta3ugjjeyjxzmuhh28pqe70urxqje0k84",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ped9637al0u0ck9gtmud27rxjkmhk2cxjt7lsqrtwd3pjzmm07jsxu8mvm",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/A1AC7F9EE2F643A68E3A35BCEB22040120BEA4059773BB56985C76BDFEBC71D9",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1pemg6m8pd8xnz2gnnmh9w8ja3rhcq9ztlnwa34md545ttj46sfwsxyzy50",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1pf3vpzz9umucchpeklwtsc4xveql0m6xsh589ek8tn4er80v9wksya3e2d",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1pg8mzjdn3yxg4gf96axyw8gpn2ur6jxq5alctz7lmjkwk9n98neshpmtkj",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/92B223EBFA74DB99BEA92B23DEAA6050734FEEAABB84689CB8E1AE8F9C9F9AF4",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1pjuess9ulvre83pyees8p688xglzl039nhgrtx8nv3j50uw8qhsqqma5jq",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1plswdqqd9nn7jy3s62vnjjmshwkk0us07shttqsmdph2gkgt6ejqmqef5c",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1pmhq2qy30wdlv4thqs9glsm38z06lp6syuh8nwa85aukw6tepmhq7eazwe",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ppc37u39xsklmuew4vyggg34crggekqnuul32x67y32g65ekprhqwfxh56",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1prazp9zy7pk9ds5s66kj6uc50uvwsu9pmr6qwel3dn3juvjps3mqku4xwt",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1prgxk3tjsmrw230k266aeevjgmerceekj89ksjpjq3gt6wa3rmes36q0kt",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
+      "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1pw3kx94kn0vu6lj048vtk3vmzx7y7mde3zc2sjxull69mcg6zjyqft9qjv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1py2nm36kk5dek5th97ljtdd509wl339zqslg89u8l9atchf9568sdlgu4k",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1pzdmgl6dnwnaers8ujawqet6fry3rxxkfwccrk0ypt8chx2prnasmlxc36",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1pzhmczzq7fl7rp72x8zrcm792ndp4r8z6pthe2rcw9vsudna4tmqdw3mmv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/71055835C7639739EAE03AACD1324FE162DBA41D09F197CB72D966D014225B1C"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1pzhzluks9p6esj0kam002a6chhxefeca86jpntlz8aewyvje69xq986agq",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1pzm7keu64vrwlz4cwscjpx70fnn8cuuqwmx3qcl9qef2ctx092dshnpg5q",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1q07hmk9ewecaa9mtnpz9uerq0tlfxj55yp2fg67lqy4xp704l5as56uq9e",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+      "ibc/E4FFAACCDB7D55CE2D257DF637C00158CB841F11D0013B2D03E31FF7800A2C58"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1q2ej0ns7n3xt3tk9m85r8rd672rnprevd2hmth2azfctfkzkpk2qqjeezx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1q3f2z5ws7vyqrxpdswzh8ray0xwpawkr45wzc5232su0lf9j068q7wvp34",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1q479s6ll6l2csetyv6jqs823qe5cexzuzeemjjdv7ej8tk2xhetsngy2kk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1q5xduzrk6v5n9jsn7nw9fqlnm6w06xkhc4p4w8gqxr9ujl08vlnq37eqdp",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1q6qdde6364m22pgvz3pe2yykze9cxjyjhutdlserkfahwaugdfps35p85a",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1q6qfznza2p9kcmnzywxj8w0ffkl6czfmwtrc97a6pdzdsc5xpyqswassc8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7ABF696369EFB3387DF22B6A24204459FE5EFD010220E8E5618DC49DB877047B",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1q6wzn67t2fsg7sga6qj5skrafh6pd3pdtyss7jq35ukp8l86z45q42yueg",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/CD942F878C80FBE9DEAB8F8E57F592C7252D06335F193635AF002ACBD69139CC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1q73hzfr0jfw84sx2rtuvr2v5xqve0jzz3qw6gq77gavxdh94c6nshw5erw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1q7ul5yz2ma5mjj8vkf5njjz859wk4u90ley2emfx8th4xyx6fg7se0z4hn",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/8E697BDABE97ACE8773C6DF7402B2D1D5104DD1EEABE12608E3469B7F64C15BA",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1q83j3062nnne65nsljaw0kwzsqam8ut7eheyzpr7ga56htsh20eqzr0vz6",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1q8uvftta2c9r25mqxd89q76vdcagwjsg7q9t6c787seamzmpcuwq2wn5uc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1q9e2rxyu360hp69rg54up2k70sclp7uxl6mq79zrxkggquwkwfwqv9xgav",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1q9m4xr0rlnh7t4rsq3cmjsunvc9lzrl6d3ww309zjmcryxqzrkus8h7lys",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1qekmfz65ce08nee5c5caags2h24uhztjn9j6vr8uvnv4hcx44deq2xds6p",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1qfu6489pfda4skcsv6defawyggetjdeer6n9ed60dn096ma5dxfsg3plhg",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1qg99g3wn2a477eumpml8wgxnhyhjj0zjwlefsfjgpdk9zcm6kxqsdt7e7y",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1qhd0uc9sc7psufty2y0u6ch2zpchtrljshr6jukly0n98yll759sncp98w",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1qjfu245d9zn893y6c2z4rd689s0nyty4myvdmh6x39awag72n8uqgtcmea",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1qjujmew5s65g97stpuckas77f9hypy84vs9x8p0e7cypwv7jph9sgguu2u",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1qkwd25wehxz5m0ddgal6yc6a70ph552pnw7ptrj2h697jflpq6yshag46w",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ql58ecue9v3qlwfa9zjc64rw2sw9cwrpct7j779ers2jcm4q4ggqrmpq6v",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1qlz6kfv2gyer5tfrlcn540atatq2xj0lmzzqgphguq5cm4rcscmqqvfggv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1qm24s5jk9mz8wtc5luad8fsenrp5v5m7prjmfhunm0plcyg74u2qrsr325",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1qqff9yppkegxgnazg933cun78eaelxa9zp2mz5m94q9fds6s4k5qaz4a32",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1qqtms0c5dfg4mlw4jgyj54tnr3cxznzrz2zutthxxgx4zz9559wsq0nlmw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1qtle736upg6t8nmra606axnvnm8fwvffugdfhsn2hs4f8mv7n2yqgvlwt2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/464",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1qvjyyc95dwwua5rhvlxf2y55qm3uq5m85063qn3vrvsuq0u59wgqnlaeq0",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1qw2zv7uq5lav3gk0j7xjapa85w0q3s0s7zlv4dws2gey84vuew6skaqu0j",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1qxdyvvnhtumm58pmhjlhhhe0pc3ye5apnma6tm0mx2r250zlga3qmn0z9j",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1qxswx2sy9u0cpf9hrgqd29gjnudpjkpffkzjtplckjkkv7mjnh5s04vy0j",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
+      "ibc/D0E5BF2940FB58D9B283A339032DE88111407AAD7D94A7F1F3EB78874F8616D4"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1qyys2gt072ke0dvhqk2mkqclr4hw2ajmsvcrz45x4x5p53rsrn2sr8nq30",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/71055835C7639739EAE03AACD1324FE162DBA41D09F197CB72D966D014225B1C",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1r52puhw7jqqx92h4r7eadpgnak5453yejda8p4de8t7whdychg2s4qtakx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1r5gj8e5pachzmsl5jphyw3njfr28jfzmykcz0w750tptzkyrhv9sf360an",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1r5v05r30s0v75py3n3lhd7sq5cdgkaltles5rk0cmgndrdq7ktxqcn64y8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1r6xjt4ykjudgvlpnulk3jvuacjxew2xjag8frez4wprxkyspq8lq7j2edq",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1r7m4vy9qfdpusvk02wyn3wln4amhz39sgvy2qyccjxq3a8drhwuss9feyu",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1r82whw6efky7yjk6rlruf4pxva2crqtezkt7s095wulqrea2w46qkxm9wd",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1r83hq5aynm6skjpxltxvrfk2ve4dn23mzczp5d2xcp9xth6skghqyn2zu8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1r8ed7qcfkvpqggzf5ckhfxzswjpgdxvkg78t3f92rr3mvla942dqq0fvj3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1rayrpuu7sravv2ug4gh8w0k769cmg2s7ykc6xen4777wm27l547qhcpzfk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/47CAF2DB8C016FAC960F33BC492FD8E454593B65CC59D70FA9D9F30424F9C32F",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1rcgcf8rx24qffmxv76xswwps8g3vcvcargf9zsq93uwlzgt3ymdq9errgw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1rclh8r9e0qtn284uusgqydgnjjv2d2w5v9e5ngrk0exzlua9x2ssnmtk48",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1re957uvznxe6jme4zmzm5d95lajz5an7mrdus85faakrj45qa57sshx5g9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1replyw8a8pp2t78k9adu35zhg7l9npknka2teh58zyt6emkg3xusyt0xew",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1rk8tjedu75vr3s0usxulggkw5kfazcmv6gq72429nvdc468mf3wq67xw8g",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1rmhusclghxyvyxr9kq4nuum9pvsgplfpuvq0x5d0ufaaxrwkefqsardn6n",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E09ED39F390EC51FA9F3F69BEA08B5BBE6A48B3057B2B1C3467FAAE9E58B021B",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1rp8xap0z59k20fkt7078q8g4t37ee8reqpwt6afgglhe3h70hvls9xl5c4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1rpu7k863l2pmdcw95452j487jxrh0mp77au489z3gjq7quhnk75st72zs4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/423967B46B1A51D78619085105B04FCFA14F7CBC0BE7539A316B2DCDFC7D8C07",
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1rq2qekdlt662cjr7zx5xknctju7zd4j8xhk7e0qcnsl4g2u0yr6qpej2sl",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1rrje5862udx9e0en3qve8539gvh33rfgfpzel9jxxvnjxxzmrnmqpc3vcz",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1rsr5pqt50eml482jhtg44mx9nc555wjd90vhz4hwkmrm7qngqx9sr3pvvp",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/022A879A5301CBCACF96216C967805F15C33C615B74DC7236027C1BA1BF664FF",
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ruqysu3pjzyv35w3fwk8mjprz8ludwc9xgexlvse40yqxd5hnmlqzlgjkm",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+      "ibc/F35C87A18804313088DAAF6FD430FCCCF1362BC3464D4FAD783C476F594C9CA7"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1rv4ercmn82tl55su3e79j2cvatgewx8qesqtgm3d9n7r6fy33esqektmlm",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1rvlrxqytp0f6rw8k9g6j5y3t45l9v26l40y2rplh00a3ape2chesgq2dc7",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1rwswjnqfhkl8der73ac3q9ydcms8qkwcypksnu8pg2y5kf7enqjq8fas74",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1rxur0nsztn90mua2zv7ectqeht7ujzdfnfzwuny25da4k8vla4rsy8hls8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/1",
+      "gamm/pool/7"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ryh98w99c3a26fjw09e4xd46jd00qfh2y9g38fk9zcd4ady5h0nqzpyvfx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1rysdtqarh8y3yzlmpjwuaqvh3rhhqznqkex35wmhaxrvuqegvu3syuz3wa",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1rz76daxyz9vhf079ahgr6l76uah9xvhe65vu8dqyf5nq7674d3yss96x7w",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1rzsrh74px4ycnvwk936ycujp2q7ndhnvka7pt65pukvkvnpskfkqxf47ue",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1s2gwy72r2dnpk0dpfs0aftz7rahxsuglz30qkqdgzqsrpczyeexqay78uk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1s3x4ey025k3ew7pamenlh89twqcd496rg0c9ye2ydnrxe6y68z8ss3g7az",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1s46juu2q7ets8tgqaytaaekfs5qu259tkex87ll068xsvfcf8uas6rkavc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1s4eem3yk9de5xk8wr9gs9shc2905skd7h4e589cqs94pyrqem5jqn8y2ru",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/410",
+      "gamm/pool/411"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1s666n6f6qhw2hcgkmwx3jxl7hz35cytrygmcvzcxxt84e8nrjfus4wyknj",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1s6nlndkuna63w5kk5npduwful69urrfvdlhn74awcan2dpx43xpsr4cxf9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1s7p0al0sygrqumxlwhw0wfdazdasgew8wx0vspvhf7fwkfcxy03q3x7rcs",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1sf7twk9v5kkkredzk465wqk6s959ttuaf4683quu28q459e3jmlqkss6pa",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1sfqrusqfe0rfydt7aj8vwe59ujleu9zt6t7zrz58y0uv50sm7vpqvw2sdt",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1shzv0vcddhe0jh4wdh2xudrrw20uzu96ugsmyv29p5zscpk85snsmyjnjl",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7C781B4C2082CD62129A972D47486D78EC17155C299270E3C89348EA026BEAF8",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1sknzx8cw662aspm7f5xygfhuh9hkf76qqgqwshaqhmp9m920ahlqanwq25",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1skxw2mkpqnja6me7hmee5xu0l3h76a5jsahnwtk7tgeqszx0l33s6depu9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27C09777C9F51B8AAE6BC15F92CFFDF2AB04067569A81D4938BA67EEC8D2E5D3",
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1sl6dla60tg44s0qk56sjvu6rhpuzfedd2xs3vm6es9v4q5smd7lqt0rgct",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1snexrsplcnsstsmwp99jf3uua2f9pazcd0drgmmfr6kj22sdwm7scdkrdj",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1spsg7ka3mfknz2s8h6y8qg2azku322mfe3ryvluyhrygh6j4rr3s6ra4ca",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1sqan5vpspvyqtjj4spykrstq7ltgkvdsxuky5rurzzswejsdgd9qes5tjx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ssj7weswfdu3lz737evr5plqvgaqk28fl4akc085gghlxnu0qwvqdms4jc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1stxalepejns0zm5rpq09jxwcg98r4a2m86kx9n598t32l079pwcsd2wg5n",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1svp9sxdq6qq4k2qpy8ldcf9368eejnawajcetpggpxkj5v5thvaswn32xf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1szh2gzzsugx6e5vs7emkcrmcy87zg75jst8xemdp896v33u5f5eqt395ku",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1szvslwsxf3y2s4lt3c7e7mm92zgy44j8krruht5zzanmhrjwyc4qqpt5nz",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/307E5C96C8F60D1CBEE269A9A86C0834E1DB06F2B3788AE4F716EDB97A48B97D",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1t0k2etaylj6w3tjs5wgn068hz4uyj7fpzs8707a4v02pj580mlrq9fyem2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1t0lgy5t88ctq2ur4xzjuk2rw6laxt434hsjn6shzwn7w0tph7z2s9p7qdc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1t2m0y54hrjmvs2zvxgy8005fjg4atqmveg9jafvzmqw64l42aawspdgj9z",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1t2qlvhu8766gmcgs7jnpyx5ey2hfje6uhjffgsn0rgzu3xx7cuzsl9wgt6",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
+      "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1t3de20l6jhz6gpx7v48upxzfkgu7d3r8nclkr5h7z53mvc7mfqyqcyqe25",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1t7zz28h30kjmd5rt0yg4gzd8g4ne0y6gpr5rf2zvsj6gs3fmcf8swfrmp8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1t9hcnngffyvx3jagrr5wwetkdu3at3sf50a8jdfj7rwe7cyq8tks6t9cz0",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1taqxtna5e558fvstm2065n3zaej3ya2x3vv49a27uun80vduvk3ss4tscg",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1tf2uj9pdmkys6wzk2fwpcnp5x90lc9t5y8qw4ha2mms2nc5kkkesu3zj54",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1tg2k5rxex7zhzh3rcvmy6a2yfvw8446ezk7utz8j80vmkrpjve2qljc6hk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1tgdxkfgc6k6fg9k8e3vpdkwxtwltx93ywfx959yn2e5ysxxpr7vsffd9jn",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1tgza0v4m0tlkgsew6jjup3zaqcv7qyx58gfzct8xyfx3d9vsv3mqetw8c7",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1thscstwxp87g0ygh7le3h92f9ff4sel9y9d2eysa25p43yf43rysk7jp93",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1tl43tjmylclp37jduelnwrzeyuef2unxn9c04wrlakmgvzsnmgtqqet6za",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1trzwktd05mqzn8arhczsf7lwvmmfxmuducfvp3upzmlzs7jl38dscuprsg",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1tusadtwjnzzyakm94t5gjqr4dlkdcp63hctlql6xvslvkf7kkdws5lfyxc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1tuxr32k9pmshd5v2tuf89e2npc7j299cmpzscc74ec59xzkrr6fqmy2eda",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1tvfrcswx4c0dsma5z2nmuct34dresknmmaay0lrpsu0wsgh9q08qkv0zj2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1tvv7j7c7hmantw8rkkkkhr2hx6kpckc5zkvnce30la6m048nckms0s5076",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1tx2ewuhrm0ypyuud04lslhwg5cwnn5ykxsqx49p9l2l94fn7tr2qw9um6j",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1txawpctjs6phpqsnkx2r5qud7yvekw93394anhuzz4dquy5jggssgqtn0l",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ty9g3v2xpn70v7pw2jmzmy6npdsdw4e9yd9l5na9rs8qpjhnk89sawgrnw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1tyjwq32pxv3xvpcdkkc8lp3gxkjdlll53grsjkqce3nsjctl328qpqfvj2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1u05s34q3hk8mu3ypw6g5eqvfdvcllck8zualccz2p75lmdnmwgaszyg9ez",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1u0mjawl7cr9qjk5zfgmat5tlqgxgj5n999kal34kuu9k0mxrghqsm58fep",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1u0xmctf2dcz3qvmkhcp8prdq2xktnryyq6lshcccyr3jwfvpf9wq0rq3xy",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1u3402aty7hhz9zpsg4kkvcxs6skg6ly8lrrmky79tcuhccszk3vq59x0t2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1u4nna8ml32n0u3fwcrfl0c3e7j8feaay0l5nzc2z850us2dkd9jqmvumll",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1u66wkjthdjxnavklpef7yzasdrvvqhckmhkqsw8uwlad3uaktr3qvny8k4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1u6wc5hkhg50kxdn9l8pye6zt6jvh5czeej86r4c6segzt0sw6wnsn7rj2x",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1u7uh9vvf85la2ukh60td0q07aq0mnvthxe7x0rutc0envm9865cqjesutw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1uc9j2thyq26jvktz4dsnya508dzr6ksjgl2w0lspsf2rdt64qu2qvgdz52",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1udj4gj4hx5l3k24qvn2cd08vmg7m6ewmxp65lxzfp2dq9xeqmv0s6kl8a7",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ueg0m04nxj230juk08w9hlua8uupp3jgeclzllk98fzq592xly8q6zgg4w",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ufuvzzlzu6qpre7hg2tkkm8st3qrx9g8ja4e9empma3kt9adqjcquklmqc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ugdp9q0nzcsmlllk9acvvuvt4h6g8fy0gspwgdtue06ya0vk4khqdka26t",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1uhpsqy52rs5dkwfpua5qulc4rcaw7y857zha0skzp3yxnd0k9k6ss44rjs",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1uny6uzpdfqa9q2cea7ycnuwfr8s6c2zvyt6s7yh2rvvzt0zvhl6q6hdhdu",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1uppkz7d2r68qalz483ppa9w2z2lt0j35ext23vk0djtd9kh85g2qk66tlm",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1upzrcc4clr9cgttqqkfrt8yz73swd085edn8yfhtv65k2jansdlqnvnfyt",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1uqzdmre9vd0y9uzzm03umja3l9wmqdx3enl8fkfh9xa26yq7m77sx7xfkc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1utasxm8e2h7jermwv8mrv55nyphnpnkm2zrqzvn8hstx927s4q3sfkfprw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/19305E20681911F14D1FB275E538CDE524C3BF88CF9AE5D5F78F4D4DA05E85B2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1uvsrputqqa8g2dg3s9673w4r6yj8dclfzr4ctsk9jtgwvjwxjq7q297cdn",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1uxp60ju3h8ghmm2hae9adfulscrg2me5pr9zvl07lngmj0nr7lksqwfv32",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1uxqg4sr2yqvamc96n4kwkgna6nmmgtypfdn2gjhvwgymuunq3qlswyrdhg",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1uyhjnu2l0qfxs3ltt2nuq6lx2fs8ff34684f0hw7sf557enrkd2ql6r2sl",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1uyhzfnjxp6a9gq3020f8d45ueszr5sj72p5cfry7hzg0zderhvzsscrkvx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+      "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1v009a23dwz827gk4p23sf4tz0chyuwkht0ygerp2v09qhpmxw5eq52q9n7",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1v2982uaxxxmfyykkcusc2jlgrh43l6q646gdd27skr2smq8d8cwqksnw4j",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/2FBAC4BF296D7844796844B35978E5899984BA5A6314B2DD8F83C215550010B3",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1v38v9n62pm4ktce0khdglyxzr3f8jdlahdux87q9m8x6uz4zfkesjv8wga",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1v4gaqzdvmhdm4varxsd3qc385jser59vgpcxm8f5u9e9sjp58lzqlaw3kw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1v4ulnkt7dj9903qvyeqz6d5u3rpjttcy6vzydt5gurqxunxyghgqw0u2d4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1v5cueex2ajn35u8a3mr586vy9xf2tzl3n5ylghnwrc9ssnwwydnsk5gvm6",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1v5eg7ch5gfj6aewdahuplj7ddhrlhq9cugp98lznnf542g4f9vgsv2lvxf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1v6py2esnzl6pe6pg6mr42n37qrvcryavq3zjamwpa5csdayrgfts8dz4fx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1v8289lc5hweg6qr3jhhsy3d4m2lf8663xz4fkwv8jcc5k3chgkwsxwky24",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1v8f030n78vpwrswjuppndv2h3p775g0q39znmew8tw6jv89fk5wsahrtk9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1v9r9d4xk9j2r3m59hcnsy7037wu75ymyg6nc0em23rpwmp9nj3yqgz5wvw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52C57FCA7D6854AA178E7A183DDBE4EF322B904B1D719FC485F6FFBC1F72A19E",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1val3zsn82xutf9tnadwxahva6cs9mscxkq7y9dhjpl5lvrqdp5xslvllw0",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
+      "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1vdlumhjnpdngk80dmuyq4vdngew4fscvlhq4tpgy8c8edswqapwse9987x",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/161D7D62BAB3B9C39003334F1671208F43C06B643CC9EDBBE82B64793C857F1D",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1vedjqp8mzcr5yg8h0s75lg0l074nx8leqkj0efzvha8wpdus3nxq0myg32",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/10",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1vgmqyyu3gmnyr8w3g27uf5l02p76jz4gvjcwzrp40cjh55xht4qsrdmdsy",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1vlqfs02w9l4ygp9wnkfpr54av4vdzea4czytvuccc5628pz7amzs2tftm6",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
+      "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1vmhq9xqcr702fspu9qmf22ggzu8fh4d374zs487068m4p5xh694sxgxza8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1vnw5jmjusus6drlae4nv4l2dn2vg90lav77dvphj0r3gn9x2rh8qmz9ckh",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1vp0kxdq263kzawqmv394tjevw7useexp2hhh7835cjqjl28nkpmsum5nhn",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1vp9mwqrxt4dsyu4c0hzjpl79sw483wkqsfq8m7jrmjh9775ddn5snw8ccv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/23CA6C8D1AB2145DD13EB1E089A2E3F960DC298B468CCE034E19E5A78B61136E",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1vsadpr4k8xu6ply4yw084tjgyrqkeee99ktnjjjfus44pyzcs6mq5ml9xj",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1vtqgpkdd7taj8ssw4rlcd7ulu7wgmujfxlyaa3qkfztva07pm0sq2qkscy",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
+      "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1vx63kemxaxedvulz9xh45d9k0gc7udec35gy4my9f7tzywfeqljs52vdzf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/B1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1vyra2jgneztsn207a39dk5jhj7xu3ruh7hwuaq9jmmlf7averklq9lx3k4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1vyz8a2xv27nj2t4xwm6h6rqpt6fhea08fsmg56tdlep7n3k3t2tsks5fxr",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1w3dsuh2hcp90vmhwrdxxftgm44edlcvn8xtzfvq2h457ma8hm00smpxet2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1w3e7ywcnj6090nedg39p34mwthpuq25ly8d92kzg0pdx9kptlesswcj39s",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1w4w9gj02z3hv7qlry8mpju625qrevrtf2f2nmywu45j3j4mnahuskfrf38",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1w5awgnxgthpwdh4nl25ymdx78x8cnjepdh6ju7ep6gaq5up35l9qhzkfyz",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1w7na4s0suuchqfqsz0fyszu2udc68wgxsgk3vsrtvzdfyyfseevsufcx4e",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1w9rj85ugnk29uepdglrhuhusdx0wwh4ep5vks92apfryaeu9pq9q7yv3gm",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1wea46n3f86um4dp37t43pwpurcky9e7lz56tujrtcql9yx6sphtqee256z",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1wehlg2lrvqxjmy26ghkqdj4c653se5kr646z9rwwfflutj25dvnsn6ef3f",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/123",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1wfghlu9wguwrdrrv3su4fzkmsc80et9k2x796k6q4n0yvn2fx5wqe0mpve",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1wh6azmp9dxraquxt2gyppgeyuvta2r3s3s72cx7xr6nprh8kgj4sl3qf0x",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1wjeftfc4708ly99x8mpty0faedwqmu6hw20v7dwxyma4vvn3u4jqmh9zh7",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1wjggh0jgm6mukp2rjcyas5w5eep20yqgxjcn9eqxh4rktcdku4aspnq4ka",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1wkspj354sp059377j67mk6uy48t7u2cm86609nq7xht47hj9mkzs39x3fd",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1wlqxs0yh5m46hz5kaq2jmzc0vetrykej4zjm25kcpe9crxnvfxtqrnker2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1wtd5nrx9f2uwu32z3njuhxtzxj4qcedrjlyrsm6q073yp84ryjgs5tgtq3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1wv6v6mgychqdmf9fj5esyrethnu86akn6gyqq7rlexacjjcht37qfsqjdl",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1wxkx8kq5uvt4snu77ezhxclpecv95t3jyvagte8em9j6dk3jgczs66quh3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/2716E3F2E146664BEFA9217F1A03BFCEDBCD5178B3C71CACB1A0D7584451D219",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1wy5zsjq8mzyehg7g72hsf0v487a2h87sr30wzztjx9h0ct593zysl6444w",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1wyv2pa3xmrfgjgkd9s6v0e23dud2va6kgaaknyqm6kly6x228xvsh45uug",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1wyz6659ctwd28cq5nlw9a4jslm7nxydvg3uex2xmcl8y9fd49tjsfegg38",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1x0ptme5tp8r2qw8gsypg3qftfwfpt2hdk4jyvp7gryywmg5l9fsqvhs8fk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1x20esk0tjalpqjf6x8rz9plrlc8yam36c39lmqpm080dsyg6klhq4jdnvx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1x2cwskve25argave9s4392lwygg7j9fzxhxra97tvvpt80kvzxsswm0hqu",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
+      "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1x2wr6fllcwv9jmcwtq3lwjvuyutmcxf55q8a853jylah057lhl8scgqn06",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1x5rh04vsyxx2u8enwpawhplmrhk7yrq82ulpj9wjcrt6j5y5n44q8vy2da",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5A7C219BA5F7582B99629BA3B2A01A61BFDA0F6FD1FE95B5366F7334C4BC0580",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1x6fpwjj6ur324atc4p2whc3rsdkaj2ecs4z5ckeu38eljv70mswqlmpqem",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1x6uvl8ef00hwl2ymgxfq40q9zjnykjw9u2w55466yl256lpqdpgqs9hpfg",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1x9g0qwks7t6u47cxnnqg6jyfaxczwk678eedr7z890n8dnwtx9fqvqwzkx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1x9pjf7ehhdlfy035xy0t8rwp3dke6vhcdrtw2s35727ceh7ra7vslncd3q",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
+      "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xct94me26df4k2fs6waecnvzca8dzv2jxl798tndqq3ync3tdkqskpn5cl",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xe9d4uyaq5ek8u85kgvxusdadnx7u9k09cauv4f8gn9e7xr4xycq7rwn88",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xf4n7h4fqt0qlc5gagfhu36n7jm05vrn8yhnf6kcxcjasf9u8eas585xt7",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xfs2qqsx3vpy3nc2rna332afmk48sxpgh7cd6usvfrw0gcdcmz2qej4ywx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xhe34xslh74jyw8xl5p4auu5238zzhre7mcpd9kcxmfkrp5fuj9s4e6ldh",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xjd0l22txgpce4fh2kgjy7gmvhszzl05nzw7e7lc76qddxrywqpscj5pl8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xky9ttqjpqltad9y420x7ylnw5k8sh6ctnk57dvytvgaesywzccsnyptkl",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
+      "ibc/C1CEF00F016FE89EA6E5B07DA895AACD91B0AAD69A991033D846B988AD4FB69D"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xlq92gxx6a9zca4gjculx80gmpykh6lz2npustn27s7g7t2hcels964a7n",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/BB6BCDB515050BAE97516111873CCD7BCF1FD0CCB723CC12F3C4F704D6C646CE",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xp9gm8zw4fg7xrvu006eh7enpc0ywtsspv9ezzf7yqzpv2gpvd4qugqgvy",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xr84lqj48rxlhk3w5weesczvl3tzemep6k5s968j6mmmvaml5e2qxhlngm",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xslx5c73axa9t7xypphtc83zw6jvucwxcahfnfltc8fclqnuxz9s0833tw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xsqe6aprxzmw4l7vzghjxxq2t3j504utx4aqpryy3tlerz7rmw7smsfnfl",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xtresmp9jt2w7p40zj8rcvatc0lgwqj62elmerqd6n2pya03yyvszt0fng",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xu8x23y94cjwexgxerr6pak0fprngxh4xwyw4stw6pny2ktw4qaq9k3xvw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xumj3tzy3f3cy0e98tj4plu3g9sq9rn86g0gzel6qk05stplwrpst2grm6",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xuufuq55r4ukh6xgfkfkvhlgvgsy2z7wacchctvj9yllcc695lusvc3hml",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5E2DFDF1734137302129EA1C1BA21A580F96F778D4F021815EA4F6DB378DA1A4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xv2t67l0x59r6gl4wpgx925qlgy38ua325jyugh0yah5jkzp0amsw0aqpc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xw730drgcts95umje5fwekx8dgpn4dg756d4a4y26jfhy6ekuu9q78qycc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xxg0pnmyxj7xlvdvxrqdzrecaa2fquq97egpkf248t6kxuklsdjqazsyq0",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xzjr9a7t3k0y2498yh9cxmexy0vk6cwlx7jcvwvhlh6trs2t44zste5zhz",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1xzwgqxu9y7dhqq8ka33p9rs9ayej8cs742jn2akvuj0jkdvvuktqf4xdxv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "gamm/pool/1",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1y04x26mggspuwp8racsxukq2avuwk4q5frwyzm59szxy2x0s52sqq8men0",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1y09t7vkps2p7ppe2aqfuqhje2zkmnk4t72yagk30286p9zw8e68s7mylm8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1y28qvpn23cuem32qt6jsrshmy5wj3ndn46lyh7p0dt5w8q0vxuwqfxhpzz",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1y3g6lwd5p72z5uxgm4z6wy7asyg53wg83np7mg3cz2wnf9zhl69q8shlnd",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1y3hutqnstzdx096nf47hw5s5pmu67cgzpz0gjh2f4cr39dw0uptstdjjln",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1y3jhypynwrdjyqu0y3t9qs6kpkuspysdcpatal25ll2792hkf2lsy9d9u8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1y3ptmx57hvu7au6s9r3fxq00856896unkdyqaump7vedag248l0qc03asg",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1y5dfzzdhyh9azqczjazk5v8vacf8we8f4gwlmyjc57s39jcgcp2s6d4l4k",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1y5wz4pl4xpwrgr9mpjfmfewfa5nfns4473s9zs29c7c5q8w7pskqccf39r",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1y6gvkz0qu93h7zgkrrhr6fqye5ny9ddpm9az2l5kjr0mmw9n48mqpmcnnv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1y820u9050hz23a48e7wzw5mnqftplvj205l0vaw3tx7g609l32zsxdyeam",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ya0hny0hsc73q4tnn6wdswk777r9e5pxhswm3ej5f624zahxmzcs2ygthd",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ycedur3klym2dwlz0w0796zqmn7fdzn6fldwc6cuzqwarejcuq2qu8z96e",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1yeu83fklh2vxjts7evnm8439rj326zwgqldaz4sr470pu29jr88qujz9hu",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1yfhmdj7akjtj8me0l3ttn3p475mdeuz032uzpl5n09q8evdzc7xsv6yj25",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1yfs3zurxezmggujt5ffxyzerx5ujjsuzm07y0dy8p69z3l9w3d5s9nyagx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/D3ADAF73F84CDF205BCB72C142FDAEEA2C612AB853CEE6D6C06F184FA38B1099",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1yggqusvjqscjy03ysdmjh5hxmt6tv20u5ufrsuy67ksnw2xqsvzql2j70s",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1yjpgrff07qx7q2tykqthtenyk7tmlnjy83097y00g20ncuxut8hsgwm4p9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
+      "ibc/AA1C80225BCA7B32ED1FC6ABF8B8E899BEB48ECDB4B417FD69873C6D715F97E7"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1yn7z42al3mafmztjayjduz42a8at3whyd279fkdsyumzar83x8mqvpw83x",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1yqqtrljj2xcdldwgtwgjeqte69lf8wdyfcx99jffc669natgslcske6ku3",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/00B6E60AD3D65CBEF5579AC8AF609527C0B57535B6E32D96C80A735344FD9DCC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ysvqrdxtp489v8q03fun60nyr2v4p7p35dsf3g6cgln4avw6d4msdpldt2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1yugu88lhymszf7plpnn9ez07a34w2fxne7j44zqfqycgu8xx8cyqxmq5w2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
+      "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1yurhrjdwh4j3h5ck5tj08u9ht38qaxq4vu9ad7nn4jcf23lnfxvsclex5j",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1yuu7x52t2df6f0287md68q8l3u90h9jxjurcnxpskvve2de9krgqmm7mjm",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1yv7jtrkt3t9t3mtsndxx7392azzmawyyy0k9qn97rv35dkluyp7qzyswmn",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ywwh6qsau3fqc507puxqv22re0eqthuyk7xpfgxvdv62d53ydlasd0lpnp",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1yxs0cp0gdrc552u8whe293q8al4w6f5v2nl5cmdeecwx3p9m2p8qk7adjc",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1z0693astkr0t976z8fs22902qxnl8rhjw44uglll9qk07h7wpt6sy77yc7",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1z390kae9wyjw5lxy5hl4mfc52w6830eflury88mfjsjl9s5708cs5ckkde",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1z4ka2c5hzfpy8qkrefwd2pu7mqnfdxjrvqgch0h0llh269zcta9qxzsty4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1z4tn4qh0dj89h5h3jyxprthh324vm88t7netqjeu6855hf7ttugqevfnew",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1z52y99kywzjjv9kf8498jkkva8n6g3epzeds6v9hth85rd90fcvq5zxp6w",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1z7pnmk64p2g8qpeu3j70uwv9eu77kj6qyk96mmxehc0lhm5lvmeq6ugylv",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1z86kzpdqmrdr6prp8dvj5n73w7t0fc54mx2gq7y30p6awyhun3kq4wxpaz",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1z9dqkuhkhuys9hcel25mtuw33awk0svp6afzg3d3j0vqft9cj9aspg97ce",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1zd2vqwlvpz4e9xrkvxvc0aa8cqsnwdvpgxulk7n449r6lr4adv3st6mzzf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/F867AE2112EFE646EC71A25CD2DFABB8927126AC1E19F1BBF0FF693A4ECA05DE",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1zd632nrrwh6r5wwqs0y6h5qslr3l3yh6kryxtg7zmrclqcrtwefqp0m097",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1zddv3kuvxqulq09dcfur8etz3tax90vjuymtlzzk23ps39ew26cqm3gykf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1zdp0cl67a25r25hslw3xzzt5mmd03ws04vevnthzklxzkg4xg35q8h8dnk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ze0t3al4zgndvjla36gp2khjkwwdzr2e4m8vl6fuzfllfrlr8mdq4wnmxt",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
+      "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1zffkpskd8vv643mwu59ujsgldfz0khlgcvsty8zv9y4t50azf6cqx0a3pp",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1zfgxnef46xmdv6dgnwvem6dpuetr58hwpnwlvvxv0pgsdv8gj86qk22vcy",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1zg4rlhp843nn3jk0uz2kvk4zzvp7wm6qpvlnuv7dnp4jlz9pmpws90duk8",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1zgnc6xvj607xmtpyu420h378cwgdnlwzhat9wjgsavgkjk5n3ckqx68328",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1zka4v4c04jr74ludyls2lfzfttzx67qzd070xtnfq90yzyacgn9qv6vend",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1zml837f5en8x2fvvger70l76cmdahrdv5y6m9e6yk0scnddn5w0qj54m60",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1zmxelh7k08hy085shm5y08mqeaqmahee7u77lpnf2h4eufnsyn6qucvfjy",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1zpjym32nr8qt8t8nm9nu2zr5hx90hferfv2jqpt824q9nz38k2vstj704t",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1zrm4msu7q238tlhkdyk2pu3px47z47n0tgwrlpf6c08f4ppmwycqfeas0n",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1zskwjdwjgxt8r3ukqgcn8z70qtzl5cswy03pkupvzvmwlvcjvtrs4fwrpx",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ztfk57933fj6278dn9ja7w60nfq44mndludh2qx62e2tg9hc29lqm8avec",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
+      "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1ztk3sfcrdvv2lnmjzfad5qerkevp3y5ny8s3n5t8c94pxwu0putqw3dqtw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "uion"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1zvc24h5fd9a2gj7xs30fvp9wmf6jydf3w0updqu5hr6g9turnkzqqh00f4",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
+      "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1zyjk6a4fapusydkauzph93h3c2ssngpfh3retatwaqw32lw20mhqcxu4xw",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo1zzn7rddfytcjg26g3s97g2qck2nwz5upfth430fdmnnyph9vjxhqpytc3l",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/1E09CB0F506ACF12FDE4683FB6B34DA62FB4BE122641E0D93AAF98A87675676C",
+      "uosmo"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
+    "id": "osmo16054sn8ug2njt8hnhzk5qy2zh7u8x6nmex3c02970dpmqfepz7hq434rlm",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
+      "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
+    ],
+    "dex": "Osmosis",
+    "type": "stable"
+  },
+  {
+    "id": "osmo17m8tjws6ce8rqgghcfz09jgew9tcakp3qlw76pt86akerxk3t7rsgkn75e",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
+      "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4"
+    ],
+    "dex": "Osmosis",
+    "type": "stable"
+  },
+  {
+    "id": "osmo17n9drfwd7sqa5rc7v7xwfv5ucfngg8nttu6j2plvxgvrrt2099qsq54urf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
+      "ibc/C491E7582E94AE921F6A029790083CDE1106C28F3F6C4AD7F1340544C13EC372"
+    ],
+    "dex": "Osmosis",
+    "type": "stable"
+  },
+  {
+    "id": "osmo1aqmdce4f8ymqcf7v0a8xcukt8xqga50zqcprta89e9p2fmscfzpscru5lr",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+      "ibc/CAA179E40F0266B0B29FB5EAA288FB9212E628822265D4141EBD1C47C3CBFCBC"
+    ],
+    "dex": "Osmosis",
+    "type": "stable"
+  },
+  {
+    "id": "osmo1cxlrfu8r0v3cyqj78fuvlsmhjdgna0r7tum8cpd0g3x7w7pte8fsfvcs84",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/46C83BB054E12E189882B5284542DB605D94C99827E367C9192CF0579CD5BC83",
+      "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
+    ],
+    "dex": "Osmosis",
+    "type": "stable"
+  },
+  {
+    "id": "osmo1d3dd4w06c2lyxqm7lf30st89esf4437f3tn42kpv9sh5zug5xdksnnp0nh",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "stable"
+  },
+  {
+    "id": "osmo1ewsz7a8zefxq67h4205hlncpfm3np4mky34upu3sktc3llrj5rgqdutjgk",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    ],
+    "dex": "Osmosis",
+    "type": "stable"
+  },
+  {
+    "id": "osmo1hayyjltd3mjx6w8g7wtpu2zckk83ecxen2eux6c7tl42unfvnfysqg9myf",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "stable"
+  },
+  {
+    "id": "osmo1kxnekx4q8yem6wvp5t9ggqvhuxaqw7san00x5qdazp3fe597f8hsqft4nq",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "stable"
+  },
+  {
+    "id": "osmo1r4r0ryw0pq2yhwcqwf8pg4w0fr764k3ztv9weuyqcn5hv0zxy67srvgfj2",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
+      "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
+    ],
+    "dex": "Osmosis",
+    "type": "stable"
+  },
+  {
+    "id": "osmo1rdcx38vnf0tvx6x0xkel747m0rqkv5lg20lfww8gtdrydmu00pyqgefkm9",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "stable"
+  },
+  {
+    "id": "osmo1xfcjgr8l0e2pp3mx2qlcu5u4x0vt84cuzhwyytvmvhlnm5kjww8qudwh8y",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
+      "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
+    ],
+    "dex": "Osmosis",
+    "type": "stable"
+  },
+  {
+    "id": "osmo1ylzwp5r95sqjmkjem3hu0ynslaxjd2tzv6udfhrlrtyhj4zerttq3343su",
+    "lp_token_id": "TODO",
+    "asset_ids": [
+      "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796",
+      "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F"
+    ],
+    "dex": "Osmosis",
+    "type": "stable"
+  }
+]

--- a/osmosis/pool.json
+++ b/osmosis/pool.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "osmo102ryca72c5ktx2ruzt8ag6mvtczdqeuvm82l09vd5uq597e7hn7sqgw28l",
-    "lp_token_id": "TODO",
+    "lp_token_id": "722",
     "asset_ids": [
       "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
       "uosmo"
@@ -11,7 +11,7 @@
   },
   {
     "id": "osmo104w884d9gw9s35ckru66ptl3uu3ss0u60xk7gplj8ky0xan6tfvsrfshe6",
-    "lp_token_id": "TODO",
+    "lp_token_id": "835",
     "asset_ids": [
       "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901",
       "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC"
@@ -21,7 +21,7 @@
   },
   {
     "id": "osmo107cnz52uqdqzvwfvwcl4z55xqlj4rz78yv04a3tgqpkn3wrnkfxqq2ze39",
-    "lp_token_id": "TODO",
+    "lp_token_id": "487",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "uosmo"
@@ -31,7 +31,7 @@
   },
   {
     "id": "osmo108scuudnnhe70xuwa2etuyxffexexak6rflvsczj9n4fhrz92ajs9zudge",
-    "lp_token_id": "TODO",
+    "lp_token_id": "572",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5"
@@ -41,7 +41,7 @@
   },
   {
     "id": "osmo109uqkhlvees202dg6mkhn89actzyfvvlm9u7ym3zzytrp9gmhcvsawlssg",
-    "lp_token_id": "TODO",
+    "lp_token_id": "412",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -51,7 +51,7 @@
   },
   {
     "id": "osmo10ce9cnt6hk4jnghvdl5asdsc5rmjfswkk7u5jrfr5ecy5puvsdzs5x6rvc",
-    "lp_token_id": "TODO",
+    "lp_token_id": "515",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -61,7 +61,7 @@
   },
   {
     "id": "osmo10cm3vypuxkrvq4uznf4px5lv43ej99f6shushwtur3fpy6z69huq7gfce8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "788",
     "asset_ids": [
       "ibc/FFA652599C77E853F017193E36B5AB2D4D9AFC4B54721A74904F80C9236BF3B7",
       "uosmo"
@@ -71,7 +71,7 @@
   },
   {
     "id": "osmo10d8ddsydag5xrnl2kacmkjtdxddstvz4jvraqqpf6ss2n7fy6lkqw4sx2f",
-    "lp_token_id": "TODO",
+    "lp_token_id": "560",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "uosmo"
@@ -81,7 +81,7 @@
   },
   {
     "id": "osmo10djas3dkuyvfzaxvgwjqp3aaf63wjrv23hx3pmk8pjaxc3f33k9ssrz8kf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "482",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
@@ -91,7 +91,7 @@
   },
   {
     "id": "osmo10ecjz4nkzsr8rwmzmk7z6uwf6ux78wyctc98yphu0rc7cey9t5sstj4zyt",
-    "lp_token_id": "TODO",
+    "lp_token_id": "478",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -101,7 +101,7 @@
   },
   {
     "id": "osmo10g4gm8px3tfeft8y0w4yc7kyxv9p9dk40aplln59j0nxmmnjnjcqhpftcf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "302",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -111,17 +111,14 @@
   },
   {
     "id": "osmo10g7srpl9gqhetplp6d2fr7l25ckjrtcsupk60984w8vf2zugcvjq6ashnq",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/102",
-      "uosmo"
-    ],
+    "lp_token_id": "103",
+    "asset_ids": ["gamm/pool/102", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo10gyurv978mfwmfpd9e824kua3f2vca8626ky93aqndhqzqfmulds36ltrz",
-    "lp_token_id": "TODO",
+    "lp_token_id": "443",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -131,7 +128,7 @@
   },
   {
     "id": "osmo10j0kv8lfy5ym3wm8m0shte5p7zu5sjtj6a6s0zslp3suqrkaqyps3kfe06",
-    "lp_token_id": "TODO",
+    "lp_token_id": "707",
     "asset_ids": [
       "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
       "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44"
@@ -141,7 +138,7 @@
   },
   {
     "id": "osmo10j25ze5tj5ryxz4jk79au6srhe62jsckk9dd6u5qt3326wv9gvnskn7tu9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "500",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -151,7 +148,7 @@
   },
   {
     "id": "osmo10k2x02xa6acekt74fnw4sl6znfgv08k37zgkd0ej303uqc4t2s7sarhsr8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "904",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/BE95D1E09F5A44FC5409F4E0F52750DF2A868D865BC91F3C3EE3C83235789D18"
@@ -161,7 +158,7 @@
   },
   {
     "id": "osmo10kepynda48va573sjsn0ch6glf3e2qrs87ukpvd63ljdmkaflg3sjxf5r4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "339",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -171,7 +168,7 @@
   },
   {
     "id": "osmo10r9v3xpzzd4752r0cvu50vacp8use9later59jcny07xz80gv6mq4yq70a",
-    "lp_token_id": "TODO",
+    "lp_token_id": "619",
     "asset_ids": [
       "ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C",
       "uosmo"
@@ -181,7 +178,7 @@
   },
   {
     "id": "osmo10rmhpg33dv9unqtw72jh67r8xdjmc07qe9zaef4jjycjyakl8q6sl76dhz",
-    "lp_token_id": "TODO",
+    "lp_token_id": "691",
     "asset_ids": [
       "ibc/DB9755CB6FE55192948AE074D18FA815E1429D3D374D5BDA8D89623C6CF235C3",
       "uosmo"
@@ -191,17 +188,14 @@
   },
   {
     "id": "osmo10sh5u7pl9dwh7ll8wfaahr0trkka4rv2k9amlj88s72k6v8paufs0qnz7p",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/222",
-      "gamm/pool/402"
-    ],
+    "lp_token_id": "403",
+    "asset_ids": ["gamm/pool/222", "gamm/pool/402"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo10tly0t6ppjaz0uhlskvlluzwwwswdc8tfy65mhhkwst6cfq07rdsxscmm9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "349",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -211,7 +205,7 @@
   },
   {
     "id": "osmo10tx2zgul27naq2p5urn9kx7lygfr0zhsk3s42nh0dcfqyudq655sadlyxj",
-    "lp_token_id": "TODO",
+    "lp_token_id": "632",
     "asset_ids": [
       "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
@@ -221,17 +215,14 @@
   },
   {
     "id": "osmo10uut208crprz36gpw3wwh50e6yuuq8jxf5yamdclg4vr84uw8cmqkunxkx",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/1",
-      "uosmo"
-    ],
+    "lp_token_id": "493",
+    "asset_ids": ["gamm/pool/1", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo10v29rzxswcz2facklsfxg7a3ns2lu5vj9f0509ateum9u7ca33tqur69mk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "277",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
@@ -241,17 +232,14 @@
   },
   {
     "id": "osmo10v35xj20k0jrfgs8p3lqt5gyga0wug3kkh4pq6xt3x4hqh5huvcssp04d3",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "lp_token_id": "255",
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo10venxtvdglryxkdmvjr8wa6n3ugja40rewddlxtg0pr30vmkf47sllgslg",
-    "lp_token_id": "TODO",
+    "lp_token_id": "678",
     "asset_ids": [
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
       "uosmo"
@@ -261,7 +249,7 @@
   },
   {
     "id": "osmo10xnwkjzqpdvgzxpz7eu5mcne5jc73c5h0xuhv9qmz0jsfyyxvr4qvhje97",
-    "lp_token_id": "TODO",
+    "lp_token_id": "777",
     "asset_ids": [
       "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
       "uosmo"
@@ -271,7 +259,7 @@
   },
   {
     "id": "osmo10xphw0uxj2k7erakdajxxdwexu4qt0fwlu0xu3a26r76kthxjyxqal4wcf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "677",
     "asset_ids": [
       "ibc/DB9755CB6FE55192948AE074D18FA815E1429D3D374D5BDA8D89623C6CF235C3",
       "uosmo"
@@ -281,7 +269,7 @@
   },
   {
     "id": "osmo10ya3d9gr2cmp268kdu8u5mna0pktqfxkt9ug54z9xrazpk3wpj0qz9zlcg",
-    "lp_token_id": "TODO",
+    "lp_token_id": "524",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -291,7 +279,7 @@
   },
   {
     "id": "osmo10yczu0hflmtny52ktkvfrrwj2cktkjn6yk9wsfyxsjf6n8pvwxfscmn4e5",
-    "lp_token_id": "TODO",
+    "lp_token_id": "144",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -301,7 +289,7 @@
   },
   {
     "id": "osmo120echqk9sfelg47lrultsc0em257582cxrp86epqhcz8gfqxf6fsluzp7z",
-    "lp_token_id": "TODO",
+    "lp_token_id": "849",
     "asset_ids": [
       "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -311,7 +299,7 @@
   },
   {
     "id": "osmo1230t5url8jlyxp9czgjv7p93kkgka4uvr3syxlwum9zjk2gpn6cs4xcxgc",
-    "lp_token_id": "TODO",
+    "lp_token_id": "590",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
@@ -321,7 +309,7 @@
   },
   {
     "id": "osmo124h7edw5f98xzfgaxmxjpnu66hdt6cn58n4g3awa90cn3h5v6d8s45246p",
-    "lp_token_id": "TODO",
+    "lp_token_id": "447",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "uosmo"
@@ -331,7 +319,7 @@
   },
   {
     "id": "osmo124qc2hs5jgp2shrmtv2usxyrt52k447702pczyct0zqadlkkh2csvh5pzv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "97",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -341,7 +329,7 @@
   },
   {
     "id": "osmo1265edur3evpvmmcter5a3lp93zlyc23wd9qp0vcu0xatn79a4q0qp24n2c",
-    "lp_token_id": "TODO",
+    "lp_token_id": "198",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
@@ -351,7 +339,7 @@
   },
   {
     "id": "osmo1272l80yvlqm4j6y5296fqhvy8ltgscsj2h4u76pumj2sy0ul82ns7hy0wu",
-    "lp_token_id": "TODO",
+    "lp_token_id": "127",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -361,7 +349,7 @@
   },
   {
     "id": "osmo128m3mqa0m6ex57nxkxkyczd3nsqns2p56wm5xu52p4jappg2jamq5jrlxe",
-    "lp_token_id": "TODO",
+    "lp_token_id": "265",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -371,7 +359,7 @@
   },
   {
     "id": "osmo12a8gxj8p07rn92zzjug6vq2a39hnqw92zhpmymxxs5avj327zslsszjqxr",
-    "lp_token_id": "TODO",
+    "lp_token_id": "229",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -381,7 +369,7 @@
   },
   {
     "id": "osmo12exa7m2esj4a9anudf0e2rpk5yynf049h585sm4zv7rqkjqun5cqs604sd",
-    "lp_token_id": "TODO",
+    "lp_token_id": "345",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -391,7 +379,7 @@
   },
   {
     "id": "osmo12fzg5z9xzw8yde57fj5w2rwqmxe6f4g3lgjdrjhhsqx8m43fqpgs7d8x8q",
-    "lp_token_id": "TODO",
+    "lp_token_id": "856",
     "asset_ids": [
       "ibc/C822645522FC3EECF817609AA38C24B64D04F5C267A23BCCF8F2E3BC5755FA88",
       "uosmo"
@@ -401,7 +389,7 @@
   },
   {
     "id": "osmo12h3748gmjdssn3pyxdtu9d6gl6wvlrem03y5e592h05f4kx6aa2ssp8jq7",
-    "lp_token_id": "TODO",
+    "lp_token_id": "422",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -411,7 +399,7 @@
   },
   {
     "id": "osmo12huxa5wnwskf8mnmr096yzwyrehm970782j95h25uuxrxxz8wdpq7udusr",
-    "lp_token_id": "TODO",
+    "lp_token_id": "303",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
@@ -421,7 +409,7 @@
   },
   {
     "id": "osmo12lzydwxr8xmyhrvg7kr0948zz4jnf4wjczwqrngppw4du85ustmqs5vpt6",
-    "lp_token_id": "TODO",
+    "lp_token_id": "263",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -431,7 +419,7 @@
   },
   {
     "id": "osmo12ng7y9c5lhyqgl2pxgap64de0fjynnwgtv3j5cme5c2ypmwezd2qwq982h",
-    "lp_token_id": "TODO",
+    "lp_token_id": "807",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B"
@@ -441,7 +429,7 @@
   },
   {
     "id": "osmo12nv2sf5qe5t93ly3fktdgrw5u9f5nn9cf8cakgt0pvhhqghvkrnqqhadah",
-    "lp_token_id": "TODO",
+    "lp_token_id": "805",
     "asset_ids": [
       "ibc/0CD46223FEABD2AEAAAF1F057D01E63BCA79B7D4BD6B68F1EB973A987344695D",
       "uosmo"
@@ -451,17 +439,14 @@
   },
   {
     "id": "osmo12nxhn6pc44eguzf53y37nkpjqv80u3n0kxtuffyqrp0h0vkqccfqu2f7pk",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/1",
-      "uosmo"
-    ],
+    "lp_token_id": "393",
+    "asset_ids": ["gamm/pool/1", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo12v9c78ctzvthgen8txmmqm06mjtdfu2gy3k68jtldxvssmwq6lrsn2fa8y",
-    "lp_token_id": "TODO",
+    "lp_token_id": "431",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -471,17 +456,14 @@
   },
   {
     "id": "osmo12vkrtnxwpkq7hnsnchs06ya7rv0vdpchxrgt7jktjm4kupzx8l2s6nfhny",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/41",
-      "gamm/pool/53"
-    ],
+    "lp_token_id": "73",
+    "asset_ids": ["gamm/pool/41", "gamm/pool/53"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo12y3z9khxjkhh7yk37c22kxjv5dl8ayxfa9s6fp0g2uekeuptmtmskvguh4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "853",
     "asset_ids": [
       "ibc/9A8A93D04917A149C8AC7C16D3DA8F470D59E8D867499C4DA97450E1D7363213",
       "uosmo"
@@ -491,7 +473,7 @@
   },
   {
     "id": "osmo12zcj6ns9sa4twqn7xnjydcfwpedt3e90y4xg9gs7ught7fq98tcszvt5uq",
-    "lp_token_id": "TODO",
+    "lp_token_id": "891",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -501,7 +483,7 @@
   },
   {
     "id": "osmo12zlm0f4wrgvdks83gue66zs97hchhc2mf75xwgg5q89ev6hd45gs7hn0zt",
-    "lp_token_id": "TODO",
+    "lp_token_id": "773",
     "asset_ids": [
       "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
       "uosmo"
@@ -511,7 +493,7 @@
   },
   {
     "id": "osmo132pj9lh5cujzql3q8umzk7zu7xyv8l9tplz3ejvra550p0ejwr0q4c3fgq",
-    "lp_token_id": "TODO",
+    "lp_token_id": "217",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
@@ -521,7 +503,7 @@
   },
   {
     "id": "osmo132qw6zaztxfnjj3a2e20adm3xwzjrycqwcc048x6wpv0w00dgl7qvlln2p",
-    "lp_token_id": "TODO",
+    "lp_token_id": "211",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uion"
@@ -531,7 +513,7 @@
   },
   {
     "id": "osmo134hkyv9330wdk8jyaltskneqxcc3nndamy5020yn4l8s6987qd9se7042l",
-    "lp_token_id": "TODO",
+    "lp_token_id": "110",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -541,7 +523,7 @@
   },
   {
     "id": "osmo137n2magslhhhp77rt0qv2l4s4fksjncj2t8vd43sn9uwzeypqw9ql0enq2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "23",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uosmo"
@@ -551,7 +533,7 @@
   },
   {
     "id": "osmo139k7lc44flz23nxzjeermnrzw6faqvys6cjkywevsqaxut93awes9lclqv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "224",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -561,7 +543,7 @@
   },
   {
     "id": "osmo13clkaupjee7n5df25v863kl2khxmcvkxk3cv9kwemz0rm77lur7qtg000v",
-    "lp_token_id": "TODO",
+    "lp_token_id": "531",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -571,7 +553,7 @@
   },
   {
     "id": "osmo13cslqv80p4uzx4cxjvpnrva68yac6z55yhafqau3k5vy6yw5027q2yx8ms",
-    "lp_token_id": "TODO",
+    "lp_token_id": "264",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uion"
@@ -581,7 +563,7 @@
   },
   {
     "id": "osmo13dnatwj7l5vdksrh66zqkp6pmvfdtqc8vr6m543dav6x26q6wvyqe3nmv6",
-    "lp_token_id": "TODO",
+    "lp_token_id": "538",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -591,7 +573,7 @@
   },
   {
     "id": "osmo13dr6zv7tf2jzvdqza692av7ah77vzt2534luprlkuj6nfk42pcaqgzp7t4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "273",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -601,7 +583,7 @@
   },
   {
     "id": "osmo13ejfnt55k897daggmc8z2kpahfufk3tvw4wq44k5y2kjt6tjjgaqm05kyd",
-    "lp_token_id": "TODO",
+    "lp_token_id": "793",
     "asset_ids": [
       "ibc/C6B6BFCB6EE49A7CAB1A7E7B021DE35B99D525AC660844952F0F6C78DCB2A57B",
       "uosmo"
@@ -611,7 +593,7 @@
   },
   {
     "id": "osmo13h85yg9msr3lr6leearsnsv5zt5hv8hv7k54gqtq2lrycn96mytqksgr48",
-    "lp_token_id": "TODO",
+    "lp_token_id": "457",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -621,7 +603,7 @@
   },
   {
     "id": "osmo13jr3p5p070h4pu7sxhtldag9899sev9pwx0r2vlvpkyravpxlqssnzsuq9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "7",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
@@ -631,7 +613,7 @@
   },
   {
     "id": "osmo13k7fkdnkw6urxecxaevy9hq2vzzvxsl40jf3kcywudvkcx0xe0nqulj3yv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "875",
     "asset_ids": [
       "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -641,7 +623,7 @@
   },
   {
     "id": "osmo13kxnazqtly05g77xnqsqs95psld5dyspe5f5xa50n06tqqq79sys2ucevl",
-    "lp_token_id": "TODO",
+    "lp_token_id": "432",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -651,7 +633,7 @@
   },
   {
     "id": "osmo13l85na80w9vtscftf2054nzwsqc7k8ncd9fv6hl3gvtpxqv84jfs4gkh5m",
-    "lp_token_id": "TODO",
+    "lp_token_id": "831",
     "asset_ids": [
       "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
       "uosmo"
@@ -661,7 +643,7 @@
   },
   {
     "id": "osmo13mczv44wvyqn6fys7f9mcv57d9fmg6e7yfkypaykp99amqfw7chq9wa5q9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "34",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uosmo"
@@ -671,7 +653,7 @@
   },
   {
     "id": "osmo13mj9ywzw3x8fpqxxnfdffuk6fgf4thv9jw78j8thu9k0uy32s92qa3an68",
-    "lp_token_id": "TODO",
+    "lp_token_id": "221",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -681,7 +663,7 @@
   },
   {
     "id": "osmo13mu0c55r8yt9mgycc7zx6jedxh73mf630xwpwvwfm7qf4q7k3edqu209ez",
-    "lp_token_id": "TODO",
+    "lp_token_id": "580",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -691,7 +673,7 @@
   },
   {
     "id": "osmo13n2p8v5w5knclf4yprk6hdrfqt3s94ynmjud7gf6djed8759qedsasl446",
-    "lp_token_id": "TODO",
+    "lp_token_id": "550",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -701,7 +683,7 @@
   },
   {
     "id": "osmo13nztwp3wht4k8zm6ztkczjqxyu74kvl8xjjfqssd7g2lwghzknhqn9gpek",
-    "lp_token_id": "TODO",
+    "lp_token_id": "332",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
@@ -711,7 +693,7 @@
   },
   {
     "id": "osmo13p8haggnllu9w0y6e0dsazcsezfywdcz4dqses8cxrnh0n0r393q05995g",
-    "lp_token_id": "TODO",
+    "lp_token_id": "544",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
@@ -721,7 +703,7 @@
   },
   {
     "id": "osmo13qvyfhzunrxulp7a0ekyn0vrl6yf26urnk8hedrnk7hn74acr49skjy00e",
-    "lp_token_id": "TODO",
+    "lp_token_id": "128",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -731,7 +713,7 @@
   },
   {
     "id": "osmo13refp99hxda7acm2rnn9nrejhh0d80ftjzxqulj7js884v3ckc3q02ssf6",
-    "lp_token_id": "TODO",
+    "lp_token_id": "334",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -741,7 +723,7 @@
   },
   {
     "id": "osmo13s0uss8gztzsrxqd08kvwmpt7d0k0tvzdfchdw0tr2suzvl3hm3s769ce5",
-    "lp_token_id": "TODO",
+    "lp_token_id": "241",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -751,7 +733,7 @@
   },
   {
     "id": "osmo13shtdrvcjzymxxe2s27k93l9xumkd4tjcmcv05pue2mfk20d66cs4r25lw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "140",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -761,7 +743,7 @@
   },
   {
     "id": "osmo13tc9ntd0rnxumtlczqefzg5nk2kf6z7agmgj898sd3gl40dkccvqy06vkm",
-    "lp_token_id": "TODO",
+    "lp_token_id": "669",
     "asset_ids": [
       "ibc/6BDB4C8CCD45033F9604E4B93ED395008A753E01EECD6992E7D1EA23D9D3B788",
       "uosmo"
@@ -771,7 +753,7 @@
   },
   {
     "id": "osmo13tp73hg0skhenwrhp4sqg48a4e6459spyvnp7ptnz2galhpcz3lsalsh0w",
-    "lp_token_id": "TODO",
+    "lp_token_id": "910",
     "asset_ids": [
       "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -781,7 +763,7 @@
   },
   {
     "id": "osmo13twh7y4pv6rdrxchtjeh7tav4qqujlwxxc9cdqpvruj9dh9xttrq8g5g9c",
-    "lp_token_id": "TODO",
+    "lp_token_id": "313",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -791,17 +773,14 @@
   },
   {
     "id": "osmo13u649up5fe79u2aq0d3rsl5x48lulu5yred75lcuw94dlugfxdqq39hz0s",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "lp_token_id": "320",
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo13xtszjfnwjs5lxetjklspuuzg3tymnepu48p5sp38rhs458kc7yq9jxjf8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "231",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -811,7 +790,7 @@
   },
   {
     "id": "osmo140c35lxmkmkzmxyh7293cmettfatdw090n0ttwzxxjwa3jraenwqqpczwd",
-    "lp_token_id": "TODO",
+    "lp_token_id": "712",
     "asset_ids": [
       "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
       "uosmo"
@@ -821,7 +800,7 @@
   },
   {
     "id": "osmo140dhzccumruw0u38dt7qlj49ttvw2p5mwgcjqsqjuv443u2s5rgqll980k",
-    "lp_token_id": "TODO",
+    "lp_token_id": "187",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -831,7 +810,7 @@
   },
   {
     "id": "osmo140lcj9njcgennv4sk2qtffq0d29s7a9qpv2l30rccghfxfc44mvqphj5uv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "401",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -841,7 +820,7 @@
   },
   {
     "id": "osmo142esjq2sxsju345f4germ3zqlc6j73f6tzzxpumkclzwxs9t5nuq5wuaal",
-    "lp_token_id": "TODO",
+    "lp_token_id": "577",
     "asset_ids": [
       "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
       "uosmo"
@@ -851,7 +830,7 @@
   },
   {
     "id": "osmo143403qx9vwa0d0m6zzna2r0fw0xyefl4ey3jgtl4krk5qdzvwd9smnr936",
-    "lp_token_id": "TODO",
+    "lp_token_id": "496",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -861,7 +840,7 @@
   },
   {
     "id": "osmo146awk6s36fxfqa2hzp974lpmvry6cz20yp52ugrlw5c5983nqgjswz9ltt",
-    "lp_token_id": "TODO",
+    "lp_token_id": "479",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
@@ -871,7 +850,7 @@
   },
   {
     "id": "osmo1497udspu0fkv9hjv5kep7vglhg8nj986v4e6dz62dleen4m3a50s8evd6c",
-    "lp_token_id": "TODO",
+    "lp_token_id": "547",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8"
@@ -881,7 +860,7 @@
   },
   {
     "id": "osmo14azf94grg0qn67tkczejnt87t9yzt5ndg5h3pqc8zapz3hpg7whq5zzsyh",
-    "lp_token_id": "TODO",
+    "lp_token_id": "535",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -891,7 +870,7 @@
   },
   {
     "id": "osmo14cg7nxexxmuszptk6kghd7d73r7t6xrjfclcmk3qrc73wpjyxtesywq20q",
-    "lp_token_id": "TODO",
+    "lp_token_id": "674",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "uosmo"
@@ -901,7 +880,7 @@
   },
   {
     "id": "osmo14dxgrj6qc5t50aedyy9fz7wqvtnv9qjcus7ls6t4lcrt3ged388qsyuhte",
-    "lp_token_id": "TODO",
+    "lp_token_id": "266",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -911,7 +890,7 @@
   },
   {
     "id": "osmo14hxmap32awjzck43xeerxmvnyzvsrjrc7559jw97z23664vx4lyst3wly2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "111",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -921,7 +900,7 @@
   },
   {
     "id": "osmo14jz33kmx87yv94x4hzh3ylrpt6kwkqvjlsaz06aus2equyjv9w3s5nw2kc",
-    "lp_token_id": "TODO",
+    "lp_token_id": "100",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -931,7 +910,7 @@
   },
   {
     "id": "osmo14klwpt49lrs76l24puae7jnct4430ufl9u42rdmz49vews0vu6zqrypt4c",
-    "lp_token_id": "TODO",
+    "lp_token_id": "692",
     "asset_ids": [
       "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
       "uosmo"
@@ -941,7 +920,7 @@
   },
   {
     "id": "osmo14me6rlskklxu3rxmlzj27vhyecf8xfvvckwdn76fxkzqgdsy03jqj49ws0",
-    "lp_token_id": "TODO",
+    "lp_token_id": "244",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -951,7 +930,7 @@
   },
   {
     "id": "osmo14mwhxhggae403crueknyqshuqzge56w2q4lltmenzqwmt94ys6fqdjgv37",
-    "lp_token_id": "TODO",
+    "lp_token_id": "491",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
@@ -961,7 +940,7 @@
   },
   {
     "id": "osmo14nkh5n0e6r3qz78zcyygj3wv906qtsgqrm5nq3zwpx2zku2lvdqshfwyv3",
-    "lp_token_id": "TODO",
+    "lp_token_id": "485",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -971,7 +950,7 @@
   },
   {
     "id": "osmo14p3mvjdxg5skeh44atnvxvc3l0mf4jjt6uk62yk5nzv7q5dyf70qw6npt2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "436",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
@@ -981,7 +960,7 @@
   },
   {
     "id": "osmo14pmk24h24cmpne8kzanagwe4f03wlqccwlm4spj4hyk7r0pxru9szmht2q",
-    "lp_token_id": "TODO",
+    "lp_token_id": "213",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -991,7 +970,7 @@
   },
   {
     "id": "osmo14ppp79wvq6xlg3tnwr86sgpqv36m4gs3uurrf8wlmgdx8cz9ly0sanpqjr",
-    "lp_token_id": "TODO",
+    "lp_token_id": "695",
     "asset_ids": [
       "ibc/52E12CF5CA2BB903D84F5298B4BFD725D66CAB95E09AA4FC75B2904CA5485FEB",
       "uosmo"
@@ -1001,7 +980,7 @@
   },
   {
     "id": "osmo14q5n9efl2lf7txvkfveskzdt4l47n7lpj2lzs7yk8u6hmzerz5ysjg6qx8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "568",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "uosmo"
@@ -1011,7 +990,7 @@
   },
   {
     "id": "osmo14slhuw6gtlsud3p2c79gy92qy72qcvjv6q6upwcrl95m8wyuepvsq9c29d",
-    "lp_token_id": "TODO",
+    "lp_token_id": "576",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -1021,7 +1000,7 @@
   },
   {
     "id": "osmo14sxd3nugue3z44lh55cvn7uq8xzzzkgfknnuxtazr569jyymcqys2eykgs",
-    "lp_token_id": "TODO",
+    "lp_token_id": "391",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uion"
@@ -1031,7 +1010,7 @@
   },
   {
     "id": "osmo14sy9cpm4adfrut88u4869ue2sz72rjjcq6hlsmf5uz97tkswvvnqnujj6t",
-    "lp_token_id": "TODO",
+    "lp_token_id": "881",
     "asset_ids": [
       "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163",
       "uosmo"
@@ -1041,7 +1020,7 @@
   },
   {
     "id": "osmo14wp02k4djfx5yqvtr052lfytdmje05jm00even373h7cdydw78vsrjp52h",
-    "lp_token_id": "TODO",
+    "lp_token_id": "672",
     "asset_ids": [
       "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5",
       "uosmo"
@@ -1051,7 +1030,7 @@
   },
   {
     "id": "osmo14xpkpdstm4xhwjsw3v8gs99f2xl949wcnxx8a8dvn0qq5460afkqcsxej3",
-    "lp_token_id": "TODO",
+    "lp_token_id": "163",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -1061,7 +1040,7 @@
   },
   {
     "id": "osmo14xt30a3pswr540lp55y7f9gfevmddv84takyjn2p28a27ayc85gs3p292f",
-    "lp_token_id": "TODO",
+    "lp_token_id": "730",
     "asset_ids": [
       "ibc/57AA1A70A4BC9769C525EBF6386F7A21536E04A79D62E1981EFCEF9428EBB205",
       "uosmo"
@@ -1071,7 +1050,7 @@
   },
   {
     "id": "osmo14y9ejauxnuyr48eu8jterwyhnz4s94s5ywggzmhf3wmu73g28gcsenvnum",
-    "lp_token_id": "TODO",
+    "lp_token_id": "223",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -1081,7 +1060,7 @@
   },
   {
     "id": "osmo14ymxts36p4z2eef06qeeuqd5s0x7fmyhzs382qvnqxsv45zcqf7q0vztv0",
-    "lp_token_id": "TODO",
+    "lp_token_id": "762",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/6A6174468758D207DD2D880363BF699C6568A29E87651337AEDAFD9E69EA7E58"
@@ -1091,17 +1070,14 @@
   },
   {
     "id": "osmo1500hy75krs9e8t50aav6fahk8sxhajn9ctp40qwvvn8tcprkk6wszun4a5",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "lp_token_id": "2",
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo150wfa0gum6sz5crkpvt9pztjf35dc8gvaufzrc40d6hr99wvyxlqcaddv9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "581",
     "asset_ids": [
       "ibc/204A582244FC241613DBB50B04D1D454116C58C4AF7866C186AA0D6EEAD42780",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -1111,7 +1087,7 @@
   },
   {
     "id": "osmo153ezzm4uwy0dqh0mmxwgxu3mu0pknvgrsn4es3u5zrzhs57jc65qtsyl4c",
-    "lp_token_id": "TODO",
+    "lp_token_id": "523",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -1121,7 +1097,7 @@
   },
   {
     "id": "osmo154fszgu6aqqqtg0zff33leallf4rw3456s6spcsdmjf0u73jtd6suf32zx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "282",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -1131,7 +1107,7 @@
   },
   {
     "id": "osmo155c60gtktr83uvnahsxc3q7gswmuwm7ukhxmz06jwl3yrjgd4k7s7k4wkr",
-    "lp_token_id": "TODO",
+    "lp_token_id": "350",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -1141,7 +1117,7 @@
   },
   {
     "id": "osmo155szru0rpgcjwlcgwtv3r35v4zdc0dkskpr4fwshqcm9r2974htsfujjuh",
-    "lp_token_id": "TODO",
+    "lp_token_id": "753",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/B4DED8861763C7674BD726FFFE5CAB09BDC3CC706E77C82E46EFEDCF9DB3B495"
@@ -1151,7 +1127,7 @@
   },
   {
     "id": "osmo155tdryrz9lqtqtsyjuc2ughrryu6nncr8vr03hepdyqqsgesag6s6ggts0",
-    "lp_token_id": "TODO",
+    "lp_token_id": "557",
     "asset_ids": [
       "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B",
       "uosmo"
@@ -1161,7 +1137,7 @@
   },
   {
     "id": "osmo157u4eawmj4ux5jth54aw9sfh3zsgvgncm20t9m9vc7er6vrkjnks9naflp",
-    "lp_token_id": "TODO",
+    "lp_token_id": "842",
     "asset_ids": [
       "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
       "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5"
@@ -1171,7 +1147,7 @@
   },
   {
     "id": "osmo157yhlzsnqxvrne3wdpukh7uca40l9mak875u44f9asufvwkldzzs7tpaal",
-    "lp_token_id": "TODO",
+    "lp_token_id": "476",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uion"
@@ -1181,7 +1157,7 @@
   },
   {
     "id": "osmo158s5v5kd2nzgrq0fse6tk60r70596e5p8qczj47pfqcqx9rc3l9s0q2v3h",
-    "lp_token_id": "TODO",
+    "lp_token_id": "143",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -1191,7 +1167,7 @@
   },
   {
     "id": "osmo159f0lecgvarm6a9snyqjnz9r32h72fwqq9q2s3py7we0v9mfp5vsx9w3ct",
-    "lp_token_id": "TODO",
+    "lp_token_id": "296",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -1201,7 +1177,7 @@
   },
   {
     "id": "osmo15d7sqmwy2snpxw2w776v0tthr328dzjvpvk7phssyuqszq4lr6xs5dcupr",
-    "lp_token_id": "TODO",
+    "lp_token_id": "917",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373"
@@ -1211,7 +1187,7 @@
   },
   {
     "id": "osmo15dz4u47sdmk4rq67k9v5n9fununc6j7y903azd3sm3yafd9wp68s9s4p5z",
-    "lp_token_id": "TODO",
+    "lp_token_id": "592",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -1221,17 +1197,14 @@
   },
   {
     "id": "osmo15e4a88d0vmd7ywh9e2ll8q447defplgamwza9ezay67z84cxmx7ssu8s6q",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/101",
-      "uosmo"
-    ],
+    "lp_token_id": "106",
+    "asset_ids": ["gamm/pool/101", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo15e9w6y0g8z5as77g29azqwvp37dp96njn7h0vt5suz3un5vw95dsj4uurl",
-    "lp_token_id": "TODO",
+    "lp_token_id": "22",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -1241,7 +1214,7 @@
   },
   {
     "id": "osmo15eg4aq5fxdehdjv5zr385h4zmswamvw6pguqhykd3fs2jrgpgr0qqmlfqc",
-    "lp_token_id": "TODO",
+    "lp_token_id": "865",
     "asset_ids": [
       "ibc/92B223EBFA74DB99BEA92B23DEAA6050734FEEAABB84689CB8E1AE8F9C9F9AF4",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -1251,7 +1224,7 @@
   },
   {
     "id": "osmo15h02q7rzpwn0gahklnek29naae4peg3j4rd5e4hcc264sm3mfugqaw6up7",
-    "lp_token_id": "TODO",
+    "lp_token_id": "665",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7"
@@ -1261,7 +1234,7 @@
   },
   {
     "id": "osmo15j2ttrqclc5j3fz53gps5n4p6eyw7qr3t2qsxna8ekjsahctgf4qe3v89q",
-    "lp_token_id": "TODO",
+    "lp_token_id": "353",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -1271,7 +1244,7 @@
   },
   {
     "id": "osmo15jt5g7jn3m2wem6an2n9m982hr6v2madrhjyt3vxrn00vew3xmmsnah0ct",
-    "lp_token_id": "TODO",
+    "lp_token_id": "552",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525"
@@ -1281,7 +1254,7 @@
   },
   {
     "id": "osmo15k82dwg2xkhm2una73jnq2ftan7c5rncul3fpyzyc9g3g6m0ae5skyswxd",
-    "lp_token_id": "TODO",
+    "lp_token_id": "751",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/7ABF696369EFB3387DF22B6A24204459FE5EFD010220E8E5618DC49DB877047B"
@@ -1291,7 +1264,7 @@
   },
   {
     "id": "osmo15krawmktxe8rzzepj4wxzgeevns9xftpzwhw7uycdg43t2k7nsxq3n6xen",
-    "lp_token_id": "TODO",
+    "lp_token_id": "710",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
@@ -1301,7 +1274,7 @@
   },
   {
     "id": "osmo15mym9nr2g994zevcslnf8n96unwnsmqa8nzkef4lgavhjkgsy8gscuq3w9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "371",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
@@ -1311,7 +1284,7 @@
   },
   {
     "id": "osmo15p62pdak6vsudduc82h09plethxq5m58k6x6t76y7fee3fgm0upq3x8553",
-    "lp_token_id": "TODO",
+    "lp_token_id": "770",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84"
@@ -1321,7 +1294,7 @@
   },
   {
     "id": "osmo15sg8553z787gk33z47yd8uvux72asllkcywnnplepe6c6lhurs5sfpy7a9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "410",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -1331,7 +1304,7 @@
   },
   {
     "id": "osmo15t7afyxut7eugx0yn4quesujf5snv358g3ureyx46afpwhjrlaas5nl3zp",
-    "lp_token_id": "TODO",
+    "lp_token_id": "664",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7"
@@ -1341,7 +1314,7 @@
   },
   {
     "id": "osmo15u42rnfp5fr0qrdmnncptxvycwdxrdutwjv5v83t9y9yy7xq948qly3844",
-    "lp_token_id": "TODO",
+    "lp_token_id": "470",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
@@ -1351,7 +1324,7 @@
   },
   {
     "id": "osmo15u5e6evufc9gjd28n4z9rvhku8lfg3arpejm0gnzhzx05w9h7e7q8665jn",
-    "lp_token_id": "TODO",
+    "lp_token_id": "13",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
@@ -1361,7 +1334,7 @@
   },
   {
     "id": "osmo15upcqtt7tupfxdh4229vjwesgm7f3s5a66ke6dhfajxnkdmzm3pqu8y7hv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "735",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
@@ -1371,7 +1344,7 @@
   },
   {
     "id": "osmo15v4mn84s9flhzpstkf9ql2mu0rnxh42pm8zhq47kh2fzs5zlwjsqaterkr",
-    "lp_token_id": "TODO",
+    "lp_token_id": "833",
     "asset_ids": [
       "ibc/D176154B0C63D1F9C6DCFB4F70349EBF2E2B5A87A05902F57A6AE92B863E9AEC",
       "uosmo"
@@ -1381,17 +1354,14 @@
   },
   {
     "id": "osmo15v7xfk7qnm27r2kwsutegh3jt2ye7haadqlnt5xf89hkp29hx0cq4sgqr6",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/361",
-      "uosmo"
-    ],
+    "lp_token_id": "364",
+    "asset_ids": ["gamm/pool/361", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo15vl4puljq9s6taqzmnsgd43gkz3ltp3hj4aexqj8x2ey4lxrrrks278cn4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "640",
     "asset_ids": [
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
       "uion"
@@ -1401,7 +1371,7 @@
   },
   {
     "id": "osmo15w6vtw48yqell0h4t3dyxhczp7dx0vl4f2xe3dgluyvznjdhhkgqnttcxy",
-    "lp_token_id": "TODO",
+    "lp_token_id": "726",
     "asset_ids": [
       "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
       "uosmo"
@@ -1411,7 +1381,7 @@
   },
   {
     "id": "osmo15zzs8muh0lgnhdmzax35e90cskgulz7x566q6fpknguvdw95s0msen0l80",
-    "lp_token_id": "TODO",
+    "lp_token_id": "855",
     "asset_ids": [
       "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
       "ibc/71055835C7639739EAE03AACD1324FE162DBA41D09F197CB72D966D014225B1C"
@@ -1421,7 +1391,7 @@
   },
   {
     "id": "osmo1605py4r32r73csszlqpz6n5t5sgax9gjjfnm68jnd7pv6qe4l54ql0w8ku",
-    "lp_token_id": "TODO",
+    "lp_token_id": "8",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
@@ -1431,7 +1401,7 @@
   },
   {
     "id": "osmo1620l9ewga9f6w3wyvfx5vhpuum3wwgz2haamn4t8lckfyzvnxd0q0chmeu",
-    "lp_token_id": "TODO",
+    "lp_token_id": "582",
     "asset_ids": [
       "ibc/204A582244FC241613DBB50B04D1D454116C58C4AF7866C186AA0D6EEAD42780",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -1441,7 +1411,7 @@
   },
   {
     "id": "osmo162yn5ntl2tuuyxxf3dmm3d76q56ch9zlka0v7852wxqd874q388s502qp2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "685",
     "asset_ids": [
       "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
       "uosmo"
@@ -1451,7 +1421,7 @@
   },
   {
     "id": "osmo163pdautlpkrj0au0s0nkqw8ln2r42gdkwjuf77c26h7crd44hj3suggfju",
-    "lp_token_id": "TODO",
+    "lp_token_id": "209",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
@@ -1461,7 +1431,7 @@
   },
   {
     "id": "osmo163sn2xvlaalva3td4hcjqmmrzzn4upu35qgdnnr4q0azp0t3v22qgfc8yz",
-    "lp_token_id": "TODO",
+    "lp_token_id": "420",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -1471,7 +1441,7 @@
   },
   {
     "id": "osmo163yhv8mj29c03zd7ktg2gwcpwjj6kcmdx933p3lfxdu66qsajt0skqkmvx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "409",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -1481,7 +1451,7 @@
   },
   {
     "id": "osmo167a9n3f6t8v64pugrqnz88f7w8tlwaxfsgge4tm7jh4gvxrhstyqgyv5jw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "536",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
@@ -1491,7 +1461,7 @@
   },
   {
     "id": "osmo167dnkr4k7ezmat3sq4nkdmwel54u7uh496n45djnu9xe82ad2w5s4qpg68",
-    "lp_token_id": "TODO",
+    "lp_token_id": "442",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -1501,7 +1471,7 @@
   },
   {
     "id": "osmo167dycqs0n3dxzfrwctg3p4hg7zxjjptr2p7nvkk9d23wu8spy4csdzvlsx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "501",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
@@ -1511,7 +1481,7 @@
   },
   {
     "id": "osmo169wdlgu8tes3qm4un02gwvhxw78yphlf3mks30j3lkwek8j7vpgqcx2zzp",
-    "lp_token_id": "TODO",
+    "lp_token_id": "114",
     "asset_ids": [
       "gamm/pool/1",
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4"
@@ -1521,7 +1491,7 @@
   },
   {
     "id": "osmo16a0su5csdrukz43z284agsqctfutps8eextnvrk3g2nhk2cxmlgsmfh4r8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "112",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -1531,7 +1501,7 @@
   },
   {
     "id": "osmo16cl5fg34wtrnpvz9rcncm37nutywn0765ldkuw59gc68xrajzuwqd9jt88",
-    "lp_token_id": "TODO",
+    "lp_token_id": "616",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2"
@@ -1541,7 +1511,7 @@
   },
   {
     "id": "osmo16cr2suh8wxyd3rdj24s7qe4kr2lnjxmm0495j07tl06jclnwfa2qqs58qg",
-    "lp_token_id": "TODO",
+    "lp_token_id": "808",
     "asset_ids": [
       "ibc/18A676A074F73B9B42DA4F9DFC8E5AEF334C9A6636DDEC8D34682F52F1DECDF6",
       "uosmo"
@@ -1551,7 +1521,7 @@
   },
   {
     "id": "osmo16d92nnsxj9nyc6j46k0pj6q0phhdu89nrz0y8657nn4el5fm3lwsut9e6k",
-    "lp_token_id": "TODO",
+    "lp_token_id": "630",
     "asset_ids": [
       "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
       "uion"
@@ -1561,7 +1531,7 @@
   },
   {
     "id": "osmo16dafzdug0nreqs3h8g2rdtp5dr75ck9k2a9qzyvvgksn6cgukteqkafeu5",
-    "lp_token_id": "TODO",
+    "lp_token_id": "697",
     "asset_ids": [
       "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
       "uosmo"
@@ -1571,17 +1541,14 @@
   },
   {
     "id": "osmo16dn4uk4xlqshzufy3f0as2pnvdpwqlwepp0m5qumwh2c4vgmp9jqaa0zsh",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "lp_token_id": "569",
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo16h2dp9v34s7dy5f8ut708tf0pjj7772u8f8n77pxs3k5aj4rkg6sl85ehj",
-    "lp_token_id": "TODO",
+    "lp_token_id": "322",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -1591,7 +1558,7 @@
   },
   {
     "id": "osmo16h9xer73q9c4rpwvmxhqdcqc4r8q0ldrgme8f3q3ljntam6sarnsd5tnlf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "456",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -1601,7 +1568,7 @@
   },
   {
     "id": "osmo16hrp33emfwydwnydry5k854ffeya64g6lgxj34ev27tl865msdxs7lpljf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "783",
     "asset_ids": [
       "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
       "uosmo"
@@ -1611,7 +1578,7 @@
   },
   {
     "id": "osmo16qetl32gwxnne8q46qsc4e65rtnx8z9w2dxqas66hllu6c2gty8q7fwz0k",
-    "lp_token_id": "TODO",
+    "lp_token_id": "821",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A"
@@ -1621,17 +1588,14 @@
   },
   {
     "id": "osmo16qzex7q0cpj3dflx79ycqvsujm0dt838lfjv9fjg80zna7jpn2ssn3cta4",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "lp_token_id": "395",
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo16u8zapr7jvqv63hrnpfzfp4ys2g9ap69rxkdzpsasaa4qlwzx45sme0eus",
-    "lp_token_id": "TODO",
+    "lp_token_id": "438",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -1641,7 +1605,7 @@
   },
   {
     "id": "osmo16w7vk8sus35draftmhuac39vcvcpwcjttvjmee54vd0rx59xqp7s5t4flu",
-    "lp_token_id": "TODO",
+    "lp_token_id": "918",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E"
@@ -1651,7 +1615,7 @@
   },
   {
     "id": "osmo16x4qnfcefwaym3znv2waqh20rfgxpney2pxv4vvnv4p9y9n8ddaq68khcy",
-    "lp_token_id": "TODO",
+    "lp_token_id": "797",
     "asset_ids": [
       "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
       "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B"
@@ -1661,7 +1625,7 @@
   },
   {
     "id": "osmo16zg36xlt7a84deeweraqtf64sw5pedh5c4cquqv0gy4e6498u52sdx2zj9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "131",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -1671,7 +1635,7 @@
   },
   {
     "id": "osmo1702m29rngg2xjsd4mdl3xscfrgv3fy039hc6uvczq8rsfwdtnj0spp4yqx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "728",
     "asset_ids": [
       "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
       "uosmo"
@@ -1681,7 +1645,7 @@
   },
   {
     "id": "osmo1706zqq68yt0gsnq63j3wjn8egqvr5sqylxnjzalvskjqkv3v7xvshu3d36",
-    "lp_token_id": "TODO",
+    "lp_token_id": "433",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
@@ -1691,7 +1655,7 @@
   },
   {
     "id": "osmo170f2kcc7ud5mepllczl23jnwrpwt6q3fsrxv0mtwtt2tqydf5u4sx4nesp",
-    "lp_token_id": "TODO",
+    "lp_token_id": "424",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
@@ -1701,7 +1665,7 @@
   },
   {
     "id": "osmo1735wj90a09zr4a3pcujmpp85mkz05tu4ynm534eaqw9nl4zw2qkqtzjpw0",
-    "lp_token_id": "TODO",
+    "lp_token_id": "305",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -1711,7 +1675,7 @@
   },
   {
     "id": "osmo1752ysawy2adr7td9an30a8pkk8ngrvcq3tan08lvnar3s7f82y5s4dt8fs",
-    "lp_token_id": "TODO",
+    "lp_token_id": "907",
     "asset_ids": [
       "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580",
       "uosmo"
@@ -1721,7 +1685,7 @@
   },
   {
     "id": "osmo175hpfs58xklq8aradgemnsufj5w27m4ymeelskntvhuvnwd9wkgqsw5lvd",
-    "lp_token_id": "TODO",
+    "lp_token_id": "134",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -1731,7 +1695,7 @@
   },
   {
     "id": "osmo177r65zqzqs50p8utgyltw2uldlxyq26v2klgyxy5440kha49vwaq6j9z8e",
-    "lp_token_id": "TODO",
+    "lp_token_id": "699",
     "asset_ids": [
       "ibc/00B6E60AD3D65CBEF5579AC8AF609527C0B57535B6E32D96C80A735344FD9DCC",
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7"
@@ -1741,7 +1705,7 @@
   },
   {
     "id": "osmo17atf6ld93djyxf0rehn8fcjka92enqy8jrcf7fc29xer4mafyv2qdz37dh",
-    "lp_token_id": "TODO",
+    "lp_token_id": "383",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
@@ -1751,7 +1715,7 @@
   },
   {
     "id": "osmo17dyt6827sq83px7gl7gsuzumlh0je00j0z9slcp08cxy8vn0ye0syrr2gh",
-    "lp_token_id": "TODO",
+    "lp_token_id": "696",
     "asset_ids": [
       "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
       "uosmo"
@@ -1761,7 +1725,7 @@
   },
   {
     "id": "osmo17ehyaducl0pyznms988c7xcfd4w0n054klqr9fp4fmqzz05y9e2q9e3pvg",
-    "lp_token_id": "TODO",
+    "lp_token_id": "375",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -1771,7 +1735,7 @@
   },
   {
     "id": "osmo17ff0mxg5j6xtuh7ma623ejcntuzuvpewu9dyjk00wkadh75au3qs0gp8pv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "18",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uion"
@@ -1781,7 +1745,7 @@
   },
   {
     "id": "osmo17gykllhtf9q4hqdrtydgl7jgvyeqf3rsvdrwef4ct6pvfhsmyg0sp423x0",
-    "lp_token_id": "TODO",
+    "lp_token_id": "823",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB"
@@ -1791,7 +1755,7 @@
   },
   {
     "id": "osmo17h0ay5zhcllwgshem7r40a2wyx7a43w2ngfrrc7w2w60rrhdklws7u6zy6",
-    "lp_token_id": "TODO",
+    "lp_token_id": "768",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/B3FB7128CE957DE1ADB687A919AA0786C77C62FB1280C07CDD78AEA032D56853"
@@ -1801,7 +1765,7 @@
   },
   {
     "id": "osmo17k408tt5xf9zz44qxf95q6f8m8tvkethvrwk93gwqgkfrlefkjms68dp7y",
-    "lp_token_id": "TODO",
+    "lp_token_id": "435",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -1811,7 +1775,7 @@
   },
   {
     "id": "osmo17kylujlrmyuxu0yvguv0gsxpvgvp44up8pvxvsyh36d0r9ww4pkq6c9zgp",
-    "lp_token_id": "TODO",
+    "lp_token_id": "212",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
@@ -1821,7 +1785,7 @@
   },
   {
     "id": "osmo17lmjln5dhd2c37npal49p2gfr2eqmrdv20h7g2u0rszg7jlqxu2sztwlgk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "293",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/CD942F878C80FBE9DEAB8F8E57F592C7252D06335F193635AF002ACBD69139CC"
@@ -1831,7 +1795,7 @@
   },
   {
     "id": "osmo17n6nngjwheahmljdk0k56dh5dfnktn2r2f33sdaj4uwnrk00y4vs0jcc0f",
-    "lp_token_id": "TODO",
+    "lp_token_id": "525",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -1841,7 +1805,7 @@
   },
   {
     "id": "osmo17n6y5d9jqjvjk3yysnuszt9spuyqwcdz6uctuuf2m66906efj0ys333va9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "160",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -1851,7 +1815,7 @@
   },
   {
     "id": "osmo17nsa8pa7cjeu2tj8v5mqen8cye3rrp2h69lzvepveruhvtmujkzq9uzjfw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "549",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
@@ -1861,7 +1825,7 @@
   },
   {
     "id": "osmo17pk7pcuqxz2hn0j2rhqknzn4npujncpzdakpe9hclz5jr605023qcgc9ty",
-    "lp_token_id": "TODO",
+    "lp_token_id": "905",
     "asset_ids": [
       "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
       "uosmo"
@@ -1871,7 +1835,7 @@
   },
   {
     "id": "osmo17rudnglqgrcnvn3am3xm02d94y4sa3l43ywkv3cp4je44p2ez5nq590lae",
-    "lp_token_id": "TODO",
+    "lp_token_id": "858",
     "asset_ids": [
       "ibc/BB936517F7E5D77A63E0ADB05217A6608B0C4CF8FBA7EA2F4BAE4107A7238F06",
       "uosmo"
@@ -1881,17 +1845,14 @@
   },
   {
     "id": "osmo17rujtwmvk8vp3uqq6xxkymk83n3qethhejuar7ayhyuupcsw66mqmg4k28",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "lp_token_id": "344",
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo17sk5nv9367kc5jgfmtf64c9esgf4sdeazd8fd5twrlhxqne3tgnqrp2qpz",
-    "lp_token_id": "TODO",
+    "lp_token_id": "613",
     "asset_ids": [
       "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD",
       "uosmo"
@@ -1901,7 +1862,7 @@
   },
   {
     "id": "osmo17wpv2azveyr59utlztg6cm8ckzyyepklrrs4lswszn0u46s9rrgqpftypp",
-    "lp_token_id": "TODO",
+    "lp_token_id": "184",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -1911,7 +1872,7 @@
   },
   {
     "id": "osmo17yl0x8s78p9nhwgqtdjfeynfzaz25mnv2j8m75ev2jznv782958su68utl",
-    "lp_token_id": "TODO",
+    "lp_token_id": "181",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
@@ -1921,7 +1882,7 @@
   },
   {
     "id": "osmo17z485xwwqknnxfcs73w4nxu0ndp4n8jf6ylj730cph4a6p47hawqrg65wr",
-    "lp_token_id": "TODO",
+    "lp_token_id": "270",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -1931,7 +1892,7 @@
   },
   {
     "id": "osmo18503q8ndu9smzuwqm9nlgw4l6373d430xp32yv4gclug6t27qy6qz7dyku",
-    "lp_token_id": "TODO",
+    "lp_token_id": "449",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -1941,7 +1902,7 @@
   },
   {
     "id": "osmo185d7wu8622egqk0hgzpp48nmaeg3fvlc4pglg2zqrgdtcjenr3hstpyagv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "425",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
@@ -1951,7 +1912,7 @@
   },
   {
     "id": "osmo185uac6gnxaa7aa9pqxgktpuqhe6ve3jkfa8wl8dcx3p3zmymzkyszj4k6j",
-    "lp_token_id": "TODO",
+    "lp_token_id": "890",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -1961,7 +1922,7 @@
   },
   {
     "id": "osmo1860equ7v4tjdcmr2vtka5kr3mzuh3ekzpcez77y7pd25972wl52q5rk9hd",
-    "lp_token_id": "TODO",
+    "lp_token_id": "351",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -1971,7 +1932,7 @@
   },
   {
     "id": "osmo18864qdsyavwstv9r7kcrtzhnuk5zcevex4gmftk0vkaqczew5sjscf7xmp",
-    "lp_token_id": "TODO",
+    "lp_token_id": "262",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -1981,7 +1942,7 @@
   },
   {
     "id": "osmo18984gjmrtrj8tzz5mlx04lqusrmjpdx28ty8h4zgf3yw7lr9r53s3ruz0e",
-    "lp_token_id": "TODO",
+    "lp_token_id": "782",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "uosmo"
@@ -1991,7 +1952,7 @@
   },
   {
     "id": "osmo189lml9kvhv8qac8eewhj3kuvz2zpy47fqlv0ahs3gtymejfty7yqqvdyk3",
-    "lp_token_id": "TODO",
+    "lp_token_id": "454",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -2001,7 +1962,7 @@
   },
   {
     "id": "osmo18ahq029ylafhmmf25wqu6lvpz6nz4nf533sv6hlqht6d49p23ehszdp5gh",
-    "lp_token_id": "TODO",
+    "lp_token_id": "38",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -2011,7 +1972,7 @@
   },
   {
     "id": "osmo18c87zv90lqd59tl6u068dqcs9x80rfwwjs5wr0vrj7shay429ntq05psnd",
-    "lp_token_id": "TODO",
+    "lp_token_id": "448",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
@@ -2021,7 +1982,7 @@
   },
   {
     "id": "osmo18dpk6wfldlfzkk2tdas2tztcth26v39tt7sc2t30drzrex6mlnqqa3hd78",
-    "lp_token_id": "TODO",
+    "lp_token_id": "757",
     "asset_ids": [
       "ibc/051A38BBEF92B9D8293AFBE1FA293E704359E9CB28297A0FD5DBA3E9CCEE9AB1",
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
@@ -2031,7 +1992,7 @@
   },
   {
     "id": "osmo18et08xm2dag9ppkdcs7epza2dvt423kxpdnr4vc670cm7d8jh22qukx7ls",
-    "lp_token_id": "TODO",
+    "lp_token_id": "488",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2041,7 +2002,7 @@
   },
   {
     "id": "osmo18f2zqvulx7wfzg95eh864jw7neqhz23sk8g9lffys3l4jnlttleq5r5kl9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "203",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2051,7 +2012,7 @@
   },
   {
     "id": "osmo18fdae3yzc2ycw27gzftx0czkpszzrsflw8cyqe99ku3c9aj7lfcq3tjzyt",
-    "lp_token_id": "TODO",
+    "lp_token_id": "869",
     "asset_ids": [
       "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -2061,7 +2022,7 @@
   },
   {
     "id": "osmo18ggsma2ef28tlyey053sxv7d3ka45lzpf7zm8mr47duezgghswrq9trxet",
-    "lp_token_id": "TODO",
+    "lp_token_id": "915",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E"
@@ -2071,7 +2032,7 @@
   },
   {
     "id": "osmo18gt77cjyv6xe2gqjp9k6ct0fk2usv67q6jjjeagdttsy8qks78ysfq82fu",
-    "lp_token_id": "TODO",
+    "lp_token_id": "747",
     "asset_ids": [
       "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
       "uosmo"
@@ -2081,7 +2042,7 @@
   },
   {
     "id": "osmo18hd0dfzfwdmlz22qp6dqfd06xryqdaug9y2qwafhkp4znc0rqz5q5ms2wr",
-    "lp_token_id": "TODO",
+    "lp_token_id": "555",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525"
@@ -2091,7 +2052,7 @@
   },
   {
     "id": "osmo18jxduxdcesftwkx8uh2lqrjl6teky87t8rpv9wd704929hpe73cq44xcwy",
-    "lp_token_id": "TODO",
+    "lp_token_id": "798",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2101,7 +2062,7 @@
   },
   {
     "id": "osmo18ltnsk33a45827l42v89wws3u2evagpfua7v57nnhslnggxkqkgq4qjmcf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "20",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -2111,7 +2072,7 @@
   },
   {
     "id": "osmo18lw3t03dmyv6975kzjgacezvaafflz5aepmqrqqc8y494gwwwpmq9vm7p8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "586",
     "asset_ids": [
       "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB",
       "uosmo"
@@ -2121,7 +2082,7 @@
   },
   {
     "id": "osmo18p7qaaevs9kzsyuzmva969s4klx4xjxtn93cccpypfkhl3mqpcrqlwvu3j",
-    "lp_token_id": "TODO",
+    "lp_token_id": "772",
     "asset_ids": [
       "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
       "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E"
@@ -2131,7 +2092,7 @@
   },
   {
     "id": "osmo18pr2rasc9428jwr6t8hf4m50fgd35am4s6lr45yae0slmfzqukgq20jmsw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "122",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
@@ -2141,7 +2102,7 @@
   },
   {
     "id": "osmo18rqwcrvsfyy9s2tlfvmchclxf2cfw2hqvrjvkuljcrhq2vpg4suse8h6tj",
-    "lp_token_id": "TODO",
+    "lp_token_id": "620",
     "asset_ids": [
       "ibc/307E5C96C8F60D1CBEE269A9A86C0834E1DB06F2B3788AE4F716EDB97A48B97D",
       "uosmo"
@@ -2151,7 +2112,7 @@
   },
   {
     "id": "osmo18svklenrqknkccu7fyh9lunj4ruw6dfx7kfmmv79s0v6sud2ht9qan8ddk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "387",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
@@ -2161,7 +2122,7 @@
   },
   {
     "id": "osmo18taz6el39wzs87vn594z5q39mm8psf4v57jyjpx52dg46ac4mg2sxrj5hy",
-    "lp_token_id": "TODO",
+    "lp_token_id": "800",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "uosmo"
@@ -2171,7 +2132,7 @@
   },
   {
     "id": "osmo18vt7x9yuda579ssr668avfe8mlngrf255fx3re23340twmh3ujyqsfr3h8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "474",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uion"
@@ -2181,7 +2142,7 @@
   },
   {
     "id": "osmo18yxeq5kpup4k47vhjgu8j4y8d82sna7sdtjlz7hkuphnqtsmh8asc9vgca",
-    "lp_token_id": "TODO",
+    "lp_token_id": "29",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "uion"
@@ -2191,7 +2152,7 @@
   },
   {
     "id": "osmo1937gh7cem2tn09r7c4uh7zgjvgjyxlffa677rv7zmspphu9dxwyqs6pw8k",
-    "lp_token_id": "TODO",
+    "lp_token_id": "668",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -2201,7 +2162,7 @@
   },
   {
     "id": "osmo193lusv4u9c7xuz7ct6wmcyq0c5evayu4x78pdhvp8ewa4huh6a9s4tt3lp",
-    "lp_token_id": "TODO",
+    "lp_token_id": "688",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC"
@@ -2211,7 +2172,7 @@
   },
   {
     "id": "osmo195dw0uzghljwwt3577352xu5gfmy3zrngfa545hdnfy2dd45acrsnsca44",
-    "lp_token_id": "TODO",
+    "lp_token_id": "683",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
@@ -2221,7 +2182,7 @@
   },
   {
     "id": "osmo195vm9cpsdntewfe7l83yx2w28hkfvx33lyu454gvfrr6f5m7gcas420nk8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "732",
     "asset_ids": [
       "ibc/F16FDC11A7662B86BC0B9CE61871CBACF7C20606F95E86260FD38915184B75B4",
       "uosmo"
@@ -2231,17 +2192,14 @@
   },
   {
     "id": "osmo196w6qg0r3cfy9rx00390wkfdj9krd93uaed3nlht5uhqfh2avcyq3aldku",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/1",
-      "uosmo"
-    ],
+    "lp_token_id": "392",
+    "asset_ids": ["gamm/pool/1", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1973kthujxy3xq49dj29t6q90uxj0s8epkg0tan82j2fnzm7ez6usuas27z",
-    "lp_token_id": "TODO",
+    "lp_token_id": "215",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2251,7 +2209,7 @@
   },
   {
     "id": "osmo19a5l88sxfdjxtm0d7x777g0g7679m0uusepaytqy0wlnnzut83wswvvezu",
-    "lp_token_id": "TODO",
+    "lp_token_id": "179",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2261,7 +2219,7 @@
   },
   {
     "id": "osmo19a6nnvczjpnjzt3wgrf4h02yej62wpvnq9cayph7ec5klhds487s9kazwf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "666",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7"
@@ -2271,7 +2229,7 @@
   },
   {
     "id": "osmo19apu4h3aqlzhtpd0suftzctxnctwqd0lpzpueus3tughvcfdv4gsnzqxu4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "156",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -2281,7 +2239,7 @@
   },
   {
     "id": "osmo19ecrtx598f0yyg2chk82gtsuzst2jfr6tkmevnwn8538lysws7sqnsg8q2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "565",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -2291,7 +2249,7 @@
   },
   {
     "id": "osmo19eq5d9ng00ttwlsh9j9fs6t898lqltt9ah4ph039a3hznrz3hrns7rxy40",
-    "lp_token_id": "TODO",
+    "lp_token_id": "306",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -2301,17 +2259,14 @@
   },
   {
     "id": "osmo19esg8fulwzufjjarprfpu4mz06zjpkmk7p0wydcw5q900lp2k3mq7afv7m",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/502",
-      "uosmo"
-    ],
+    "lp_token_id": "503",
+    "asset_ids": ["gamm/pool/502", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo19ffd2uz59gf0w594hpwxjgzrkt3c2vd70gzw6lhdtsz07hl2m7sqfky68k",
-    "lp_token_id": "TODO",
+    "lp_token_id": "254",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uion"
@@ -2321,7 +2276,7 @@
   },
   {
     "id": "osmo19fm8jtzyw8ujsnsqm5rznudn8fhhkykjh4ra8rvx9lsfslw2pc2sp36h3r",
-    "lp_token_id": "TODO",
+    "lp_token_id": "9",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -2331,7 +2286,7 @@
   },
   {
     "id": "osmo19g97e0xshdd4xefn39wwquftq3g9u0a7jk8wcety6fgv58cpsx5sdjnvre",
-    "lp_token_id": "TODO",
+    "lp_token_id": "516",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -2341,7 +2296,7 @@
   },
   {
     "id": "osmo19gffpaavnhhzryktpskz7782ttt5qfs4cqfmhyuygc3cxytljfcqyggf5t",
-    "lp_token_id": "TODO",
+    "lp_token_id": "859",
     "asset_ids": [
       "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
       "uosmo"
@@ -2351,7 +2306,7 @@
   },
   {
     "id": "osmo19hcj893wcz2cwk7jkzgvqxlwqqp7cl2v66f2e2l68hy4wezuegmqdcuk0e",
-    "lp_token_id": "TODO",
+    "lp_token_id": "654",
     "asset_ids": [
       "ibc/6F4EFBEAF2659742F33499C9B4D272CFD824DD785156DF4C5C453F95CEF27D98",
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
@@ -2361,7 +2316,7 @@
   },
   {
     "id": "osmo19hp7h8xhg8r3z8wv0hf3hw95n09q5vxtfefeha97kuwflttq926qe8xs83",
-    "lp_token_id": "TODO",
+    "lp_token_id": "267",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -2371,7 +2326,7 @@
   },
   {
     "id": "osmo19jeyxdr0maeeh9uedgaemyghd8jgfcucv59mjnw867vhwkysf7fsqf2yxk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "756",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/56C276FC136E239449DCE664292DBEEF5795C4EF4B5B35DB98BD1C0948274867"
@@ -2381,7 +2336,7 @@
   },
   {
     "id": "osmo19jglnr7dv7ppezmk5v6sk3drydxc97nda2wxujzjmh8ef33lq0tstn9y4k",
-    "lp_token_id": "TODO",
+    "lp_token_id": "834",
     "asset_ids": [
       "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
       "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
@@ -2391,7 +2346,7 @@
   },
   {
     "id": "osmo19kdw6jce9eclvydnl8656z569ygjj060pehg9z8xq2p3ffyger6s6dj7tk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "451",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2401,7 +2356,7 @@
   },
   {
     "id": "osmo19mzey7tczk8fz5r2u2qnrmt6wlpgfh8k2wcnt20k2rhmspsv6h6s9t9327",
-    "lp_token_id": "TODO",
+    "lp_token_id": "415",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2411,7 +2366,7 @@
   },
   {
     "id": "osmo19ntgdh5wuu9zeh6svqc7x9h8zv6w7u4p7sxn2t980p7ct8st3s5sc8u9yy",
-    "lp_token_id": "TODO",
+    "lp_token_id": "307",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2421,7 +2376,7 @@
   },
   {
     "id": "osmo19qawwfrlkz9upglmpqj6akgz9ap7v2mnd05pxzgmxw3ywz58wnvqtet2mg",
-    "lp_token_id": "TODO",
+    "lp_token_id": "627",
     "asset_ids": [
       "ibc/9BBA9A1C257E971E38C1422780CE6F0B0686F0A3085E2D61118D904BFE0F5F5E",
       "uosmo"
@@ -2431,7 +2386,7 @@
   },
   {
     "id": "osmo19rrapg60r2f6s2h534n8d2tflv6kwed443jguxrvg2lf7pyggmmqq6mu8d",
-    "lp_token_id": "TODO",
+    "lp_token_id": "370",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2441,7 +2396,7 @@
   },
   {
     "id": "osmo19sp2fqdyr4p8mwn0206jk9ps06ewpavxxxz07zpseyphuy9uwmgspv87l4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "228",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2451,7 +2406,7 @@
   },
   {
     "id": "osmo19xaz97zcvcmp5q3ur3g4fqe6mlhz7k2dqd8w639yzk3greh6afws2wjlt3",
-    "lp_token_id": "TODO",
+    "lp_token_id": "618",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C"
@@ -2461,7 +2416,7 @@
   },
   {
     "id": "osmo19yat2nwf4h3d667xgyvtr2pg05nsxy2y8z408pnf8ypmkrqwyruqnnn4hz",
-    "lp_token_id": "TODO",
+    "lp_token_id": "118",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -2471,7 +2426,7 @@
   },
   {
     "id": "osmo19zg3tz4q5t3x6d2hdmwfkud4d3l3x8r4szr6clvlssw277y3g35srvkczc",
-    "lp_token_id": "TODO",
+    "lp_token_id": "597",
     "asset_ids": [
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4",
       "uosmo"
@@ -2481,17 +2436,14 @@
   },
   {
     "id": "osmo1a0ev3jr6fts7y09as95pryn59hzwfkaletpusfzctejjy0wqa47sxqgy3a",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/356",
-      "gamm/pool/357"
-    ],
+    "lp_token_id": "358",
+    "asset_ids": ["gamm/pool/356", "gamm/pool/357"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1a482ur89qhmuv07gmnt93jnmqww3ae3mdj4pd5hh4uje7zk57wys258nqn",
-    "lp_token_id": "TODO",
+    "lp_token_id": "252",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -2501,7 +2453,7 @@
   },
   {
     "id": "osmo1a6rvlkd2jw32mjf2pt78fte7f2hqu7gvr0yqsqek2c7anftrunkqqq798z",
-    "lp_token_id": "TODO",
+    "lp_token_id": "26",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uion"
@@ -2511,7 +2463,7 @@
   },
   {
     "id": "osmo1a86mk698pzmwsv28pcs5f4hvl22eexc3krc4k03j27fgkeqtaftqgnvlq3",
-    "lp_token_id": "TODO",
+    "lp_token_id": "365",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
@@ -2521,7 +2473,7 @@
   },
   {
     "id": "osmo1aaaa5xedavww3s9j48zpfjy4tcqll26wpr6fkt8wys3ufzlwv89qc6f8t8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "603",
     "asset_ids": [
       "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
       "uosmo"
@@ -2531,7 +2483,7 @@
   },
   {
     "id": "osmo1aav62u4pls035r93uuy4h2dckl06hc2atpsdzm8947qvlc34pprs3edc28",
-    "lp_token_id": "TODO",
+    "lp_token_id": "400",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2541,7 +2493,7 @@
   },
   {
     "id": "osmo1aavgx9ta75dchrwjf46z086pcjr44t4qkvz0c7walmvf5j3lxqnsulxsfw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "532",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -2551,7 +2503,7 @@
   },
   {
     "id": "osmo1adqhma2hfrqr04uy4t4lmu3rft2k7rjj3j7xyye0v3tg09urg0xqcm28q5",
-    "lp_token_id": "TODO",
+    "lp_token_id": "567",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -2561,17 +2513,14 @@
   },
   {
     "id": "osmo1adzv0qftyywfavf06uqh0lutcqz5nz5favasq58rkvnu4l3zvs7shy9kxu",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/364",
-      "uosmo"
-    ],
+    "lp_token_id": "367",
+    "asset_ids": ["gamm/pool/364", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1ag2w5l8av9msvzhks4vyd920r9lzaesekes6yg3vykp9fch5n22sk6er50",
-    "lp_token_id": "TODO",
+    "lp_token_id": "812",
     "asset_ids": [
       "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
       "uosmo"
@@ -2581,7 +2530,7 @@
   },
   {
     "id": "osmo1ah0sdvddcp3jjgfsyd960gud26l4dwz5gkqtx0qw42sv7kpsakhqyv257p",
-    "lp_token_id": "TODO",
+    "lp_token_id": "471",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
@@ -2591,7 +2540,7 @@
   },
   {
     "id": "osmo1ajghgy4ltm4ghn5smlrr29egrk3mq72642jsq8hqqet4cnwv4kssm9mrw8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "91",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2601,7 +2550,7 @@
   },
   {
     "id": "osmo1ak0lwxqlp70chxtt2fd4kr0ywhuk2fr6ncsjr884psu7h8m59vuqm6p42n",
-    "lp_token_id": "TODO",
+    "lp_token_id": "641",
     "asset_ids": [
       "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
       "uosmo"
@@ -2611,7 +2560,7 @@
   },
   {
     "id": "osmo1amh63u7vgtrak5rmetdjrl67jhl6rate05r792ywyxzp5jt6eq7sx5uphr",
-    "lp_token_id": "TODO",
+    "lp_token_id": "585",
     "asset_ids": [
       "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -2621,17 +2570,14 @@
   },
   {
     "id": "osmo1ang9dlvxrc0n835xyxvwf66mj0mm0sznyqwtu03kdd2dmhg40hlqnq36up",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/1",
-      "gamm/pool/8"
-    ],
+    "lp_token_id": "246",
+    "asset_ids": ["gamm/pool/1", "gamm/pool/8"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1avdp69rp58an6hysjh5n6g9w0wx73sytfxcg3qjynnxcar5t5qfqxukm2s",
-    "lp_token_id": "TODO",
+    "lp_token_id": "673",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5"
@@ -2641,7 +2587,7 @@
   },
   {
     "id": "osmo1avm2f4fegrla4wcxft7ct3rksnuxvjl3mhv9gljg2e0c2swvlmqsaxy3xv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "37",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -2651,7 +2597,7 @@
   },
   {
     "id": "osmo1awdgj7l3rjq2hmevgxuha99w39600fek27vsun4rztvy7s5h6n8sklwc8d",
-    "lp_token_id": "TODO",
+    "lp_token_id": "477",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
@@ -2661,7 +2607,7 @@
   },
   {
     "id": "osmo1ayjsj697r8ne5pnda82s96hdjvu5svp7ucjj3ekzlj886epq78cs2e48n3",
-    "lp_token_id": "TODO",
+    "lp_token_id": "789",
     "asset_ids": [
       "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
       "uosmo"
@@ -2671,7 +2617,7 @@
   },
   {
     "id": "osmo1c0l0m8tvta5qdr5cutfnydw2h6r6qpzxtwtk8e7677v2h7es3tfsgv986d",
-    "lp_token_id": "TODO",
+    "lp_token_id": "826",
     "asset_ids": [
       "ibc/80825E8F04B12D914ABEADB1F4D39C04755B12C8402F6876EE3168450C0A90BB",
       "uosmo"
@@ -2681,7 +2627,7 @@
   },
   {
     "id": "osmo1c0utzzgn56dhacxt2rzf8mvgkql54xnu78fhpnxqnx6hld9hue0qe79a7c",
-    "lp_token_id": "TODO",
+    "lp_token_id": "83",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -2691,7 +2637,7 @@
   },
   {
     "id": "osmo1c2agkt3smeangnelsxqqr97fm6kd0s7erqsgcuvc3nu06yr63qnqcz22mj",
-    "lp_token_id": "TODO",
+    "lp_token_id": "606",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
@@ -2701,7 +2647,7 @@
   },
   {
     "id": "osmo1c3vwd6kvev6499jg6tseszqky6p69mwdg5n66j060hvytxd6hjrsvzxk6u",
-    "lp_token_id": "TODO",
+    "lp_token_id": "445",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2711,7 +2657,7 @@
   },
   {
     "id": "osmo1c4xsza76pfcauuqadpa3gq6mj6zjzjx4upm8p9388jp7tk52qars6p8e30",
-    "lp_token_id": "TODO",
+    "lp_token_id": "238",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2721,7 +2667,7 @@
   },
   {
     "id": "osmo1c59p7ddraqwrtxe0camylyhra9s6w35qtywuaavravzx6us3cpsqn3dgn3",
-    "lp_token_id": "TODO",
+    "lp_token_id": "133",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -2731,7 +2677,7 @@
   },
   {
     "id": "osmo1c89mqqr6p979nl0jheysulp84zzpg84ujq5r0dzsmn7xl6aj38pq5fvwdw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "883",
     "asset_ids": [
       "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D",
       "uosmo"
@@ -2741,17 +2687,14 @@
   },
   {
     "id": "osmo1c8gdt3cquepqadv6ys2m9ht8eys40c2ws46ntwm7zknr2hwcsuhsly32ft",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/13",
-      "gamm/pool/5"
-    ],
+    "lp_token_id": "81",
+    "asset_ids": ["gamm/pool/13", "gamm/pool/5"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1c9gj5nwxhuh2gz7wwg4r8e8tw8v7ggy9lh2hu7kkdgh0t450754qh9cpvd",
-    "lp_token_id": "TODO",
+    "lp_token_id": "3",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -2761,7 +2704,7 @@
   },
   {
     "id": "osmo1c9x2kvqge4r2z5rf7p64sg0fvdmjsklxcexmmre2amxsqjxeex2qrlmr3h",
-    "lp_token_id": "TODO",
+    "lp_token_id": "208",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
@@ -2771,7 +2714,7 @@
   },
   {
     "id": "osmo1cafjr2f6uek4jc7g0sgxwxnssu3uq2c5uvlzkg2mwkg6jdwu6a9sa7qg4m",
-    "lp_token_id": "TODO",
+    "lp_token_id": "716",
     "asset_ids": [
       "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
       "ibc/AA1C80225BCA7B32ED1FC6ABF8B8E899BEB48ECDB4B417FD69873C6D715F97E7"
@@ -2781,7 +2724,7 @@
   },
   {
     "id": "osmo1ccfjmcfe09k0f6fdcfdgkc52c52l2c0jywfc57sn5qd22texqr3qla0e5m",
-    "lp_token_id": "TODO",
+    "lp_token_id": "787",
     "asset_ids": [
       "ibc/9B6FBABA36BB4A3BF127AE5E96B572A5197FD9F3111D895D8919B07BC290764A",
       "uosmo"
@@ -2791,7 +2734,7 @@
   },
   {
     "id": "osmo1ccjfm7gpa37mc9zwq553p0ttzq3ga5g6jzarz37lcq4qlnsdcxhsghcv3y",
-    "lp_token_id": "TODO",
+    "lp_token_id": "810",
     "asset_ids": [
       "ibc/5DD1F95ED336014D00CE2520977EC71566D282F9749170ADC83A392E0EA7426A",
       "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
@@ -2801,7 +2744,7 @@
   },
   {
     "id": "osmo1cdtygs9r2lf9smh79j9l883wfxearsweevfqrrehfh7up3xw4nxqrsjwlw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "373",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
@@ -2811,7 +2754,7 @@
   },
   {
     "id": "osmo1cf892ucxz0g5y9tlakunhn6hlgk40w0s6fy6hcjzsqnmx4u77xcqjafnfd",
-    "lp_token_id": "TODO",
+    "lp_token_id": "791",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "uosmo"
@@ -2821,7 +2764,7 @@
   },
   {
     "id": "osmo1cgr0zcfetq39yc3zhex2eaw2unczcw90m6qn7msw45r6qae9k0xqputy2m",
-    "lp_token_id": "TODO",
+    "lp_token_id": "737",
     "asset_ids": [
       "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -2831,17 +2774,14 @@
   },
   {
     "id": "osmo1cgw34ya7ndpmplgv5wyec4mz7hq3crc64uqq02qv6zk9vxun2rksk8fcja",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/73",
-      "gamm/pool/74"
-    ],
+    "lp_token_id": "75",
+    "asset_ids": ["gamm/pool/73", "gamm/pool/74"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1cj8dxdkgugvj0dysm79zha8mgkn9r7x9yg9n4cmdmqv9ucjkv2dsj5evg5",
-    "lp_token_id": "TODO",
+    "lp_token_id": "533",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -2851,7 +2791,7 @@
   },
   {
     "id": "osmo1csvn07y2n36dy3glfvdxeke80sxrhp8xwtjfds8nhvjullkqzpmq4zzh2s",
-    "lp_token_id": "TODO",
+    "lp_token_id": "337",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2861,7 +2801,7 @@
   },
   {
     "id": "osmo1cu6nmf563q57u4lc7v9t23sytz25t5cya0f060227vwsy6u0cpaquldl5e",
-    "lp_token_id": "TODO",
+    "lp_token_id": "376",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2871,7 +2811,7 @@
   },
   {
     "id": "osmo1cu9q2r5r09uct7ykpepyttk64hf30aygjn0ky567qrky5nthl56spqtnxz",
-    "lp_token_id": "TODO",
+    "lp_token_id": "593",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -2881,7 +2821,7 @@
   },
   {
     "id": "osmo1cwauwz0e490vkszxhrfhmawjsaw8ulac8fr03wccssn4eqswdxpsn2ycxj",
-    "lp_token_id": "TODO",
+    "lp_token_id": "294",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -2891,7 +2831,7 @@
   },
   {
     "id": "osmo1cxfkytmxzs55c00anuftly389mzg3gzvncfm8s4u9zeulhj8hsfq87snws",
-    "lp_token_id": "TODO",
+    "lp_token_id": "95",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -2901,7 +2841,7 @@
   },
   {
     "id": "osmo1cyjmqv92kx6trjjjsmemj3hvs9qg5jsrhscmq5km05hpkdsv62zqwpnggf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "740",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2911,7 +2851,7 @@
   },
   {
     "id": "osmo1cyllu6l6dw88t2wlk5ex4femwvj8nh249uff5uzzt2409aw0gy7su6lq2h",
-    "lp_token_id": "TODO",
+    "lp_token_id": "85",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2921,7 +2861,7 @@
   },
   {
     "id": "osmo1czqlvqjdlm2raj6t65nansxt5zlv8ny04fn66gcm9llgl24axmksd2px7e",
-    "lp_token_id": "TODO",
+    "lp_token_id": "882",
     "asset_ids": [
       "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163",
       "uosmo"
@@ -2931,7 +2871,7 @@
   },
   {
     "id": "osmo1czvns32qxxcyckqdfn02j7taflphz5dxawc6ksg7j5h58nlnen2sh8xxyj",
-    "lp_token_id": "TODO",
+    "lp_token_id": "138",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2941,7 +2881,7 @@
   },
   {
     "id": "osmo1czyl3pef9apzjzwn949jk4lsfcql2mg66xxrmlvcukt2x3q0y03s7v06d3",
-    "lp_token_id": "TODO",
+    "lp_token_id": "271",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2951,7 +2891,7 @@
   },
   {
     "id": "osmo1d0elgsavwgez5xf0fdan3krzfjm5jkdtcgxzlvunu4jndycs8u8qzs5h33",
-    "lp_token_id": "TODO",
+    "lp_token_id": "19",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uion"
@@ -2961,7 +2901,7 @@
   },
   {
     "id": "osmo1d338zex4aayp5r6r4rtrvclcwdx4x0jqnpy0qzyszn700hk9n75snwxtsf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "125",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2971,7 +2911,7 @@
   },
   {
     "id": "osmo1d3nk4hhy929kyqnrxf874xvdey46szrw4mxk3n8v26kzck6a8r2s677wyq",
-    "lp_token_id": "TODO",
+    "lp_token_id": "240",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -2981,7 +2921,7 @@
   },
   {
     "id": "osmo1d4t6lpc8glprq3nfg49u4887hv8jhxvllsey27mvpu7qf4pawkjsplh3pn",
-    "lp_token_id": "TODO",
+    "lp_token_id": "354",
     "asset_ids": [
       "ibc/A91B70554A510310B2A068979C8E7A9B433EF689E82A9321922D8A1B845B95F5",
       "uosmo"
@@ -2991,7 +2931,7 @@
   },
   {
     "id": "osmo1d6h0xq4vsgpay9n77yrzuaqyvs96x83c0wrrffr92pkcxnuk6lsqff43ne",
-    "lp_token_id": "TODO",
+    "lp_token_id": "452",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3001,7 +2941,7 @@
   },
   {
     "id": "osmo1d735wcpt6x0w4ynqe874lr7ch9laufgas0dr2nfs6e4zzlurlf9q5st28n",
-    "lp_token_id": "TODO",
+    "lp_token_id": "781",
     "asset_ids": [
       "ibc/AB589511ED0DD5FA56171A39978AFBF1371DB986EC1C3526CE138A16377E39BB",
       "uosmo"
@@ -3011,7 +2951,7 @@
   },
   {
     "id": "osmo1d7khqcglglgvkkj8jwt62mw0h7ak9y7de5js9zccn9kgtmx0j2qsm56cev",
-    "lp_token_id": "TODO",
+    "lp_token_id": "551",
     "asset_ids": [
       "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
       "uosmo"
@@ -3021,7 +2961,7 @@
   },
   {
     "id": "osmo1d7tu6pz4nx5e4yzj2keu6ftvr9u5p22u2vu5t6ts8syqt0e3reesqnpun0",
-    "lp_token_id": "TODO",
+    "lp_token_id": "319",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3031,7 +2971,7 @@
   },
   {
     "id": "osmo1d9y4rs70crz90a49fa3khad0dxy6yg7ezgdzlvuvjrujwvaspawqjut7t4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "818",
     "asset_ids": [
       "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
       "uosmo"
@@ -3041,7 +2981,7 @@
   },
   {
     "id": "osmo1dal655pjhghjfnlaxppj6kacgdrr50xf47dsheeanwaxzya2dm5qfmljhe",
-    "lp_token_id": "TODO",
+    "lp_token_id": "191",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -3051,17 +2991,14 @@
   },
   {
     "id": "osmo1daztxlwd90kqt7yw7mvakhp9kjd34g250dywutq06nvlze2u6uhsuk26xw",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "lp_token_id": "194",
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1dcvgttz6jwepg3gchu097aa2vxjgp3g5gm0t0p7z20lyclu7y0rqmc232t",
-    "lp_token_id": "TODO",
+    "lp_token_id": "652",
     "asset_ids": [
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
       "uosmo"
@@ -3071,7 +3008,7 @@
   },
   {
     "id": "osmo1def45s6km7yvg37czsyxdalscd63w9k2v6yynskcgq3l6slm4tps2kvurk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "404",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -3081,7 +3018,7 @@
   },
   {
     "id": "osmo1dejxnyjlhkfr8vjh9j47vjl9j9cvs3jk6aql6nvmxyyv547mumgqtcfc5w",
-    "lp_token_id": "TODO",
+    "lp_token_id": "329",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3091,7 +3028,7 @@
   },
   {
     "id": "osmo1dgnr0ajw2p2wxh05lv8s8znts6rpz3n2rcepng368tzr5h4pzm7swkyfru",
-    "lp_token_id": "TODO",
+    "lp_token_id": "748",
     "asset_ids": [
       "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -3101,7 +3038,7 @@
   },
   {
     "id": "osmo1dgnsyv3zj9uhen85ttf0heulkzcjj7nn27jw00hzpzp0ecfwx82slyu0ta",
-    "lp_token_id": "TODO",
+    "lp_token_id": "406",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3111,7 +3048,7 @@
   },
   {
     "id": "osmo1dgrkc9rt7653dyvkepwk25tqjfnkel0alywgwl35p9jtjw4a92gq7f7mnz",
-    "lp_token_id": "TODO",
+    "lp_token_id": "159",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3121,7 +3058,7 @@
   },
   {
     "id": "osmo1dh38ppn36hhdl365atjw4anr3d4faxzc6j0tassym738k276rx4q2rqkrs",
-    "lp_token_id": "TODO",
+    "lp_token_id": "814",
     "asset_ids": [
       "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
       "ibc/E09ED39F390EC51FA9F3F69BEA08B5BBE6A48B3057B2B1C3467FAAE9E58B021B"
@@ -3131,7 +3068,7 @@
   },
   {
     "id": "osmo1dj7rqa2r8psqp36asc4r6j20v8u62zjpqqwt8khxe24t5dzwssns3aph35",
-    "lp_token_id": "TODO",
+    "lp_token_id": "499",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -3141,7 +3078,7 @@
   },
   {
     "id": "osmo1djnm5mvg2s9p0appalcypxcjd7cd0xw6564k96r8dylgva3vmfnq0ca434",
-    "lp_token_id": "TODO",
+    "lp_token_id": "145",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3151,7 +3088,7 @@
   },
   {
     "id": "osmo1dlahvz8g205z94g4xpxfxa77wmm5kn0janhs34ft22yxyljuyfaspawg0m",
-    "lp_token_id": "TODO",
+    "lp_token_id": "279",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3161,7 +3098,7 @@
   },
   {
     "id": "osmo1dq3745uz8j2qd5fq2wtyvz9xzr5587awdnpn08272946dmn5pq5qjknyr9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "520",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3171,7 +3108,7 @@
   },
   {
     "id": "osmo1dsdccxrhra2pndxay08s7vajz72kr5vxqayalv7xt4gntey2xkmqa8u2x9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "680",
     "asset_ids": [
       "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
       "uosmo"
@@ -3181,7 +3118,7 @@
   },
   {
     "id": "osmo1dssdhlzawzthqsg60a5zms6xtx4tsktfzswal4qsxgugaad6j6wsxd6yk3",
-    "lp_token_id": "TODO",
+    "lp_token_id": "385",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3191,7 +3128,7 @@
   },
   {
     "id": "osmo1dt25gt7wgeh9l66adztvyl9x2l94mane2zdkrp29e4y7s3484qcsgv24y5",
-    "lp_token_id": "TODO",
+    "lp_token_id": "129",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -3201,7 +3138,7 @@
   },
   {
     "id": "osmo1dt568undkrrlullpzz0c27548vjdrhnsxwhygxrdtacv2dns2ryqa28jhs",
-    "lp_token_id": "TODO",
+    "lp_token_id": "24",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uosmo"
@@ -3211,7 +3148,7 @@
   },
   {
     "id": "osmo1dtlq83lwessktl65gxz6u8ufqc9lz0knh6nnw3rwklgla6jumrfq5a3clp",
-    "lp_token_id": "TODO",
+    "lp_token_id": "546",
     "asset_ids": [
       "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8",
       "uosmo"
@@ -3221,7 +3158,7 @@
   },
   {
     "id": "osmo1du947dpr6v3nlcwu8a2x2qtzkqm6z2nay7dqkzj8fgcqmull6mvq8wum5e",
-    "lp_token_id": "TODO",
+    "lp_token_id": "167",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3231,7 +3168,7 @@
   },
   {
     "id": "osmo1dufw6sdwhp6cxuxh8kfg9t50erne08t9sl37a6jeyswpknufftws5w7w8y",
-    "lp_token_id": "TODO",
+    "lp_token_id": "629",
     "asset_ids": [
       "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB",
       "uosmo"
@@ -3241,7 +3178,7 @@
   },
   {
     "id": "osmo1dyvjg5eyr58e73fpnw3z6c7wz2h0wvarmpmvq0c60vawm8e6q70q44v94n",
-    "lp_token_id": "TODO",
+    "lp_token_id": "147",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
@@ -3251,7 +3188,7 @@
   },
   {
     "id": "osmo1dzwru0m7m0klhxqj84hd3vhhltk07r6try7pj7s3qy47nqq43g0s6fsy2n",
-    "lp_token_id": "TODO",
+    "lp_token_id": "214",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -3261,7 +3198,7 @@
   },
   {
     "id": "osmo1e0m28qylp9k0s4l6quk2skv9g3w0p8qvu8aqmxuf2n6tt7ctkuyqrw5d48",
-    "lp_token_id": "TODO",
+    "lp_token_id": "761",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/8A07D4BD40E0F44ECFDF360F7EA7008B288926FB87C54489FE54DB81A5340E0C"
@@ -3271,7 +3208,7 @@
   },
   {
     "id": "osmo1e5xkxxpszq9t08yuu828rjzrmj5gvpwnf9ywv74ryz4frsyr0zlqyx76xf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "766",
     "asset_ids": [
       "ibc/1DE9A32D603EE05E9B8619DF24D90FD518C932AE0B5B3209A986B7262DBADE2A",
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
@@ -3281,7 +3218,7 @@
   },
   {
     "id": "osmo1e63smvqcnxpgxuvhrknfapmyvjy98csgm7z6xr6zjnkwmjf7zeaqsc66vn",
-    "lp_token_id": "TODO",
+    "lp_token_id": "236",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -3291,7 +3228,7 @@
   },
   {
     "id": "osmo1e6szkqkkt3g6u7ukjpdz493mkvm9njknrxpe4vcfahl4dlx358msqgnrxz",
-    "lp_token_id": "TODO",
+    "lp_token_id": "292",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3301,7 +3238,7 @@
   },
   {
     "id": "osmo1e92udnupts46czvcwtjcpgyvjhjv3grpjg43p60d8el8r24td3zqt8gfv0",
-    "lp_token_id": "TODO",
+    "lp_token_id": "792",
     "asset_ids": [
       "ibc/C78F65E1648A3DFE0BAEB6C4CDA69CC2A75437F1793C0E6386DFDA26393790AE",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -3311,7 +3248,7 @@
   },
   {
     "id": "osmo1e9s595ml68g99m9vtat2jl66v65ravl7wlu3usj7mu3arz56flpssletl2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "689",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC"
@@ -3321,7 +3258,7 @@
   },
   {
     "id": "osmo1ea5ymws7tufhg7v72wjwp3qskngmnpl729uc9h4anusfasmg48tqwje94x",
-    "lp_token_id": "TODO",
+    "lp_token_id": "825",
     "asset_ids": [
       "ibc/1E26DB0E5122AED464D98462BD384FCCB595732A66B3970AE6CE0B58BAE0FC49",
       "uosmo"
@@ -3331,7 +3268,7 @@
   },
   {
     "id": "osmo1ecljlcqy3z4tfrr7rql0tmr83mh3qfjdzmpgwad9zm6q908k347qhc23ht",
-    "lp_token_id": "TODO",
+    "lp_token_id": "192",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -3341,7 +3278,7 @@
   },
   {
     "id": "osmo1edal9l38mgcm2hj27hgz0mcqapkp9yla3pgtusxap824hwqvfttq00m4wy",
-    "lp_token_id": "TODO",
+    "lp_token_id": "59",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
@@ -3351,7 +3288,7 @@
   },
   {
     "id": "osmo1efnu25xj2cp6th0jacx9e7qn6zlwnceq24v74pz0wn9gxtlc8pvsqn0l0v",
-    "lp_token_id": "TODO",
+    "lp_token_id": "421",
     "asset_ids": [
       "gamm/pool/420",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -3361,7 +3298,7 @@
   },
   {
     "id": "osmo1eft30ela0axavl9xa3plmv00ah005vkhyexsm0rc0cmfkz8jujjsaqq56h",
-    "lp_token_id": "TODO",
+    "lp_token_id": "326",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3371,7 +3308,7 @@
   },
   {
     "id": "osmo1eg26w7fg3hdzjxyxv5x846ekjmw0rdewlxlp6rf20efursfurh7q78cyu2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "758",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/B797E4F42CD33C50511B341E50C5CC0E8EF0D93B1E1247ABAA071583B8619202"
@@ -3381,7 +3318,7 @@
   },
   {
     "id": "osmo1egng4w6ht85nhy5038hfs5xvx6ddg0l6mqslaxnudqssq5jm4y2qrh2han",
-    "lp_token_id": "TODO",
+    "lp_token_id": "539",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -3391,7 +3328,7 @@
   },
   {
     "id": "osmo1ehnfys6czdccwsg4twezh3w37a6zxgaa6ud0s0mn0c6yuqnj6dkq6jx9u5",
-    "lp_token_id": "TODO",
+    "lp_token_id": "119",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
@@ -3401,7 +3338,7 @@
   },
   {
     "id": "osmo1ejaswj8lcyh0zgnes8zt45e0w7tqm4mrxr74sfwgpdh72shp58ms4fdqsk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "611",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
@@ -3411,17 +3348,14 @@
   },
   {
     "id": "osmo1ejcrrmfxaphd6nf270r34467u2a407mewhq5g5cz6hdhzqs7nnxsvpthf9",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "lp_token_id": "380",
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1ejm5jcfnsvcw5zxvc5h2k5d2yppww7tk9jt7hnqh9upaudckp8cqjn2578",
-    "lp_token_id": "TODO",
+    "lp_token_id": "105",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3431,7 +3365,7 @@
   },
   {
     "id": "osmo1ekrucs08jgx45nf5d6rtkd2px4m60v9hwa4l2mj9frkvv908mwvsqz7z96",
-    "lp_token_id": "TODO",
+    "lp_token_id": "390",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3441,7 +3375,7 @@
   },
   {
     "id": "osmo1eljhrrff3eklwl6t6lv8znt8pyej5k9k54cvr3gyakqmr6xldt7qu2vhgl",
-    "lp_token_id": "TODO",
+    "lp_token_id": "434",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3451,7 +3385,7 @@
   },
   {
     "id": "osmo1emy3l3y30eqv25kfrwcs54whga4smrzvf39rl8km45rupcjz7uaqcmxtup",
-    "lp_token_id": "TODO",
+    "lp_token_id": "609",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -3461,7 +3395,7 @@
   },
   {
     "id": "osmo1ep9jw2xkuu3mhdqstgpeqw2tr2txw7aulx5cx0lar2lc3pw0huzs6j5ty5",
-    "lp_token_id": "TODO",
+    "lp_token_id": "141",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3471,7 +3405,7 @@
   },
   {
     "id": "osmo1ephgyd57rw7mzf0p5gdjjezt2j442jpzdezvkjdvpke703fyy06qtstsmk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "771",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/AA1C80225BCA7B32ED1FC6ABF8B8E899BEB48ECDB4B417FD69873C6D715F97E7"
@@ -3481,7 +3415,7 @@
   },
   {
     "id": "osmo1exr9ekmy6ucvp8f8mqzu8qetxzsgzuz4d4h28y70ftwqwfcfvgqq2ywwh9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "340",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3491,7 +3425,7 @@
   },
   {
     "id": "osmo1ey4fm0hsg5h0el6c4duhkmu8ujgp0ndv0u04jpnkg696lsx6kytscdw7tp",
-    "lp_token_id": "TODO",
+    "lp_token_id": "310",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -3501,7 +3435,7 @@
   },
   {
     "id": "osmo1f2tlf4lnhzsrh9pyu9y3u6wju2nlqzummm3zs70jerk2s7a0fq4qfq9epf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "510",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -3511,7 +3445,7 @@
   },
   {
     "id": "osmo1f33v0n0kn6vtu7vkxuf2rm9dxncnwuga5825tzupc3t9umsgt0rsl6u29e",
-    "lp_token_id": "TODO",
+    "lp_token_id": "151",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
@@ -3521,7 +3455,7 @@
   },
   {
     "id": "osmo1f4lp47dxu7w2ykr5dpgd8yeylx94xg5xv4cfmrcsfu4v77tqv73s3y3cmp",
-    "lp_token_id": "TODO",
+    "lp_token_id": "253",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -3531,7 +3465,7 @@
   },
   {
     "id": "osmo1f5fse04elu35trhlkf9dq4crgjay6pfh2nnmgx88acj7xmcarnvqgvq45v",
-    "lp_token_id": "TODO",
+    "lp_token_id": "600",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/EA3E1640F9B1532AB129A571203A0B9F789A7F14BB66E350DCBFA18E1A1931F0"
@@ -3541,7 +3475,7 @@
   },
   {
     "id": "osmo1f602n58fsvphaledcyyxeczukyee0dnum08psrqrl894s3cc57zq6jyvyq",
-    "lp_token_id": "TODO",
+    "lp_token_id": "12",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
@@ -3551,7 +3485,7 @@
   },
   {
     "id": "osmo1f7cj0tc02qqwaps8d98s3pnwfyudsvfj9w4zmdmxdrp9gw0sh27spf7yyl",
-    "lp_token_id": "TODO",
+    "lp_token_id": "164",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -3561,7 +3495,7 @@
   },
   {
     "id": "osmo1f7rg0se3mhuwkjuzwdys2j64f4ktk5pz9lmf2cas5xu84urf5ulqy2qmpc",
-    "lp_token_id": "TODO",
+    "lp_token_id": "234",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -3571,7 +3505,7 @@
   },
   {
     "id": "osmo1f7vufh36kuhn8gtjhzzm98h22w6830zww86zwx8f6f47cz76r5yqvg67p5",
-    "lp_token_id": "TODO",
+    "lp_token_id": "158",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -3581,7 +3515,7 @@
   },
   {
     "id": "osmo1f7x8t6zv4tdmu2txgztqc9jwfa0kmx2jpgcmah69njaxc6h5gszsp8884g",
-    "lp_token_id": "TODO",
+    "lp_token_id": "561",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "uosmo"
@@ -3591,7 +3525,7 @@
   },
   {
     "id": "osmo1f95y595e89tucsuqrzdpgvtetyc8mzswdrqp4rrt8v8dexa2t4nquuee0m",
-    "lp_token_id": "TODO",
+    "lp_token_id": "682",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447"
@@ -3601,7 +3535,7 @@
   },
   {
     "id": "osmo1f9862pvm6htudctzex2c67ezkkp5z4lt07h76kdjl7gayez95eus2ekuhs",
-    "lp_token_id": "TODO",
+    "lp_token_id": "115",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3611,7 +3545,7 @@
   },
   {
     "id": "osmo1fcl04ma3dhc080jscyzkgf65u2ctv9v67ec03an3cff0gnfqkllqqkufhx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "21",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -3621,7 +3555,7 @@
   },
   {
     "id": "osmo1fg5xzrgah8mr6uqcgfjv5m0l9n2ce0ptye4sraavt3me3uh7yfeqy755dg",
-    "lp_token_id": "TODO",
+    "lp_token_id": "489",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3631,7 +3565,7 @@
   },
   {
     "id": "osmo1fharjyp6vl6xx67f59jn2mrc0p6vl5lf32zpweuyevdhpusv5uysamun60",
-    "lp_token_id": "TODO",
+    "lp_token_id": "480",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
@@ -3641,7 +3575,7 @@
   },
   {
     "id": "osmo1fjjqzp80dgpq2lr0jzzyc9x05eeu6th36lc9r24x3m26af0vm5tsdzkt00",
-    "lp_token_id": "TODO",
+    "lp_token_id": "723",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B"
@@ -3651,7 +3585,7 @@
   },
   {
     "id": "osmo1fjrk6zk2st8uzgzedh8rx9rt8gk7rmxmstr8923v0xsqn2gjafmqr99vc5",
-    "lp_token_id": "TODO",
+    "lp_token_id": "502",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
@@ -3661,7 +3595,7 @@
   },
   {
     "id": "osmo1fksasqaynht6wz2nhzyjnc6ef0d5caevyt9uqczhclfuzd8kyycqpl4g5j",
-    "lp_token_id": "TODO",
+    "lp_token_id": "686",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC"
@@ -3671,7 +3605,7 @@
   },
   {
     "id": "osmo1fmz4zaaj377th482zzrvc5d9rx7hpreyhfprvum9hd2vyedg0trquug78j",
-    "lp_token_id": "TODO",
+    "lp_token_id": "528",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -3681,7 +3615,7 @@
   },
   {
     "id": "osmo1fpv2vn8xz4arzvwjqc52eh085rc4ktnsdwmpg3tum0rvgyf2hfqqw035mc",
-    "lp_token_id": "TODO",
+    "lp_token_id": "169",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -3691,7 +3625,7 @@
   },
   {
     "id": "osmo1fpzttww633v3jqz7vkf9csjcvjlmfl7rq3654uf0j6seq0p4h4esrjmuxw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "602",
     "asset_ids": [
       "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA",
       "uosmo"
@@ -3701,7 +3635,7 @@
   },
   {
     "id": "osmo1fqu4s8f5dha4tgf3swet43jlmeutxeynmm265mv2m8awauy6cvfstu4xyg",
-    "lp_token_id": "TODO",
+    "lp_token_id": "121",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3711,7 +3645,7 @@
   },
   {
     "id": "osmo1frnc03evn4vnyrcvqqv85304rgegj3g44xj8vpdktmuaqwaqxtasefugr5",
-    "lp_token_id": "TODO",
+    "lp_token_id": "648",
     "asset_ids": [
       "ibc/8061A06D3BD4D52C4A28FFECF7150D370393AF0BA661C3776C54FF32836C3961",
       "uosmo"
@@ -3721,7 +3655,7 @@
   },
   {
     "id": "osmo1fwexzng4wjqvga4avsvmqs6ay09yv80g4w6wrn9um05d95vsqw6saqxjgm",
-    "lp_token_id": "TODO",
+    "lp_token_id": "441",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
@@ -3731,7 +3665,7 @@
   },
   {
     "id": "osmo1fyav6ky62qrtu5hu6hv6jrx2mu058gvke6ncqyke6ns5mjgvtj5sv52acw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "864",
     "asset_ids": [
       "ibc/92B223EBFA74DB99BEA92B23DEAA6050734FEEAABB84689CB8E1AE8F9C9F9AF4",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -3741,7 +3675,7 @@
   },
   {
     "id": "osmo1fyxn5dnns58s2k0r8h3tf3llj6drwxn2lxqh7gv92hpy4953ka8qx6hey5",
-    "lp_token_id": "TODO",
+    "lp_token_id": "518",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -3751,7 +3685,7 @@
   },
   {
     "id": "osmo1g0c2n00paxpku0t4psy50kz385htrv50yk5szm6z57c0rzpd6qesjhwxwh",
-    "lp_token_id": "TODO",
+    "lp_token_id": "724",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5"
@@ -3761,7 +3695,7 @@
   },
   {
     "id": "osmo1g0e2en7r0juxqx2mmp9gc6nxtx9xfrsll5swvccsskywrfd7utjsmkt4l7",
-    "lp_token_id": "TODO",
+    "lp_token_id": "896",
     "asset_ids": [
       "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
       "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796"
@@ -3771,7 +3705,7 @@
   },
   {
     "id": "osmo1g0jmvyrlmed35fd42rfu8emhn8mndyknn7rmx26943nt8jcz70rsd5su83",
-    "lp_token_id": "TODO",
+    "lp_token_id": "463",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "uosmo"
@@ -3781,7 +3715,7 @@
   },
   {
     "id": "osmo1g2y3ptjh8rndpsq6r2cty94nl777fugke3z2rq37ac3uldtfagcsspp8xt",
-    "lp_token_id": "TODO",
+    "lp_token_id": "829",
     "asset_ids": [
       "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -3791,7 +3725,7 @@
   },
   {
     "id": "osmo1g4u4df420klg8xnkuhezz065p7e4q6emwagx3ctd9qv3gcl32h7sfygnlq",
-    "lp_token_id": "TODO",
+    "lp_token_id": "651",
     "asset_ids": [
       "ibc/8FEFAE6AECF6E2A255585617F781F35A8D5709A545A804482A261C0C9548A9D3",
       "uosmo"
@@ -3801,7 +3735,7 @@
   },
   {
     "id": "osmo1g7jq4a7hw9n65tdv9mn28gckr7zqrzp0czvlxa0gqftrmtw28c5qc82aan",
-    "lp_token_id": "TODO",
+    "lp_token_id": "743",
     "asset_ids": [
       "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -3811,7 +3745,7 @@
   },
   {
     "id": "osmo1g96kuarfld3nfeenuvdke2ec6584qvhrpx8eq0qxntk5llgzdlesk20neg",
-    "lp_token_id": "TODO",
+    "lp_token_id": "225",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3821,7 +3755,7 @@
   },
   {
     "id": "osmo1gaern4gnnuu05dlzfr9ax5hl9hwt6tcymklv3vy4cs0tz8kkqqnqlxesce",
-    "lp_token_id": "TODO",
+    "lp_token_id": "60",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3831,7 +3765,7 @@
   },
   {
     "id": "osmo1gdfp7xyv7j7wm7v0z42rqcaumf8emz3c9whfzmhmu6qauu6xfdts9t5dcm",
-    "lp_token_id": "TODO",
+    "lp_token_id": "889",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "uosmo"
@@ -3841,7 +3775,7 @@
   },
   {
     "id": "osmo1gesjuqekz3pyuuz0fg7j2ctckeqkltn8h225ce0fd93fckd9sksshu4wzn",
-    "lp_token_id": "TODO",
+    "lp_token_id": "566",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -3851,7 +3785,7 @@
   },
   {
     "id": "osmo1gf86c7l352dk4zcgruldykckr99jn86khvjy2efcvevewrjkv3msxur0kp",
-    "lp_token_id": "TODO",
+    "lp_token_id": "514",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -3861,7 +3795,7 @@
   },
   {
     "id": "osmo1gfzdnqyy95cgvjl3vkr7vs3ra9f06xu7mu0w4ldxj6rqszkhvnts0vs24p",
-    "lp_token_id": "TODO",
+    "lp_token_id": "39",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3871,7 +3805,7 @@
   },
   {
     "id": "osmo1ghy3kl2fvyzag0q68zwmve4afl26avtt4sn80um6gw7zqx7p35ns83cch8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "537",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
@@ -3881,7 +3815,7 @@
   },
   {
     "id": "osmo1gjfqv5vtwnm99dwac9v9ug4l9msyq9wejnatnvj35ex25ak2nrssh3pat9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "268",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
@@ -3891,7 +3825,7 @@
   },
   {
     "id": "osmo1gkq0x059rrnv6egs8snzy7m80zrz3uygtu3khxr3llgnljm2wjpqmeqlz4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "703",
     "asset_ids": [
       "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "uosmo"
@@ -3901,7 +3835,7 @@
   },
   {
     "id": "osmo1glc2ym96m3tsncmulludzhksuahvk09rwyjlm7t20dewlwk8vzxs529ngm",
-    "lp_token_id": "TODO",
+    "lp_token_id": "381",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3911,7 +3845,7 @@
   },
   {
     "id": "osmo1glls893n6fdgw2nrx5kl6l940qrxpvd3k5qlf3udu0r5zhgc6dqqs98en8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "204",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
@@ -3921,7 +3855,7 @@
   },
   {
     "id": "osmo1gms9szd899acpscedg46za5zjmut2yalkgnr6x2ekw7q3l6ppqvs0h3lu0",
-    "lp_token_id": "TODO",
+    "lp_token_id": "459",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
@@ -3931,7 +3865,7 @@
   },
   {
     "id": "osmo1gnq7pvafrxq0yg74ph5r7vxl6dh6rsp5yncrq5gd4sr6vtjppndqsd3jjl",
-    "lp_token_id": "TODO",
+    "lp_token_id": "670",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E"
@@ -3941,7 +3875,7 @@
   },
   {
     "id": "osmo1gr45uf6rm02778wdwlhkdxt3c94fr6eqtk6284fpr804r24nrersnasvtx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "684",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "ibc/CD20AC50CE57F1CF2EA680D7D47733DA9213641D2D116C5806A880F508609A7A"
@@ -3951,7 +3885,7 @@
   },
   {
     "id": "osmo1grw4dy9teaam0u2jywd9sw49max4ua9vj6hgsvjnr3jva8cr3husxrc3g0",
-    "lp_token_id": "TODO",
+    "lp_token_id": "175",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
@@ -3961,7 +3895,7 @@
   },
   {
     "id": "osmo1grzll8mqv9c0tkwe0secf225mpxnrx86fffnnlz4ffhwkqsr3gaswfa52j",
-    "lp_token_id": "TODO",
+    "lp_token_id": "719",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -3971,7 +3905,7 @@
   },
   {
     "id": "osmo1grzzz4rwj8l06wuf83dwhhhss39zv3302edgpa3tx6s6g45etsrqjjrz3v",
-    "lp_token_id": "TODO",
+    "lp_token_id": "70",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -3981,7 +3915,7 @@
   },
   {
     "id": "osmo1gs0czr9thyy0fgneenmj5swnew73gk5xktr352qggxlhhm5uwkpq77sgns",
-    "lp_token_id": "TODO",
+    "lp_token_id": "741",
     "asset_ids": [
       "ibc/C360EF34A86D334F625E4CBB7DA3223AEA97174B61F35BB3758081A8160F7D9B",
       "uosmo"
@@ -3991,7 +3925,7 @@
   },
   {
     "id": "osmo1gtc9dqfscgnlrw73yalnan4v2fwy2hz5447sqgclx68yz46us3xs38v2eh",
-    "lp_token_id": "TODO",
+    "lp_token_id": "522",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -4001,7 +3935,7 @@
   },
   {
     "id": "osmo1gtxfvhhvx8n5xvytrrp48qgu5vflpr0qm5e5c4p3zqwd4mr4u0uq6wv5d4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "570",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4011,7 +3945,7 @@
   },
   {
     "id": "osmo1gvcvxl68u9rgwgfctxkfuhmyqxqzn3lrxw9cn5qg3q5er27ex65q6vlpuh",
-    "lp_token_id": "TODO",
+    "lp_token_id": "289",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4021,7 +3955,7 @@
   },
   {
     "id": "osmo1gwzs6qa626az6nhqcg93uxa8mfcfcc4mm7xecctwqaelfl70jewsgtkfh5",
-    "lp_token_id": "TODO",
+    "lp_token_id": "348",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4031,7 +3965,7 @@
   },
   {
     "id": "osmo1gxdq040aa9qk9d5uvtlt00uwhaskslthdq9k2kpkwm430u4cnyqsj7ml7k",
-    "lp_token_id": "TODO",
+    "lp_token_id": "79",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4041,17 +3975,14 @@
   },
   {
     "id": "osmo1gy7usssxrzsepfpn9z07456cqqmumtmn5mw3wgc5jpmwt2ha8qdqwxy09x",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/1",
-      "gamm/pool/73"
-    ],
+    "lp_token_id": "74",
+    "asset_ids": ["gamm/pool/1", "gamm/pool/73"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1h5hz4uttwlnvvn4xf0r0sr89v6rgtv399le6y0ksv458jvg9vm2q8nyvdh",
-    "lp_token_id": "TODO",
+    "lp_token_id": "919",
     "asset_ids": [
       "ibc/3FF92D26B407FD61AE95D975712A7C319CDE28DE4D80BDC9978D935932B991D7",
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
@@ -4061,7 +3992,7 @@
   },
   {
     "id": "osmo1h6tps4e40h66y5xunmgazkd4kvpcl26367ue3ta4ukjzw4j5j7tqxqqxh0",
-    "lp_token_id": "TODO",
+    "lp_token_id": "172",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4071,7 +4002,7 @@
   },
   {
     "id": "osmo1h7yfu7x4qsv2urnkl4kzydgxegdfyjdry5ee4xzj98jwz0uh07rqdkmprr",
-    "lp_token_id": "TODO",
+    "lp_token_id": "497",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -4081,7 +4012,7 @@
   },
   {
     "id": "osmo1haqvxq0ykcxa5wjzpvpdpu96jdss0v0du7hfly595rhlamtzlmzq9a748l",
-    "lp_token_id": "TODO",
+    "lp_token_id": "99",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -4091,7 +4022,7 @@
   },
   {
     "id": "osmo1hcpnvyer3r93x2ux72w0347plas3vzs0f886lwa4thhdqth04jcqkc0k3c",
-    "lp_token_id": "TODO",
+    "lp_token_id": "467",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4101,7 +4032,7 @@
   },
   {
     "id": "osmo1hdsvaxe9898kryxy2zlljtazl5dur9qxhph9q0qnrcqylyf9j9gq6peqep",
-    "lp_token_id": "TODO",
+    "lp_token_id": "427",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -4111,7 +4042,7 @@
   },
   {
     "id": "osmo1hecg2sghe8y69el3r9s0ysvlgqrwhg626lwujq5wzh0hah8zsqgspe678n",
-    "lp_token_id": "TODO",
+    "lp_token_id": "16",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -4121,7 +4052,7 @@
   },
   {
     "id": "osmo1hedgxlrrcls3aefh83vhqq4aema6yglhu24w8x67nulyc7655ghsdfvv60",
-    "lp_token_id": "TODO",
+    "lp_token_id": "653",
     "asset_ids": [
       "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B",
       "uosmo"
@@ -4131,7 +4062,7 @@
   },
   {
     "id": "osmo1hek3fwgtlxgjvsgplhsucpz7w7q9vlp6mjm5m0c84na0x2y9y43qynrs6g",
-    "lp_token_id": "TODO",
+    "lp_token_id": "285",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -4141,7 +4072,7 @@
   },
   {
     "id": "osmo1hg0eeayprkg6a66fqs07sncy09rw6tae9k6g7ryrjk0k4nypfjwqrl6wy4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "746",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
@@ -4151,7 +4082,7 @@
   },
   {
     "id": "osmo1hg2963kvsu2arwx69hcqmsl2ms4x5pjw9x7w43lvspn5tgz4aqksk0sk5c",
-    "lp_token_id": "TODO",
+    "lp_token_id": "58",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4161,17 +4092,14 @@
   },
   {
     "id": "osmo1hgxsqpxghfw7pwwl8jwxzy04cyll8nhf6ejnxpx3wvkszkq6rznqap0yuc",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/503",
-      "uosmo"
-    ],
+    "lp_token_id": "505",
+    "asset_ids": ["gamm/pool/503", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1hhrh0atndq75k3wws0jp8z4q4sdr5hs2u629wk2l35yuu92mah3sfa06ns",
-    "lp_token_id": "TODO",
+    "lp_token_id": "148",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -4181,7 +4109,7 @@
   },
   {
     "id": "osmo1hjffj5jr5z53gepl9754vl5z8vxahz6r6yq0kaj2kppxrcrzu7lqvuzgqx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "146",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -4191,7 +4119,7 @@
   },
   {
     "id": "osmo1hjkkjcc88t8mf2h4n2rzdxtdpmscv53ek33vs48jxk5x0d2uf9hs59teze",
-    "lp_token_id": "TODO",
+    "lp_token_id": "72",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
@@ -4201,7 +4129,7 @@
   },
   {
     "id": "osmo1hl0s405ggpxp8z5svx4myy23s4vsxm2n0040xcug59gx0cmdhqwq5t7x0y",
-    "lp_token_id": "TODO",
+    "lp_token_id": "304",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -4211,7 +4139,7 @@
   },
   {
     "id": "osmo1hlxc9ypgx9pfnrt8vacsyw8d0hj32n8vymg2u7aaxar2f6aulpeq2t095k",
-    "lp_token_id": "TODO",
+    "lp_token_id": "662",
     "asset_ids": [
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
       "uosmo"
@@ -4221,7 +4149,7 @@
   },
   {
     "id": "osmo1hpfr8caa9swnqj2wapqwjfakqkfvdq70uvjv37pdst3xunsde2hqkz0na4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "28",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "uion"
@@ -4231,7 +4159,7 @@
   },
   {
     "id": "osmo1hpgavxcjzhzrfj6y36ut7klat093w9wq9rdk399gmr8u3s96uqmsmqx9zn",
-    "lp_token_id": "TODO",
+    "lp_token_id": "554",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525"
@@ -4241,7 +4169,7 @@
   },
   {
     "id": "osmo1hs78pxgz4v0tmqs4gau9zpdsaeu4jumkr2r7qy0v40uqnws26ussyxt7ga",
-    "lp_token_id": "TODO",
+    "lp_token_id": "506",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -4251,7 +4179,7 @@
   },
   {
     "id": "osmo1hvm4qlmmpy60ed3ex4zfdlpwmurex6uunudfu0rjh6w87tvtawsq3aj6v5",
-    "lp_token_id": "TODO",
+    "lp_token_id": "346",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4261,7 +4189,7 @@
   },
   {
     "id": "osmo1hxddxnuw6whdd4e8kwln9xeaws45kz7cuwe5asd05ws7xnltgjwszmq7np",
-    "lp_token_id": "TODO",
+    "lp_token_id": "247",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4271,7 +4199,7 @@
   },
   {
     "id": "osmo1hz6eyl2u990ge6nq7c3uq8fnlx2ghedkervym8s9psnqjcj44wxqlewm4v",
-    "lp_token_id": "TODO",
+    "lp_token_id": "775",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -4281,7 +4209,7 @@
   },
   {
     "id": "osmo1j4ak6hul4x2m93rqnnjpxx7x6zml435zmv7y7wet0adr3sfw8crsnhd3cl",
-    "lp_token_id": "TODO",
+    "lp_token_id": "713",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/F292A17CF920E3462C816CBE6B042E779F676CAB59096904C4C1C966413E3DF5"
@@ -4291,7 +4219,7 @@
   },
   {
     "id": "osmo1j4j7kxkmu6kdenrx9ky50k9x86s36mcaqxukr8sjtl2rwp9vkwfqljjd3r",
-    "lp_token_id": "TODO",
+    "lp_token_id": "701",
     "asset_ids": [
       "ibc/67C89B8B0A70C08F093C909A4DD996DD10E0494C87E28FD9A551697BF173D4CA",
       "uosmo"
@@ -4301,7 +4229,7 @@
   },
   {
     "id": "osmo1j4xmzkea5t8s077t0s39vs5psp6f6dacpjswn64ln2v4pncwxg3qjs30zl",
-    "lp_token_id": "TODO",
+    "lp_token_id": "93",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4311,7 +4239,7 @@
   },
   {
     "id": "osmo1j5l9ysw5xv0uqz9uh7mcg0l5rlerqm695ec9kkg2t8rp600zv47q82eqwa",
-    "lp_token_id": "TODO",
+    "lp_token_id": "5",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
@@ -4321,7 +4249,7 @@
   },
   {
     "id": "osmo1j5ywgvensu0uez4te9ql2eslg4qt96evhpldwd7j8h2mr66c8s7scvx4w8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "623",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
@@ -4331,7 +4259,7 @@
   },
   {
     "id": "osmo1j6vmgahwmxgcpra7dudw570g44cntyvx9pz3k83ny8z0qgytq8aqmf8j0s",
-    "lp_token_id": "TODO",
+    "lp_token_id": "634",
     "asset_ids": [
       "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
       "uosmo"
@@ -4341,7 +4269,7 @@
   },
   {
     "id": "osmo1j8cp3mdc9jq7vmgf0hpr8uz6e3at6uctwtzhn6qlm7g3shvzavwqg4qxyr",
-    "lp_token_id": "TODO",
+    "lp_token_id": "251",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4351,7 +4279,7 @@
   },
   {
     "id": "osmo1jaemtd5g8h2dwegte0h3r76xt7uahrj4tdmdyypl5ptlswhnfves5cvs3v",
-    "lp_token_id": "TODO",
+    "lp_token_id": "227",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4361,7 +4289,7 @@
   },
   {
     "id": "osmo1jajfyerkktqn6qfyxefeg078lfrdpkl87gsyhy925nwc6hysrtzq7zx9g4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "407",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4371,7 +4299,7 @@
   },
   {
     "id": "osmo1jaldjtc7ksfldxgg604zyspyd94p8kn6tleaarcdwl8wakul6w7sy50gam",
-    "lp_token_id": "TODO",
+    "lp_token_id": "139",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -4381,7 +4309,7 @@
   },
   {
     "id": "osmo1jatt233sux9mxjuqmtmaavucvatj23m2v6nyh3rel60qpjegkduqewylk7",
-    "lp_token_id": "TODO",
+    "lp_token_id": "912",
     "asset_ids": [
       "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
@@ -4391,7 +4319,7 @@
   },
   {
     "id": "osmo1jeku67d5x534pn4l3ules7yye2s6kkj92hmn0lyldwnv5xv6cq3qjujw5y",
-    "lp_token_id": "TODO",
+    "lp_token_id": "512",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -4401,7 +4329,7 @@
   },
   {
     "id": "osmo1jm5tyuxars5j84jdeeqkp0zpyfk2ea84x7fec8jq03x00708f3qqwr3f57",
-    "lp_token_id": "TODO",
+    "lp_token_id": "66",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4411,7 +4339,7 @@
   },
   {
     "id": "osmo1jn6lsmjf2qcgqyj6zzl9llunm3u38x3dh3dggyx043ysxy6jjwssq3h7ha",
-    "lp_token_id": "TODO",
+    "lp_token_id": "162",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -4421,7 +4349,7 @@
   },
   {
     "id": "osmo1jn8pdd9kez2n7422vg8qvwn7angtz2v8gjwkff3glprxypr25v0qp7zwkt",
-    "lp_token_id": "TODO",
+    "lp_token_id": "610",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "ibc/EA3E1640F9B1532AB129A571203A0B9F789A7F14BB66E350DCBFA18E1A1931F0"
@@ -4431,7 +4359,7 @@
   },
   {
     "id": "osmo1jqvyxwgq5eujwp58ef2hgaf0xsn6vh0w9at77adyjj3uafrv8r7qjpks4h",
-    "lp_token_id": "TODO",
+    "lp_token_id": "847",
     "asset_ids": [
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
       "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC"
@@ -4441,7 +4369,7 @@
   },
   {
     "id": "osmo1js8gkwluk3uux73v9u83f0egh7862sezq2f80l2c9eetylr9meqq698nvz",
-    "lp_token_id": "TODO",
+    "lp_token_id": "84",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4451,7 +4379,7 @@
   },
   {
     "id": "osmo1jsfqrh9y0mjvrh09u82ja7az4fsyew64gn2pfg98c8969zg5zmhq2njffj",
-    "lp_token_id": "TODO",
+    "lp_token_id": "786",
     "asset_ids": [
       "ibc/5A7C219BA5F7582B99629BA3B2A01A61BFDA0F6FD1FE95B5366F7334C4BC0580",
       "uosmo"
@@ -4461,7 +4389,7 @@
   },
   {
     "id": "osmo1jsr3q3yw5pt3gtnsdsr0c6hx23f83cpv6st6ze3pplthwrc67j8sjge00h",
-    "lp_token_id": "TODO",
+    "lp_token_id": "815",
     "asset_ids": [
       "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
       "uosmo"
@@ -4471,7 +4399,7 @@
   },
   {
     "id": "osmo1jtzkz2383cegga8pzq7azm7tp3lcutep95urpvuqxz3x85sfpw7ssaqpc5",
-    "lp_token_id": "TODO",
+    "lp_token_id": "596",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
@@ -4481,7 +4409,7 @@
   },
   {
     "id": "osmo1jve7zc9y29kl8jalu0aaz8v38y2vpjucdk7thg79ektq4t7aswcsa6w45d",
-    "lp_token_id": "TODO",
+    "lp_token_id": "193",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
@@ -4491,7 +4419,7 @@
   },
   {
     "id": "osmo1jz730xfzjnkp2zaasvqg9e3smv2a4f8qvrm6p8cs83m2srkr56hs4wtm3w",
-    "lp_token_id": "TODO",
+    "lp_token_id": "749",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04"
@@ -4501,17 +4429,14 @@
   },
   {
     "id": "osmo1k33jzr6syz8fs9jlsjerwum53ctu9nzkfdr3uy58ddt2tpsnsw0sl8ff3s",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "lp_token_id": "135",
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1k3hmk0dyeu7m0jx6w0ltufvh76kjk0zscthmk0u86u3y95dy4xhqmqgeww",
-    "lp_token_id": "TODO",
+    "lp_token_id": "483",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -4521,17 +4446,14 @@
   },
   {
     "id": "osmo1k4gj3utpx0s3pmtq7shmyhdq2dp605e03hcprvzvec7jq2ge2u7s4r0wp4",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "lp_token_id": "545",
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1k4nr7aguzj733ch3kdpl4834ex5uep84gcvtnumj2ekgrh4xlfssslwlpd",
-    "lp_token_id": "TODO",
+    "lp_token_id": "767",
     "asset_ids": [
       "ibc/239A507997222805E441956EBE8087D7E2D05D6535C6D4C75EF8DCF83B3DE1A1",
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
@@ -4541,7 +4463,7 @@
   },
   {
     "id": "osmo1k5s6tga7smv266aftu7l4trqsdqg3slgq5kj2q02dppdxlw7pjvsxjzjrk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "368",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
@@ -4551,7 +4473,7 @@
   },
   {
     "id": "osmo1k6mv2aefssjt0jq8gwvccwaa0xsv7m0dxl5kzqay47pepy6e8kqq3rage2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "718",
     "asset_ids": [
       "ibc/0CB9DB3441D0D50F35699DEE22B9C965487E83FB2D9F483D1CC5CA34E856C484",
       "uosmo"
@@ -4561,7 +4483,7 @@
   },
   {
     "id": "osmo1k804l4hsemvreuguf96rnv8f8rmgmr2fm0nuy7z9s7je7j63dktqgamzc3",
-    "lp_token_id": "TODO",
+    "lp_token_id": "841",
     "asset_ids": [
       "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -4571,7 +4493,7 @@
   },
   {
     "id": "osmo1k9a068d7990a52fncvt70magqvzsfkeg9a6qnqehv20qwwdqfrdqux5s24",
-    "lp_token_id": "TODO",
+    "lp_token_id": "89",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uosmo"
@@ -4581,7 +4503,7 @@
   },
   {
     "id": "osmo1kaekqycnekvhhstysh7e9wwkl0w79wt9pr7vusmqfqkfcqgqac7s2fc6dj",
-    "lp_token_id": "TODO",
+    "lp_token_id": "845",
     "asset_ids": [
       "ibc/A6383B6CF5EA23E067666C06BC34E2A96869927BD9744DC0C1643E589C710AA3",
       "uosmo"
@@ -4591,7 +4513,7 @@
   },
   {
     "id": "osmo1kavqnurym4exfwyz85j68mkggacegptpkvpv08d3g6q9vavhw94qvj756k",
-    "lp_token_id": "TODO",
+    "lp_token_id": "848",
     "asset_ids": [
       "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
       "uosmo"
@@ -4601,17 +4523,14 @@
   },
   {
     "id": "osmo1kchnwg6y2y4r2nyjartp9q3ss4ysjkx9gzgxwdtg6624g6natn3seyj0f4",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/222",
-      "gamm/pool/323"
-    ],
+    "lp_token_id": "402",
+    "asset_ids": ["gamm/pool/222", "gamm/pool/323"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1kcra3rvreavuzm94jfwl6pd4kysppvdn0g72d2d846qrg0gaaz2scsukt6",
-    "lp_token_id": "TODO",
+    "lp_token_id": "174",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
@@ -4621,7 +4540,7 @@
   },
   {
     "id": "osmo1kdnj8qjhya69n2yj820mzt9wjunjekkyu5ewwn7l5ppyn6qhu9zqzj8fk8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "694",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796"
@@ -4631,7 +4550,7 @@
   },
   {
     "id": "osmo1ked4s6v8a5fnr7wshk3825c4dc44hth4aln264ygjxqw9ck4ry6qg6ysxy",
-    "lp_token_id": "TODO",
+    "lp_token_id": "509",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
@@ -4641,7 +4560,7 @@
   },
   {
     "id": "osmo1kg2ga83a9g5rhv5xu2m24q8rnqjv5vr6257cc2ny5x5737ttkg4sjh2zm9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "667",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7"
@@ -4651,7 +4570,7 @@
   },
   {
     "id": "osmo1kgg8uct2yut6etpprx2sdfn2fq7890jez9jd5arunsgg734mv68st55v0w",
-    "lp_token_id": "TODO",
+    "lp_token_id": "230",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
@@ -4661,7 +4580,7 @@
   },
   {
     "id": "osmo1kljure6uz60xec9ecmq7sldzgz2x8n2r8snxgvuwla4rn7kpvjzsjczqqx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "760",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/C9864D1B9623F703C75BBF72B7FF8A7317E1535C96538D21467A4311246DC3B5"
@@ -4671,7 +4590,7 @@
   },
   {
     "id": "osmo1knufp26cx4y9p4eecgra5z4deu6hek0hh9let2gwjns2g3tzue0qt4xzsf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "458",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4681,7 +4600,7 @@
   },
   {
     "id": "osmo1kp5sa9gkqwtcksupd30hdez9mfx4ak65c7m99yqj4pk599tlfh5q96u2e4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "453",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -4691,7 +4610,7 @@
   },
   {
     "id": "osmo1kpf2xfutvfqfum9aj2juvjcjcxzp7k3le389v6ql6lurzcq0hausa6uyx8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "14",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
@@ -4701,7 +4620,7 @@
   },
   {
     "id": "osmo1kqmrg9qyqfgkys9q892m8st5mkesez8vpnegppecex0ylqqp8h8sedeu4q",
-    "lp_token_id": "TODO",
+    "lp_token_id": "660",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/F6B691D5F7126579DDC87357B09D653B47FDCE0A3383FF33C8D8B544FE29A8A6"
@@ -4711,7 +4630,7 @@
   },
   {
     "id": "osmo1krp38zzc3zz5as9ndqkyskhkzv6x9e30ckcq5g4lcsu5wpwcqy0sa3dea2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "10",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -4721,7 +4640,7 @@
   },
   {
     "id": "osmo1kskty9u0uvqrn89p4ultt4m2se2jjkrt404d20zgqftdch5t4k6qmysqvn",
-    "lp_token_id": "TODO",
+    "lp_token_id": "649",
     "asset_ids": [
       "ibc/F6B691D5F7126579DDC87357B09D653B47FDCE0A3383FF33C8D8B544FE29A8A6",
       "uosmo"
@@ -4731,7 +4650,7 @@
   },
   {
     "id": "osmo1ku38urrhfsz29778kcwr7zaesfcv86js2alyy58t6dnzh8nnf73qpwkwtw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "564",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -4741,7 +4660,7 @@
   },
   {
     "id": "osmo1ku7t6f3pcl3e9kfzlzrp5jwktsl7vqu4dym7fzvn2gsj47qp9e5se820kn",
-    "lp_token_id": "TODO",
+    "lp_token_id": "256",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4751,7 +4670,7 @@
   },
   {
     "id": "osmo1kuceh0se3p3f6xf7ca5yh5ud33my9rzk9jyjh0hk5ufvh02vvn8slg06wy",
-    "lp_token_id": "TODO",
+    "lp_token_id": "206",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4761,7 +4680,7 @@
   },
   {
     "id": "osmo1kuecnt3tye9q23d5ytw6xmfp70w7gz4te6sjs42ptep9utrx5v4q5uuj9u",
-    "lp_token_id": "TODO",
+    "lp_token_id": "446",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4771,7 +4690,7 @@
   },
   {
     "id": "osmo1kxlcgxrc2lqn7hmks2ukld6a8f0fdfm0dwstut2uragrugkryyvq7eyxmv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "794",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A"
@@ -4781,7 +4700,7 @@
   },
   {
     "id": "osmo1kyrc9u2g4f44empz8achjdxzkftprxhx56p28ft02lkaucvztyqsrlsrd3",
-    "lp_token_id": "TODO",
+    "lp_token_id": "259",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -4790,8 +4709,18 @@
     "type": "balancerV1"
   },
   {
+    "id": "osmo1kyw5a3cuukhc63r7pry549fdzt2wtn9w6fesz70q6lg25rzlas3s0el87c",
+    "lp_token_id": "921",
+    "asset_ids": [
+      "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
+      "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049"
+    ],
+    "dex": "Osmosis",
+    "type": "balancerV1"
+  },
+  {
     "id": "osmo1kze098t3xxs3w6mfhxkdeehrktjd49582g8vtgfh5cke2jfh2hhsqqjvgx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "88",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
@@ -4801,7 +4730,7 @@
   },
   {
     "id": "osmo1l0s5xy5nm9qwdn72nux9dyck9k52l4mg907ghrxc0lw8rn6vxuaseq3t9f",
-    "lp_token_id": "TODO",
+    "lp_token_id": "207",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "uosmo"
@@ -4811,7 +4740,7 @@
   },
   {
     "id": "osmo1l265e7cug3tk3eugex8hpq2adk5drdecxzp6lsytn6dls6jpjkssvp9zqe",
-    "lp_token_id": "TODO",
+    "lp_token_id": "584",
     "asset_ids": [
       "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
       "uosmo"
@@ -4821,7 +4750,7 @@
   },
   {
     "id": "osmo1l2a4nmtjuv8mfucrenpujyn9j04vl3gmrsyq0vaj5f8e6apmavvqhtje00",
-    "lp_token_id": "TODO",
+    "lp_token_id": "860",
     "asset_ids": [
       "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
       "uosmo"
@@ -4831,7 +4760,7 @@
   },
   {
     "id": "osmo1l2sd4j9yq6hz0q039hnjydx6zj2lptu34f846yg5jutgu0r7juvszgk2xy",
-    "lp_token_id": "TODO",
+    "lp_token_id": "261",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
@@ -4841,7 +4770,7 @@
   },
   {
     "id": "osmo1l45a67tujfxl99qt39a09cqf9ep0vtqyn8xnuua66yvjtc7e8lvsua2hjn",
-    "lp_token_id": "TODO",
+    "lp_token_id": "17",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -4851,17 +4780,14 @@
   },
   {
     "id": "osmo1l5ehe7cqgf5fplxegqaukwygaz8g2h62yhdt06te6uem30l2j9mswf6qct",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "lp_token_id": "50",
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1l7vu8utujujfy0j2xrhcfzcz27q85j29vxxyjx4w7lnxzsevjfwq69qxrq",
-    "lp_token_id": "TODO",
+    "lp_token_id": "513",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -4871,7 +4797,7 @@
   },
   {
     "id": "osmo1l87xgwa4j9ntqfuz440pw5xgsw27y227rddfz2knekfk59k0satqj9as7f",
-    "lp_token_id": "TODO",
+    "lp_token_id": "575",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -4881,17 +4807,14 @@
   },
   {
     "id": "osmo1lahkpd2rxat3huy3kqkphvugruzxm3d5n0jxve6c8xzmkcvgfw9qjdnkhf",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/104",
-      "uosmo"
-    ],
+    "lp_token_id": "107",
+    "asset_ids": ["gamm/pool/104", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1lc77pdqlnj3s7typ0nvq7xxt79gmtec7mvazdsw8c2ffy4j9hjrs6crft0",
-    "lp_token_id": "TODO",
+    "lp_token_id": "624",
     "asset_ids": [
       "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8",
       "uosmo"
@@ -4901,7 +4824,7 @@
   },
   {
     "id": "osmo1leu9xn7ecn7wq58kz949827zspj7xzf98200mukzctgnrpsqwsfscnwc7s",
-    "lp_token_id": "TODO",
+    "lp_token_id": "658",
     "asset_ids": [
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
@@ -4911,7 +4834,7 @@
   },
   {
     "id": "osmo1lg3y6n2qc382ukpl8y6hfxlk6lprw3aye47zsld7xpnktfhvxneqxjf4f7",
-    "lp_token_id": "TODO",
+    "lp_token_id": "774",
     "asset_ids": [
       "ibc/AD185F62399F770CCCE8A36A180A77879FF6C26A0398BD3D2A74E087B0BFA121",
       "uosmo"
@@ -4921,7 +4844,7 @@
   },
   {
     "id": "osmo1lh3kh39lzupfnupjsl5vda29utlzkaz2673hepw2cdck8rqm3arssz7skt",
-    "lp_token_id": "TODO",
+    "lp_token_id": "589",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5"
@@ -4931,7 +4854,7 @@
   },
   {
     "id": "osmo1lherhrcrxe9yev22rjda9auagvr9nupncmtn4yajs48kvfe42t2sq83s4w",
-    "lp_token_id": "TODO",
+    "lp_token_id": "909",
     "asset_ids": [
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
       "ibc/D38BB3DD46864694F009AF01DA5A815B3A875F8CC52FF5679BFFCC35DC7451D5"
@@ -4941,7 +4864,7 @@
   },
   {
     "id": "osmo1lhg9ec0lmn0wec4tsxwk7kwqd5px203vwvh7wth5wls4jeu2hjlqxn7gte",
-    "lp_token_id": "TODO",
+    "lp_token_id": "734",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3"
@@ -4951,7 +4874,7 @@
   },
   {
     "id": "osmo1lkam7g0tg3r9uaq0y7tgzax5934zaevuhe70evqxaaga7n9wqgasqeale8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "687",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC"
@@ -4961,17 +4884,14 @@
   },
   {
     "id": "osmo1lmk3mgsj2ajp4s34jzfsqscz60nfys4rlsg5u8k03a9420ggyh2qldlmzq",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/38",
-      "uosmo"
-    ],
+    "lp_token_id": "61",
+    "asset_ids": ["gamm/pool/38", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1lu9gpwx7n5phng70yap748t48ws5p82rher9hvkqqvpczj0f9rwqc3rmy5",
-    "lp_token_id": "TODO",
+    "lp_token_id": "430",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4981,7 +4901,7 @@
   },
   {
     "id": "osmo1lughuhtdk7fj9n9pzx7hu5ulrcg6g84mk5j3aezgw86f4vae79qqw5wzd4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "389",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -4991,7 +4911,7 @@
   },
   {
     "id": "osmo1lv9ju9nuzr4vgazyma7l8hsw0zcafwwm77vvdjm79mku6ydpq4mskdpsd2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "291",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/CD942F878C80FBE9DEAB8F8E57F592C7252D06335F193635AF002ACBD69139CC"
@@ -5001,7 +4921,7 @@
   },
   {
     "id": "osmo1ly2shj6fznqwqskswmpwmrkqxdsavhmlmkr92wg3hcqqxnn2y5vsrkhc6u",
-    "lp_token_id": "TODO",
+    "lp_token_id": "601",
     "asset_ids": [
       "ibc/EA3E1640F9B1532AB129A571203A0B9F789A7F14BB66E350DCBFA18E1A1931F0",
       "uosmo"
@@ -5011,7 +4931,7 @@
   },
   {
     "id": "osmo1lzwv0glchfcw0fpwzdwfdsepmvluv6z6eh4qunxdml33sj06q3yq7xwtde",
-    "lp_token_id": "TODO",
+    "lp_token_id": "4",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -5021,7 +4941,7 @@
   },
   {
     "id": "osmo1m0qkljyn3a0sm2m9sgj6485frrmxnqpetc0lqstun5nzqj28fctqkt2qeh",
-    "lp_token_id": "TODO",
+    "lp_token_id": "843",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/CAA179E40F0266B0B29FB5EAA288FB9212E628822265D4141EBD1C47C3CBFCBC"
@@ -5031,7 +4951,7 @@
   },
   {
     "id": "osmo1m0yntqzum06tc7ztw34sn646clwf32p7x2cfymaf8jx0cyf3jvlqfe5d6x",
-    "lp_token_id": "TODO",
+    "lp_token_id": "183",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
@@ -5041,7 +4961,7 @@
   },
   {
     "id": "osmo1m28rqxevywfn76c4lf5vws64shd0hxvxyvzazzswlj5n7q48pxrqvlgry5",
-    "lp_token_id": "TODO",
+    "lp_token_id": "643",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C"
@@ -5051,7 +4971,7 @@
   },
   {
     "id": "osmo1m3690pyfyadnny62ylj44xdlhzen7dluzmlrwwayzmnmm8deqy6sd86xla",
-    "lp_token_id": "TODO",
+    "lp_token_id": "517",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5061,7 +4981,7 @@
   },
   {
     "id": "osmo1m3lgd2ekfvtde7suplqwgz0c38dfw0rcrnds86876680u0ud8sfqkg63dx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "729",
     "asset_ids": [
       "ibc/2716E3F2E146664BEFA9217F1A03BFCEDBCD5178B3C71CACB1A0D7584451D219",
       "uosmo"
@@ -5071,7 +4991,7 @@
   },
   {
     "id": "osmo1m4qg2yg542hp38yrdnp7wxhpm8j3agu78sg7f6lz0dzpmk4t4cysy9x5mj",
-    "lp_token_id": "TODO",
+    "lp_token_id": "177",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uion"
@@ -5081,7 +5001,7 @@
   },
   {
     "id": "osmo1m728dvj3vg684xgcv3skek3ylzjxryu5v0qyyl9jv3zz7vkga9fq7jpkck",
-    "lp_token_id": "TODO",
+    "lp_token_id": "308",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5091,7 +5011,7 @@
   },
   {
     "id": "osmo1m80fnqvvsd83we8gnh998re55jq8cq2mdkccclqmuqw8xpm69agsm8ffd6",
-    "lp_token_id": "TODO",
+    "lp_token_id": "553",
     "asset_ids": [
       "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
       "uosmo"
@@ -5101,7 +5021,7 @@
   },
   {
     "id": "osmo1masvawn2hnrddygr7czdkhjgnnuf86qgf657u4jpm4xg3qz53nkq0hkjy7",
-    "lp_token_id": "TODO",
+    "lp_token_id": "355",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5111,7 +5031,7 @@
   },
   {
     "id": "osmo1maw9j25fppqf3c2l4ufxxhn7leu58ke2c5lm9r8ehm60fnzgpzfsu8jzhk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "32",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -5121,17 +5041,14 @@
   },
   {
     "id": "osmo1mdqhf078cs0qe7gfcv9rdw0yzvzf0wejvyrlx8hyzcpsfn2zgpyq7l9ly6",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/108",
-      "uosmo"
-    ],
+    "lp_token_id": "153",
+    "asset_ids": ["gamm/pool/108", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1mel7yxyqx2n39zrw8eqrxv8gjltvlchqaycjz6gg0x8qgs7zhe9sc5gavj",
-    "lp_token_id": "TODO",
+    "lp_token_id": "507",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -5141,7 +5058,7 @@
   },
   {
     "id": "osmo1mh2eclfdnq5e9pz8ejyz7q245nry7p0q4u6t6xj363xw9uxt0uqqf26dzm",
-    "lp_token_id": "TODO",
+    "lp_token_id": "300",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5151,7 +5068,7 @@
   },
   {
     "id": "osmo1mhnddjymtcxxn9mj9en37ufnf9s9tfg0rzgy24y7f06d7t5v340sdhlfen",
-    "lp_token_id": "TODO",
+    "lp_token_id": "171",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5161,7 +5078,7 @@
   },
   {
     "id": "osmo1mrlrvqret269x5aqvkycy0fnu4jz3fqqf6tqflptygpewn264jpsw8kega",
-    "lp_token_id": "TODO",
+    "lp_token_id": "195",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
@@ -5171,7 +5088,7 @@
   },
   {
     "id": "osmo1mrltfv8y3jf4v3ggw0hnjjxzmwmq749rsjgvgvjuk0ezzs4hycfskm6c6a",
-    "lp_token_id": "TODO",
+    "lp_token_id": "301",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
@@ -5181,7 +5098,7 @@
   },
   {
     "id": "osmo1mtarz7hmt5m0h7muks3pdnwfmwqps9nndrrq6xrz5rhdsl6s3cwssm4vv3",
-    "lp_token_id": "TODO",
+    "lp_token_id": "867",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/D3B574938631B0A1BA704879020C696E514CFADAA7643CDE4BD5EB010BDE327B"
@@ -5191,7 +5108,7 @@
   },
   {
     "id": "osmo1mtn55pzt3huxrskm986s89e465u3kvln9uum5deeza27f0vtmucs9ysvr6",
-    "lp_token_id": "TODO",
+    "lp_token_id": "542",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
@@ -5201,7 +5118,7 @@
   },
   {
     "id": "osmo1mvpqp7xujzf7c5jyamxg3u23zflz6ye0vnalx94khkyf4fp4m7aq96z76w",
-    "lp_token_id": "TODO",
+    "lp_token_id": "844",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5211,7 +5128,7 @@
   },
   {
     "id": "osmo1mw0ac6rwlp5r8wapwk3zs6g29h8fcscxqakdzw9emkne6c8wjp9q0t3v8t",
-    "lp_token_id": "TODO",
+    "lp_token_id": "1",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5221,7 +5138,7 @@
   },
   {
     "id": "osmo1mxcjnczrsd9ge4pkczpt9e84rntk08h27ez0d36yaxumsk2smdys3vsucj",
-    "lp_token_id": "TODO",
+    "lp_token_id": "625",
     "asset_ids": [
       "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
       "uosmo"
@@ -5231,7 +5148,7 @@
   },
   {
     "id": "osmo1n22kz2zhwzl06ftd64heah7vahlythhsrj2388l0z95jlsjpkyuq0qd5dz",
-    "lp_token_id": "TODO",
+    "lp_token_id": "173",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5241,7 +5158,7 @@
   },
   {
     "id": "osmo1n34cvctdvs54y3mkmk0pmj5f47k38eecl509q68ml66x2xlxfgysu26f8u",
-    "lp_token_id": "TODO",
+    "lp_token_id": "130",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5251,7 +5168,7 @@
   },
   {
     "id": "osmo1n44k0kzvzqn3duscgzznh73p24je0vw38huugm5cg6k7fjren64s9a837a",
-    "lp_token_id": "TODO",
+    "lp_token_id": "836",
     "asset_ids": [
       "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
       "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E"
@@ -5261,7 +5178,7 @@
   },
   {
     "id": "osmo1n8eyte6zq4njjcfjw3re4vhrgf9n32zstulurxg8k66dp7uk9leqjyeavk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "168",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5271,7 +5188,7 @@
   },
   {
     "id": "osmo1na36haex62rq9y0rz34unlk8agh5kygug5eheelvhw3hxhmwwmgqppr5zx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "287",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5281,7 +5198,7 @@
   },
   {
     "id": "osmo1nam3pd3u93sqxns28k5xu4vznnv5a654hh38fnwud5pakqqq04xs6upegq",
-    "lp_token_id": "TODO",
+    "lp_token_id": "541",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/655BCEF3CDEBE32863FF281DBBE3B06160339E9897DC9C9C9821932A5F8BA6F8"
@@ -5291,7 +5208,7 @@
   },
   {
     "id": "osmo1namquuyzajapzsffw7vy28sfdwsjzk559vt0p6rzpkhzwplt0m3snd6ppr",
-    "lp_token_id": "TODO",
+    "lp_token_id": "379",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5301,7 +5218,7 @@
   },
   {
     "id": "osmo1nanwkuh98tjrft7v4js0p8efjp3w2h4jjmesprlzjdnfvzyuvcmscnuhr6",
-    "lp_token_id": "TODO",
+    "lp_token_id": "281",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -5311,7 +5228,7 @@
   },
   {
     "id": "osmo1nefum67tu9gzamyzvsp960auxayp5ft3pkwey67h434nkytuys4svyml98",
-    "lp_token_id": "TODO",
+    "lp_token_id": "579",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E"
@@ -5321,17 +5238,14 @@
   },
   {
     "id": "osmo1nfn4h33t30prnuyrhn20ntvgclzhc8x40mzkngc740r9r3sap4yqaf9c3a",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/359",
-      "uosmo"
-    ],
+    "lp_token_id": "360",
+    "asset_ids": ["gamm/pool/359", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1ng6lckhx52kpr7ww9ynayuzzlsp5m6jcnkztysf03sncg9zz472ss3x370",
-    "lp_token_id": "TODO",
+    "lp_token_id": "626",
     "asset_ids": [
       "ibc/F867AE2112EFE646EC71A25CD2DFABB8927126AC1E19F1BBF0FF693A4ECA05DE",
       "uosmo"
@@ -5341,7 +5255,7 @@
   },
   {
     "id": "osmo1nggsx9rkkyyrg6pksejtpq9zea90yu6mjq6u5pwsmu53xweda4psp5jsfv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "361",
     "asset_ids": [
       "gamm/pool/360",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -5351,7 +5265,7 @@
   },
   {
     "id": "osmo1nh9vsmgqtdtrrrldfzxtjy3l444grmt7flrmyc265ey0arsng8dqqzfag3",
-    "lp_token_id": "TODO",
+    "lp_token_id": "879",
     "asset_ids": [
       "ibc/6329DD8CF31A334DD5BE3F68C846C9FE313281362B37686A62343BAC1EB1546D",
       "uosmo"
@@ -5361,17 +5275,14 @@
   },
   {
     "id": "osmo1nk8ha9xldmqjn7adgz56tmu87e3yryuzj3upsk20kmy64vmg702squcxue",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/474",
-      "uosmo"
-    ],
+    "lp_token_id": "475",
+    "asset_ids": ["gamm/pool/474", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1nkt8zu53tz64m9muw9jgaw2xfhxl3c6p8hkte57j46ctjdpduh6qgays4a",
-    "lp_token_id": "TODO",
+    "lp_token_id": "102",
     "asset_ids": [
       "gamm/pool/90",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -5381,7 +5292,7 @@
   },
   {
     "id": "osmo1nmlwj8wfpq5r2dukds3lkg74t324y53j4eegk4h3u09hu5rn3kpqctntge",
-    "lp_token_id": "TODO",
+    "lp_token_id": "189",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
@@ -5391,7 +5302,7 @@
   },
   {
     "id": "osmo1npz80ntx3vwkv3w9ryzc8g074hlykmw497ar0j7dqzk4yanjylqshan44d",
-    "lp_token_id": "TODO",
+    "lp_token_id": "274",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -5401,7 +5312,7 @@
   },
   {
     "id": "osmo1nreqp8gx5nmej0ckrh7v2jy2p6j8pjv7xcyzrpylkstfamkm2slqxsvllj",
-    "lp_token_id": "TODO",
+    "lp_token_id": "661",
     "asset_ids": [
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
       "uosmo"
@@ -5411,7 +5322,7 @@
   },
   {
     "id": "osmo1nspf22mwajwdka4zxk3k0vcn9xtqskur5we6u255q7hgcjhnj72qkdn45s",
-    "lp_token_id": "TODO",
+    "lp_token_id": "450",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -5421,7 +5332,7 @@
   },
   {
     "id": "osmo1nukez7tx3w75sesfecus9tuedre25uhvs737t0g35uqzeaks5jusvvp5r4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "464",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -5431,7 +5342,7 @@
   },
   {
     "id": "osmo1nukyq8kzw4353yt8gvzjgfvvzar7h6skzkwptxkcrecjzfhxqdaqk4shck",
-    "lp_token_id": "TODO",
+    "lp_token_id": "123",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5441,7 +5352,7 @@
   },
   {
     "id": "osmo1nvjv09u5tcunewz468ad285z5dum9h4hvc0lcnsjvncq63umu8pq63czxa",
-    "lp_token_id": "TODO",
+    "lp_token_id": "755",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/7F1A862E98185A286F011DD093D8BD2FA1B7CD1A723EC5E6C59F76692F1728F7"
@@ -5451,7 +5362,7 @@
   },
   {
     "id": "osmo1nw8fdm6elm9h06zfxf5sltxjp0xw9cgcpzqzfqwpea5584xr0g7qhzzx2q",
-    "lp_token_id": "TODO",
+    "lp_token_id": "827",
     "asset_ids": [
       "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
       "uosmo"
@@ -5461,7 +5372,7 @@
   },
   {
     "id": "osmo1nxm52c20twfrr44cdh5g4f7dufnuc7r60n5y9uqe27494qgw2qes2g4432",
-    "lp_token_id": "TODO",
+    "lp_token_id": "731",
     "asset_ids": [
       "ibc/D3327A763C23F01EC43D1F0DB3CEFEC390C362569B6FD191F40A5192F8960049",
       "uosmo"
@@ -5471,7 +5382,7 @@
   },
   {
     "id": "osmo1nzky8dqcmzzf84hrwse3pggyq5kqe9njewn00fphaku4lgjw5gxsejdw0f",
-    "lp_token_id": "TODO",
+    "lp_token_id": "166",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5481,7 +5392,7 @@
   },
   {
     "id": "osmo1p0rpttlp8v2hy7m82l2t9p6545788f2ac3yksgrlycke2wr4mu0qdr7ytu",
-    "lp_token_id": "TODO",
+    "lp_token_id": "6",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -5491,7 +5402,7 @@
   },
   {
     "id": "osmo1p352w3c2ms04cj6un55hnkwuw2fq748tgxjn57fujvp9pmx8mhnsr4jsgv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "650",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD"
@@ -5501,7 +5412,7 @@
   },
   {
     "id": "osmo1p4qpdv38znav3egx44yysvp5zwazsmw0p30vk8yxq43qraxspz0sdrq6td",
-    "lp_token_id": "TODO",
+    "lp_token_id": "178",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5511,7 +5422,7 @@
   },
   {
     "id": "osmo1p8amm7au5ajkuay8nrnwelwheazxqw23va9yq42ehx0s4reexu7s2jff2l",
-    "lp_token_id": "TODO",
+    "lp_token_id": "817",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/84502A75BCA4A5F68D464C00B3F610CE2585847D59B52E5FFB7C3C9D2DDCD3FE"
@@ -5521,7 +5432,7 @@
   },
   {
     "id": "osmo1p9mdkst9230ngdunv654l3trklnrpzlh9lr82fs4qes879l3n42stya63r",
-    "lp_token_id": "TODO",
+    "lp_token_id": "705",
     "asset_ids": [
       "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -5531,17 +5442,14 @@
   },
   {
     "id": "osmo1p9pa7umdvry4u4338hgu4x5pkepnk9pcqddpg65zdj0k3a3ucjts85hj73",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "lp_token_id": "35",
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1pa8d43s0t8hwdekx2uyq224tapyzxn60578ywzlkupkh60tyzhus2wcrez",
-    "lp_token_id": "TODO",
+    "lp_token_id": "188",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -5551,7 +5459,7 @@
   },
   {
     "id": "osmo1pc849m5xe9wa7w9r4k2dv7pq958fm84a8t626ftufs8m5rs09guqxx8j3y",
-    "lp_token_id": "TODO",
+    "lp_token_id": "795",
     "asset_ids": [
       "ibc/2DA9C149E9AD2BD27FEFA635458FB37093C256C1A940392634A16BEA45262604",
       "uosmo"
@@ -5561,7 +5469,7 @@
   },
   {
     "id": "osmo1pd4pfnj36p39q9zdpycjfms7zta3ugjjeyjxzmuhh28pqe70urxqje0k84",
-    "lp_token_id": "TODO",
+    "lp_token_id": "870",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
@@ -5571,7 +5479,7 @@
   },
   {
     "id": "osmo1ped9637al0u0ck9gtmud27rxjkmhk2cxjt7lsqrtwd3pjzmm07jsxu8mvm",
-    "lp_token_id": "TODO",
+    "lp_token_id": "813",
     "asset_ids": [
       "ibc/A1AC7F9EE2F643A68E3A35BCEB22040120BEA4059773BB56985C76BDFEBC71D9",
       "uosmo"
@@ -5581,7 +5489,7 @@
   },
   {
     "id": "osmo1pemg6m8pd8xnz2gnnmh9w8ja3rhcq9ztlnwa34md545ttj46sfwsxyzy50",
-    "lp_token_id": "TODO",
+    "lp_token_id": "248",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5591,7 +5499,7 @@
   },
   {
     "id": "osmo1pf3vpzz9umucchpeklwtsc4xveql0m6xsh589ek8tn4er80v9wksya3e2d",
-    "lp_token_id": "TODO",
+    "lp_token_id": "257",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -5601,7 +5509,7 @@
   },
   {
     "id": "osmo1pg8mzjdn3yxg4gf96axyw8gpn2ur6jxq5alctz7lmjkwk9n98neshpmtkj",
-    "lp_token_id": "TODO",
+    "lp_token_id": "866",
     "asset_ids": [
       "ibc/92B223EBFA74DB99BEA92B23DEAA6050734FEEAABB84689CB8E1AE8F9C9F9AF4",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -5611,7 +5519,7 @@
   },
   {
     "id": "osmo1pjuess9ulvre83pyees8p688xglzl039nhgrtx8nv3j50uw8qhsqqma5jq",
-    "lp_token_id": "TODO",
+    "lp_token_id": "347",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5621,7 +5529,7 @@
   },
   {
     "id": "osmo1plswdqqd9nn7jy3s62vnjjmshwkk0us07shttqsmdph2gkgt6ejqmqef5c",
-    "lp_token_id": "TODO",
+    "lp_token_id": "45",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5631,7 +5539,7 @@
   },
   {
     "id": "osmo1pmhq2qy30wdlv4thqs9glsm38z06lp6syuh8nwa85aukw6tepmhq7eazwe",
-    "lp_token_id": "TODO",
+    "lp_token_id": "405",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -5641,7 +5549,7 @@
   },
   {
     "id": "osmo1ppc37u39xsklmuew4vyggg34crggekqnuul32x67y32g65ekprhqwfxh56",
-    "lp_token_id": "TODO",
+    "lp_token_id": "428",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5651,7 +5559,7 @@
   },
   {
     "id": "osmo1prazp9zy7pk9ds5s66kj6uc50uvwsu9pmr6qwel3dn3juvjps3mqku4xwt",
-    "lp_token_id": "TODO",
+    "lp_token_id": "439",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
@@ -5661,7 +5569,7 @@
   },
   {
     "id": "osmo1prgxk3tjsmrw230k266aeevjgmerceekj89ksjpjq3gt6wa3rmes36q0kt",
-    "lp_token_id": "TODO",
+    "lp_token_id": "656",
     "asset_ids": [
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
@@ -5671,7 +5579,7 @@
   },
   {
     "id": "osmo1pw3kx94kn0vu6lj048vtk3vmzx7y7mde3zc2sjxull69mcg6zjyqft9qjv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "136",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -5681,7 +5589,7 @@
   },
   {
     "id": "osmo1py2nm36kk5dek5th97ljtdd509wl339zqslg89u8l9atchf9568sdlgu4k",
-    "lp_token_id": "TODO",
+    "lp_token_id": "249",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5691,7 +5599,7 @@
   },
   {
     "id": "osmo1pzdmgl6dnwnaers8ujawqet6fry3rxxkfwccrk0ypt8chx2prnasmlxc36",
-    "lp_token_id": "TODO",
+    "lp_token_id": "411",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5701,7 +5609,7 @@
   },
   {
     "id": "osmo1pzhmczzq7fl7rp72x8zrcm792ndp4r8z6pthe2rcw9vsudna4tmqdw3mmv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "852",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/71055835C7639739EAE03AACD1324FE162DBA41D09F197CB72D966D014225B1C"
@@ -5711,7 +5619,7 @@
   },
   {
     "id": "osmo1pzhzluks9p6esj0kam002a6chhxefeca86jpntlz8aewyvje69xq986agq",
-    "lp_token_id": "TODO",
+    "lp_token_id": "647",
     "asset_ids": [
       "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20",
       "uosmo"
@@ -5721,7 +5629,7 @@
   },
   {
     "id": "osmo1pzm7keu64vrwlz4cwscjpx70fnn8cuuqwmx3qcl9qef2ctx092dshnpg5q",
-    "lp_token_id": "TODO",
+    "lp_token_id": "466",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "uosmo"
@@ -5731,7 +5639,7 @@
   },
   {
     "id": "osmo1q07hmk9ewecaa9mtnpz9uerq0tlfxj55yp2fg67lqy4xp704l5as56uq9e",
-    "lp_token_id": "TODO",
+    "lp_token_id": "759",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/E4FFAACCDB7D55CE2D257DF637C00158CB841F11D0013B2D03E31FF7800A2C58"
@@ -5741,7 +5649,7 @@
   },
   {
     "id": "osmo1q2ej0ns7n3xt3tk9m85r8rd672rnprevd2hmth2azfctfkzkpk2qqjeezx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "311",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -5751,7 +5659,7 @@
   },
   {
     "id": "osmo1q3f2z5ws7vyqrxpdswzh8ray0xwpawkr45wzc5232su0lf9j068q7wvp34",
-    "lp_token_id": "TODO",
+    "lp_token_id": "180",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uosmo"
@@ -5761,7 +5669,7 @@
   },
   {
     "id": "osmo1q479s6ll6l2csetyv6jqs823qe5cexzuzeemjjdv7ej8tk2xhetsngy2kk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "838",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5"
@@ -5771,7 +5679,7 @@
   },
   {
     "id": "osmo1q5xduzrk6v5n9jsn7nw9fqlnm6w06xkhc4p4w8gqxr9ujl08vlnq37eqdp",
-    "lp_token_id": "TODO",
+    "lp_token_id": "200",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5781,7 +5689,7 @@
   },
   {
     "id": "osmo1q6qdde6364m22pgvz3pe2yykze9cxjyjhutdlserkfahwaugdfps35p85a",
-    "lp_token_id": "TODO",
+    "lp_token_id": "558",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/F3FF7A84A73B62921538642F9797C423D2B4C4ACB3C7FCFFCE7F12AA69909C4B"
@@ -5791,7 +5699,7 @@
   },
   {
     "id": "osmo1q6qfznza2p9kcmnzywxj8w0ffkl6czfmwtrc97a6pdzdsc5xpyqswassc8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "824",
     "asset_ids": [
       "ibc/7ABF696369EFB3387DF22B6A24204459FE5EFD010220E8E5618DC49DB877047B",
       "uosmo"
@@ -5801,7 +5709,7 @@
   },
   {
     "id": "osmo1q6wzn67t2fsg7sga6qj5skrafh6pd3pdtyss7jq35ukp8l86z45q42yueg",
-    "lp_token_id": "TODO",
+    "lp_token_id": "290",
     "asset_ids": [
       "ibc/CD942F878C80FBE9DEAB8F8E57F592C7252D06335F193635AF002ACBD69139CC",
       "uosmo"
@@ -5811,7 +5719,7 @@
   },
   {
     "id": "osmo1q73hzfr0jfw84sx2rtuvr2v5xqve0jzz3qw6gq77gavxdh94c6nshw5erw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "298",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5821,7 +5729,7 @@
   },
   {
     "id": "osmo1q7ul5yz2ma5mjj8vkf5njjz859wk4u90ley2emfx8th4xyx6fg7se0z4hn",
-    "lp_token_id": "TODO",
+    "lp_token_id": "832",
     "asset_ids": [
       "ibc/8E697BDABE97ACE8773C6DF7402B2D1D5104DD1EEABE12608E3469B7F64C15BA",
       "uosmo"
@@ -5831,7 +5739,7 @@
   },
   {
     "id": "osmo1q83j3062nnne65nsljaw0kwzsqam8ut7eheyzpr7ga56htsh20eqzr0vz6",
-    "lp_token_id": "TODO",
+    "lp_token_id": "186",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -5841,7 +5749,7 @@
   },
   {
     "id": "osmo1q8uvftta2c9r25mqxd89q76vdcagwjsg7q9t6c787seamzmpcuwq2wn5uc",
-    "lp_token_id": "TODO",
+    "lp_token_id": "327",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
@@ -5851,7 +5759,7 @@
   },
   {
     "id": "osmo1q9e2rxyu360hp69rg54up2k70sclp7uxl6mq79zrxkggquwkwfwqv9xgav",
-    "lp_token_id": "TODO",
+    "lp_token_id": "408",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
@@ -5861,7 +5769,7 @@
   },
   {
     "id": "osmo1q9m4xr0rlnh7t4rsq3cmjsunvc9lzrl6d3ww309zjmcryxqzrkus8h7lys",
-    "lp_token_id": "TODO",
+    "lp_token_id": "182",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
@@ -5871,7 +5779,7 @@
   },
   {
     "id": "osmo1qekmfz65ce08nee5c5caags2h24uhztjn9j6vr8uvnv4hcx44deq2xds6p",
-    "lp_token_id": "TODO",
+    "lp_token_id": "830",
     "asset_ids": [
       "ibc/608EF5C0CE64FEA097500DB39657BDD36CA708CC5DCC2E250A024B6981DD36BC",
       "uosmo"
@@ -5881,7 +5789,7 @@
   },
   {
     "id": "osmo1qfu6489pfda4skcsv6defawyggetjdeer6n9ed60dn096ma5dxfsg3plhg",
-    "lp_token_id": "TODO",
+    "lp_token_id": "352",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
@@ -5891,7 +5799,7 @@
   },
   {
     "id": "osmo1qg99g3wn2a477eumpml8wgxnhyhjj0zjwlefsfjgpdk9zcm6kxqsdt7e7y",
-    "lp_token_id": "TODO",
+    "lp_token_id": "607",
     "asset_ids": [
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
       "uosmo"
@@ -5901,7 +5809,7 @@
   },
   {
     "id": "osmo1qhd0uc9sc7psufty2y0u6ch2zpchtrljshr6jukly0n98yll759sncp98w",
-    "lp_token_id": "TODO",
+    "lp_token_id": "325",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -5911,7 +5819,7 @@
   },
   {
     "id": "osmo1qjfu245d9zn893y6c2z4rd689s0nyty4myvdmh6x39awag72n8uqgtcmea",
-    "lp_token_id": "TODO",
+    "lp_token_id": "336",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5921,7 +5829,7 @@
   },
   {
     "id": "osmo1qjujmew5s65g97stpuckas77f9hypy84vs9x8p0e7cypwv7jph9sgguu2u",
-    "lp_token_id": "TODO",
+    "lp_token_id": "386",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -5931,7 +5839,7 @@
   },
   {
     "id": "osmo1qkwd25wehxz5m0ddgal6yc6a70ph552pnw7ptrj2h697jflpq6yshag46w",
-    "lp_token_id": "TODO",
+    "lp_token_id": "472",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
@@ -5941,7 +5849,7 @@
   },
   {
     "id": "osmo1ql58ecue9v3qlwfa9zjc64rw2sw9cwrpct7j779ers2jcm4q4ggqrmpq6v",
-    "lp_token_id": "TODO",
+    "lp_token_id": "543",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uosmo"
@@ -5951,7 +5859,7 @@
   },
   {
     "id": "osmo1qlz6kfv2gyer5tfrlcn540atatq2xj0lmzzqgphguq5cm4rcscmqqvfggv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "469",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -5961,7 +5869,7 @@
   },
   {
     "id": "osmo1qm24s5jk9mz8wtc5luad8fsenrp5v5m7prjmfhunm0plcyg74u2qrsr325",
-    "lp_token_id": "TODO",
+    "lp_token_id": "15",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "uosmo"
@@ -5971,7 +5879,7 @@
   },
   {
     "id": "osmo1qqff9yppkegxgnazg933cun78eaelxa9zp2mz5m94q9fds6s4k5qaz4a32",
-    "lp_token_id": "TODO",
+    "lp_token_id": "839",
     "asset_ids": [
       "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -5981,7 +5889,7 @@
   },
   {
     "id": "osmo1qqtms0c5dfg4mlw4jgyj54tnr3cxznzrz2zutthxxgx4zz9559wsq0nlmw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "840",
     "asset_ids": [
       "ibc/F4A070A6D78496D53127EA85C094A9EC87DFC1F36071B8CCDDBD020F933D213D",
       "uosmo"
@@ -5991,17 +5899,14 @@
   },
   {
     "id": "osmo1qtle736upg6t8nmra606axnvnm8fwvffugdfhsn2hs4f8mv7n2yqgvlwt2",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/464",
-      "uosmo"
-    ],
+    "lp_token_id": "486",
+    "asset_ids": ["gamm/pool/464", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1qvjyyc95dwwua5rhvlxf2y55qm3uq5m85063qn3vrvsuq0u59wgqnlaeq0",
-    "lp_token_id": "TODO",
+    "lp_token_id": "196",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
@@ -6011,7 +5916,7 @@
   },
   {
     "id": "osmo1qw2zv7uq5lav3gk0j7xjapa85w0q3s0s7zlv4dws2gey84vuew6skaqu0j",
-    "lp_token_id": "TODO",
+    "lp_token_id": "216",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6021,7 +5926,7 @@
   },
   {
     "id": "osmo1qxdyvvnhtumm58pmhjlhhhe0pc3ye5apnma6tm0mx2r250zlga3qmn0z9j",
-    "lp_token_id": "TODO",
+    "lp_token_id": "283",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
@@ -6031,7 +5936,7 @@
   },
   {
     "id": "osmo1qxswx2sy9u0cpf9hrgqd29gjnudpjkpffkzjtplckjkkv7mjnh5s04vy0j",
-    "lp_token_id": "TODO",
+    "lp_token_id": "854",
     "asset_ids": [
       "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
       "ibc/D0E5BF2940FB58D9B283A339032DE88111407AAD7D94A7F1F3EB78874F8616D4"
@@ -6041,7 +5946,7 @@
   },
   {
     "id": "osmo1qyys2gt072ke0dvhqk2mkqclr4hw2ajmsvcrz45x4x5p53rsrn2sr8nq30",
-    "lp_token_id": "TODO",
+    "lp_token_id": "846",
     "asset_ids": [
       "ibc/71055835C7639739EAE03AACD1324FE162DBA41D09F197CB72D966D014225B1C",
       "uosmo"
@@ -6051,7 +5956,7 @@
   },
   {
     "id": "osmo1r52puhw7jqqx92h4r7eadpgnak5453yejda8p4de8t7whdychg2s4qtakx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "232",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6061,7 +5966,7 @@
   },
   {
     "id": "osmo1r5gj8e5pachzmsl5jphyw3njfr28jfzmykcz0w750tptzkyrhv9sf360an",
-    "lp_token_id": "TODO",
+    "lp_token_id": "802",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901"
@@ -6071,17 +5976,14 @@
   },
   {
     "id": "osmo1r5v05r30s0v75py3n3lhd7sq5cdgkaltles5rk0cmgndrdq7ktxqcn64y8",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "lp_token_id": "426",
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1r6xjt4ykjudgvlpnulk3jvuacjxew2xjag8frez4wprxkyspq8lq7j2edq",
-    "lp_token_id": "TODO",
+    "lp_token_id": "676",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -6091,7 +5993,7 @@
   },
   {
     "id": "osmo1r7m4vy9qfdpusvk02wyn3wln4amhz39sgvy2qyccjxq3a8drhwuss9feyu",
-    "lp_token_id": "TODO",
+    "lp_token_id": "324",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6101,7 +6003,7 @@
   },
   {
     "id": "osmo1r82whw6efky7yjk6rlruf4pxva2crqtezkt7s095wulqrea2w46qkxm9wd",
-    "lp_token_id": "TODO",
+    "lp_token_id": "419",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -6111,7 +6013,7 @@
   },
   {
     "id": "osmo1r83hq5aynm6skjpxltxvrfk2ve4dn23mzczp5d2xcp9xth6skghqyn2zu8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "638",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593"
@@ -6121,7 +6023,7 @@
   },
   {
     "id": "osmo1r8ed7qcfkvpqggzf5ckhfxzswjpgdxvkg78t3f92rr3mvla942dqq0fvj3",
-    "lp_token_id": "TODO",
+    "lp_token_id": "312",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6131,7 +6033,7 @@
   },
   {
     "id": "osmo1rayrpuu7sravv2ug4gh8w0k769cmg2s7ykc6xen4777wm27l547qhcpzfk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "901",
     "asset_ids": [
       "ibc/47CAF2DB8C016FAC960F33BC492FD8E454593B65CC59D70FA9D9F30424F9C32F",
       "uosmo"
@@ -6141,7 +6043,7 @@
   },
   {
     "id": "osmo1rcgcf8rx24qffmxv76xswwps8g3vcvcargf9zsq93uwlzgt3ymdq9errgw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "727",
     "asset_ids": [
       "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
       "uosmo"
@@ -6151,7 +6053,7 @@
   },
   {
     "id": "osmo1rclh8r9e0qtn284uusgqydgnjjv2d2w5v9e5ngrk0exzlua9x2ssnmtk48",
-    "lp_token_id": "TODO",
+    "lp_token_id": "583",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -6161,7 +6063,7 @@
   },
   {
     "id": "osmo1re957uvznxe6jme4zmzm5d95lajz5an7mrdus85faakrj45qa57sshx5g9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "155",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -6171,7 +6073,7 @@
   },
   {
     "id": "osmo1replyw8a8pp2t78k9adu35zhg7l9npknka2teh58zyt6emkg3xusyt0xew",
-    "lp_token_id": "TODO",
+    "lp_token_id": "245",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6181,7 +6083,7 @@
   },
   {
     "id": "osmo1rk8tjedu75vr3s0usxulggkw5kfazcmv6gq72429nvdc468mf3wq67xw8g",
-    "lp_token_id": "TODO",
+    "lp_token_id": "342",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6191,7 +6093,7 @@
   },
   {
     "id": "osmo1rmhusclghxyvyxr9kq4nuum9pvsgplfpuvq0x5d0ufaaxrwkefqsardn6n",
-    "lp_token_id": "TODO",
+    "lp_token_id": "796",
     "asset_ids": [
       "ibc/E09ED39F390EC51FA9F3F69BEA08B5BBE6A48B3057B2B1C3467FAAE9E58B021B",
       "uosmo"
@@ -6201,7 +6103,7 @@
   },
   {
     "id": "osmo1rp8xap0z59k20fkt7078q8g4t37ee8reqpwt6afgglhe3h70hvls9xl5c4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "885",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/B9606D347599F0F2FDF82BA3EE339000673B7D274EA50F59494DC51EFCD42163"
@@ -6211,7 +6113,7 @@
   },
   {
     "id": "osmo1rpu7k863l2pmdcw95452j487jxrh0mp77au489z3gjq7quhnk75st72zs4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "765",
     "asset_ids": [
       "ibc/423967B46B1A51D78619085105B04FCFA14F7CBC0BE7539A316B2DCDFC7D8C07",
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
@@ -6221,7 +6123,7 @@
   },
   {
     "id": "osmo1rq2qekdlt662cjr7zx5xknctju7zd4j8xhk7e0qcnsl4g2u0yr6qpej2sl",
-    "lp_token_id": "TODO",
+    "lp_token_id": "343",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
@@ -6231,7 +6133,7 @@
   },
   {
     "id": "osmo1rrje5862udx9e0en3qve8539gvh33rfgfpzel9jxxvnjxxzmrnmqpc3vcz",
-    "lp_token_id": "TODO",
+    "lp_token_id": "645",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84"
@@ -6241,7 +6143,7 @@
   },
   {
     "id": "osmo1rsr5pqt50eml482jhtg44mx9nc555wjd90vhz4hwkmrm7qngqx9sr3pvvp",
-    "lp_token_id": "TODO",
+    "lp_token_id": "763",
     "asset_ids": [
       "ibc/022A879A5301CBCACF96216C967805F15C33C615B74DC7236027C1BA1BF664FF",
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
@@ -6251,7 +6153,7 @@
   },
   {
     "id": "osmo1ruqysu3pjzyv35w3fwk8mjprz8ludwc9xgexlvse40yqxd5hnmlqzlgjkm",
-    "lp_token_id": "TODO",
+    "lp_token_id": "752",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/F35C87A18804313088DAAF6FD430FCCCF1362BC3464D4FAD783C476F594C9CA7"
@@ -6261,7 +6163,7 @@
   },
   {
     "id": "osmo1rv4ercmn82tl55su3e79j2cvatgewx8qesqtgm3d9n7r6fy33esqektmlm",
-    "lp_token_id": "TODO",
+    "lp_token_id": "622",
     "asset_ids": [
       "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -6271,7 +6173,7 @@
   },
   {
     "id": "osmo1rvlrxqytp0f6rw8k9g6j5y3t45l9v26l40y2rplh00a3ape2chesgq2dc7",
-    "lp_token_id": "TODO",
+    "lp_token_id": "377",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
@@ -6281,7 +6183,7 @@
   },
   {
     "id": "osmo1rwswjnqfhkl8der73ac3q9ydcms8qkwcypksnu8pg2y5kf7enqjq8fas74",
-    "lp_token_id": "TODO",
+    "lp_token_id": "321",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -6291,17 +6193,14 @@
   },
   {
     "id": "osmo1rxur0nsztn90mua2zv7ectqeht7ujzdfnfzwuny25da4k8vla4rsy8hls8",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/1",
-      "gamm/pool/7"
-    ],
+    "lp_token_id": "429",
+    "asset_ids": ["gamm/pool/1", "gamm/pool/7"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1ryh98w99c3a26fjw09e4xd46jd00qfh2y9g38fk9zcd4ady5h0nqzpyvfx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "165",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uosmo"
@@ -6311,7 +6210,7 @@
   },
   {
     "id": "osmo1rysdtqarh8y3yzlmpjwuaqvh3rhhqznqkex35wmhaxrvuqegvu3syuz3wa",
-    "lp_token_id": "TODO",
+    "lp_token_id": "646",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/4F3B0EC2FE2D370D10C3671A1B7B06D2A964C721470C305CBB846ED60E6CAA20"
@@ -6321,7 +6220,7 @@
   },
   {
     "id": "osmo1rz76daxyz9vhf079ahgr6l76uah9xvhe65vu8dqyf5nq7674d3yss96x7w",
-    "lp_token_id": "TODO",
+    "lp_token_id": "530",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
@@ -6331,7 +6230,7 @@
   },
   {
     "id": "osmo1rzsrh74px4ycnvwk936ycujp2q7ndhnvka7pt65pukvkvnpskfkqxf47ue",
-    "lp_token_id": "TODO",
+    "lp_token_id": "417",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6341,7 +6240,7 @@
   },
   {
     "id": "osmo1s2gwy72r2dnpk0dpfs0aftz7rahxsuglz30qkqdgzqsrpczyeexqay78uk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "205",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6351,7 +6250,7 @@
   },
   {
     "id": "osmo1s3x4ey025k3ew7pamenlh89twqcd496rg0c9ye2ydnrxe6y68z8ss3g7az",
-    "lp_token_id": "TODO",
+    "lp_token_id": "706",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -6361,27 +6260,21 @@
   },
   {
     "id": "osmo1s46juu2q7ets8tgqaytaaekfs5qu259tkex87ll068xsvfcf8uas6rkavc",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "lp_token_id": "598",
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1s4eem3yk9de5xk8wr9gs9shc2905skd7h4e589cqs94pyrqem5jqn8y2ru",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/410",
-      "gamm/pool/411"
-    ],
+    "lp_token_id": "413",
+    "asset_ids": ["gamm/pool/410", "gamm/pool/411"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1s666n6f6qhw2hcgkmwx3jxl7hz35cytrygmcvzcxxt84e8nrjfus4wyknj",
-    "lp_token_id": "TODO",
+    "lp_token_id": "739",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -6391,7 +6284,7 @@
   },
   {
     "id": "osmo1s6nlndkuna63w5kk5npduwful69urrfvdlhn74awcan2dpx43xpsr4cxf9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "527",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
@@ -6401,7 +6294,7 @@
   },
   {
     "id": "osmo1s7p0al0sygrqumxlwhw0wfdazdasgew8wx0vspvhf7fwkfcxy03q3x7rcs",
-    "lp_token_id": "TODO",
+    "lp_token_id": "199",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
@@ -6411,7 +6304,7 @@
   },
   {
     "id": "osmo1sf7twk9v5kkkredzk465wqk6s959ttuaf4683quu28q459e3jmlqkss6pa",
-    "lp_token_id": "TODO",
+    "lp_token_id": "556",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6421,7 +6314,7 @@
   },
   {
     "id": "osmo1sfqrusqfe0rfydt7aj8vwe59ujleu9zt6t7zrz58y0uv50sm7vpqvw2sdt",
-    "lp_token_id": "TODO",
+    "lp_token_id": "219",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -6431,7 +6324,7 @@
   },
   {
     "id": "osmo1shzv0vcddhe0jh4wdh2xudrrw20uzu96ugsmyv29p5zscpk85snsmyjnjl",
-    "lp_token_id": "TODO",
+    "lp_token_id": "790",
     "asset_ids": [
       "ibc/7C781B4C2082CD62129A972D47486D78EC17155C299270E3C89348EA026BEAF8",
       "uosmo"
@@ -6441,7 +6334,7 @@
   },
   {
     "id": "osmo1sknzx8cw662aspm7f5xygfhuh9hkf76qqgqwshaqhmp9m920ahlqanwq25",
-    "lp_token_id": "TODO",
+    "lp_token_id": "36",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6451,7 +6344,7 @@
   },
   {
     "id": "osmo1skxw2mkpqnja6me7hmee5xu0l3h76a5jsahnwtk7tgeqszx0l33s6depu9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "754",
     "asset_ids": [
       "ibc/27C09777C9F51B8AAE6BC15F92CFFDF2AB04067569A81D4938BA67EEC8D2E5D3",
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
@@ -6461,7 +6354,7 @@
   },
   {
     "id": "osmo1sl6dla60tg44s0qk56sjvu6rhpuzfedd2xs3vm6es9v4q5smd7lqt0rgct",
-    "lp_token_id": "TODO",
+    "lp_token_id": "816",
     "asset_ids": [
       "ibc/EB7FB9C8B425F289B63703413327C2051030E848CE4EAAEA2E51199D6D39D3EC",
       "uosmo"
@@ -6471,7 +6364,7 @@
   },
   {
     "id": "osmo1snexrsplcnsstsmwp99jf3uua2f9pazcd0drgmmfr6kj22sdwm7scdkrdj",
-    "lp_token_id": "TODO",
+    "lp_token_id": "62",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
@@ -6481,7 +6374,7 @@
   },
   {
     "id": "osmo1spsg7ka3mfknz2s8h6y8qg2azku322mfe3ryvluyhrygh6j4rr3s6ra4ca",
-    "lp_token_id": "TODO",
+    "lp_token_id": "161",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
@@ -6491,7 +6384,7 @@
   },
   {
     "id": "osmo1sqan5vpspvyqtjj4spykrstq7ltgkvdsxuky5rurzzswejsdgd9qes5tjx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "78",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6501,7 +6394,7 @@
   },
   {
     "id": "osmo1ssj7weswfdu3lz737evr5plqvgaqk28fl4akc085gghlxnu0qwvqdms4jc",
-    "lp_token_id": "TODO",
+    "lp_token_id": "222",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "uosmo"
@@ -6511,7 +6404,7 @@
   },
   {
     "id": "osmo1stxalepejns0zm5rpq09jxwcg98r4a2m86kx9n598t32l079pwcsd2wg5n",
-    "lp_token_id": "TODO",
+    "lp_token_id": "197",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
@@ -6521,7 +6414,7 @@
   },
   {
     "id": "osmo1svp9sxdq6qq4k2qpy8ldcf9368eejnawajcetpggpxkj5v5thvaswn32xf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "414",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6531,7 +6424,7 @@
   },
   {
     "id": "osmo1szh2gzzsugx6e5vs7emkcrmcy87zg75jst8xemdp896v33u5f5eqt395ku",
-    "lp_token_id": "TODO",
+    "lp_token_id": "356",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uion"
@@ -6541,7 +6434,7 @@
   },
   {
     "id": "osmo1szvslwsxf3y2s4lt3c7e7mm92zgy44j8krruht5zzanmhrjwyc4qqpt5nz",
-    "lp_token_id": "TODO",
+    "lp_token_id": "621",
     "asset_ids": [
       "ibc/307E5C96C8F60D1CBEE269A9A86C0834E1DB06F2B3788AE4F716EDB97A48B97D",
       "uosmo"
@@ -6551,7 +6444,7 @@
   },
   {
     "id": "osmo1t0k2etaylj6w3tjs5wgn068hz4uyj7fpzs8707a4v02pj580mlrq9fyem2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "738",
     "asset_ids": [
       "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -6561,7 +6454,7 @@
   },
   {
     "id": "osmo1t0lgy5t88ctq2ur4xzjuk2rw6laxt434hsjn6shzwn7w0tph7z2s9p7qdc",
-    "lp_token_id": "TODO",
+    "lp_token_id": "819",
     "asset_ids": [
       "ibc/44492EAB24B72E3FB59B9FA619A22337FB74F95D8808FE6BC78CC0E6C18DC2EC",
       "uosmo"
@@ -6571,7 +6464,7 @@
   },
   {
     "id": "osmo1t2m0y54hrjmvs2zvxgy8005fjg4atqmveg9jafvzmqw64l42aawspdgj9z",
-    "lp_token_id": "TODO",
+    "lp_token_id": "328",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
@@ -6581,7 +6474,7 @@
   },
   {
     "id": "osmo1t2qlvhu8766gmcgs7jnpyx5ey2hfje6uhjffgsn0rgzu3xx7cuzsl9wgt6",
-    "lp_token_id": "TODO",
+    "lp_token_id": "655",
     "asset_ids": [
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
@@ -6591,7 +6484,7 @@
   },
   {
     "id": "osmo1t3de20l6jhz6gpx7v48upxzfkgu7d3r8nclkr5h7z53mvc7mfqyqcyqe25",
-    "lp_token_id": "TODO",
+    "lp_token_id": "440",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -6601,7 +6494,7 @@
   },
   {
     "id": "osmo1t7zz28h30kjmd5rt0yg4gzd8g4ne0y6gpr5rf2zvsj6gs3fmcf8swfrmp8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "394",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6611,7 +6504,7 @@
   },
   {
     "id": "osmo1t9hcnngffyvx3jagrr5wwetkdu3at3sf50a8jdfj7rwe7cyq8tks6t9cz0",
-    "lp_token_id": "TODO",
+    "lp_token_id": "382",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
@@ -6621,7 +6514,7 @@
   },
   {
     "id": "osmo1taqxtna5e558fvstm2065n3zaej3ya2x3vv49a27uun80vduvk3ss4tscg",
-    "lp_token_id": "TODO",
+    "lp_token_id": "330",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6631,7 +6524,7 @@
   },
   {
     "id": "osmo1tf2uj9pdmkys6wzk2fwpcnp5x90lc9t5y8qw4ha2mms2nc5kkkesu3zj54",
-    "lp_token_id": "TODO",
+    "lp_token_id": "559",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525"
@@ -6641,7 +6534,7 @@
   },
   {
     "id": "osmo1tg2k5rxex7zhzh3rcvmy6a2yfvw8446ezk7utz8j80vmkrpjve2qljc6hk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "803",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901"
@@ -6651,7 +6544,7 @@
   },
   {
     "id": "osmo1tgdxkfgc6k6fg9k8e3vpdkwxtwltx93ywfx959yn2e5ysxxpr7vsffd9jn",
-    "lp_token_id": "TODO",
+    "lp_token_id": "220",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6661,7 +6554,7 @@
   },
   {
     "id": "osmo1tgza0v4m0tlkgsew6jjup3zaqcv7qyx58gfzct8xyfx3d9vsv3mqetw8c7",
-    "lp_token_id": "TODO",
+    "lp_token_id": "185",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6671,7 +6564,7 @@
   },
   {
     "id": "osmo1thscstwxp87g0ygh7le3h92f9ff4sel9y9d2eysa25p43yf43rysk7jp93",
-    "lp_token_id": "TODO",
+    "lp_token_id": "604",
     "asset_ids": [
       "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4",
       "uosmo"
@@ -6681,7 +6574,7 @@
   },
   {
     "id": "osmo1tl43tjmylclp37jduelnwrzeyuef2unxn9c04wrlakmgvzsnmgtqqet6za",
-    "lp_token_id": "TODO",
+    "lp_token_id": "628",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6691,7 +6584,7 @@
   },
   {
     "id": "osmo1trzwktd05mqzn8arhczsf7lwvmmfxmuducfvp3upzmlzs7jl38dscuprsg",
-    "lp_token_id": "TODO",
+    "lp_token_id": "637",
     "asset_ids": [
       "ibc/346786EA82F41FE55FAD14BF69AD8BA9B36985406E43F3CB23E6C45A285A9593",
       "uosmo"
@@ -6701,7 +6594,7 @@
   },
   {
     "id": "osmo1tusadtwjnzzyakm94t5gjqr4dlkdcp63hctlql6xvslvkf7kkdws5lfyxc",
-    "lp_token_id": "TODO",
+    "lp_token_id": "498",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
@@ -6711,7 +6604,7 @@
   },
   {
     "id": "osmo1tuxr32k9pmshd5v2tuf89e2npc7j299cmpzscc74ec59xzkrr6fqmy2eda",
-    "lp_token_id": "TODO",
+    "lp_token_id": "822",
     "asset_ids": [
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC",
       "uosmo"
@@ -6721,7 +6614,7 @@
   },
   {
     "id": "osmo1tvfrcswx4c0dsma5z2nmuct34dresknmmaay0lrpsu0wsgh9q08qkv0zj2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "612",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -6731,7 +6624,7 @@
   },
   {
     "id": "osmo1tvv7j7c7hmantw8rkkkkhr2hx6kpckc5zkvnce30la6m048nckms0s5076",
-    "lp_token_id": "TODO",
+    "lp_token_id": "243",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6741,7 +6634,7 @@
   },
   {
     "id": "osmo1tx2ewuhrm0ypyuud04lslhwg5cwnn5ykxsqx49p9l2l94fn7tr2qw9um6j",
-    "lp_token_id": "TODO",
+    "lp_token_id": "318",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6751,7 +6644,7 @@
   },
   {
     "id": "osmo1txawpctjs6phpqsnkx2r5qud7yvekw93394anhuzz4dquy5jggssgqtn0l",
-    "lp_token_id": "TODO",
+    "lp_token_id": "42",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "uosmo"
@@ -6761,7 +6654,7 @@
   },
   {
     "id": "osmo1ty9g3v2xpn70v7pw2jmzmy6npdsdw4e9yd9l5na9rs8qpjhnk89sawgrnw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "599",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -6771,7 +6664,7 @@
   },
   {
     "id": "osmo1tyjwq32pxv3xvpcdkkc8lp3gxkjdlll53grsjkqce3nsjctl328qpqfvj2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "495",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
@@ -6781,7 +6674,7 @@
   },
   {
     "id": "osmo1u05s34q3hk8mu3ypw6g5eqvfdvcllck8zualccz2p75lmdnmwgaszyg9ez",
-    "lp_token_id": "TODO",
+    "lp_token_id": "508",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
@@ -6791,7 +6684,7 @@
   },
   {
     "id": "osmo1u0mjawl7cr9qjk5zfgmat5tlqgxgj5n999kal34kuu9k0mxrghqsm58fep",
-    "lp_token_id": "TODO",
+    "lp_token_id": "384",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6801,7 +6694,7 @@
   },
   {
     "id": "osmo1u0xmctf2dcz3qvmkhcp8prdq2xktnryyq6lshcccyr3jwfvpf9wq0rq3xy",
-    "lp_token_id": "TODO",
+    "lp_token_id": "157",
     "asset_ids": [
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -6811,7 +6704,7 @@
   },
   {
     "id": "osmo1u3402aty7hhz9zpsg4kkvcxs6skg6ly8lrrmky79tcuhccszk3vq59x0t2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "260",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6821,7 +6714,7 @@
   },
   {
     "id": "osmo1u4nna8ml32n0u3fwcrfl0c3e7j8feaay0l5nzc2z850us2dkd9jqmvumll",
-    "lp_token_id": "TODO",
+    "lp_token_id": "86",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6831,7 +6724,7 @@
   },
   {
     "id": "osmo1u66wkjthdjxnavklpef7yzasdrvvqhckmhkqsw8uwlad3uaktr3qvny8k4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "681",
     "asset_ids": [
       "ibc/5D1F516200EE8C6B2354102143B78A2DEDA25EDE771AC0F8DC3C1837C8FD4447",
       "uosmo"
@@ -6841,7 +6734,7 @@
   },
   {
     "id": "osmo1u6wc5hkhg50kxdn9l8pye6zt6jvh5czeej86r4c6segzt0sw6wnsn7rj2x",
-    "lp_token_id": "TODO",
+    "lp_token_id": "280",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
@@ -6851,7 +6744,7 @@
   },
   {
     "id": "osmo1u7uh9vvf85la2ukh60td0q07aq0mnvthxe7x0rutc0envm9865cqjesutw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "736",
     "asset_ids": [
       "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
       "uosmo"
@@ -6861,7 +6754,7 @@
   },
   {
     "id": "osmo1uc9j2thyq26jvktz4dsnya508dzr6ksjgl2w0lspsf2rdt64qu2qvgdz52",
-    "lp_token_id": "TODO",
+    "lp_token_id": "46",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -6871,7 +6764,7 @@
   },
   {
     "id": "osmo1udj4gj4hx5l3k24qvn2cd08vmg7m6ewmxp65lxzfp2dq9xeqmv0s6kl8a7",
-    "lp_token_id": "TODO",
+    "lp_token_id": "366",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
@@ -6881,7 +6774,7 @@
   },
   {
     "id": "osmo1ueg0m04nxj230juk08w9hlua8uupp3jgeclzllk98fzq592xly8q6zgg4w",
-    "lp_token_id": "TODO",
+    "lp_token_id": "465",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "uosmo"
@@ -6891,7 +6784,7 @@
   },
   {
     "id": "osmo1ufuvzzlzu6qpre7hg2tkkm8st3qrx9g8ja4e9empma3kt9adqjcquklmqc",
-    "lp_token_id": "TODO",
+    "lp_token_id": "397",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -6901,7 +6794,7 @@
   },
   {
     "id": "osmo1ugdp9q0nzcsmlllk9acvvuvt4h6g8fy0gspwgdtue06ya0vk4khqdka26t",
-    "lp_token_id": "TODO",
+    "lp_token_id": "258",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -6911,7 +6804,7 @@
   },
   {
     "id": "osmo1uhpsqy52rs5dkwfpua5qulc4rcaw7y857zha0skzp3yxnd0k9k6ss44rjs",
-    "lp_token_id": "TODO",
+    "lp_token_id": "642",
     "asset_ids": [
       "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -6921,7 +6814,7 @@
   },
   {
     "id": "osmo1uny6uzpdfqa9q2cea7ycnuwfr8s6c2zvyt6s7yh2rvvzt0zvhl6q6hdhdu",
-    "lp_token_id": "TODO",
+    "lp_token_id": "98",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
@@ -6931,7 +6824,7 @@
   },
   {
     "id": "osmo1uppkz7d2r68qalz483ppa9w2z2lt0j35ext23vk0djtd9kh85g2qk66tlm",
-    "lp_token_id": "TODO",
+    "lp_token_id": "521",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6941,7 +6834,7 @@
   },
   {
     "id": "osmo1upzrcc4clr9cgttqqkfrt8yz73swd085edn8yfhtv65k2jansdlqnvnfyt",
-    "lp_token_id": "TODO",
+    "lp_token_id": "573",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "uosmo"
@@ -6951,7 +6844,7 @@
   },
   {
     "id": "osmo1uqzdmre9vd0y9uzzm03umja3l9wmqdx3enl8fkfh9xa26yq7m77sx7xfkc",
-    "lp_token_id": "TODO",
+    "lp_token_id": "820",
     "asset_ids": [
       "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -6961,7 +6854,7 @@
   },
   {
     "id": "osmo1utasxm8e2h7jermwv8mrv55nyphnpnkm2zrqzvn8hstx927s4q3sfkfprw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "880",
     "asset_ids": [
       "ibc/19305E20681911F14D1FB275E538CDE524C3BF88CF9AE5D5F78F4D4DA05E85B2",
       "uosmo"
@@ -6971,7 +6864,7 @@
   },
   {
     "id": "osmo1uvsrputqqa8g2dg3s9673w4r6yj8dclfzr4ctsk9jtgwvjwxjq7q297cdn",
-    "lp_token_id": "TODO",
+    "lp_token_id": "396",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6981,7 +6874,7 @@
   },
   {
     "id": "osmo1uxp60ju3h8ghmm2hae9adfulscrg2me5pr9zvl07lngmj0nr7lksqwfv32",
-    "lp_token_id": "TODO",
+    "lp_token_id": "784",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -6991,7 +6884,7 @@
   },
   {
     "id": "osmo1uxqg4sr2yqvamc96n4kwkgna6nmmgtypfdn2gjhvwgymuunq3qlswyrdhg",
-    "lp_token_id": "TODO",
+    "lp_token_id": "725",
     "asset_ids": [
       "ibc/64BA6E31FE887D66C6F8F31C7B1A80C7CA179239677B4088BB55F5EA07DBE273",
       "uosmo"
@@ -7001,7 +6894,7 @@
   },
   {
     "id": "osmo1uyhjnu2l0qfxs3ltt2nuq6lx2fs8ff34684f0hw7sf557enrkd2ql6r2sl",
-    "lp_token_id": "TODO",
+    "lp_token_id": "239",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -7011,7 +6904,7 @@
   },
   {
     "id": "osmo1uyhzfnjxp6a9gq3020f8d45ueszr5sj72p5cfry7hzg0zderhvzsscrkvx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "878",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9"
@@ -7021,7 +6914,7 @@
   },
   {
     "id": "osmo1v009a23dwz827gk4p23sf4tz0chyuwkht0ygerp2v09qhpmxw5eq52q9n7",
-    "lp_token_id": "TODO",
+    "lp_token_id": "286",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
@@ -7031,7 +6924,7 @@
   },
   {
     "id": "osmo1v2982uaxxxmfyykkcusc2jlgrh43l6q646gdd27skr2smq8d8cwqksnw4j",
-    "lp_token_id": "TODO",
+    "lp_token_id": "902",
     "asset_ids": [
       "ibc/2FBAC4BF296D7844796844B35978E5899984BA5A6314B2DD8F83C215550010B3",
       "uosmo"
@@ -7041,7 +6934,7 @@
   },
   {
     "id": "osmo1v38v9n62pm4ktce0khdglyxzr3f8jdlahdux87q9m8x6uz4zfkesjv8wga",
-    "lp_token_id": "TODO",
+    "lp_token_id": "663",
     "asset_ids": [
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -7051,7 +6944,7 @@
   },
   {
     "id": "osmo1v4gaqzdvmhdm4varxsd3qc385jser59vgpcxm8f5u9e9sjp58lzqlaw3kw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "804",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/C140AFD542AE77BD7DCC83F13FDD8C5E5BB8C4929785E6EC2F4C636F98F17901"
@@ -7061,7 +6954,7 @@
   },
   {
     "id": "osmo1v4ulnkt7dj9903qvyeqz6d5u3rpjttcy6vzydt5gurqxunxyghgqw0u2d4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "113",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
@@ -7071,7 +6964,7 @@
   },
   {
     "id": "osmo1v5cueex2ajn35u8a3mr586vy9xf2tzl3n5ylghnwrc9ssnwwydnsk5gvm6",
-    "lp_token_id": "TODO",
+    "lp_token_id": "578",
     "asset_ids": [
       "ibc/B547DC9B897E7C3AA5B824696110B8E3D2C31E3ED3F02FF363DCBAD82457E07E",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -7081,7 +6974,7 @@
   },
   {
     "id": "osmo1v5eg7ch5gfj6aewdahuplj7ddhrlhq9cugp98lznnf542g4f9vgsv2lvxf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "317",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -7091,7 +6984,7 @@
   },
   {
     "id": "osmo1v6py2esnzl6pe6pg6mr42n37qrvcryavq3zjamwpa5csdayrgfts8dz4fx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "170",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -7101,7 +6994,7 @@
   },
   {
     "id": "osmo1v8289lc5hweg6qr3jhhsy3d4m2lf8663xz4fkwv8jcc5k3chgkwsxwky24",
-    "lp_token_id": "TODO",
+    "lp_token_id": "659",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "ibc/8318FD63C42203D16DDCAF49FE10E8590669B3219A3E87676AC9DA50722687FB"
@@ -7111,7 +7004,7 @@
   },
   {
     "id": "osmo1v8f030n78vpwrswjuppndv2h3p775g0q39znmew8tw6jv89fk5wsahrtk9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "150",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -7121,7 +7014,7 @@
   },
   {
     "id": "osmo1v9r9d4xk9j2r3m59hcnsy7037wu75ymyg6nc0em23rpwmp9nj3yqgz5wvw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "778",
     "asset_ids": [
       "ibc/52C57FCA7D6854AA178E7A183DDBE4EF322B904B1D719FC485F6FFBC1F72A19E",
       "uosmo"
@@ -7131,7 +7024,7 @@
   },
   {
     "id": "osmo1val3zsn82xutf9tnadwxahva6cs9mscxkq7y9dhjpl5lvrqdp5xslvllw0",
-    "lp_token_id": "TODO",
+    "lp_token_id": "801",
     "asset_ids": [
       "ibc/67795E528DF67C5606FC20F824EA39A6EF55BA133F4DC79C90A8C47A0901E17C",
       "ibc/C2A2E9CA95DDD4828B75124B5E27B8401C7D8493BC48353D418CBFC04565899B"
@@ -7141,7 +7034,7 @@
   },
   {
     "id": "osmo1vdlumhjnpdngk80dmuyq4vdngew4fscvlhq4tpgy8c8edswqapwse9987x",
-    "lp_token_id": "TODO",
+    "lp_token_id": "799",
     "asset_ids": [
       "ibc/161D7D62BAB3B9C39003334F1671208F43C06B643CC9EDBBE82B64793C857F1D",
       "uosmo"
@@ -7151,17 +7044,14 @@
   },
   {
     "id": "osmo1vedjqp8mzcr5yg8h0s75lg0l074nx8leqkj0efzvha8wpdus3nxq0myg32",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/10",
-      "uosmo"
-    ],
+    "lp_token_id": "101",
+    "asset_ids": ["gamm/pool/10", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1vgmqyyu3gmnyr8w3g27uf5l02p76jz4gvjcwzrp40cjh55xht4qsrdmdsy",
-    "lp_token_id": "TODO",
+    "lp_token_id": "605",
     "asset_ids": [
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228",
       "uosmo"
@@ -7171,7 +7061,7 @@
   },
   {
     "id": "osmo1vlqfs02w9l4ygp9wnkfpr54av4vdzea4czytvuccc5628pz7amzs2tftm6",
-    "lp_token_id": "TODO",
+    "lp_token_id": "893",
     "asset_ids": [
       "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
       "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796"
@@ -7181,7 +7071,7 @@
   },
   {
     "id": "osmo1vmhq9xqcr702fspu9qmf22ggzu8fh4d374zs487068m4p5xh694sxgxza8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "461",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
@@ -7191,7 +7081,7 @@
   },
   {
     "id": "osmo1vnw5jmjusus6drlae4nv4l2dn2vg90lav77dvphj0r3gn9x2rh8qmz9ckh",
-    "lp_token_id": "TODO",
+    "lp_token_id": "369",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076"
@@ -7201,7 +7091,7 @@
   },
   {
     "id": "osmo1vp0kxdq263kzawqmv394tjevw7useexp2hhh7835cjqjl28nkpmsum5nhn",
-    "lp_token_id": "TODO",
+    "lp_token_id": "473",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
@@ -7211,7 +7101,7 @@
   },
   {
     "id": "osmo1vp9mwqrxt4dsyu4c0hzjpl79sw483wkqsfq8m7jrmjh9775ddn5snw8ccv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "857",
     "asset_ids": [
       "ibc/23CA6C8D1AB2145DD13EB1E089A2E3F960DC298B468CCE034E19E5A78B61136E",
       "uosmo"
@@ -7221,7 +7111,7 @@
   },
   {
     "id": "osmo1vsadpr4k8xu6ply4yw084tjgyrqkeee99ktnjjjfus44pyzcs6mq5ml9xj",
-    "lp_token_id": "TODO",
+    "lp_token_id": "540",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
@@ -7231,7 +7121,7 @@
   },
   {
     "id": "osmo1vtqgpkdd7taj8ssw4rlcd7ulu7wgmujfxlyaa3qkfztva07pm0sq2qkscy",
-    "lp_token_id": "TODO",
+    "lp_token_id": "911",
     "asset_ids": [
       "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
@@ -7241,7 +7131,7 @@
   },
   {
     "id": "osmo1vx63kemxaxedvulz9xh45d9k0gc7udec35gy4my9f7tzywfeqljs52vdzf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "898",
     "asset_ids": [
       "ibc/B1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF",
       "uosmo"
@@ -7251,7 +7141,7 @@
   },
   {
     "id": "osmo1vyra2jgneztsn207a39dk5jhj7xu3ruh7hwuaq9jmmlf7averklq9lx3k4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "460",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -7261,7 +7151,7 @@
   },
   {
     "id": "osmo1vyz8a2xv27nj2t4xwm6h6rqpt6fhea08fsmg56tdlep7n3k3t2tsks5fxr",
-    "lp_token_id": "TODO",
+    "lp_token_id": "574",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452"
@@ -7271,7 +7161,7 @@
   },
   {
     "id": "osmo1w3dsuh2hcp90vmhwrdxxftgm44edlcvn8xtzfvq2h457ma8hm00smpxet2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "235",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -7281,7 +7171,7 @@
   },
   {
     "id": "osmo1w3e7ywcnj6090nedg39p34mwthpuq25ly8d92kzg0pdx9kptlesswcj39s",
-    "lp_token_id": "TODO",
+    "lp_token_id": "916",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/573FCD90FACEE750F55A8864EF7D38265F07E5A9273FA0E8DAFD39951332B580"
@@ -7291,7 +7181,7 @@
   },
   {
     "id": "osmo1w4w9gj02z3hv7qlry8mpju625qrevrtf2f2nmywu45j3j4mnahuskfrf38",
-    "lp_token_id": "TODO",
+    "lp_token_id": "90",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -7301,7 +7191,7 @@
   },
   {
     "id": "osmo1w5awgnxgthpwdh4nl25ymdx78x8cnjepdh6ju7ep6gaq5up35l9qhzkfyz",
-    "lp_token_id": "TODO",
+    "lp_token_id": "594",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -7311,7 +7201,7 @@
   },
   {
     "id": "osmo1w7na4s0suuchqfqsz0fyszu2udc68wgxsgk3vsrtvzdfyyfseevsufcx4e",
-    "lp_token_id": "TODO",
+    "lp_token_id": "276",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -7321,7 +7211,7 @@
   },
   {
     "id": "osmo1w9rj85ugnk29uepdglrhuhusdx0wwh4ep5vks92apfryaeu9pq9q7yv3gm",
-    "lp_token_id": "TODO",
+    "lp_token_id": "288",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -7331,7 +7221,7 @@
   },
   {
     "id": "osmo1wea46n3f86um4dp37t43pwpurcky9e7lz56tujrtcql9yx6sphtqee256z",
-    "lp_token_id": "TODO",
+    "lp_token_id": "529",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED"
@@ -7341,17 +7231,14 @@
   },
   {
     "id": "osmo1wehlg2lrvqxjmy26ghkqdj4c653se5kr646z9rwwfflutj25dvnsn6ef3f",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/123",
-      "uosmo"
-    ],
+    "lp_token_id": "284",
+    "asset_ids": ["gamm/pool/123", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1wfghlu9wguwrdrrv3su4fzkmsc80et9k2x796k6q4n0yvn2fx5wqe0mpve",
-    "lp_token_id": "TODO",
+    "lp_token_id": "742",
     "asset_ids": [
       "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -7361,7 +7248,7 @@
   },
   {
     "id": "osmo1wh6azmp9dxraquxt2gyppgeyuvta2r3s3s72cx7xr6nprh8kgj4sl3qf0x",
-    "lp_token_id": "TODO",
+    "lp_token_id": "548",
     "asset_ids": [
       "ibc/1DCC8A6CB5689018431323953344A9F6CC4D0BFB261E88C9F7777372C10CD076",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
@@ -7371,7 +7258,7 @@
   },
   {
     "id": "osmo1wjeftfc4708ly99x8mpty0faedwqmu6hw20v7dwxyma4vvn3u4jqmh9zh7",
-    "lp_token_id": "TODO",
+    "lp_token_id": "126",
     "asset_ids": [
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
       "uosmo"
@@ -7381,7 +7268,7 @@
   },
   {
     "id": "osmo1wjggh0jgm6mukp2rjcyas5w5eep20yqgxjcn9eqxh4rktcdku4aspnq4ka",
-    "lp_token_id": "TODO",
+    "lp_token_id": "137",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -7391,17 +7278,14 @@
   },
   {
     "id": "osmo1wkspj354sp059377j67mk6uy48t7u2cm86609nq7xht47hj9mkzs39x3fd",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "gamm/pool/1",
-      "uosmo"
-    ],
+    "lp_token_id": "152",
+    "asset_ids": ["gamm/pool/1", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1wlqxs0yh5m46hz5kaq2jmzc0vetrykej4zjm25kcpe9crxnvfxtqrnker2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "714",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
@@ -7411,7 +7295,7 @@
   },
   {
     "id": "osmo1wtd5nrx9f2uwu32z3njuhxtzxj4qcedrjlyrsm6q073yp84ryjgs5tgtq3",
-    "lp_token_id": "TODO",
+    "lp_token_id": "733",
     "asset_ids": [
       "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3",
       "uosmo"
@@ -7421,7 +7305,7 @@
   },
   {
     "id": "osmo1wv6v6mgychqdmf9fj5esyrethnu86akn6gyqq7rlexacjjcht37qfsqjdl",
-    "lp_token_id": "TODO",
+    "lp_token_id": "698",
     "asset_ids": [
       "ibc/F49DE040EBA5AB2FAD5F660C2A1DDF98A68470FAE82229818BE775EBF3EE79F2",
       "uosmo"
@@ -7431,7 +7315,7 @@
   },
   {
     "id": "osmo1wxkx8kq5uvt4snu77ezhxclpecv95t3jyvagte8em9j6dk3jgczs66quh3",
-    "lp_token_id": "TODO",
+    "lp_token_id": "715",
     "asset_ids": [
       "ibc/2716E3F2E146664BEFA9217F1A03BFCEDBCD5178B3C71CACB1A0D7584451D219",
       "uosmo"
@@ -7441,7 +7325,7 @@
   },
   {
     "id": "osmo1wy5zsjq8mzyehg7g72hsf0v487a2h87sr30wzztjx9h0ct593zysl6444w",
-    "lp_token_id": "TODO",
+    "lp_token_id": "636",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -7451,7 +7335,7 @@
   },
   {
     "id": "osmo1wyv2pa3xmrfgjgkd9s6v0e23dud2va6kgaaknyqm6kly6x228xvsh45uug",
-    "lp_token_id": "TODO",
+    "lp_token_id": "120",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -7461,7 +7345,7 @@
   },
   {
     "id": "osmo1wyz6659ctwd28cq5nlw9a4jslm7nxydvg3uex2xmcl8y9fd49tjsfegg38",
-    "lp_token_id": "TODO",
+    "lp_token_id": "309",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -7471,7 +7355,7 @@
   },
   {
     "id": "osmo1x0ptme5tp8r2qw8gsypg3qftfwfpt2hdk4jyvp7gryywmg5l9fsqvhs8fk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "806",
     "asset_ids": [
       "ibc/A8CA5EE328FA10C9519DF6057DA1F69682D28F7D0F5CCC7ECB72E3DCA2D157A4",
       "uosmo"
@@ -7481,7 +7365,7 @@
   },
   {
     "id": "osmo1x20esk0tjalpqjf6x8rz9plrlc8yam36c39lmqpm080dsyg6klhq4jdnvx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "644",
     "asset_ids": [
       "ibc/9BCB27203424535B6230D594553F1659C77EC173E36D9CF4759E7186EE747E84",
       "uosmo"
@@ -7491,7 +7375,7 @@
   },
   {
     "id": "osmo1x2cwskve25argave9s4392lwygg7j9fzxhxra97tvvpt80kvzxsswm0hqu",
-    "lp_token_id": "TODO",
+    "lp_token_id": "657",
     "asset_ids": [
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
       "ibc/B9E0A1A524E98BB407D3CED8720EFEFD186002F90C1B1B7964811DD0CCC12228"
@@ -7501,7 +7385,7 @@
   },
   {
     "id": "osmo1x2wr6fllcwv9jmcwtq3lwjvuyutmcxf55q8a853jylah057lhl8scgqn06",
-    "lp_token_id": "TODO",
+    "lp_token_id": "690",
     "asset_ids": [
       "ibc/CBA34207E969623D95D057D9B11B0C8B32B89A71F170577D982FDDE623813FFC",
       "uosmo"
@@ -7511,7 +7395,7 @@
   },
   {
     "id": "osmo1x5rh04vsyxx2u8enwpawhplmrhk7yrq82ulpj9wjcrt6j5y5n44q8vy2da",
-    "lp_token_id": "TODO",
+    "lp_token_id": "785",
     "asset_ids": [
       "ibc/5A7C219BA5F7582B99629BA3B2A01A61BFDA0F6FD1FE95B5366F7334C4BC0580",
       "uosmo"
@@ -7521,7 +7405,7 @@
   },
   {
     "id": "osmo1x6fpwjj6ur324atc4p2whc3rsdkaj2ecs4z5ckeu38eljv70mswqlmpqem",
-    "lp_token_id": "TODO",
+    "lp_token_id": "914",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -7531,7 +7415,7 @@
   },
   {
     "id": "osmo1x6uvl8ef00hwl2ymgxfq40q9zjnykjw9u2w55466yl256lpqdpgqs9hpfg",
-    "lp_token_id": "TODO",
+    "lp_token_id": "63",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
@@ -7541,7 +7425,7 @@
   },
   {
     "id": "osmo1x9g0qwks7t6u47cxnnqg6jyfaxczwk678eedr7z890n8dnwtx9fqvqwzkx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "124",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -7551,7 +7435,7 @@
   },
   {
     "id": "osmo1x9pjf7ehhdlfy035xy0t8rwp3dke6vhcdrtw2s35727ceh7ra7vslncd3q",
-    "lp_token_id": "TODO",
+    "lp_token_id": "721",
     "asset_ids": [
       "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F",
       "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
@@ -7561,7 +7445,7 @@
   },
   {
     "id": "osmo1xct94me26df4k2fs6waecnvzca8dzv2jxl798tndqq3ync3tdkqskpn5cl",
-    "lp_token_id": "TODO",
+    "lp_token_id": "709",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -7571,7 +7455,7 @@
   },
   {
     "id": "osmo1xe9d4uyaq5ek8u85kgvxusdadnx7u9k09cauv4f8gn9e7xr4xycq7rwn88",
-    "lp_token_id": "TODO",
+    "lp_token_id": "87",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -7581,7 +7465,7 @@
   },
   {
     "id": "osmo1xf4n7h4fqt0qlc5gagfhu36n7jm05vrn8yhnf6kcxcjasf9u8eas585xt7",
-    "lp_token_id": "TODO",
+    "lp_token_id": "416",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -7591,7 +7475,7 @@
   },
   {
     "id": "osmo1xfs2qqsx3vpy3nc2rna332afmk48sxpgh7cd6usvfrw0gcdcmz2qej4ywx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "237",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC"
@@ -7601,7 +7485,7 @@
   },
   {
     "id": "osmo1xhe34xslh74jyw8xl5p4auu5238zzhre7mcpd9kcxmfkrp5fuj9s4e6ldh",
-    "lp_token_id": "TODO",
+    "lp_token_id": "811",
     "asset_ids": [
       "ibc/903A61A498756EA560B85A85132D3AEE21B5DEDD41213725D22ABF276EA6945E",
       "uosmo"
@@ -7611,7 +7495,7 @@
   },
   {
     "id": "osmo1xjd0l22txgpce4fh2kgjy7gmvhszzl05nzw7e7lc76qddxrywqpscj5pl8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "54",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -7621,7 +7505,7 @@
   },
   {
     "id": "osmo1xky9ttqjpqltad9y420x7ylnw5k8sh6ctnk57dvytvgaesywzccsnyptkl",
-    "lp_token_id": "TODO",
+    "lp_token_id": "764",
     "asset_ids": [
       "ibc/4E5444C35610CC76FC94E7F7886B93121175C28262DDFDDE6F84E82BF2425452",
       "ibc/C1CEF00F016FE89EA6E5B07DA895AACD91B0AAD69A991033D846B988AD4FB69D"
@@ -7631,7 +7515,7 @@
   },
   {
     "id": "osmo1xlq92gxx6a9zca4gjculx80gmpykh6lz2npustn27s7g7t2hcels964a7n",
-    "lp_token_id": "TODO",
+    "lp_token_id": "744",
     "asset_ids": [
       "ibc/BB6BCDB515050BAE97516111873CCD7BCF1FD0CCB723CC12F3C4F704D6C646CE",
       "uosmo"
@@ -7641,7 +7525,7 @@
   },
   {
     "id": "osmo1xp9gm8zw4fg7xrvu006eh7enpc0ywtsspv9ezzf7yqzpv2gpvd4qugqgvy",
-    "lp_token_id": "TODO",
+    "lp_token_id": "614",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -7651,7 +7535,7 @@
   },
   {
     "id": "osmo1xr84lqj48rxlhk3w5weesczvl3tzemep6k5s968j6mmmvaml5e2qxhlngm",
-    "lp_token_id": "TODO",
+    "lp_token_id": "490",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293"
@@ -7661,7 +7545,7 @@
   },
   {
     "id": "osmo1xslx5c73axa9t7xypphtc83zw6jvucwxcahfnfltc8fclqnuxz9s0833tw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "633",
     "asset_ids": [
       "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
       "uosmo"
@@ -7671,7 +7555,7 @@
   },
   {
     "id": "osmo1xsqe6aprxzmw4l7vzghjxxq2t3j504utx4aqpryy3tlerz7rmw7smsfnfl",
-    "lp_token_id": "TODO",
+    "lp_token_id": "372",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -7681,7 +7565,7 @@
   },
   {
     "id": "osmo1xtresmp9jt2w7p40zj8rcvatc0lgwqj62elmerqd6n2pya03yyvszt0fng",
-    "lp_token_id": "TODO",
+    "lp_token_id": "363",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -7691,7 +7575,7 @@
   },
   {
     "id": "osmo1xu8x23y94cjwexgxerr6pak0fprngxh4xwyw4stw6pny2ktw4qaq9k3xvw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "780",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/D27DDDF34BB47E5D5A570742CC667DE53277867116CCCA341F27785E899A70F3"
@@ -7701,7 +7585,7 @@
   },
   {
     "id": "osmo1xumj3tzy3f3cy0e98tj4plu3g9sq9rn86g0gzel6qk05stplwrpst2grm6",
-    "lp_token_id": "TODO",
+    "lp_token_id": "374",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -7711,7 +7595,7 @@
   },
   {
     "id": "osmo1xuufuq55r4ukh6xgfkfkvhlgvgsy2z7wacchctvj9yllcc695lusvc3hml",
-    "lp_token_id": "TODO",
+    "lp_token_id": "900",
     "asset_ids": [
       "ibc/5E2DFDF1734137302129EA1C1BA21A580F96F778D4F021815EA4F6DB378DA1A4",
       "uosmo"
@@ -7721,7 +7605,7 @@
   },
   {
     "id": "osmo1xv2t67l0x59r6gl4wpgx925qlgy38ua325jyugh0yah5jkzp0amsw0aqpc",
-    "lp_token_id": "TODO",
+    "lp_token_id": "378",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -7731,7 +7615,7 @@
   },
   {
     "id": "osmo1xw730drgcts95umje5fwekx8dgpn4dg756d4a4y26jfhy6ekuu9q78qycc",
-    "lp_token_id": "TODO",
+    "lp_token_id": "704",
     "asset_ids": [
       "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
       "uosmo"
@@ -7741,7 +7625,7 @@
   },
   {
     "id": "osmo1xxg0pnmyxj7xlvdvxrqdzrecaa2fquq97egpkf248t6kxuklsdjqazsyq0",
-    "lp_token_id": "TODO",
+    "lp_token_id": "850",
     "asset_ids": [
       "ibc/47EE224A9B33CF0ABEAC82106E52F0F6E8D8CEC5BA80B9D9A6F55172CBB0177D",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -7751,7 +7635,7 @@
   },
   {
     "id": "osmo1xzjr9a7t3k0y2498yh9cxmexy0vk6cwlx7jcvwvhlh6trs2t44zste5zhz",
-    "lp_token_id": "TODO",
+    "lp_token_id": "314",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -7761,7 +7645,7 @@
   },
   {
     "id": "osmo1xzwgqxu9y7dhqq8ka33p9rs9ayej8cs742jn2akvuj0jkdvvuktqf4xdxv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "68",
     "asset_ids": [
       "gamm/pool/1",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -7771,7 +7655,7 @@
   },
   {
     "id": "osmo1y04x26mggspuwp8racsxukq2avuwk4q5frwyzm59szxy2x0s52sqq8men0",
-    "lp_token_id": "TODO",
+    "lp_token_id": "711",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -7781,7 +7665,7 @@
   },
   {
     "id": "osmo1y09t7vkps2p7ppe2aqfuqhje2zkmnk4t72yagk30286p9zw8e68s7mylm8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "338",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -7791,7 +7675,7 @@
   },
   {
     "id": "osmo1y28qvpn23cuem32qt6jsrshmy5wj3ndn46lyh7p0dt5w8q0vxuwqfxhpzz",
-    "lp_token_id": "TODO",
+    "lp_token_id": "275",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -7801,7 +7685,7 @@
   },
   {
     "id": "osmo1y3g6lwd5p72z5uxgm4z6wy7asyg53wg83np7mg3cz2wnf9zhl69q8shlnd",
-    "lp_token_id": "TODO",
+    "lp_token_id": "587",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/3BCCC93AD5DF58D11A6F8A05FA8BC801CBA0BA61A981F57E91B8B598BF8061CB"
@@ -7811,7 +7695,7 @@
   },
   {
     "id": "osmo1y3hutqnstzdx096nf47hw5s5pmu67cgzpz0gjh2f4cr39dw0uptstdjjln",
-    "lp_token_id": "TODO",
+    "lp_token_id": "519",
     "asset_ids": [
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1",
       "uosmo"
@@ -7821,7 +7705,7 @@
   },
   {
     "id": "osmo1y3jhypynwrdjyqu0y3t9qs6kpkuspysdcpatal25ll2792hkf2lsy9d9u8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "588",
     "asset_ids": [
       "ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -7831,7 +7715,7 @@
   },
   {
     "id": "osmo1y3ptmx57hvu7au6s9r3fxq00856896unkdyqaump7vedag248l0qc03asg",
-    "lp_token_id": "TODO",
+    "lp_token_id": "481",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "uosmo"
@@ -7841,7 +7725,7 @@
   },
   {
     "id": "osmo1y5dfzzdhyh9azqczjazk5v8vacf8we8f4gwlmyjc57s39jcgcp2s6d4l4k",
-    "lp_token_id": "TODO",
+    "lp_token_id": "80",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -7851,7 +7735,7 @@
   },
   {
     "id": "osmo1y5wz4pl4xpwrgr9mpjfmfewfa5nfns4473s9zs29c7c5q8w7pskqccf39r",
-    "lp_token_id": "TODO",
+    "lp_token_id": "595",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
@@ -7861,7 +7745,7 @@
   },
   {
     "id": "osmo1y6gvkz0qu93h7zgkrrhr6fqye5ny9ddpm9az2l5kjr0mmw9n48mqpmcnnv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "571",
     "asset_ids": [
       "ibc/D805F1DA50D31B96E4282C1D4181EDDFB1A44A598BFF5666F4B43E4B8BEA95A5",
       "uosmo"
@@ -7871,7 +7755,7 @@
   },
   {
     "id": "osmo1y820u9050hz23a48e7wzw5mnqftplvj205l0vaw3tx7g609l32zsxdyeam",
-    "lp_token_id": "TODO",
+    "lp_token_id": "504",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -7881,7 +7765,7 @@
   },
   {
     "id": "osmo1ya0hny0hsc73q4tnn6wdswk777r9e5pxhswm3ej5f624zahxmzcs2ygthd",
-    "lp_token_id": "TODO",
+    "lp_token_id": "779",
     "asset_ids": [
       "ibc/49C2B2C444B7C5F0066657A4DBF19D676E0D185FF721CFD3E14FA253BCB9BC04",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -7891,7 +7775,7 @@
   },
   {
     "id": "osmo1ycedur3klym2dwlz0w0796zqmn7fdzn6fldwc6cuzqwarejcuq2qu8z96e",
-    "lp_token_id": "TODO",
+    "lp_token_id": "899",
     "asset_ids": [
       "ibc/6F62F01D913E3FFE472A38C78235B8F021B511BC6596ADFF02615C8F83D3B373",
       "uosmo"
@@ -7901,7 +7785,7 @@
   },
   {
     "id": "osmo1yeu83fklh2vxjts7evnm8439rj326zwgqldaz4sr470pu29jr88qujz9hu",
-    "lp_token_id": "TODO",
+    "lp_token_id": "269",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -7911,7 +7795,7 @@
   },
   {
     "id": "osmo1yfhmdj7akjtj8me0l3ttn3p475mdeuz032uzpl5n09q8evdzc7xsv6yj25",
-    "lp_token_id": "TODO",
+    "lp_token_id": "563",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -7921,7 +7805,7 @@
   },
   {
     "id": "osmo1yfs3zurxezmggujt5ffxyzerx5ujjsuzm07y0dy8p69z3l9w3d5s9nyagx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "894",
     "asset_ids": [
       "ibc/D3ADAF73F84CDF205BCB72C142FDAEEA2C612AB853CEE6D6C06F184FA38B1099",
       "uosmo"
@@ -7931,7 +7815,7 @@
   },
   {
     "id": "osmo1yggqusvjqscjy03ysdmjh5hxmt6tv20u5ufrsuy67ksnw2xqsvzql2j70s",
-    "lp_token_id": "TODO",
+    "lp_token_id": "562",
     "asset_ids": [
       "ibc/0EF15DF2F02480ADE0BB6E85D9EBB5DAEA2836D3860E9F97F9AADE4F57A31AA0",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -7941,7 +7825,7 @@
   },
   {
     "id": "osmo1yjpgrff07qx7q2tykqthtenyk7tmlnjy83097y00g20ncuxut8hsgwm4p9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "717",
     "asset_ids": [
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F",
       "ibc/AA1C80225BCA7B32ED1FC6ABF8B8E899BEB48ECDB4B417FD69873C6D715F97E7"
@@ -7951,7 +7835,7 @@
   },
   {
     "id": "osmo1yn7z42al3mafmztjayjduz42a8at3whyd279fkdsyumzar83x8mqvpw83x",
-    "lp_token_id": "TODO",
+    "lp_token_id": "631",
     "asset_ids": [
       "ibc/297C64CC42B5A8D8F82FE2EBE208A6FE8F94B86037FA28C4529A23701C228F7A",
       "uosmo"
@@ -7961,7 +7845,7 @@
   },
   {
     "id": "osmo1yqqtrljj2xcdldwgtwgjeqte69lf8wdyfcx99jffc669natgslcske6ku3",
-    "lp_token_id": "TODO",
+    "lp_token_id": "700",
     "asset_ids": [
       "ibc/00B6E60AD3D65CBEF5579AC8AF609527C0B57535B6E32D96C80A735344FD9DCC",
       "uosmo"
@@ -7971,7 +7855,7 @@
   },
   {
     "id": "osmo1ysvqrdxtp489v8q03fun60nyr2v4p7p35dsf3g6cgln4avw6d4msdpldt2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "278",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -7981,7 +7865,7 @@
   },
   {
     "id": "osmo1yugu88lhymszf7plpnn9ez07a34w2fxne7j44zqfqycgu8xx8cyqxmq5w2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "750",
     "asset_ids": [
       "ibc/E97634A40119F1898989C2A23224ED83FDD0A57EA46B3A094E287288D1672B44",
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
@@ -7991,7 +7875,7 @@
   },
   {
     "id": "osmo1yurhrjdwh4j3h5ck5tj08u9ht38qaxq4vu9ad7nn4jcf23lnfxvsclex5j",
-    "lp_token_id": "TODO",
+    "lp_token_id": "142",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -8001,7 +7885,7 @@
   },
   {
     "id": "osmo1yuu7x52t2df6f0287md68q8l3u90h9jxjurcnxpskvve2de9krgqmm7mjm",
-    "lp_token_id": "TODO",
+    "lp_token_id": "693",
     "asset_ids": [
       "ibc/CE5BFF1D9BADA03BB5CCA5F56939392A761B53A10FBD03B37506669C3218D3B2",
       "uosmo"
@@ -8011,7 +7895,7 @@
   },
   {
     "id": "osmo1yv7jtrkt3t9t3mtsndxx7392azzmawyyy0k9qn97rv35dkluyp7qzyswmn",
-    "lp_token_id": "TODO",
+    "lp_token_id": "720",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -8021,7 +7905,7 @@
   },
   {
     "id": "osmo1ywwh6qsau3fqc507puxqv22re0eqthuyk7xpfgxvdv62d53ydlasd0lpnp",
-    "lp_token_id": "TODO",
+    "lp_token_id": "335",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84"
@@ -8031,7 +7915,7 @@
   },
   {
     "id": "osmo1yxs0cp0gdrc552u8whe293q8al4w6f5v2nl5cmdeecwx3p9m2p8qk7adjc",
-    "lp_token_id": "TODO",
+    "lp_token_id": "617",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA"
@@ -8041,7 +7925,7 @@
   },
   {
     "id": "osmo1z0693astkr0t976z8fs22902qxnl8rhjw44uglll9qk07h7wpt6sy77yc7",
-    "lp_token_id": "TODO",
+    "lp_token_id": "511",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -8051,7 +7935,7 @@
   },
   {
     "id": "osmo1z390kae9wyjw5lxy5hl4mfc52w6830eflury88mfjsjl9s5708cs5ckkde",
-    "lp_token_id": "TODO",
+    "lp_token_id": "333",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
@@ -8061,7 +7945,7 @@
   },
   {
     "id": "osmo1z4ka2c5hzfpy8qkrefwd2pu7mqnfdxjrvqgch0h0llh269zcta9qxzsty4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "468",
     "asset_ids": [
       "ibc/1DC495FCEFDA068A3820F903EDBD78B942FBD204D7E93D3BA2B432E9669D1A59",
       "uosmo"
@@ -8071,7 +7955,7 @@
   },
   {
     "id": "osmo1z4tn4qh0dj89h5h3jyxprthh324vm88t7netqjeu6855hf7ttugqevfnew",
-    "lp_token_id": "TODO",
+    "lp_token_id": "526",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
@@ -8081,7 +7965,7 @@
   },
   {
     "id": "osmo1z52y99kywzjjv9kf8498jkkva8n6g3epzeds6v9hth85rd90fcvq5zxp6w",
-    "lp_token_id": "TODO",
+    "lp_token_id": "210",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -8091,7 +7975,7 @@
   },
   {
     "id": "osmo1z7pnmk64p2g8qpeu3j70uwv9eu77kj6qyk96mmxehc0lhm5lvmeq6ugylv",
-    "lp_token_id": "TODO",
+    "lp_token_id": "388",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -8101,7 +7985,7 @@
   },
   {
     "id": "osmo1z86kzpdqmrdr6prp8dvj5n73w7t0fc54mx2gq7y30p6awyhun3kq4wxpaz",
-    "lp_token_id": "TODO",
+    "lp_token_id": "492",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -8111,7 +7995,7 @@
   },
   {
     "id": "osmo1z9dqkuhkhuys9hcel25mtuw33awk0svp6afzg3d3j0vqft9cj9aspg97ce",
-    "lp_token_id": "TODO",
+    "lp_token_id": "316",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -8121,7 +8005,7 @@
   },
   {
     "id": "osmo1zd2vqwlvpz4e9xrkvxvc0aa8cqsnwdvpgxulk7n449r6lr4adv3st6mzzf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "639",
     "asset_ids": [
       "ibc/F867AE2112EFE646EC71A25CD2DFABB8927126AC1E19F1BBF0FF693A4ECA05DE",
       "uosmo"
@@ -8131,7 +8015,7 @@
   },
   {
     "id": "osmo1zd632nrrwh6r5wwqs0y6h5qslr3l3yh6kryxtg7zmrclqcrtwefqp0m097",
-    "lp_token_id": "TODO",
+    "lp_token_id": "776",
     "asset_ids": [
       "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
       "uosmo"
@@ -8141,7 +8025,7 @@
   },
   {
     "id": "osmo1zddv3kuvxqulq09dcfur8etz3tax90vjuymtlzzk23ps39ew26cqm3gykf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "233",
     "asset_ids": [
       "ibc/52B1AA623B34EB78FD767CEA69E8D7FA6C9CFE1FBF49C5406268FD325E2CC2AC",
       "uosmo"
@@ -8151,7 +8035,7 @@
   },
   {
     "id": "osmo1zdp0cl67a25r25hslw3xzzt5mmd03ws04vevnthzklxzkg4xg35q8h8dnk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "226",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "uosmo"
@@ -8161,7 +8045,7 @@
   },
   {
     "id": "osmo1ze0t3al4zgndvjla36gp2khjkwwdzr2e4m8vl6fuzfllfrlr8mdq4wnmxt",
-    "lp_token_id": "TODO",
+    "lp_token_id": "745",
     "asset_ids": [
       "ibc/6AE98883D4D5D5FF9E50D7130F1305DA2FFA0C652D1DD9C123657C6B4EB2DF8A",
       "ibc/FE2CD1E6828EC0FAB8AF39BAC45BC25B965BA67CCBC50C13A14BD610B0D1E2C4"
@@ -8171,7 +8055,7 @@
   },
   {
     "id": "osmo1zffkpskd8vv643mwu59ujsgldfz0khlgcvsty8zv9y4t50azf6cqx0a3pp",
-    "lp_token_id": "TODO",
+    "lp_token_id": "615",
     "asset_ids": [
       "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -8181,7 +8065,7 @@
   },
   {
     "id": "osmo1zfgxnef46xmdv6dgnwvem6dpuetr58hwpnwlvvxv0pgsdv8gj86qk22vcy",
-    "lp_token_id": "TODO",
+    "lp_token_id": "897",
     "asset_ids": [
       "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796",
       "uosmo"
@@ -8191,7 +8075,7 @@
   },
   {
     "id": "osmo1zg4rlhp843nn3jk0uz2kvk4zzvp7wm6qpvlnuv7dnp4jlz9pmpws90duk8",
-    "lp_token_id": "TODO",
+    "lp_token_id": "82",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "ibc/7C4D60AA95E5A7558B0A364860979CA34B7FF8AAF255B87AF9E879374470CEC0"
@@ -8201,7 +8085,7 @@
   },
   {
     "id": "osmo1zgnc6xvj607xmtpyu420h378cwgdnlwzhat9wjgsavgkjk5n3ckqx68328",
-    "lp_token_id": "TODO",
+    "lp_token_id": "608",
     "asset_ids": [
       "ibc/8A34AF0C1943FD0DFCDE9ADBF0B2C9959C45E87E6088EA2FC6ADACD59261B8A2",
       "uosmo"
@@ -8211,17 +8095,14 @@
   },
   {
     "id": "osmo1zka4v4c04jr74ludyls2lfzfttzx67qzd070xtnfq90yzyacgn9qv6vend",
-    "lp_token_id": "TODO",
-    "asset_ids": [
-      "uion",
-      "uosmo"
-    ],
+    "lp_token_id": "11",
+    "asset_ids": ["uion", "uosmo"],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1zml837f5en8x2fvvger70l76cmdahrdv5y6m9e6yk0scnddn5w0qj54m60",
-    "lp_token_id": "TODO",
+    "lp_token_id": "837",
     "asset_ids": [
       "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
       "uosmo"
@@ -8231,7 +8112,7 @@
   },
   {
     "id": "osmo1zmxelh7k08hy085shm5y08mqeaqmahee7u77lpnf2h4eufnsyn6qucvfjy",
-    "lp_token_id": "TODO",
+    "lp_token_id": "43",
     "asset_ids": [
       "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
       "uosmo"
@@ -8241,7 +8122,7 @@
   },
   {
     "id": "osmo1zpjym32nr8qt8t8nm9nu2zr5hx90hferfv2jqpt824q9nz38k2vstj704t",
-    "lp_token_id": "TODO",
+    "lp_token_id": "250",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -8251,7 +8132,7 @@
   },
   {
     "id": "osmo1zrm4msu7q238tlhkdyk2pu3px47z47n0tgwrlpf6c08f4ppmwycqfeas0n",
-    "lp_token_id": "TODO",
+    "lp_token_id": "96",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uosmo"
@@ -8261,7 +8142,7 @@
   },
   {
     "id": "osmo1zskwjdwjgxt8r3ukqgcn8z70qtzl5cswy03pkupvzvmwlvcjvtrs4fwrpx",
-    "lp_token_id": "TODO",
+    "lp_token_id": "462",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/5973C068568365FFF40DEDCF1A1CB7582B6116B731CD31A12231AE25E20B871F"
@@ -8271,7 +8152,7 @@
   },
   {
     "id": "osmo1ztfk57933fj6278dn9ja7w60nfq44mndludh2qx62e2tg9hc29lqm8avec",
-    "lp_token_id": "TODO",
+    "lp_token_id": "671",
     "asset_ids": [
       "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
       "ibc/BE1BB42D4BE3C30D50B68D7C41DB4DFCE9678E8EF8C539F6E6A9345048894FCC"
@@ -8281,7 +8162,7 @@
   },
   {
     "id": "osmo1ztk3sfcrdvv2lnmjzfad5qerkevp3y5ny8s3n5t8c94pxwu0putqw3dqtw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "69",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uion"
@@ -8291,7 +8172,7 @@
   },
   {
     "id": "osmo1zvc24h5fd9a2gj7xs30fvp9wmf6jydf3w0updqu5hr6g9turnkzqqh00f4",
-    "lp_token_id": "TODO",
+    "lp_token_id": "190",
     "asset_ids": [
       "ibc/9712DBB13B9631EDFA9BF61B55F1B2D290B2ADB67E3A4EB3A875F3B6081B3B84",
       "ibc/E6931F78057F7CC5DA0FD6CEF82FF39373A6E0452BF1FD76910B93292CF356C1"
@@ -8301,7 +8182,7 @@
   },
   {
     "id": "osmo1zyjk6a4fapusydkauzph93h3c2ssngpfh3retatwaqw32lw20mhqcxu4xw",
-    "lp_token_id": "TODO",
+    "lp_token_id": "534",
     "asset_ids": [
       "ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED",
       "uosmo"
@@ -8311,7 +8192,7 @@
   },
   {
     "id": "osmo1zzn7rddfytcjg26g3s97g2qck2nwz5upfth430fdmnnyph9vjxhqpytc3l",
-    "lp_token_id": "TODO",
+    "lp_token_id": "769",
     "asset_ids": [
       "ibc/1E09CB0F506ACF12FDE4683FB6B34DA62FB4BE122641E0D93AAF98A87675676C",
       "uosmo"
@@ -8321,7 +8202,7 @@
   },
   {
     "id": "osmo16054sn8ug2njt8hnhzk5qy2zh7u8x6nmex3c02970dpmqfepz7hq434rlm",
-    "lp_token_id": "TODO",
+    "lp_token_id": "920",
     "asset_ids": [
       "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
       "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
@@ -8331,7 +8212,7 @@
   },
   {
     "id": "osmo17m8tjws6ce8rqgghcfz09jgew9tcakp3qlw76pt86akerxk3t7rsgkn75e",
-    "lp_token_id": "TODO",
+    "lp_token_id": "873",
     "asset_ids": [
       "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
       "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4"
@@ -8341,7 +8222,7 @@
   },
   {
     "id": "osmo17n9drfwd7sqa5rc7v7xwfv5ucfngg8nttu6j2plvxgvrrt2099qsq54urf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "913",
     "asset_ids": [
       "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
       "ibc/C491E7582E94AE921F6A029790083CDE1106C28F3F6C4AD7F1340544C13EC372"
@@ -8351,7 +8232,7 @@
   },
   {
     "id": "osmo1aqmdce4f8ymqcf7v0a8xcukt8xqga50zqcprta89e9p2fmscfzpscru5lr",
-    "lp_token_id": "TODO",
+    "lp_token_id": "886",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/CAA179E40F0266B0B29FB5EAA288FB9212E628822265D4141EBD1C47C3CBFCBC"
@@ -8361,7 +8242,7 @@
   },
   {
     "id": "osmo1cxlrfu8r0v3cyqj78fuvlsmhjdgna0r7tum8cpd0g3x7w7pte8fsfvcs84",
-    "lp_token_id": "TODO",
+    "lp_token_id": "903",
     "asset_ids": [
       "ibc/46C83BB054E12E189882B5284542DB605D94C99827E367C9192CF0579CD5BC83",
       "ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4"
@@ -8371,7 +8252,7 @@
   },
   {
     "id": "osmo1d3dd4w06c2lyxqm7lf30st89esf4437f3tn42kpv9sh5zug5xdksnnp0nh",
-    "lp_token_id": "TODO",
+    "lp_token_id": "892",
     "asset_ids": [
       "ibc/785AFEC6B3741100D15E7AF01374E3C4C36F24888E96479B1C33F5C71F364EF9",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -8381,7 +8262,7 @@
   },
   {
     "id": "osmo1ewsz7a8zefxq67h4205hlncpfm3np4mky34upu3sktc3llrj5rgqdutjgk",
-    "lp_token_id": "TODO",
+    "lp_token_id": "868",
     "asset_ids": [
       "ibc/01E94A5FF29B8DDEFC86F412CC3927F7330E9B523CC63A6194B1108F5276025C",
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
@@ -8391,7 +8272,7 @@
   },
   {
     "id": "osmo1hayyjltd3mjx6w8g7wtpu2zckk83ecxen2eux6c7tl42unfvnfysqg9myf",
-    "lp_token_id": "TODO",
+    "lp_token_id": "906",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -8401,7 +8282,7 @@
   },
   {
     "id": "osmo1kxnekx4q8yem6wvp5t9ggqvhuxaqw7san00x5qdazp3fe597f8hsqft4nq",
-    "lp_token_id": "TODO",
+    "lp_token_id": "872",
     "asset_ids": [
       "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -8411,7 +8292,7 @@
   },
   {
     "id": "osmo1r4r0ryw0pq2yhwcqwf8pg4w0fr764k3ztv9weuyqcn5hv0zxy67srvgfj2",
-    "lp_token_id": "TODO",
+    "lp_token_id": "884",
     "asset_ids": [
       "ibc/65381C5F3FD21442283D56925E62EA524DED8B6927F0FF94E21E0020954C40B5",
       "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5"
@@ -8421,7 +8302,7 @@
   },
   {
     "id": "osmo1rdcx38vnf0tvx6x0xkel747m0rqkv5lg20lfww8gtdrydmu00pyqgefkm9",
-    "lp_token_id": "TODO",
+    "lp_token_id": "862",
     "asset_ids": [
       "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -8431,7 +8312,7 @@
   },
   {
     "id": "osmo1xfcjgr8l0e2pp3mx2qlcu5u4x0vt84cuzhwyytvmvhlnm5kjww8qudwh8y",
-    "lp_token_id": "TODO",
+    "lp_token_id": "863",
     "asset_ids": [
       "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
       "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858"
@@ -8441,7 +8322,7 @@
   },
   {
     "id": "osmo1ylzwp5r95sqjmkjem3hu0ynslaxjd2tzv6udfhrlrtyhj4zerttq3343su",
-    "lp_token_id": "TODO",
+    "lp_token_id": "888",
     "asset_ids": [
       "ibc/C9B0D48FD2C5B91135F118FF2484551888966590D7BDC20F6A87308DBA670796",
       "ibc/D1542AA8762DB13087D8364F3EA6509FD6F009A34F00426AF9E4F9FA85CBBF1F"

--- a/osmosis/pool.json
+++ b/osmosis/pool.json
@@ -112,7 +112,10 @@
   {
     "id": "osmo10g7srpl9gqhetplp6d2fr7l25ckjrtcsupk60984w8vf2zugcvjq6ashnq",
     "lp_token_id": "103",
-    "asset_ids": ["gamm/pool/102", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/102",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -189,7 +192,10 @@
   {
     "id": "osmo10sh5u7pl9dwh7ll8wfaahr0trkka4rv2k9amlj88s72k6v8paufs0qnz7p",
     "lp_token_id": "403",
-    "asset_ids": ["gamm/pool/222", "gamm/pool/402"],
+    "asset_ids": [
+      "gamm/pool/222",
+      "gamm/pool/402"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -216,7 +222,10 @@
   {
     "id": "osmo10uut208crprz36gpw3wwh50e6yuuq8jxf5yamdclg4vr84uw8cmqkunxkx",
     "lp_token_id": "493",
-    "asset_ids": ["gamm/pool/1", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/1",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -233,7 +242,10 @@
   {
     "id": "osmo10v35xj20k0jrfgs8p3lqt5gyga0wug3kkh4pq6xt3x4hqh5huvcssp04d3",
     "lp_token_id": "255",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -440,7 +452,10 @@
   {
     "id": "osmo12nxhn6pc44eguzf53y37nkpjqv80u3n0kxtuffyqrp0h0vkqccfqu2f7pk",
     "lp_token_id": "393",
-    "asset_ids": ["gamm/pool/1", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/1",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -457,7 +472,10 @@
   {
     "id": "osmo12vkrtnxwpkq7hnsnchs06ya7rv0vdpchxrgt7jktjm4kupzx8l2s6nfhny",
     "lp_token_id": "73",
-    "asset_ids": ["gamm/pool/41", "gamm/pool/53"],
+    "asset_ids": [
+      "gamm/pool/41",
+      "gamm/pool/53"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -774,7 +792,10 @@
   {
     "id": "osmo13u649up5fe79u2aq0d3rsl5x48lulu5yred75lcuw94dlugfxdqq39hz0s",
     "lp_token_id": "320",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -1071,7 +1092,10 @@
   {
     "id": "osmo1500hy75krs9e8t50aav6fahk8sxhajn9ctp40qwvvn8tcprkk6wszun4a5",
     "lp_token_id": "2",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -1198,7 +1222,10 @@
   {
     "id": "osmo15e4a88d0vmd7ywh9e2ll8q447defplgamwza9ezay67z84cxmx7ssu8s6q",
     "lp_token_id": "106",
-    "asset_ids": ["gamm/pool/101", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/101",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -1355,7 +1382,10 @@
   {
     "id": "osmo15v7xfk7qnm27r2kwsutegh3jt2ye7haadqlnt5xf89hkp29hx0cq4sgqr6",
     "lp_token_id": "364",
-    "asset_ids": ["gamm/pool/361", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/361",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -1542,7 +1572,10 @@
   {
     "id": "osmo16dn4uk4xlqshzufy3f0as2pnvdpwqlwepp0m5qumwh2c4vgmp9jqaa0zsh",
     "lp_token_id": "569",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -1589,7 +1622,10 @@
   {
     "id": "osmo16qzex7q0cpj3dflx79ycqvsujm0dt838lfjv9fjg80zna7jpn2ssn3cta4",
     "lp_token_id": "395",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -1846,7 +1882,10 @@
   {
     "id": "osmo17rujtwmvk8vp3uqq6xxkymk83n3qethhejuar7ayhyuupcsw66mqmg4k28",
     "lp_token_id": "344",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -2193,7 +2232,10 @@
   {
     "id": "osmo196w6qg0r3cfy9rx00390wkfdj9krd93uaed3nlht5uhqfh2avcyq3aldku",
     "lp_token_id": "392",
-    "asset_ids": ["gamm/pool/1", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/1",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -2260,7 +2302,10 @@
   {
     "id": "osmo19esg8fulwzufjjarprfpu4mz06zjpkmk7p0wydcw5q900lp2k3mq7afv7m",
     "lp_token_id": "503",
-    "asset_ids": ["gamm/pool/502", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/502",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -2437,7 +2482,10 @@
   {
     "id": "osmo1a0ev3jr6fts7y09as95pryn59hzwfkaletpusfzctejjy0wqa47sxqgy3a",
     "lp_token_id": "358",
-    "asset_ids": ["gamm/pool/356", "gamm/pool/357"],
+    "asset_ids": [
+      "gamm/pool/356",
+      "gamm/pool/357"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -2514,7 +2562,10 @@
   {
     "id": "osmo1adzv0qftyywfavf06uqh0lutcqz5nz5favasq58rkvnu4l3zvs7shy9kxu",
     "lp_token_id": "367",
-    "asset_ids": ["gamm/pool/364", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/364",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -2571,7 +2622,10 @@
   {
     "id": "osmo1ang9dlvxrc0n835xyxvwf66mj0mm0sznyqwtu03kdd2dmhg40hlqnq36up",
     "lp_token_id": "246",
-    "asset_ids": ["gamm/pool/1", "gamm/pool/8"],
+    "asset_ids": [
+      "gamm/pool/1",
+      "gamm/pool/8"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -2688,7 +2742,10 @@
   {
     "id": "osmo1c8gdt3cquepqadv6ys2m9ht8eys40c2ws46ntwm7zknr2hwcsuhsly32ft",
     "lp_token_id": "81",
-    "asset_ids": ["gamm/pool/13", "gamm/pool/5"],
+    "asset_ids": [
+      "gamm/pool/13",
+      "gamm/pool/5"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -2775,7 +2832,10 @@
   {
     "id": "osmo1cgw34ya7ndpmplgv5wyec4mz7hq3crc64uqq02qv6zk9vxun2rksk8fcja",
     "lp_token_id": "75",
-    "asset_ids": ["gamm/pool/73", "gamm/pool/74"],
+    "asset_ids": [
+      "gamm/pool/73",
+      "gamm/pool/74"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -2992,7 +3052,10 @@
   {
     "id": "osmo1daztxlwd90kqt7yw7mvakhp9kjd34g250dywutq06nvlze2u6uhsuk26xw",
     "lp_token_id": "194",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -3349,7 +3412,10 @@
   {
     "id": "osmo1ejcrrmfxaphd6nf270r34467u2a407mewhq5g5cz6hdhzqs7nnxsvpthf9",
     "lp_token_id": "380",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -3976,7 +4042,10 @@
   {
     "id": "osmo1gy7usssxrzsepfpn9z07456cqqmumtmn5mw3wgc5jpmwt2ha8qdqwxy09x",
     "lp_token_id": "74",
-    "asset_ids": ["gamm/pool/1", "gamm/pool/73"],
+    "asset_ids": [
+      "gamm/pool/1",
+      "gamm/pool/73"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -4093,7 +4162,10 @@
   {
     "id": "osmo1hgxsqpxghfw7pwwl8jwxzy04cyll8nhf6ejnxpx3wvkszkq6rznqap0yuc",
     "lp_token_id": "505",
-    "asset_ids": ["gamm/pool/503", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/503",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -4430,7 +4502,10 @@
   {
     "id": "osmo1k33jzr6syz8fs9jlsjerwum53ctu9nzkfdr3uy58ddt2tpsnsw0sl8ff3s",
     "lp_token_id": "135",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -4447,7 +4522,10 @@
   {
     "id": "osmo1k4gj3utpx0s3pmtq7shmyhdq2dp605e03hcprvzvec7jq2ge2u7s4r0wp4",
     "lp_token_id": "545",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -4524,7 +4602,10 @@
   {
     "id": "osmo1kchnwg6y2y4r2nyjartp9q3ss4ysjkx9gzgxwdtg6624g6natn3seyj0f4",
     "lp_token_id": "402",
-    "asset_ids": ["gamm/pool/222", "gamm/pool/323"],
+    "asset_ids": [
+      "gamm/pool/222",
+      "gamm/pool/323"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -4781,7 +4862,10 @@
   {
     "id": "osmo1l5ehe7cqgf5fplxegqaukwygaz8g2h62yhdt06te6uem30l2j9mswf6qct",
     "lp_token_id": "50",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -4808,7 +4892,10 @@
   {
     "id": "osmo1lahkpd2rxat3huy3kqkphvugruzxm3d5n0jxve6c8xzmkcvgfw9qjdnkhf",
     "lp_token_id": "107",
-    "asset_ids": ["gamm/pool/104", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/104",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -4885,7 +4972,10 @@
   {
     "id": "osmo1lmk3mgsj2ajp4s34jzfsqscz60nfys4rlsg5u8k03a9420ggyh2qldlmzq",
     "lp_token_id": "61",
-    "asset_ids": ["gamm/pool/38", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/38",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -5042,7 +5132,10 @@
   {
     "id": "osmo1mdqhf078cs0qe7gfcv9rdw0yzvzf0wejvyrlx8hyzcpsfn2zgpyq7l9ly6",
     "lp_token_id": "153",
-    "asset_ids": ["gamm/pool/108", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/108",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -5239,7 +5332,10 @@
   {
     "id": "osmo1nfn4h33t30prnuyrhn20ntvgclzhc8x40mzkngc740r9r3sap4yqaf9c3a",
     "lp_token_id": "360",
-    "asset_ids": ["gamm/pool/359", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/359",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -5276,7 +5372,10 @@
   {
     "id": "osmo1nk8ha9xldmqjn7adgz56tmu87e3yryuzj3upsk20kmy64vmg702squcxue",
     "lp_token_id": "475",
-    "asset_ids": ["gamm/pool/474", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/474",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -5443,7 +5542,10 @@
   {
     "id": "osmo1p9pa7umdvry4u4338hgu4x5pkepnk9pcqddpg65zdj0k3a3ucjts85hj73",
     "lp_token_id": "35",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -5900,7 +6002,10 @@
   {
     "id": "osmo1qtle736upg6t8nmra606axnvnm8fwvffugdfhsn2hs4f8mv7n2yqgvlwt2",
     "lp_token_id": "486",
-    "asset_ids": ["gamm/pool/464", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/464",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -5977,7 +6082,10 @@
   {
     "id": "osmo1r5v05r30s0v75py3n3lhd7sq5cdgkaltles5rk0cmgndrdq7ktxqcn64y8",
     "lp_token_id": "426",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -6194,7 +6302,10 @@
   {
     "id": "osmo1rxur0nsztn90mua2zv7ectqeht7ujzdfnfzwuny25da4k8vla4rsy8hls8",
     "lp_token_id": "429",
-    "asset_ids": ["gamm/pool/1", "gamm/pool/7"],
+    "asset_ids": [
+      "gamm/pool/1",
+      "gamm/pool/7"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -6261,14 +6372,20 @@
   {
     "id": "osmo1s46juu2q7ets8tgqaytaaekfs5qu259tkex87ll068xsvfcf8uas6rkavc",
     "lp_token_id": "598",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
   {
     "id": "osmo1s4eem3yk9de5xk8wr9gs9shc2905skd7h4e589cqs94pyrqem5jqn8y2ru",
     "lp_token_id": "413",
-    "asset_ids": ["gamm/pool/410", "gamm/pool/411"],
+    "asset_ids": [
+      "gamm/pool/410",
+      "gamm/pool/411"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -7045,7 +7162,10 @@
   {
     "id": "osmo1vedjqp8mzcr5yg8h0s75lg0l074nx8leqkj0efzvha8wpdus3nxq0myg32",
     "lp_token_id": "101",
-    "asset_ids": ["gamm/pool/10", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/10",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -7232,7 +7352,10 @@
   {
     "id": "osmo1wehlg2lrvqxjmy26ghkqdj4c653se5kr646z9rwwfflutj25dvnsn6ef3f",
     "lp_token_id": "284",
-    "asset_ids": ["gamm/pool/123", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/123",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -7279,7 +7402,10 @@
   {
     "id": "osmo1wkspj354sp059377j67mk6uy48t7u2cm86609nq7xht47hj9mkzs39x3fd",
     "lp_token_id": "152",
-    "asset_ids": ["gamm/pool/1", "uosmo"],
+    "asset_ids": [
+      "gamm/pool/1",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },
@@ -8096,7 +8222,10 @@
   {
     "id": "osmo1zka4v4c04jr74ludyls2lfzfttzx67qzd070xtnfq90yzyacgn9qv6vend",
     "lp_token_id": "11",
-    "asset_ids": ["uion", "uosmo"],
+    "asset_ids": [
+      "uion",
+      "uosmo"
+    ],
     "dex": "Osmosis",
     "type": "balancerV1"
   },

--- a/terra/asset.json
+++ b/terra/asset.json
@@ -5790,12 +5790,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra129gzxm65ckt7p9tp3rnq8q0zvaz6m48e5l7qpxtmy2s3fnhcjd0sag3tm3",
-    "name": "Stader LunaX Token",
-    "symbol": "LunaX",
-    "decimals": "6"
-  },
-  {
     "id": "terra1s2lr8u69xammmg3s8hemegcz57y07ae0wa7c7d2adupp6du3neyqfukkaz",
     "name": "Stader LunaX Token",
     "symbol": "LunaX",

--- a/terra/asset.json
+++ b/terra/asset.json
@@ -941,7 +941,9 @@
     "name": "Graviton",
     "symbol": "GRAV",
     "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/ibc/GRAV.svg"
+    "icon": "https://assets.terra.money/icon/svg/ibc/GRAV.svg",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/grav/",
+    "coingecko": "https://www.coingecko.com/en/coins/graviton"
   },
   {
     "id": "ibc/4CD525F166D32B0132C095F353F4C6F033B0FF5C49141470D1EFDA1D63303D04",

--- a/terra/asset.json
+++ b/terra/asset.json
@@ -909,8 +909,8 @@
     "symbol": "ATOM",
     "decimals": "6",
     "icon": "https://assets.terra.money/icon/svg/ibc/ATOM.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/cosmos-hub",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/cosmos/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/cosmos/",
+    "coingecko": "https://www.coingecko.com/en/coins/cosmos-hub"
   },
   {
     "id": "ibc/B090DC21658BD57698522880590CA53947B8B09355764131AA94EC75517D46A5",
@@ -945,8 +945,8 @@
     "symbol": "GRAV",
     "decimals": "6",
     "icon": "https://assets.terra.money/icon/svg/ibc/GRAV.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/graviton",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/grav/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/grav/",
+    "coingecko": "https://www.coingecko.com/en/coins/graviton"
   },
   {
     "id": "ibc/4CD525F166D32B0132C095F353F4C6F033B0FF5C49141470D1EFDA1D63303D04",
@@ -955,8 +955,8 @@
     "symbol": "JUNO",
     "decimals": "6",
     "icon": "https://assets.terra.money/icon/svg/ibc/JUNO.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/juno-network",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/juno/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/juno/",
+    "coingecko": "https://www.coingecko.com/en/coins/juno-network"
   },
   {
     "id": "ibc/B22B4DD21586965DAEF42A7600BA371EA77C02E90FC8A7F2330BF9F9DE129B07",
@@ -1005,8 +1005,8 @@
     "symbol": "OSMO",
     "decimals": "6",
     "icon": "https://assets.terra.money/icon/svg/ibc/OSMO.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/osmosis",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/osmosis/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/osmosis/",
+    "coingecko": "https://www.coingecko.com/en/coins/osmosis"
   },
   {
     "id": "terra167khnalh9aawqx9qynj7kk9y0n8hc30qe6s8cy7y5yu2azrc2edqyjprp9",
@@ -1129,8 +1129,8 @@
     "symbol": "SCRT",
     "decimals": "6",
     "icon": "https://assets.terra.money/icon/svg/ibc/SCRT.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/secret",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/secret/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/secret/",
+    "coingecko": "https://www.coingecko.com/en/coins/secret"
   },
   {
     "id": "terra1l23rtnsp0fcfgs2zlww4gcd8dlznkm580p5yrsangcen9jjjhuqstd2sle",
@@ -1155,8 +1155,8 @@
     "decimals": "6",
     "circ_supply_api": "https://phoenix-lcd.terra.dev/cosmwasm/wasm/v1/contract/terra14xsm2wzvu7xaf567r693vgfkhmvfs08l68h4tjj5wjgyn5ky8e2qvzyanh/smart/eyJ0b2tlbl9pbmZvIjp7fX0=",
     "icon": "https://raw.githubusercontent.com/stader-labs/assets/main/terra/LunaX_1.png",
-    "coingecko": "https://www.coingecko.com/en/coins/stader-lunax",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/stader-lunax/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/stader-lunax/",
+    "coingecko": "https://www.coingecko.com/en/coins/stader-lunax"
   },
   {
     "id": "terra1xumzh893lfa7ak5qvpwmnle5m5xp47t3suwwa9s0ydqa8d8s5faqn6x7al",
@@ -1174,8 +1174,8 @@
     "decimals": "6",
     "circ_supply_api": "https://phoenix-api.terra.dev/balance/circulating-supply",
     "icon": "https://assets.terra.money/icon/svg/Luna.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/terra",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-luna-v2/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-luna-v2/",
+    "coingecko": "https://www.coingecko.com/en/coins/terra"
   },
   {
     "id": "terra13j2k5rfkg0qhk58vz63cze0uze4hwswlrfnm0fa4rnyggjyfrcnqcrs5z2",
@@ -1582,8 +1582,8 @@
     "decimals": "6",
     "circ_supply_api": "https://terra-api.valkyrieprotocol.com/partner/coinhall/circulating-supply",
     "icon": "https://app.valkyrieprotocol.com/icon_vkr.png",
-    "coingecko": "https://www.coingecko.com/en/coins/valkyrie-protocol",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/valkyrie-protocol/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/valkyrie-protocol/",
+    "coingecko": "https://www.coingecko.com/en/coins/valkyrie-protocol"
   },
   {
     "id": "terra1qmnxhecc3vnmhef9q7vap7spx9tgpnw9fqe8ljqfwrlz7rur9y5qu2dlp6",
@@ -1592,8 +1592,8 @@
     "symbol": "WAVAX",
     "decimals": "8",
     "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/AVAX_wh.png",
-    "coingecko": "https://www.coingecko.com/en/coins/wrapped-avax",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/wavax/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/wavax/",
+    "coingecko": "https://www.coingecko.com/en/coins/wrapped-avax"
   },
   {
     "id": "terra15hhqg8gyz04zapynqtk7uvlsp7lzay7etrt9ann0276v94yae63sxygeat",
@@ -1602,8 +1602,8 @@
     "symbol": "WETH",
     "decimals": "8",
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs/logo.png",
-    "coingecko": "https://www.coingecko.com/en/coins/weth",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/weth/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/weth/",
+    "coingecko": "https://www.coingecko.com/en/coins/weth"
   },
   {
     "id": "terra1ctelwayk6t2zu30a8v9kdg3u2gr0slpjdfny5pjp7m3tuquk32ysugyjdg",
@@ -1612,8 +1612,8 @@
     "symbol": "SOL",
     "decimals": "8",
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png",
-    "coingecko": "https://www.coingecko.com/en/coins/wrapped-solana",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/wrapped-solana/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/wrapped-solana/",
+    "coingecko": "https://www.coingecko.com/en/coins/wrapped-solana"
   },
   {
     "id": "terra1dwtgrdjtgx3d3laypgx8ptch0kk20skh4p6ra3euy38x6n9s7kws4yzlgf",
@@ -4068,8 +4068,8 @@
     "symbol": "LUNC",
     "decimals": "6",
     "icon": "https://assets.terra.money/icon/svg/LUNC.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/terra-luna-classic",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-luna/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-luna/",
+    "coingecko": "https://www.coingecko.com/en/coins/terra-luna-classic"
   },
   {
     "id": "terra1fvdcu2j85nrlhwhy0rmhttst2caaxtf36ytjcngg47qkt8ndcu8sm6qff6",
@@ -6692,8 +6692,8 @@
     "name": "UST (Wormhole)",
     "symbol": "UST",
     "decimals": "6",
-    "coingecko": "https://www.coingecko.com/en/coins/terrausd-wormhole",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/terrausd-wormhole/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terrausd-wormhole/",
+    "coingecko": "https://www.coingecko.com/en/coins/terrausd-wormhole"
   },
   {
     "id": "terra10tclyxjfcx7u0wd0d0he4muqvhd6nn6d7lr2ktmga275tq0axamqs6gxnj",

--- a/terra/asset.json
+++ b/terra/asset.json
@@ -1091,7 +1091,7 @@
   {
     "id": "terra1q8kfp0v9rhef0d3u44ds9shwvwcusjheh8nhye3n7gwjd95ze96sehyp6w",
     "entity": "Santerra",
-    "name": "Santerra SANT",
+    "name": "Santerra",
     "symbol": "SANT",
     "decimals": "6",
     "icon": "https://santerra.app/sant_logo.svg"
@@ -1128,6 +1128,13 @@
     "symbol": "SD",
     "decimals": "8",
     "icon": "https://raw.githubusercontent.com/stader-labs/assets/main/terra/SD_Token.png"
+  },
+  {
+    "id": "terra129gzxm65ckt7p9tp3rnq8q0zvaz6m48e5l7qpxtmy2s3fnhcjd0sag3tm3",
+    "entity": "Stader Labs",
+    "name": "Stader LunaX Token",
+    "symbol": "LunaX",
+    "decimals": "6"
   },
   {
     "id": "terra14xsm2wzvu7xaf567r693vgfkhmvfs08l68h4tjj5wjgyn5ky8e2qvzyanh",
@@ -1597,6 +1604,24 @@
     "decimals": "6"
   },
   {
+    "id": "terra19jtesa3t75krekhf62jjedtrk3y7l9phnkspfhyyrfqxz7c4jhusw5vlux",
+    "name": "__proto__ (Wormhole)",
+    "symbol": "__proto__",
+    "decimals": "8"
+  },
+  {
+    "id": "terra14vcfzv7f3ucedpmxsue9glsg6gnkw38js7srjynmmu60zpn3w3ys2ukckv",
+    "name": "__proto__.__proto__ (Wormhole)",
+    "symbol": "__proto__.__proto__",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1zk5vshetgylrptlr8x5swd9kp5jprtuhxp9axc6tc6ds30vsj72ss4yee3",
+    "name": "__proto__.admin = true; (Wormhole)",
+    "symbol": "__proto__.admin = true;",
+    "decimals": "8"
+  },
+  {
     "id": "terra1wzp5fl2jdca9xlqgl6wmncuuylfz44y29tg7y8fe77ljc73hedlsaquqay",
     "name": "__T (Wormhole)",
     "symbol": "__T",
@@ -1615,6 +1640,30 @@
     "decimals": "6"
   },
   {
+    "id": "terra16x6ymtdpru5pfmpjdcx3te9dtmz4almzqy5ur4ghth06023udrqqfdea99",
+    "name": ":::::::::::::::::::::::::::::::: (Wormhole)",
+    "symbol": "::::::::::::::::::::::::::::::::",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1lls0emf6ra0gjtc7ym35f7eaaf9f9u5cd92t9u9wjzuw40aru4ds0j34km",
+    "name": ":::::::::::::::::::::::::::::::: (Wormhole)",
+    "symbol": "::::::::::::::::::::::::::::::::",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1vk5efw9sdx09hkzfatpvxzk2jse5t0gj2w8hgnk8m2f0rk5zeazsnuyv3r",
+    "name": ":::::::::::::::::::::::::::::::: (Wormhole)",
+    "symbol": "::::::::::::::::::::::::::::::::",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1wwz4299eputh34ya8jp25kc3m5f7d3kql0ydvh8kj3fku3sayyas7r64wv",
+    "name": ":::::::::::::::::::::::::::::::: (Wormhole)",
+    "symbol": "::::::::::::::::::::::::::::::::",
+    "decimals": "8"
+  },
+  {
     "id": "terra1cmvf7863w80wykszfy5xj8s4asy8urv3u6sfup6wvzezd0alqhsq2ak99c",
     "name": "::T (Wormhole)",
     "symbol": "::T",
@@ -1631,6 +1680,12 @@
     "name": "\"\"T (Wormhole)",
     "symbol": "\"\"T",
     "decimals": "6"
+  },
+  {
+    "id": "terra1nw80nxy20lg2xtkragal0785jregaqeqgeyypn7cacfxt3cqdwtsds64u3",
+    "name": "@darky_daria art",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1rnaz3celr57g5z06qz2qlzrjvlga6zk7wtjdwyltx4tc9tc9nnpq2pr3a2",
@@ -1717,14 +1772,332 @@
     "decimals": "6"
   },
   {
+    "id": "terra13xc83q58y74qplhwstu9er6axycapdjmnfrw288kndt3gdukxtmq8hedc2",
+    "name": "10% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra172mepny4gzvseeunw3wu0acywk0r9hzyzn5gzqxgssfhnw9p36gsf7uz3e",
+    "name": "10% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12nkef0actgu77mzl2ywt6gratctps8mheq7n3uvagzeffyhusnrq7rc77x",
+    "name": "10% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qdujz3vtn6nsc0lyf2jzukwzvpqa8mwfcl6mgdhkp07hkpwlyr6q3a6qfn",
+    "name": "100% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y0yajkqm3dfa2mcyq5cdffhk9dn6v40d6qm67gde7vaj40cmx9uq0qncja",
+    "name": "100% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lz689avwnzzthqer5nw9xsv5pu7pxe9z5ajml8hea3he33zpsysqll5h87",
+    "name": "100% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ahzlzgvcf8879da55es9mly2vrr750na6vksyuu26wxm6g6xw4xqz88lka",
+    "name": "20% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ghpf3cwp0exaq685yrkxfzpjyr69lstm2yakrzm25emng0xvqs0sq5q5r5",
+    "name": "20% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18st042rg72wm60z7vjcufnej64kdr57qpemmkjtmkrv5laxlh3hq558sqy",
+    "name": "20% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hqg5nfwdkm6858tm0sxgplkh87f66ry0jgrc84nd8yj5mtxn7d7quwspmg",
+    "name": "30% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13t6ndytpw7td2yjls6ln64062x8vxywsclzd0gytmd87pecg8ursdw43p8",
+    "name": "30% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1chgx4qzdgsa5rykng5nwhm82gld9au6jkwg4ueayt2dkm8skhfssgwe63r",
+    "name": "30% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pmdjqw6cuql7e4wakcvte4xh8ltvkky7rzn8gqwpcx9vfst46g3q7c04w4",
+    "name": "40% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yff2t0wdhftjmy67ydjhyv6h4f3kz4sc3sn3ff4tje0axs82lpvs24ykqa",
+    "name": "40% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zu389vgu4pkpqrulfz3yk3jm870fwrd2hs0pes5en4rjwrsqx54sven5em",
+    "name": "40% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vf4z3lys8awmcxcclxsu8d9lwxv0wzhxtzkkfg0ntth4kks7pu2sv45ku8",
+    "name": "50% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1l420mu6pkgffqhsxz9w42lxls80l7yg7f7la5ajdz99g07u94xhqdxlv9l",
+    "name": "50% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1d9k26t24afcq3gha076yg39y4eg0hcayg9xzlskheluq59l5ut4s75qjuf",
+    "name": "50% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f8yude2jpdyfhx3f4p99nnreelx09950hkqcd263mpr9w9jykkmq58xsae",
+    "name": "60% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mt942r7k6c9wlkk32nzt2ewhs5p5y0haxkx5nepwk2astr6e2uxqkta3ps",
+    "name": "60% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z5x2rzk79eljmjnjfpt262hf2alnsph4eq8vr6vgl3dmn3q6k7nqvyqc6a",
+    "name": "60% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1p0x4c5r6n9dz4lm0mqssee8s8j4lafpwf46vvqyclputftcnh0rq3mueus",
+    "name": "70% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1axg4x9pgx7xhlslcza9el0xqsyxd8fl69svs83895ycl0v22dv8styklnx",
+    "name": "70% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16uun4j2ajew6pxz095d6nglswed6kjruevus9rn6y63djtrlkkeqx6cx4u",
+    "name": "70% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xmj3ln6hyfyzc4ky4vh9cl5x8tv8f5hx7lwmy0xgar069kqnehcq6fe3xs",
+    "name": "80% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pj8ng6reunzed6f0z26k7hfpd03g73z8jdhsnx8reu8uqsyapydqnjk50m",
+    "name": "80% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14504gwrp7gvhd42l7qny4ld67xaqrnrvk6dm33xp37rls3ert9cs7c43f5",
+    "name": "80% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ftpzlskr027fulju0mj9sz83zysy55whtspqghhxx2kjtu2mgqqsewnjkz",
+    "name": "90% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wf9gd0yuszsuqqxkm0gu0rzgnkr3yp5awzm8clurv4ljyc34j9vqamar9p",
+    "name": "90% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14a7sujcak07xe90axfrplc3qd2uykt0snq3huastvu7jffdwpnlsqe5lyz",
+    "name": "90% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s53ze5358jeq0rggeuf8pqvt4y7fpe23w4hepl8g6zlkzklc374qllh09v",
+    "name": "90s PUNKS",
+    "symbol": "9PKS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1e88qgtfw4c5zmgv9zhwsy569jwwsav4gukz64l5ewyxa3xaqckksc0z3hc",
+    "name": "A Space Doodle",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra17nyvdvmm2hjdajldme6x3y3nle6kp9wtn8qfmajw76hkk7g5tpuqgpkum5",
+    "name": "A Spooky Doodle",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1mdsnqpzj558p5qkujywpx6e59cmm68hkctfzm39zlgnlxfl738dqq2g47a",
+    "name": "A-Folkalypse",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1h48d3ccyaf50pzef0zc3v40vnv9zkq6mmslgm3gwl9s5s66cz42qz9enxe",
+    "name": "A-Team Lunaside ",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1zdwggjn7rkrpgz8ukm77yeh7a4gsallhq67f9dxjd9pmklve2gksc23gc2",
+    "name": "AAAA NFT Collection",
+    "symbol": "ADFC",
+    "decimals": "0"
+  },
+  {
     "id": "terra1x4lm86rnw376xtuca3jux27yqwwnc9gu76vt4gggzp54hrxnegtqhz57e4",
     "name": "ABCMETA Token (Wormhole)",
     "symbol": "META",
     "decimals": "8"
   },
   {
+    "id": "terra1f7lvy8xrm4xnue6vtzkerzuwhszne5gqekmxx7y3fx7m603jzm8qjh2xsg",
+    "name": "Adventure of Homies",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1693sgskk3tj24n8atssq5x7aq090awq6wy7hkmpew403vg6svzjq6x04nh",
+    "name": "alentejo.money",
+    "symbol": "alem",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10330cpst4uvum97nvrqcrt3wachznh0akxgtzfxn20kvn0y7ue7qv2m5s3",
+    "name": "All i END 2.0",
+    "symbol": "AIE2",
+    "decimals": "0"
+  },
+  {
+    "id": "terra15rqxf0fdmja0vxay3q7jspmkxd3yh6mcqf5jyppme5ue459csshqnm57cc",
+    "name": "Alpha Ark Test",
+    "symbol": "ALPHA_ARK_TEST",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1zvm0y8x4pxq7dhpvuevv3v3cdkvlcxtv99e67lcrtfayrr9glpns3fjara",
+    "name": "Alpha Ark Test",
+    "symbol": "ALPHA_ARK_TEST",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1rpsh2wzwupdkp9ka5muq43fdnh9vkw8ee4uzznpy46ety0e56h2qk8407d",
+    "name": "Alphabreedies",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1g79985x9uyqqynn8ckynk32rj04juqxecjqtmxazz7dq3weywz2swen6s3",
+    "name": "ALUN-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m7rxu2099cdglmlz46ldqhkxtk26lwjgydszrq2v8ffauzmg5saq0n7rcc",
+    "name": "AMAZE",
+    "symbol": "AMG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e5vchf97lakl6sulztkn54aapekzfzsa6amdt88exvwmu25s3z0sg6hplq",
+    "name": "amp-ASTR-IBC/-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16akp34qkh3v6537gra4ypqj4z208fmesdpzp9vgx3w3luruplgmse5rvku",
+    "name": "amp-BLUN-ULUN-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cgtn7dnlexpqdzr44srt7t5edxlwjqae970prfmlzywjhttae99sche4v8",
+    "name": "amp-IBC/-IBC/-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xxyr0tduxlggrujcsqmnllu74dmg4697heyjmvvyv6tj3q0hh0qqqq8d6h",
+    "name": "amp-RED-ULUN-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra1rlfuqcq935j6avrwsurzn6altrq6htet0ggz3hv86kueeewfzunqj2u6lw",
     "name": "amp-SAYV-ULUN-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m9fvkwjpwd4ddgkxd5ddvc2jst9wtv33u7kj89tq2wr0tjm34j8qyfmpwm",
+    "name": "amp-TPT-ULUN-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ymwcpz20lcaue5kkawj3t2fe7et4xd7xkxtuxzc43at0dvcywrsqcuunk2",
+    "name": "amp-ULUN-AMPL-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1as76h247wvey3aqmw22mlkq8g6vj8zj7qw4wywwn388s2mjt0rtqpp570z",
+    "name": "amp-ULUN-IBC/-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kle8kd6gwx9fwpav6spj8zg25uhftsm87gdss4ssmej4pnee2rtshhyct4",
+    "name": "amp-ULUN-LUNA-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nrzw3c28h5sq9q7pw9umc0882607exz8he5uj9yx2yw22m3mhrmsxw2lql",
+    "name": "amp-VKR-IBC/-LP",
     "symbol": "ampLP",
     "decimals": "6"
   },
@@ -1735,9 +2108,27 @@
     "decimals": "6"
   },
   {
+    "id": "terra1ppjw8uh4d7mpp8ymutfdtv4ch0acgll7rrs059y3ghhvrs4jgm2szjp74n",
+    "name": "ampLuna Pool",
+    "symbol": "ptAmpLuna",
+    "decimals": "6"
+  },
+  {
     "id": "terra1qxfq924wkxpx0vwy7eudxlumkn3k96e37eynvxdmhje96ftv0h8qykyyrv",
     "name": "ampLuna Pool",
     "symbol": "ptAmpLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wu5cts7zr3sfmwlxfh7an3nthrx9cuz8fx7xfesmdudg2kzcwmhsaw24r8",
+    "name": "ANC",
+    "symbol": "ANC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gwdxyqtu75es0x5l6cd9flqhh87zjtj7qdankayyr0vtt7s9w4ssm7ds8m",
+    "name": "Anchor Terra axlUSD",
+    "symbol": "aaxlUSDT",
     "decimals": "6"
   },
   {
@@ -1750,6 +2141,12 @@
     "id": "terra1tyacsyss53dmsss5fj8rv7fzu2nm55p2pyre0ylz9wfjgzp9z3yqsarc8m",
     "name": "Anchor Terra axlUSD",
     "symbol": "aaxlUSDT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16j2duml4u8rlmggc26w4nz8ctxpk3h55l25fgz7u6zjg5evs4suqkc3uws",
+    "name": "Anchor Terra USD (Wormhole)",
+    "symbol": "aUST",
     "decimals": "6"
   },
   {
@@ -1777,15 +2174,99 @@
     "decimals": "6"
   },
   {
+    "id": "terra1vppkxz6706zmd0qq037sv76qhlr4sw8wxyrhr99upmsfez3a576sj7g6wk",
+    "name": "And Enjoy",
+    "symbol": "ENJOY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19zz9g0lze6s2hjtslhr96h8hn9kl7zktmrx200cqpywrun9z4a0sktfxwr",
+    "name": "Android 51",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra12ew4cuffqj20l8cz35lzngtk6x2f278dk77wm8pfpc28wle5pd6q88yrp0",
+    "name": "Ankr Reward Bearing BNB (Wormhole)",
+    "symbol": "ankrBNB",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1vj8jwvu0896hhq34r37krtqpfknfm3vway8vghygnrnr7kfzmncqurnvvl",
+    "name": "Ankr Reward Earning BNB (Wormhole)",
+    "symbol": "aBNBb",
+    "decimals": "8"
+  },
+  {
     "id": "terra1p67lldutk5haqpmnk5thuhmhyff8ntf8axa37mzm87qq58082u0qqp9mmu",
     "name": "Apple (Wormhole)",
     "symbol": "mAAPL",
     "decimals": "6"
   },
   {
+    "id": "terra16hx93yrc3s7xlx8facausmtz3sfrgknd6mf70fhmzhjkej97g42qkflfs2",
+    "name": "Aptos Coin (Wormhole)",
+    "symbol": "APT",
+    "decimals": "8"
+  },
+  {
     "id": "terra1plhefzma59lh6rjk5gfkq45pz2chfq35nm9xgdz4pcuhp3nnwekq8sthua",
     "name": "APY 365%",
     "symbol": "BOND",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12xzq4mpgzp357yh5pwpztr3j66aaqph5xucttt24f9qw0hf9lg3q686kru",
+    "name": "ARGO TOKEN",
+    "symbol": "ARGO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19yuxlwnndlayj4p4d2ue0cpdw0wlhgvekshefar5vvxgkt8rsnlqst9wdx",
+    "name": "ARTerraLand - Mar de Pulpi",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra10fjq3tt0gzffek4099uwtrdv3acaeh69l86j0xycqr54qxyq98nqpj46lg",
+    "name": "Artistic Alphabots",
+    "symbol": "AABT",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1aukmt9xg0857dtzky3pd6cl83ken8dtgagntykytg7yfz9elrccsatlr4z",
+    "name": "Artistic Alphabots",
+    "symbol": "AABZ",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1c3kcc689kuexyx6ylgy6dj0ha3f8vfyhsruntuhj3xsnkcawfmvs6qsgy7",
+    "name": "Artistic Alphabots",
+    "symbol": "AABT",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1kcr0ymnr02ffn2amk3kd6wwdp5c90x5utqpwe4847c55ws634eqst53k24",
+    "name": "Artistic Alphabots",
+    "symbol": "ARLBOTS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1p7nwjxm2mjjys9vxg4gkvl2jjjf3qqqtvpkysptf5s833nvv96xsxaelq5",
+    "name": "Artistic Alphabots",
+    "symbol": "AABT",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1s9gdu78jm0yg8e8ceeefcn2j8upmxuf7f6zku4lkwtsngdct6yuqd289yd",
+    "name": "asd",
+    "symbol": "asdsad",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mrg8rzx2mc43grmzveulyqxpw3enh2uvzlv7vv7ue28gv2d7wcgsap9cag",
+    "name": "ASPARAGOID",
+    "symbol": "MOUSE",
     "decimals": "6"
   },
   {
@@ -1813,6 +2294,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra1e8panxssahk726tf0uualyl7z3n8x9w80lxz6nmdqflm806rs3jq6f7wwm",
+    "name": "ASTR-IDC-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra1u9amrmxnnhfwecku6ndaxk2034e73cddxau96avzg4r0xvta4wns2ckane",
     "name": "ASTR-TPT-LP",
     "symbol": "uLP",
@@ -1825,9 +2312,75 @@
     "decimals": "6"
   },
   {
+    "id": "terra1w47prn6mgznc0crx57ckg676kt93y8tr6ts6va5el02juf6rdydskf5spy",
+    "name": "Astro Herro",
+    "symbol": "Astro",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1m2s0tezk5y56cryqnvh7d8zt526th20my5hs02f5eaaya020kmvs0el8nk",
+    "name": "Astroport (Wormhole)",
+    "symbol": "ASTRO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pkw7a047dna36hc7kxce90f9v3trszjamr2swzun0cfmc0k2jxdqahzf9c",
+    "name": "Astroport Lockdrop NFT",
+    "symbol": "n/a",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1pm0gpgsqmjk3rgy43m8z5edmjjx80r738mq4enyswgfz9uhppg4s849crt",
+    "name": "Astroverse #01",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ur483uv42hht0dz73ammau4wav7mlxuxgtxvmgqx7swy9lg94qhqxjfhzx",
+    "name": "Astroverse #02",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra16968kw24zy3uayaexe6prht89e9zvntcgjuz6a4tf4ujewwfm4ls4jsfp4",
+    "name": "Astroverse x Vinboy",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1jh37p2akmwprfwr2235kjyt3wuz0s2sfenhtytg9cajsxnxfvdasnaurdp",
+    "name": "Auto",
+    "symbol": "AUTO",
+    "decimals": "6"
+  },
+  {
     "id": "terra1jqt5mmlpd6x3jtwfdsxwtrknvaczz2xmplukzc8h86xhupg7fe7q7nkzdp",
     "name": "Auto TOKEN",
     "symbol": "AUTO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19cx22u6uxzdv4mn7ga8g039wm5yzfe4k7rg4an4f5hwst9vjpxfqt5qfd4",
+    "name": "Axelar Wrapped LUNA (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15wg4cwcar39mxq0yg3zlpgcsm5s75sptrp9f57deycmvu30gh5nsshktux",
+    "name": "Axelar Wrapped USDC (Wormhole)",
+    "symbol": "axlUSDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16dqd7fy7z9rxn0ytue6xjz0flwqyux00vnyqnjlv8j4fya8jeuzq3vs4jk",
+    "name": "Axelar Wrapped USDC (Wormhole)",
+    "symbol": "axlUSDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q9rn56280frulg8h9qmv2r2zjxqhx04fdls322egged43n4308xqsxe3pd",
+    "name": "Axelar Wrapped UST (Wormhole)",
+    "symbol": "UST",
     "decimals": "6"
   },
   {
@@ -1837,10 +2390,22 @@
     "decimals": "6"
   },
   {
+    "id": "terra1j7ckshknp3px4vggcews2ezp9llqkw65v7f383t2lhqvdvdgkngsgp0npu",
+    "name": "AXL INU (Wormhole)",
+    "symbol": "AXL",
+    "decimals": "8"
+  },
+  {
     "id": "terra1kkrplzf5hfz04l6pey44s0wd6nctdpv0nrsx47a5ts5s2wagsjcsly7cn4",
     "name": "AXT (Wormhole)",
     "symbol": "AXT",
     "decimals": "6"
+  },
+  {
+    "id": "terra1v4u6kjlc0m6lq089tczfpve2vwpw5cqvrdklcc55xyws2qphqctqp3tp4g",
+    "name": "Bag of D*cks",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1km69jdkp00zvsqya0pmyqn8e3thg7csuud2yw0v2a7jy87uh52qqz7rcq5",
@@ -1867,9 +2432,63 @@
     "decimals": "6"
   },
   {
+    "id": "terra10k0kuaxr2lrgqlp9wqc0xxs3u5lwx434ttg2avc0mtttavykzh2qssgtku",
+    "name": "BAZ",
+    "symbol": "BAZ",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1a7zeajhk6nnj7jzu2rxynwr3yvp58gj2ffxe9k4dneyte0v5kkeqnmzwvq",
+    "name": "BAZ",
+    "symbol": "BAZ",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xaqh7av93gwvuf2jj0n9sk3fju5pkclh033r8g5phtzawmu5hzusahf5r2",
+    "name": "BAZ",
+    "symbol": "BAZ",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gyg0pys40ex2f6a4dytd3ewpx2xfrsnt3rdc2t4j3s3jc9qx8kqsrd5c0p",
+    "name": "bETH (Wormhole) (Wormhole)",
+    "symbol": "bETH",
+    "decimals": "8"
+  },
+  {
+    "id": "terra18sv25lxt8v2z2zueatehtchjzv6f67qwsqah9anjyjzntf2rkkxqe9hnd7",
+    "name": "Bitcoin",
+    "symbol": "BTC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1urs3y9w7rsk3ysshtftkqtmx90dwxen59j8e0gj79m0wcpygy24ql7flqh",
+    "name": "Bitcoin (Wormhole)",
+    "symbol": "mBTC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra147kkv9tdq4lcuksu2u2h38ucp2rc9sk783wr5zhuxq3p709funpqrl0hk7",
+    "name": "BitLift",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1nfgjhx7yh7j0qzw5uz24kr5q2wtneuya9ahs8cet2e0kcetu2seqh46nnu",
+    "name": "Blocks By Artog",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra1vpcj4fj0yxy4m928lxf8us7tk8kdqr3ny6q2gtx7g0s935awdreqppm7au",
     "name": "BLUN-USDC-LP",
     "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra173yxt55wz7aemm7xf2v83ttpnvtwxsaa4q53xp4jdz7m8g97plmsnv2duv",
+    "name": "bLuna",
+    "symbol": "bLuna",
     "decimals": "6"
   },
   {
@@ -1883,6 +2502,61 @@
     "name": "Bonded Luna (Wormhole)",
     "symbol": "BLUNA",
     "decimals": "6"
+  },
+  {
+    "id": "terra14rpyyhc6vgrachny6ycu4evjyx06j7f46w5gh8ckhay7ueecukss43m2vx",
+    "name": "Bone Luna",
+    "symbol": "bLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kl3kqkmfe8cdu42y6gdl0stwuckegvxdm8td7jndtj025zxelp6skktt0t",
+    "name": "boneLuna",
+    "symbol": "bLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dpsvhwqqnyllpg40l9ylttnhj3z4wqmwhsjn2u4s8lwvxs6zln3s89ezn8",
+    "name": "Bored Brat Squad 1st Collections ",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1czc4z2r4xvj90xr537e664et7pq9xs2c4vkdwxlk3hdhzxwc4cqsmmarah",
+    "name": "Bored SkullPIX Club",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra18wzq25g7cfleaca0rypsrz5dnu73agjqk7j3lg2uj4c9vtp29efseldtqj",
+    "name": "Bored Skullz",
+    "symbol": "BS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1fenpr826qpr42a6u5qwp9lktvzx84cq8dnmpm05fl3d65t75q84sf2yx78",
+    "name": "Born Sinner",
+    "symbol": "LUNA",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1syksjwl88dhetkzfw9snr8f8sg0spsmlvm9h4jq6y7sd6axjd9yqxu3w5u",
+    "name": "Born Sinner",
+    "symbol": "LUNA",
+    "decimals": "0"
+  },
+  {
+    "id": "terra15mygj54nztctlmq0g7hfjaetsd2zryjnmctws9v2mjdteppp5znqusylxa",
+    "name": "Brand Governance Token",
+    "symbol": "BGT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kkpf3f049trkyscv0av2pa9ad02dzls7f6m8s24q07ehetggytesru7qqp",
+    "name": "Brand Governance Token",
+    "symbol": "BGT",
+    "decimals": "6",
+    "icon": "https://s3.ap-southeast-2.wasabisys.com/bgt/bgtoken.png"
   },
   {
     "id": "terra15sad8j5wx8u0aptgfvmz7zwsjrl7mfuc207d3gljh9gdaxx0d0kqq8d7kc",
@@ -1915,6 +2589,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra1pjpkzmnsuupnchte5vz8svwyf4vgr74hdtw7h8vqhd3hcts2ttpskkjeax",
+    "name": "BTC boys",
+    "symbol": "BB",
+    "decimals": "0"
+  },
+  {
     "id": "terra1uy87s853kqhlac6m7fdc7w2zx43ww5y20qv5llnuanj8fp9lek6q8djl75",
     "name": "Burger",
     "symbol": "BRGR",
@@ -1927,10 +2607,34 @@
     "decimals": "6"
   },
   {
+    "id": "terra1z0fvc52jy3630rx36vcya4u3qmnxf9jdjqq40hsumddme8rjpdfsxvhlxk",
+    "name": "Burnt LUNC Using MM Pool",
+    "symbol": "BLUMP",
+    "decimals": "6"
+  },
+  {
     "id": "terra129zjaxquhh3h5upn0clqzdawnze43a9z34ktt4l6um2hf5w0xqjsta42u5",
     "name": "BUSD Token (Wormhole)",
     "symbol": "BUSD",
     "decimals": "8"
+  },
+  {
+    "id": "terra1aplktggys8uf3mm8rnx5nz2vz66jgu4pszpjg72nn6kst299y58qv46ajc",
+    "name": "BushMills",
+    "symbol": "MILLS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13y658n8mssa6sesrnqcz05mmxfd7ucma6gg04vwkd2862a2ptexssar2h7",
+    "name": "BushMills2",
+    "symbol": "MILLSTWO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xmn82g2e6pch8fwfrxfc90gquek93n6glf38z450mx3hxl8fteasluup20",
+    "name": "BushMills3",
+    "symbol": "MILLSTHREE",
+    "decimals": "6"
   },
   {
     "id": "terra1ndlsnn3lcc8s2arj9t5x9qqj8vxsqd4r2rt60zzg7cldwr4askpqlza99x",
@@ -1939,7 +2643,43 @@
     "decimals": "6"
   },
   {
+    "id": "terra1szqw035afuqmdc42tr2sxd6z5ady0ap9k97fhadzt8mdh46ts2ms2lmsqg",
+    "name": "Cactus MetaGloria",
+    "symbol": "GLORIA",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1l3uautulwdvn0v4pl928merxhh40fj46v8vgtpv0yymtk5t3n95s509m0z",
+    "name": "Canvas Worlds",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra15cqf7tdtef7umt9tm7lwf72qg4rdxf2wug0pdqznjduam0c9v9rq0rsw6x",
+    "name": "Captain Cookies",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1cyaaw5d03vqp20j0lttlqsnx2ey6e7jgc226fys2q6fnc48mlzwqrdfrdz",
+    "name": "Captive Insurance DAO",
+    "symbol": "CID",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17n96e2maa553se4u6ntmyzaqan93y6r4q33hwhwr5p386fulk0qqer6jj0",
+    "name": "Catching Fire",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra14zhee4jgeage596qhcwzx7u49yguwud9dn80sesa98r878ly3f6sjleq3m",
+    "name": "Cavern Bonded Luna",
+    "symbol": "aLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra170e8mepwmndwfgs5897almdewrt6phnkksktlf958s90eh055xvsrndvku",
     "name": "Cavern Bonded Luna",
     "symbol": "aLUNA",
     "decimals": "6"
@@ -1949,6 +2689,96 @@
     "name": "Cavern Bonded Luna",
     "symbol": "aLUNA",
     "decimals": "6"
+  },
+  {
+    "id": "terra1cadlgv6qes2ee94qj8d8uyll3ujr4qdl8u3u3rsww2ezyutfjnmsqwr8sw",
+    "name": "Cavern Protocol Documents",
+    "symbol": "CAVDOCS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1cx38qvyv4mj9hrn6p6m4fj7vhj726t5dg3ldpeupkkgel495ngnq5rtplq",
+    "name": "Cavern Protocol Documents",
+    "symbol": "CAVDOCS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1v30xmf35gw2lh4rxc8a26ltt65h6ej99fqxmcaxed78uex8ygctstd7864",
+    "name": "Cavern Protocol Documents",
+    "symbol": "CAVDOCS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1w9j54nkyuc4733tp2fz52md27k3qe95y7dfq0x39rcuk6nsjj5sqpmarhl",
+    "name": "Celo native asset (Wormhole)",
+    "symbol": "CELO",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1thjqc88nra6sv9c702qpxgjs4n4mdje526uyfal5z2zzf03k9qcq83evd5",
+    "name": "ChainLink Token (Wormhole)",
+    "symbol": "LINK",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1m4anzhza4w5jf78f298f45s0wm2hzjpjfnn3v4xrax3yfvfjhxqqe0xqy3",
+    "name": "Charlie's Crew",
+    "symbol": "Crew",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1273k2c654p6jdu36mel90rxs2cdu7lk5tj9n3wfgkun2rll6pm2qypnu6y",
+    "name": "Chatmasala",
+    "symbol": "Chm",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1r9sy95elmdvur3et4xgkx6scgfmcaywlnvjsq7eatwnhjqc6hwaq3j660v",
+    "name": "CLUN-LUNA-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hsqqj2namaepxt9h80snquszljxlsygl7kr32k5wyr424zs3j8zsl76l9d",
+    "name": "COAL",
+    "symbol": "COAL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1u4caj7h7f89w9jzudr9ryy3aq9kr6skwa9gf2k764wpzqjj0k55s0nsp2e",
+    "name": "Coffee Planets",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1dkkpnzmq88fsl4gfah4r6k9445vtpeqsucxpu34x6lp2cnkgu4lsae6d27",
+    "name": "colinB",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra10l5yur0teqfllu296sd86y86xxmh49wgy3sahws2yt3t3xh45g8q0zwqdp",
+    "name": "Cool Ape Punk",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1j2qpcu8c3rgwtnq4azh0lpn035phmw9ummds7g3llrjuj5xvksjs6epy6t",
+    "name": "Cool Jerry Gang",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19pwawxl2xzve0k06uehl5pl8fhvcykxuc0yfpzqy2pv39jv03fpqha5uwe",
+    "name": "Cool Teenager ",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1s28fv278avrpazql4ktsstgymj8un6ua8t4yjehcr3kj2qm2ns8splxk40",
+    "name": "CrazyGhostsss",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1vkzknym2gw2xe59vsn8lf20lvdd0zrduew8km49fwjvn7a223kfserjsgy",
@@ -1963,9 +2793,202 @@
     "decimals": "6"
   },
   {
+    "id": "terra1s53wmnfeu5zj394jfc4p5uhgzlkc6wjgva7w8ksv5gc3avg9jhps8xlqle",
+    "name": "CrudeArt: Wildcard",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra14kzm7p634852h2k2qqg2cr3zvaqvn796lejflycg53sfkmgq02fsmlnj6n",
+    "name": "Crypto Compass",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ew4g9l5gh9tgls7yd9uz3lyue9m2u0u6z0jtw7s0fgvq8gvl693s07wepu",
+    "name": "Crypto Donkeys",
+    "symbol": "CDK",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1yqacrx2jvrnede4x87w370g4qgsstq3qjnqaqy77ypx3fqeynrjqfaa023",
+    "name": "Crypto King",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1akahwercw3vmmd6ac4hudum9kj3tlvuw28ku064tj3gnk00d5w0qg2j6vs",
+    "name": "CryptoGlobe",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra16aq0p35g346xe3h60yuhkns3rhj6k66wwtz6czwgep7fwvmyjxqqw5gktz",
+    "name": "Cryptoismyjam",
+    "symbol": "JADE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1a3kqxlfgqnlmzrx6c22w7g94ucxlhcmnyafr8d8sldjzgplk66gq35fdtk",
+    "name": "Cute Corgi Crew",
+    "symbol": "CCC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1gdxwdrezs9dcrwgyjha9a0dwypumragsxqwm3x6hv7tfea8zzqtshsm5f4",
+    "name": "Cute Fat Chonky White Cats",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1q4l8zelhlcte9l496spty7wxdmlp74vvxjyqdjjw063x9qqc4udsyd29we",
+    "name": "Cuties of the Terra Universe",
+    "symbol": "WOOF",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1g2xx0jjngyahfhh4j2zdp5hwt8l0runfl9td6fx8l8vdx82rc8yqqy9hww",
+    "name": "cw-plus:cw20_base",
+    "symbol": "TEST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1490pnjx2g7tce3ywcrzn3detm6r8w0jm5vzcc6kxvgzvg2eplgwqewl349",
+    "name": "Cyberdeck: First Settlers",
+    "symbol": "CBD",
+    "decimals": "0"
+  },
+  {
+    "id": "terra16vdmyrgc344tsj3p5sz25wtx608nx97wl65w96x98s8x9we84dasnlpxdw",
+    "name": "danku_r | WAGMIstones",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1jva62gxl46aga43p8pfpp2xrujw73g37605334m7cng9mus39qksurqsdn",
+    "name": "Dark Waters - EP",
+    "symbol": "TESDW",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1w6szmq0vwlc8wlqt59fyrucw96xlptwrvejz3amhlp3ejdeuc5dqcuxjyq",
+    "name": "Dark Waters - EP",
+    "symbol": "TESDW",
+    "decimals": "0"
+  },
+  {
+    "id": "terra133ehn057cmupzcnk5l5rmgzqn90wfe6qemj2mj9r4mlh0l5slgfsznda3t",
+    "name": "demo_token",
+    "symbol": "udemo",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1zre8uunucxf7g3gyxnmntj4e723wjad0phmj9xtar5g67kcep73s9qlqsk",
+    "name": "demo_token",
+    "symbol": "udemo",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1hfg2yzqnvaplc04mnhu9cwff7llwxvhq2fjh50449q7kh9u4xuxsdcngfs",
+    "name": "Dengue's Fever",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19j7859076jveetfhdskc6hwjnr7cpt2t78llp8nz9qnaqtgvj8ns0qgp9j",
+    "name": "Depeg Nation",
+    "symbol": "DPEG",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1kad44vp08yqcz9ec366krj89yvsvs6nmauvhqu6sl93jjw5ugw2qd3xdnw",
+    "name": "Depeg Nation - Tales of dUST ",
+    "symbol": "DPEGC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra17gck626vgax9jpe6utm7dhx4vdzawfkt0jhru03l7a3dzu98wedsfad4sz",
+    "name": "Depegged UST",
+    "symbol": "dUST",
+    "decimals": "6",
+    "icon": "https://gateway.pinata.cloud/ipfs/QmTEo7AmbgygF2mek89MHBJ1wPrB23TA811VeXCdcXW5pf"
+  },
+  {
+    "id": "terra1n3j3l0w2eclpv3me28yxzjesfa9cqt4m0e2d3xhxjk03pch2uxqsds9fud",
+    "name": "Depegged UST",
+    "symbol": "dUST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1p648gcmx8zmjfqqk095zp6jxr5c4an0mdgl5rlrs8r82rp33yngsxw4qs2",
+    "name": "Día de Muertos",
+    "symbol": "Dia",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1rfr0epuuk5adhlp7qay7fxy6sdf78u492epen2jfs844cfxcqltqze6jmz",
+    "name": "Día de Muertos",
+    "symbol": "Dia",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1vnzcsvy7ytan9tnjnzzhg8k7hpg0f30seg26xe6c66t4e8p0d84sqls0w0",
+    "name": "Dinheiros",
+    "symbol": "Dinheiros",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hm53sx43hhdaad8uhvuz8gnh9zq7ukr7au7257adevcwpn267zashyfcjr",
+    "name": "Dino Hodl Crew",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra17ytwg38lx24x4nhker06er64sa2tvr9h6ppdc9ewupnswgqxxjpqq0q2fl",
     "name": "DKT (Wormhole)",
     "symbol": "DKT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xvxmxw8rsywqzxmlzpw9wu9ddtxts5hwwusayya95fva7up4577slfmp55",
+    "name": "DN",
+    "symbol": "DN",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1sdvvdhaeusr96sq5yunkkn78uvlwr4uuaasctjq85gh5sy6f7w2sqqqzhq",
+    "name": "Do Klown Kwonzi Inu",
+    "symbol": "KLOWNZI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra183tzpzemhgjdsfh6ahsvkc43s6xajd58qgppd2r2rrc0afetzftq624xw8",
+    "name": "Doge",
+    "symbol": "DOGE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1j6l6q3cnwqgpldf2k92mce2cd888wtecz3fun7yffcpghw3wn9qsgl52nv",
+    "name": "Doodle Baby Ape",
+    "symbol": "DBA",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1usnq8smssvxfjcdt2jdl0f6vc0wxssjy8vdx698mlyluy25ejrzslq3t5x",
+    "name": "DoodlesXXX",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1nm3hvfs4g6l48zrnxp75js39dvmdvjt85eh0pzz20mhvf92ler3qrrspek",
+    "name": "DOSCOIN",
+    "symbol": "DOSCOIN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tqpzf2f5ll3zmm53nwczatp8fzlu2stzrlxwrjgqsx3wxqwxw8uskh9qfp",
+    "name": "DOUN",
+    "symbol": "DOUN",
     "decimals": "6"
   },
   {
@@ -2005,10 +3028,118 @@
     "decimals": "6"
   },
   {
+    "id": "terra1trh2tl98zdu4swpghhnxdnna4rf029eptxau95kgscz520f4tp9sexmvkv",
+    "name": "Duke Token",
+    "symbol": "DUKE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13cdqlhz4z7ml27y792xx4rnf93u05y4m49jmfh7jn7cglg7qn7cqggt7dq",
+    "name": "dUST",
+    "symbol": "dUST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1uegpgqzy3aqwzpkfeyp7e8ljs0m3jm9upq77g4f7kv7jcfrd9lcslayred",
+    "name": "eCash (Wormhole)",
+    "symbol": "XEC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1d9ac0uug25qdu00te7mlsam608aqy7608k9ay406kz3zz60f23csq058vv",
+    "name": "Edge AxlUSDC",
+    "symbol": "eaxlUSDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fjane47sgaaljgm0qe0ysjwtuqjlp493ar4gwt8rez45qaazf9gsfgc6af",
+    "name": "Edge AxlUSDC",
+    "symbol": "eaxlUSDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gpcn0jvm6rv2zxce7dlgmh0k3l8zns72m5l2u47m44ehyxgar2dq6v8p75",
+    "name": "Edge AxlUSDC",
+    "symbol": "eaxlUSDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v6v4rcut5tsyufktp6da4vnn0a7jgm8e83ypdndsgykev5fu8uvqg5x2q7",
+    "name": "Edge AxlUSDC",
+    "symbol": "eaxlUSDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15a409g7juszev4k88pvvvh80654903k7q00qtlddjasqynhjj45qzvk893",
+    "name": "Edge LUNA",
+    "symbol": "eLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18p9qapupd23gv7pf5k0n4ce5staqq39p7msl6vcvntrr3kgm54xqkrhffh",
+    "name": "Edge LUNA",
+    "symbol": "eLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1texwq26vke5vqem2lljwteqvyd9azy7x4mm0nxfgq7kleg8k5ukquvnqft",
+    "name": "Edge LUNA",
+    "symbol": "eLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zd49uw3gd3z2v4tujlxyapsdw62e3g0n29gm2kpn5crl0y5zfg7slhxykm",
+    "name": "Edge LUNA",
+    "symbol": "eLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10mdchp7kmpj8v5maqk902pwnm0ynj39shme66krac6nm2cw9zh4qxvvcx9",
+    "name": "EGA",
+    "symbol": "EGA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e427e4zp7unnpr2677wkegqjdxqx9w7mtdenewjyg755ell0238qz27c6z",
+    "name": "EGA-EGB-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v0g6jel2c5rf00yw5szjw38fn527w5p6szujmw44n2x9azkfumcqpv4j9s",
+    "name": "EGB",
+    "symbol": "EGB",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1md6qktuqpa0uat6gk7glh8lfxs87t04ym2pmy4uvxg83jwxdcmasrcxt90",
+    "name": "EMIYA",
+    "symbol": "EMD",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1w0ajeq6pu757yy0uxkvg4g0ayssdvx4r570d9a93u88ax2uau7wstvhywy",
+    "name": "Eris Amplified LUNC (Wormhole)",
+    "symbol": "ampLUNC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1t4m5lcffscupfuzthf06s30w5ghkzupyfnknsh8f4rwtm69x6fsqrxrhme",
+    "name": "Escudo",
+    "symbol": "ESCUDO",
+    "decimals": "6"
+  },
+  {
     "id": "terra1ly8vd2q69h3jlyjgnwqq0q4wngulmr2l2gr0lxd93tqle42596rsq5zz5d",
     "name": "ETH  in USDC",
     "symbol": "uETH",
     "decimals": "6"
+  },
+  {
+    "id": "terra1ggefs7qz3spjmkmjk9k37xycljlf8525ea6sf4d356vufnrn9z0s7hrjy5",
+    "name": "Ethereum (Wormhole)",
+    "symbol": "ETH",
+    "decimals": "8"
   },
   {
     "id": "terra1m24v9uumvuuhqu27xjlcqyzt8v78766vuu9sae5gt83u4xffam9s57vq6k",
@@ -2017,9 +3148,51 @@
     "decimals": "6"
   },
   {
+    "id": "terra1uhepfcw3va42nd8uwjymtjykuqs24y2jxgrjcfh69nd3gzwxj2ws5s8xf8",
+    "name": "FAFA",
+    "symbol": "FAFA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19m0l67v6atfmu4cfmu9dw3hvum3rju6gt4jcw2ecpc6qr5lln2gsjs0439",
+    "name": "Fake Punk",
+    "symbol": "FP",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1jyfsmyzgk54gwjqcvvmq5xxaruada40hnfzvfzlt3njt7y72a0zqng56p8",
+    "name": "Fake Punk",
+    "symbol": "FP",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1v8787ruq4sgy2ple8pq5r4v5gsrjytnutxeseuknqjqpjxh555esar9wzs",
+    "name": "Fake Punk",
+    "symbol": "FP",
+    "decimals": "0"
+  },
+  {
+    "id": "terra142rnaaef6m5085p8kexfs0gfzky0evq47zffst7leezgdtsksrrqytxaaz",
+    "name": "Fallen Guardians",
+    "symbol": "WHALE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19eg7fk4aw0muwe57lnawjpu6gvxe0e7naewnkgh8ytx686te2gks59sg28",
+    "name": "Falling Squares",
+    "symbol": "FLS",
+    "decimals": "0"
+  },
+  {
     "id": "terra1vmqa8hls3axrk8vqwqcztuu02t5w5hkrx6mzt7pn7jrhnx5xkxcs7lk6rg",
     "name": "FAT (Wormhole)",
     "symbol": "FAT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dtaqwlmzlk3jku5un6h6rfunttmwsqnfz7evvdf4pwr0wypsl68q6nuam0",
+    "name": "FatManTerra",
+    "symbol": "FATMAN",
     "decimals": "6"
   },
   {
@@ -2029,10 +3202,58 @@
     "decimals": "6"
   },
   {
+    "id": "terra129w4tcrmzxk8u37qqtc0hezp66mkef45m3d9atnvlz09dar9a50qv30u04",
+    "name": "FIFI",
+    "symbol": "FIFI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xpwvt75aqj69kxcez0mm4z2fty40gaxc2ed0vzdy0y47qnswpxhq3d4wpg",
+    "name": "FIFI",
+    "symbol": "FIFI",
+    "decimals": "6"
+  },
+  {
     "id": "terra10exkttsx4xq2j5k3uel9h4gvxy63yd90u46yt3qzn9vfcuh2utwqydz8rq",
     "name": "Froggy",
     "symbol": "FRGY",
     "decimals": "6"
+  },
+  {
+    "id": "terra1p08zvpe4qr53w26fjjs2sjsh7tuhdfmuz5s3eltr7t6htmc6vh5qslqfga",
+    "name": "Galactic Cat Club",
+    "symbol": "GCC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra16ds898j530kn4nnlc7xlj6hcxzqpcxxk4mj8gkcl3vswksu6s3zszs8kp2",
+    "name": "Galactic Punks",
+    "symbol": "GP",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1dpryq9v7aqdzgkjkn9tgxstw7mclj78evh7zegupek4jjwsgt0wq7r26wp",
+    "name": "Galactic Punks",
+    "symbol": "GP",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1cmz3jsnf0r6z5f5zsxjsgspeyqdn06w4sr9jmtuvm544s400a8dsc8jtrx",
+    "name": "GAMMA aUST (Wormhole)",
+    "symbol": "gaUST",
+    "decimals": "8"
+  },
+  {
+    "id": "terra16eryf4yctfe39ppa48507a40dl2dka4psm33tasg0c3ra2n57jxstf6za6",
+    "name": "GavertC",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1f7zfr8j7etlmcypgm2aw6mky3sqfq4hn8au4kulj5puxkls6wvkqm5gy8y",
+    "name": "GavertC",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
   },
   {
     "id": "terra105eh7wgzv9k39unzre6yfey9tvzdex737uc6ylk6phpmtfepylpqy6v6nw",
@@ -2044,6 +3265,24 @@
     "id": "terra13jlm0anpdd3hc0xctw9vtncmcfnrag8dh686s2juy7m226unwd4q0tmx2v",
     "name": "GEA",
     "symbol": "GEA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m496u7arteks5hg29dea8gd64f9jvtg3rlg8we8rese6v70ggvpqjt4e60",
+    "name": "GEA-GEB-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1asmlnmhg7kua2ceyaedyjh54hs6w9wu28dlqu8a2rqw0d49ya5lqqptjfz",
+    "name": "GEA-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v5j5azhyxl54h78udlt9n9vs24flvw4h0syfnpj6fr4v23tukzssgz9yys",
+    "name": "GEA-IBC/-LP",
+    "symbol": "uLP",
     "decimals": "6"
   },
   {
@@ -2059,14 +3298,206 @@
     "decimals": "6"
   },
   {
+    "id": "terra14phr0v3x8spgxwp64lxckzwzdlcfqtel3ynn5zcv6k7ded67pe6qk2my2r",
+    "name": "GIRL FROME KNOWHERE ",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1at27manc5tsujxfulas6rucuh24tsrkrr5spl5k7xryxlfd62ylsjpg6s4",
+    "name": "Girl's on Illustration.",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1y8z5urkg2e0ludtghuvrkspluzy2a5a7dwyv7n2pkw5heuczjavq3nrpqj",
+    "name": "Girls in kimono",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1q8e48hqgqr6kkrxyf0x2e4ngy5pxfq832nqr3md54wgpk4gnf9esrh6fw9",
+    "name": "Goblin Punks",
+    "symbol": "GP",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1u8z5eyklvsuutcmrxf7szr6u099e7c7phrm7jhywnplqkdxxgj9s0ked3h",
+    "name": "gold luna",
+    "symbol": "gold luna",
+    "decimals": "0"
+  },
+  {
+    "id": "terra139xv68tuktzq68u6fuv3snfk8tc34z8y3xgv7jw3kmcztuzmc3uq6dd32m",
+    "name": "Gorilla Haus",
+    "symbol": "GHS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra123sjspx2v6hf2yjms3npz6nkmnx4vcxa9arce5q4n7w7k07wz0uspvsfgf",
+    "name": "Gorilla Haus Alpha",
+    "symbol": "GHA2",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1latd9ny36pdpehr3eukyq26jgm2c89ledpyg7es5e8muz5rul0lshstszh",
+    "name": "Gorilla Haus Alpha",
+    "symbol": "GHA2",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ryy9h3zn6yrs6m2et3drkgszjfzjutfkmajytp98dq7xr8uqwfxs80zfut",
+    "name": "Gorilla Haus v2",
+    "symbol": "GH2",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1wez7n48nvcvw6wr6hctery68zzvfcerqks9phv2nat7ttpkesumqsa5ghv",
+    "name": "GORILLA HAUS v2",
+    "symbol": "GH2",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ekfzeqk8mhvndg0npe9fcuhr06p8c9uv9h8czryheprgma8avmfq2s354e",
+    "name": "Gorilla League Members",
+    "symbol": "GLM",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19cqs4lhwtq5uz037w0w7w5kjszyjrj6n0d0js7p5nmhnlzegxpxsvea3nk",
+    "name": "Green Autonomous Society",
+    "symbol": "GAS",
+    "decimals": "9"
+  },
+  {
+    "id": "terra1hqemjht73a5zwuspk36gdrf4e05t30kcmckfh4lpy2fqv5rgyw3sgh5qpe",
+    "name": "Groovy Lunacy",
+    "symbol": "GROOVY",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1swdw97vxj3895nj88d0jhdu0acem6gy2cchcxzlhwfq2pz2p0cksqt50t2",
+    "name": "Groovy Lunacy",
+    "symbol": "GROOVY",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1kv690w4w7ad2d6st3edmwd9y5zxj5j0ckqtnfywwut555jpw68pq0kz5p6",
+    "name": "GT Capital",
+    "symbol": "GTC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mzexcawct0dle4h2pced5efj5zk7gs3dgfulrlxewkaawm2anmes8hfzrf",
+    "name": "Guess who's back",
+    "symbol": "BCK",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1zlls6m9t2eg60t2wmw58aatt6umrh0xw93947kzt2rczkrcejcxsxf6u2d",
+    "name": "Guess Who's Back",
+    "symbol": "GWB",
+    "decimals": "0"
+  },
+  {
     "id": "terra1klxa4rxjgpg9xuaf5mwpgykpv7x9decrvgg3ejresupcne69cgdqzx5yhu",
     "name": "HERO",
     "symbol": "HERO",
     "decimals": "6"
   },
   {
+    "id": "terra13cdhq2uhsfe3p74jm28j5jf7ap3emj60v6cgmezy2er7hs6zh72sh3rxs4",
+    "name": "Hero Classic",
+    "symbol": "HERO",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1qlpzs5v95dk3f4n8v5nyf5shyq3sye4wecvgjntdxkurrgfrxgpsut38xr",
+    "name": "Hex Gorilla Alpha Terra",
+    "symbol": "HGAT",
+    "decimals": "0"
+  },
+  {
+    "id": "terra18mkl3dmcpa2uc6fr0hcct476jf62k7904puuzv70l99ffwdg5dds229q20",
+    "name": "Hex Gorilla Collab Collection",
+    "symbol": "HCC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1zqjcslj503p4j9svq6hfskzruetn2xtgqsyjmw4qljy2nwhsdmsssahppu",
+    "name": "Hex Gorilla Collab Collection",
+    "symbol": "HCC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1mvf9q3r84rhm3l52xmumluqfj5qvk4n422ycrvgt9z4w8df2f6dsaz4wf2",
+    "name": "Hex Gorilla Faces",
+    "symbol": "HGF",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1sg6wz6h3qngjjreeq96mlcffmu8v40gmgmhrm7l68v7w8zruddws2x54dm",
+    "name": "Hex Gorilla Genesis",
+    "symbol": "HEX",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1sq2ykswasmt352tarwqwn0g32w3rnm2maptryqe5mcdssn27mxgqzwt9kx",
+    "name": "Hex Gorilla Season One",
+    "symbol": "HEXO",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1tf4h7aytval74gk54amuwh45cmztu3fkh2jtkna60wum8mz3pqxqtdyxgu",
+    "name": "HODL ME CLUB",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra155lgyldnjskt687h9dtk5gfzamzqkt6t9zcjfamwrzj22mn945vqdgvyxp",
+    "name": "Hot Heather Animals Help Crypto",
+    "symbol": "HAC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13f7jnzh7yjfpakahzrup5uxnpdxz5vcng5m96jxskhfs5lwlq8aqcgv4ds",
+    "name": "HOT WEATHER ANIMAL HELP CRYPTO ",
+    "symbol": "HAC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lnk3sukea5heg6gjaf7328xez85ta0a60glzrj6zvdsfy65cyaasycn479",
+    "name": "Hudpire Token",
+    "symbol": "hud",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1k94scguypw7ggah8w7t7ly8kxk00wnry3s40a9npdfegtrg76fusmpzlqf",
+    "name": "Hxxk's Airdrops",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1z7ft787p3m94yjch3uhkcydjhmrxz4yccn70uq4e55u2y0jfukkslhdlyt",
+    "name": "Hyper Testing Token",
+    "symbol": "HYTT",
+    "decimals": "6"
+  },
+  {
     "id": "terra1lg5wyah066tc679ehp4d9d9cuk82grxk7vd7u73vpq6md8qzm9fq35lx7v",
     "name": "IBC/-AAXL-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17arxq8nn63u7zghp53kh33alkvuad743d8h77tc6psnq570zuupslmdgur",
+    "name": "IBC/-CLUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yehzc2k78ywgckv2sn2lvaslquffdlf8aypytgt8gcv8ettaxmdqfaslw6",
+    "name": "IBC/-DUST-LP",
     "symbol": "uLP",
     "decimals": "6"
   },
@@ -2083,6 +3514,18 @@
     "decimals": "6"
   },
   {
+    "id": "terra1uv507zlee8j5u4dzaxd6wekyqjuqqjkva94w7p26qxf8u62jjh0q4rlf6k",
+    "name": "IBC/-LUNA-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lmjj99vmu5pxt8rv0taknr4j9v5evv2llk6sulmyexce4vr76gjsvj792v",
+    "name": "IBC/-PN-U-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra14n22zd24nath0tf8fwn468nz7753rjuks67ppddrcqwq37x2xsxsddqxqc",
     "name": "IBC/-ULUN-LP",
     "symbol": "uLP",
@@ -2095,14 +3538,38 @@
     "decimals": "6"
   },
   {
+    "id": "terra1g6466sm9recxrmxhpu2aw79vdh4ahhkswjwq3tpq4mfdawd9nj6s8cxx3n",
+    "name": "IBC/-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra1zgtka8nyjvnet5v4xhecwl4afpmkv26mp7c22jegsavhp2pmpcrquhluuz",
     "name": "IBC/-ULUN-LP",
     "symbol": "uLP",
     "decimals": "6"
   },
   {
+    "id": "terra1fxh9c0v6vpvjrlxnywjq6k545yd09vyjdg536eafqk9ngd23l5vq4lfcgu",
+    "name": "IBC/-USD-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra12857xqnmsxdcd73qvtl7cr92djguxs03mmpgmgksey0xxzmkzqvs29aadp",
     "name": "IBC/-USDC-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1j3q7gcxsp20hkrggh2eqa305asmjnsvgzjdc0jjz9rajg0q8shwqpzqhdy",
+    "name": "IBC/-VKR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15spkcas6jj2jrevvff5r0g7ht2s6h3mal7u8fmnjngk7k82rzt9s4gtnmj",
+    "name": "IBC/-YLUN-LP",
     "symbol": "uLP",
     "decimals": "6"
   },
@@ -2125,22 +3592,185 @@
     "decimals": "6"
   },
   {
+    "id": "terra1l7z4lddtwstgmag6u7pu6jlthqrapk39wrlczm7vp0tjfxh6e84s4d055r",
+    "name": "IDC",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1w7ryjz65q6l48ydht9nnrc687p84jwt8qk5z4afj7z6unf5greas0z4qup",
+    "name": "IDC-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10d4ss2p86v5caxjzsnlsexepjw78f98dqjxvjj66l5dp4qdp2f7s5j7g6y",
+    "name": "IDC-TPT-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14qsj3px3g3nfwhdp36nml33flfqy6hkgurcanae7t6sfl3yu4duq8xlppd",
+    "name": "IDC-WETH-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lt30ry90758wz7mugmagkjr7ehn5t3pk7amlytd3c639sqddwz4qmrgmde",
+    "name": "Initiates of the Flame",
+    "symbol": "FIRE",
+    "decimals": "4"
+  },
+  {
+    "id": "terra1c5urwcswu23k40q640klugf3sz7dlh0m3nxxs07u40xpahtqrwgsrax3gq",
+    "name": "Inspiring Artists",
+    "symbol": "Insp",
+    "decimals": "0"
+  },
+  {
     "id": "terra1sxnyuh2dxzqrx75e9x62fw0pns7tvcyjkjsdkl0yvzdac7myjgeqep5mel",
     "name": "INT (Wormhole)",
     "symbol": "INT",
     "decimals": "6"
   },
   {
+    "id": "terra14dadch35htr43e6fu5ra7vxzdq7a8w6jzgx6ksm5awg55aw9wzeqwnpjg7",
+    "name": "Inter galaxy colli by 12yo son",
+    "symbol": "IGLX",
+    "decimals": "0"
+  },
+  {
     "id": "terra1d4j9lsl453mkvtlg4ctw8y52rdkhafsaefug0hq0z06phczuvvvs7uq0vg",
     "name": "INTERCHAIN DAO COIN",
     "symbol": "IDC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/IDC1201/IDC/f22b0f203867414b6473f8e8a935c3edf5524296/ASSET/IDC.png"
+  },
+  {
+    "id": "terra1f7w3h99varl067u5qlsnpuss4etktcelv53at9jcyppsgkp3je4qajud0c",
+    "name": "INTERCHAIN DAO COIN",
+    "symbol": "IDC",
     "decimals": "6"
+  },
+  {
+    "id": "terra10h2zxfgap3ld4evqc6jczhpn6vjcdfhny4gx0k82c0xc658z9dnsepkndm",
+    "name": "InterNFT",
+    "symbol": "n/a",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1087lrvk5zulanrjhdtcfrf49udx70dxqt7erhn4qssu5k60vz92qcrpv8w",
+    "name": "ITO Token",
+    "symbol": "ITO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14fh69r7jvjmzkna7ucssdusufjmgc5y834ua6k5zgd3d4279f88q54w09g",
+    "name": "ITO Token",
+    "symbol": "ITO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1c5vpgnu4kjzxehmvh8adx08ljcappve3jcqcvxha5klqpxc0pguszglelw",
+    "name": "ITO Token",
+    "symbol": "ITO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f9znhfh3uhzrs3rrmt9m2a4f0f5u7jcxuxr3a63wknlxre4vks8s30ljmf",
+    "name": "ITO Token",
+    "symbol": "ITO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ncstskapt4ccg94glnkkylnlgdknpelwf82s5us4xyxj3pmpc54qd7gtky",
+    "name": "ITO Token",
+    "symbol": "ITO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1u3dcmvrdnutlx5rtvw079fgesucwfav5znpv9d4z584nxmnnn6eqydajhm",
+    "name": "ITO-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q6gqwja73tlz0jvatvdaassp5czam533vkcvewqyl2kg5tcm96yqdk3hpk",
+    "name": "JEFE TOKEN (Wormhole)",
+    "symbol": "JEFE",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1afyue93pvg6dq2hmqfhnvawn9q4qpvmfe5aj3e5h0rrcjqcg0l8q3qql79",
+    "name": "Joeken",
+    "symbol": "JOE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ajcht9tj6ujkpw3vyaadasslz85rp2geppu90yehz2gz6z4depaq0f7fqv",
+    "name": "Justice Kingsman",
+    "symbol": "100",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ppjlgcuk70yzexfnnwarcalz9ur0v4yay8h6s3tfc78vyc3q0y8shmaenc",
+    "name": "JUXTAPOSITIONS  ▞",
+    "symbol": "MSC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1cm5tgyvtrr383xp39z4dhz8xwrcsut3gw0nzqs3z2ugpa5pxmh5qtrfetz",
+    "name": "KateEatsPizza",
+    "symbol": "KATEPIZZA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fjlj3twnm3yyt2utd738tsrx7fcerkx3xtpgn3x70yp9tak8ufdq0el8x8",
+    "name": "KIKI",
+    "symbol": "KIKI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qnfwdkcm92l8ecefz7ypnwlx9xsd63n0mlqtcdavy6trhm8xr2tqlh3mws",
+    "name": "KingsmanDAO Art",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1wwehdgkm6aa7vtuzhc3rs39txve0vv00mkhknru4m6ew0fazhfcsuk0zsc",
+    "name": "Knowhere NFT Contest ",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1ndslkk6vfv5dc53chrlsl3k8qzympt4rrynjjttyl72jhuqyqy7s6am3lt",
     "name": "KRT (Wormhole)",
     "symbol": "KRT",
     "decimals": "6"
+  },
+  {
+    "id": "terra10n6dj60zrndyru0udh85elvj7wzy6wtjw3t3gepvnxkexv9deztq8j3z86",
+    "name": "Kuji (Wormhole)",
+    "symbol": "KUJI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s9aew7kfrkn0feqpcau5pxjzyrgx58fyhpq2v7jk3tnld237l6gqr39jlk",
+    "name": "Las Caras en Blanco",
+    "symbol": "LCB",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1pn7uq2wtv93rlpuemv5ulppf5p37ff8z5m4a2lc6kt0aek2cej9q37vwxv",
+    "name": "LDAO",
+    "symbol": "LDAO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1c5h92xmgl6gjp4pq6ka6p8avsjkr23vatr05pulmzdvtcd38vvqs4epenh",
+    "name": "League Of Gorillas",
+    "symbol": "LOG",
+    "decimals": "0"
   },
   {
     "id": "terra1tquaelpx4tw6xnv9wh8xj8e48auhyyy888s756z699ssfqpq2wasz00fmx",
@@ -2179,10 +3809,172 @@
     "decimals": "18"
   },
   {
+    "id": "terra1cd64uj7mhtgdncx3s62p7f02zvk4w7umtn85hkeemwf244075j4qe2eu9v",
+    "name": "Lira",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ekn2a5h298endnvf7sryt3ec8pwraqpphxte0xpuhgdd3ngn3y8qezatcj",
+    "name": "Lira",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mfmfcet8l7khfwq68jxsqnerv246gv4ztpunjsgdj8ulwe3r0x0s5xa8r0",
+    "name": "Lira",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1n6k0pg6hh5k2qd2u3tw9fr48vcl2q6a7zrt27anqjajnrm63vldq4a23vt",
+    "name": "Lira",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q8hcpc4atfpq8743kk3xq6uux9y20krd383995gye4c7qxy2y6ls79eemw",
+    "name": "Lira",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v9yne0lvwxfv2um36rqwutphgwxznr2suwl5ml9h6xzn2u29vz7q28ez0p",
+    "name": "Lira",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1c45hdhurx9jaz86z9hrt83ddut9nqsz46p2sgey5ewf7vqz0kqvssrhecp",
+    "name": "Lira (Wormhole)",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1njtkekd6dqxgz9vlrs52pf9lfd2mna9vgh2r0mf0wvp5gg6zu3lqf78fqu",
+    "name": "Lira (Wormhole) (Wormhole)",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z2e3mh27wuynd9whzsvm3rfyhcv8g4753ev8qfdd46esrcm4unxq374wy8",
+    "name": "Lira (Wormhole) (Wormhole)",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1prcysrw4ys9kp53m3s3dhx4psus4yj7lyakxr5f68zm7640ss03sccdeqs",
+    "name": "Lira (Wormhole) (Wormhole) (Worm (Wormhole)",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s5uwl6gaxyj9mjtkwze4vwadc5jqtmqrkcxcave9c09frm5uzxpsjzjzy7",
+    "name": "Lira (Wormhole) (Wormhole) (Worm (Wormhole)",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1uqauk8jrgzdp7zy700g6g6mw3txy3u2j9rtp00wven7prkqsc4rsafk4qg",
+    "name": "Lira (Wormhole) (Wormhole) (Worm (Wormhole)",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xdg4gtzsdacv8svusarsmndpsqpnafxhmdfqlhse7rk05ys3326s8f5pc5",
+    "name": "Lira (Wormhole) (Wormhole) (Worm (Wormhole)",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1k8vt0lrm0ah37fpd3t5d0jc969khc200twsg5pqaf8xpg9sy5fnst0p7ka",
+    "name": "Lira (Wormhole) (Wormhole) (Wormhole)",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rjsmxyv46ashe8hlzsesyawltd6c9ftxkpglf5g688xn08g66v0q0ny2zs",
+    "name": "Little Whale",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1c4tcf7xfaer6rk47s25skqy358jgwhs8jrgxkq3nr7dzmcrtsqxssln0s3",
+    "name": "Livia Testes",
+    "symbol": "liviatestes",
+    "decimals": "3"
+  },
+  {
+    "id": "terra16a6qkmxpqzeyez8gh3w7qhrk7x3xe3arlv9nwfg944y8vzg9smrqntark3",
+    "name": "lns",
+    "symbol": "lns",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1fdea6s9g2w740ml0jmzr3szhwp85c2lg9hjgth70vzst43nz8yzqcyqaxg",
+    "name": "lns",
+    "symbol": "lns",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19gsaaq8wyvgf5l5aaqtr6et83sunsu07dmhklhaghmtw8glwt63s9sdcaj",
+    "name": "Local Alentejo Coin",
+    "symbol": "LACO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f0rhjvayf6ea79jf9ls6zhwm36wjy8wvqtuu2gpq8z5ddnwd3saq9ytkev",
+    "name": "Local Alentejo Coin",
+    "symbol": "LACO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1prnyz7ezw85dt9zeyjcdufldjcf6h4lxxzmvl5ctspyj50w7mt5syn69t8",
+    "name": "Local Alentejo Coin",
+    "symbol": "LACO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1x5332um7nvaudzsgklnujepmdzz28grhn8h0yrl9djpvxva5agvsyaqn8x",
+    "name": "Local Alentejo Coin",
+    "symbol": "LACO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yetl2gafkhtanr6utpmxp0zqtkhkc05k4dgjg0zfyf86p9fzw3ssslv0fj",
+    "name": "Local Alentejo Coin",
+    "symbol": "LACO",
+    "decimals": "6"
+  },
+  {
     "id": "terra1xzkel96e5e8vfmqw7valzdzzv9hqasfyslclvnmvxdejvpda3xwsskxzus",
     "name": "Local Terra Token (Wormhole)",
     "symbol": "LOCAL",
     "decimals": "6"
+  },
+  {
+    "id": "terra1h4me76lqd2450e8jnduewen2vpyfrxlekhtql9aed6kt48thkqqqu00vjq",
+    "name": "Lootopian Items",
+    "symbol": "LOOTITEMS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1c649ctpkwqa9h65g6xmplrncc55d5nzqgz30zhtkcysedkd63zcq02uhs8",
+    "name": "Lootopians",
+    "symbol": "LOOTOPIANS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1jv9h8w29drd2r4fugsvsdnkrsl99wpr2xmn3wn5ukn6acv6g9esqf0uh9x",
+    "name": "LOVE",
+    "symbol": "TERRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ed0k9whkuc0upf65znurquqqvhchdawzv3fp9vum496tumwa60rqktjsy0",
+    "name": "Luna (Wormhole)",
+    "symbol": "Luna",
+    "decimals": "8"
   },
   {
     "id": "terra1leavh38n7ycjh5xed5us2s8f576zmpj48ec0nhjs25r0wq5au9lqw3kdqz",
@@ -2191,8 +3983,32 @@
     "decimals": "6"
   },
   {
+    "id": "terra1fqxs98wj9eeenq95093gkfqzq3emfzxe88hvdr87p46ymyu4agaql5hhv8",
+    "name": "LUNA (Wormhole)",
+    "symbol": "uluna",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1teycrt4svt52jfmhkwywgk5gg9thrvgz87qm3edc8u63kte23djqlv5u0t",
+    "name": "LUNA (Wormhole)",
+    "symbol": "__proto__",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1ukv6djf73m9g459a3pwhq6c8jvuy832gpv8ck4eyyeaj2rptxkvqyxlz43",
+    "name": "LUNA (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "8"
+  },
+  {
     "id": "terra173scyqe32fh2cec7ctmy5jnxtqpghhlrw69p3z84vk9huzn9s8yqggvjzj",
     "name": "Luna (Wormhole) (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18ywl0l4z3u6rjcxg4rwtjhztj89k8nneqfz96jg9tgh9c7tgxjns93v75d",
+    "name": "LUNA (Wormhole) (Wormhole)",
     "symbol": "LUNA",
     "decimals": "6"
   },
@@ -2203,10 +4019,22 @@
     "decimals": "8"
   },
   {
+    "id": "terra1sdr0trqyfjh3469a5j0fvga4u7ged6u4m56jskv0llz9zkm2twyqcgr4ez",
+    "name": "LUNA (Wormhole) (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "6"
+  },
+  {
     "id": "terra1rq683n66vng4hqp5fuq8jja0z9wdfvem204ckyvwf0r02nvr8xuqgrwglu",
     "name": "Luna (Wormhole) (Wormhole) (Worm (Wormhole)",
     "symbol": "LUNA",
     "decimals": "6"
+  },
+  {
+    "id": "terra17vysjt8ws64v8w696mavjpqs8mksf8s993qghlust9yey8qcmppqnhgw0e",
+    "name": "Luna Ape Club",
+    "symbol": "LAPEC",
+    "decimals": "0"
   },
   {
     "id": "terra16h7keds26d52xj8rn9jfx6lj2x0ja79lt56yxnmlm4xsttf5mu5smq5f78",
@@ -2216,10 +4044,166 @@
     "icon": "https://assets.terra.money/icon/svg/LUNC.svg"
   },
   {
+    "id": "terra1fvdcu2j85nrlhwhy0rmhttst2caaxtf36ytjcngg47qkt8ndcu8sm6qff6",
+    "name": "Luna Classic (Wormhole)",
+    "symbol": "LUNC",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1y9guyavsd5cjz4hh9jxlsu4th2ce95kjqurc3aprkrgrwg4cj7hqx25p6v",
+    "name": "Luna Classic (Wormhole)",
+    "symbol": "LUNC",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1m20djcturk5yxv8u84s0t6xh5evjx98pmlc3xj8u99qeuwy79hrq5l9dz2",
+    "name": "Luna Crash Survivooors",
+    "symbol": "LCS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra16nfcvfcfd8fnurp6m20xpa2d8c5y3v47g4y0r9jqzr7t6auersxqxd2jf9",
+    "name": "Luna Doodle Bears",
+    "symbol": "LDB",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1rwwtz3aac6w9yxmxa32hzggn0j7swt7e2lrs9838wmygq9wlnl9sdhq3wc",
+    "name": "Luna Doodle Bears",
+    "symbol": "LDB",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1crxcd4m9wvr35j7gjcgwquum6lxtz2f3dssd7f9959xn5jq5lu3q5dyrgh",
+    "name": "Luna Fight Club",
+    "symbol": "LFC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1dddhkvrdwjd30xgmamld3zdtvfmjlpeh2u49mluqjx65wgnwarcs882qme",
+    "name": "Luna Kiddy",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1fcqy0khmxkap332srawukpsqc2p9uaujv9us368pkvnpxwzz6r2s8trv6d",
+    "name": "Luna Kiddy Collection X - Hello Moon",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1swldwd2jaj6ewxyckhxu9cdjlhwvsky55rhd02jszfmsgvjcq6hsp04jx5",
+    "name": "Luna Moonz",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1gutsrmwdls9pva4jv8tghe29qt4rfmhnplx8qvy9h9l5f0y9l0xqestddh",
+    "name": "Luna optimizer token",
+    "symbol": "OPZA",
+    "decimals": "6"
+  },
+  {
     "id": "terra1ry9f6alqyf9dpj04u9ymq5u4whjndu485agh6gusn89dmqse3ggsnzducj",
     "name": "Luna optimizer token",
     "symbol": "OPZA",
     "decimals": "6"
+  },
+  {
+    "id": "terra1ldhrtdqhfffrg67q65rgnk9exwrjyv5rpk3p77hrcndg3vu8d9ws2h93nv",
+    "name": "Luna Saver",
+    "symbol": "LUSA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ace6qznlfmng9ucmf3s02qa4j4jau702dz0mzjktacqr5yx4hulqysvs3r",
+    "name": "LUNA-Swap.io (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1vh3djwh20p34y5xla3a8c45n7z2xgvyejy0kp2eke5xgtax7fmrs8a3g77",
+    "name": "LUNABIRD",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1tu3fljc4ksy785l4j7cwj387hvfwxp88avrc6rwxc0clckrjalvq0ctr3j",
+    "name": "LunaGorilla",
+    "symbol": "LG",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1p4z3k297lvxtc8awfewf5g63gjgunakgknh5wj2pnarydltlwz8qx93mmf",
+    "name": "LunaKittys",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1525vl2n9zh3w4yx22u96j8jua6mt4rmuy5tuclc9d8yjsekjxnrsnfr7wn",
+    "name": "LunaLapin",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1lxlm3dhchddr0gs9rw0s87c0prhw8xvmzjqh2s920v7pxtzqy9sqwsyqc0",
+    "name": "LUNANA",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1hvjl89vxv6lk5nmwl4tnz70pe7t24plgw7xa4r2yps0l2uytt8xscmhud5",
+    "name": "LunaPunks",
+    "symbol": "LunaPunks",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ntnkf7k3twr4j7j2h6y4k95rz0nfhcx9e3e0ke957vjvpzwynd6qas43zl",
+    "name": "LunaPunks",
+    "symbol": "LunaPunks",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ew0rx3lgecmkeh8qscz92kvw2268flpr0r49k7m44xk3musg4a6spw8yj7",
+    "name": "Lunar Assistant: The Giving",
+    "symbol": "LAV2",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1t5934pztkw2j983azhsgkvkvfp2vgfpgvzrpy58h88krr4uvph6sevnsdm",
+    "name": "Lunar Boots",
+    "symbol": "BOOTS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1723fcqetu8dxjqe3as7djqtmzyjwcp7k6rs5mv2jrsytjer032kqvr0vtq",
+    "name": "LUNASKULLS",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra196uh50ak5h6m8zffjpc0uv3vfu56q4lmcwh6hetyzvaldu6yy3gqkmpw23",
+    "name": "Lunatic ConDoms",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1hf3c5ryyk90spej29h8eyxvqkvvl6834x497ruedh9q8ej0v54gq08jmsu",
+    "name": "Lunatic Punks",
+    "symbol": "LP",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ew6ve6nuq8rf33vfnkj7jfsygq4au9gkkkapr2xnp6vhrl30484s99ph5x",
+    "name": "Lunatics Punks",
+    "symbol": "LNP",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19ersf68qqnpc4vu93l3fr4t3e0dwg7v374ynv0k75hk2ggad693q3y9p6z",
+    "name": "LunaV2.io (Luna Token) (Wormhole)",
+    "symbol": "LunaV2.io (Luna Token)",
+    "decimals": "8"
   },
   {
     "id": "terra13su0l0gx7r52ttqc5srxhg3keu575eyq3admtz39m0c2k0yv499smrty24",
@@ -2228,9 +4212,87 @@
     "decimals": "6"
   },
   {
+    "id": "terra168x6eryjuwkwdnqkksps0a6e0dr65mjpfclmhswxyurztyqy345qv6y39e",
+    "name": "LunaX Pool",
+    "symbol": "SMBL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10vz23p5agfdmryj62mh8srx9lcctlulnmg28upx2e8x47k6dmc4ssvahhf",
+    "name": "LUNC (Wormhole)",
+    "symbol": "LUNC",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1pujwphjvqww94vvefkhuq7vdlmxqunf5shnlf2zvpdeu8n3suces0r9lta",
+    "name": "LUNC (Wormhole) (Wormhole)",
+    "symbol": "LUNC",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1ulr678u52qwt27dsgxrftthq20a8v8t9s8f3hz5z8s62wsu6rslqyezul4",
+    "name": "LUNC Burn Token",
+    "symbol": "LBUN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16fk7y0rn7fxdxv44gzv86uq4w3uq4v57y84v5tm6xmklu2v77tes2gwsy0",
+    "name": "LUNC Holocracy Token",
+    "symbol": "HOLO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1897y20wkvefn994e5jx0vtmcyu6nkxdsnlg4kfg6uefe0s6ct8hshtakjh",
+    "name": "Lunc Trains",
+    "symbol": "LuncTrains",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1m22wjsm4vyuf5s9mpcczdckhqyqw5jmspxkdftju9v0u9tg8smxq9wdd23",
+    "name": "Lunciferrium - Invaders",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1vfme2h5ffueendzymf0n4hs0g898ncp6ww5n09z8uw5rn8cfwhxq7qnk86",
+    "name": "LUNITA",
+    "symbol": "LUNITA",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1as057wvx6vjqefawk2cql39k90v62fltn03tuw4262dcqtzppv6qrh897m",
+    "name": "Lylith Iconic Woman",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1pupw8tmlgf7fgz5w9jn4876zkxw03es23jpm8v0207m2g7dpjtqsmdylpv",
+    "name": "MARS (Wormhole)",
+    "symbol": "MARS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15gykrtjfdxfy5q52v3jvdaqa0e7sw84nymvxltc4a4jfelvhspgqfwx4w0",
+    "name": "Mars Protocol Token (Wormhole)",
+    "symbol": "MARS",
+    "decimals": "8"
+  },
+  {
     "id": "terra1s8u586k3s7xtvasxv4p6ldl0jrxht9w886v8ymkst6crg5hxue3sqn49r9",
     "name": "Microsoft Corporation (Wormhole)",
     "symbol": "mMSFT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y5e4plp8evsh2urycmhy35lrqxneqc8ewdqzjpvlu5z9wurpqw7sfj9u5x",
+    "name": "Mine",
+    "symbol": "Mine",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q2mc9srv908j0jt3mpevdvpqsmy4s8tt0vwgwvae7r6d9cvklfwqgzwk4d",
+    "name": "Mirror (Wormhole)",
+    "symbol": "MIR",
     "decimals": "6"
   },
   {
@@ -2240,9 +4302,27 @@
     "decimals": "6"
   },
   {
+    "id": "terra1saxy7j45avta7z6q8qv3j08p4t0qz0nfsyxwhraejek90eege6asumnl5f",
+    "name": "moon",
+    "symbol": "moon",
+    "decimals": "6"
+  },
+  {
     "id": "terra1jg848acg7rzt7tnz6zqaxzsc94w2yjhafad80d3uel9937grkmfsv8aycw",
     "name": "MOON",
     "symbol": "MOON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jzl4telukvjx56l72zxuts0xm60gefgu3kla36fvfqlfxn0ckuvsgd6akd",
+    "name": "MuskTerra",
+    "symbol": "Musk",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y92wp8u58396mtaejwhtasz24vrcf0lhsznl7rj0nhw0khp8kchscuqgfs",
+    "name": "MuskTerra",
+    "symbol": "MUSK",
     "decimals": "6"
   },
   {
@@ -2250,6 +4330,12 @@
     "name": "MuskTerra",
     "symbol": "Musk",
     "decimals": "6"
+  },
+  {
+    "id": "terra12rh4v7lwszqwcf73k38yxv05j78vntckczngh4ym8a9dqtzqc08sucptw9",
+    "name": "My Get Rich Token (Wormhole)",
+    "symbol": "MGRT",
+    "decimals": "8"
   },
   {
     "id": "terra1gd3ntqq04lvd623xs8ht6dly0s7n4gxnz7lmlw5ga0qnamg9wyrqcggn2h",
@@ -2261,6 +4347,18 @@
     "id": "terra1l02355pejytcakcpq6g3n57ydwpqeysuw5nj679hlnrrsz3sc3wssxr69j",
     "name": "Nauticus Luna Yield 042923",
     "symbol": "yLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13g39gz8uv4s8h9a7pzmg2pezcmd46jz774lffhe2n9dqckn87mlqqg86nc",
+    "name": "Nauticus Principal: LUNA/LUNAX LP Astro",
+    "symbol": "pLUNA-LUNAX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gqe4qzemuhj8nxn5f3fj9tcscszy90klrapxsjpr2td2a0fnlxmq2klheq",
+    "name": "Nauticus Principal: LUNA/LUNAX LP Astro",
+    "symbol": "pLUNA-LUNAX",
     "decimals": "6"
   },
   {
@@ -2288,6 +4386,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra157n39w0p0ux2wcec2fwyn30rywfd9tunxjc40qm22z6g5sdlr9uqcv8rza",
+    "name": "Nauticus Yield: LUNA/LUNAX LP Astro",
+    "symbol": "yLUNA-LUNAX",
+    "decimals": "6"
+  },
+  {
     "id": "terra1mecwgl3p77l57lv5ksn7zet0p97rjd6c6cdk4vmvrl52m680pk3qgf5y2u",
     "name": "Nauticus Yield: LUNA/LUNAX LP Astro",
     "symbol": "yLUNA-LUNAX",
@@ -2295,6 +4399,12 @@
   },
   {
     "id": "terra1sqxtvf93tpu08evzt6va072cefy45xuvjghutgmcv93pk2aaazgs220eev",
+    "name": "Nauticus Yield: LUNA/LUNAX LP Astro",
+    "symbol": "yLUNA-LUNAX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wjzwg8megt6zsfsr2tduwklh8sx3mpptquqcm7h0krxuzwc5n86sn2xh9a",
     "name": "Nauticus Yield: LUNA/LUNAX LP Astro",
     "symbol": "yLUNA-LUNAX",
     "decimals": "6"
@@ -2318,10 +4428,76 @@
     "decimals": "6"
   },
   {
+    "id": "terra1hw6ymqhxla8a5wk7xjjfqhxnvewvzqgdv5c5gfhlateg7sfhtymq6ccfuc",
+    "name": "Netflix (Wormhole) (Wormhole)",
+    "symbol": "mNFLX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1w3fjl2nuhpqwwu6mkaarkgnvpugs25t5sd4pj02ktdjn0ayw08ys50lepk",
+    "name": "NETONE",
+    "symbol": "NTO",
+    "decimals": "6"
+  },
+  {
     "id": "terra10804tj9tsguuhe5k3yt0xm2h6wdtn8zhea4mj9v8s04w6enstf0sgf0mtq",
     "name": "New Community Luna (Wormhole)",
     "symbol": "cLuna",
     "decimals": "8"
+  },
+  {
+    "id": "terra1ymkvnzclutwd8plps056479wl26cw4m7ynelg2fxwnswlrct5syse9725q",
+    "name": "NFA",
+    "symbol": "NFA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10cev4e2n2xjen5eqwx2454zusej5yvzfcd8ymzldtaujecwxpxcschl3et",
+    "name": "NFaTman",
+    "symbol": "NFAT",
+    "decimals": "0"
+  },
+  {
+    "id": "terra17gg9tteke98elqlfgcy2m4ymx3hzqzs2efdmtvutjml03gxvanpqmzne87",
+    "name": "NICOL DAO COIN",
+    "symbol": "NDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tejajvl4y8f9remfdtlpl555zmr7ltqq2rvvs2vrmx3ke98twepsyutyu2",
+    "name": "no-name-yet",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ey8nrqhufmj0lfcn33x345hf7zhggz03nss03keavs3nxcml0w8spl0w58",
+    "name": "NUSANTARA",
+    "symbol": "NUSA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14kxhyva49afm4hzurmwgzxf5qftrmtlqap6yyty29rgvzt9f0dkszt5de8",
+    "name": "ONLY-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zd27zxxn976s0ygqa7h2cmgzq0emcuy2h4dk04a6s8jm5a346dfs3zc6u2",
+    "name": "OnlyFeet",
+    "symbol": "ONLY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xvfaprudv2nwh4kcz3rx4hurwfqgxwdencuf5ull6dt8q092ph0q9m7s20",
+    "name": "Orne (Wormhole)",
+    "symbol": "ORNE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s3uyn9nakk9ht6hq455vj89r34y6twc6nejgl63swqyz8ushwtwsg7zh8q",
+    "name": "ORNE-ASTR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
   },
   {
     "id": "terra1zhwjeh96z0ce0l7ze6veynuekmqkhatmawgnmvkfnutg3z4ymsass9cfev",
@@ -2336,15 +4512,63 @@
     "decimals": "6"
   },
   {
+    "id": "terra14mvqh98pklf3h9e0ug6tr4h5kpkn4hxqcqkhqvvedszjmef5vzqs9kkn0f",
+    "name": "Ozone Vault 1 01/27",
+    "symbol": "OZ-VaultOne",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16phy60cckrwcl9memglr0m25tp4p50av26n2cnnf2h4kre3gvffsd99kpx",
+    "name": "Ozone Vault 1 01/27",
+    "symbol": "OZ-VaultOne",
+    "decimals": "6"
+  },
+  {
     "id": "terra1saegtxk5vym89ydrfrfw75smhpfg7202mkje2f4gwx4tvh5m54cqz9xscy",
     "name": "Ozone Vault 1 04/31",
     "symbol": "OZ-VaultOne",
     "decimals": "6"
   },
   {
+    "id": "terra12562rn6zu6n54gat6nsv83xetexe6kjs50a3mulhmsv8lqwxgaxq5paym4",
+    "name": "Pacha X DCentralize",
+    "symbol": "DCENT",
+    "decimals": "0"
+  },
+  {
     "id": "terra1dzahfzk3vavwy4zqt0x49guswvwe6ef8jm60fpl2cqmq0yl7pp4qyrx3cr",
     "name": "Pce",
     "symbol": "Pce",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16zlyx8s596gfrswryazttjtvae2qwc72j27vuvnefcezc2qlazssjmmdn6",
+    "name": "PCE-ASTR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e89c3swfuyykycw0gkqnwdvuwd0lxsg55tqydf3367dwhp73mrqqad6u4f",
+    "name": "PEG",
+    "symbol": "PEG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1h7g332d4r6chhv63umey9y2g5g5dq3h88s5az6xzpj6mrdefwcgswv558v",
+    "name": "Pinx Ladies",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1kxeefnas9zsgz8dpequcdp85t0mlxshcjd3sar9889z5wwnwad5seexp60",
+    "name": "Pla-net Universe",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra18enrpukca3tnun2qstkdnwy27xc326d75fjj682yevzmwe58mqkqcl27n3",
+    "name": "PlayNity token (Wormhole)",
+    "symbol": "PLY",
     "decimals": "6"
   },
   {
@@ -2360,9 +4584,891 @@
     "decimals": "6"
   },
   {
+    "id": "terra1n5392a80qr69ee2waudrtrqrwufk0vjavd42q5ea9nut3hlfscpswx7t80",
+    "name": "PLUN-YLUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16ptks602wpdjqtmd0qg5kpulkm7qf3wr2h6t5hatgrec6cl3l3jsxnkt7r",
+    "name": "PN-U-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1axc098v7zqalr4rgt9dxcw9zh3la4sgcwwlj40easet7yjs00e7q6mn3lf",
+    "name": "Poki Cube",
+    "symbol": "PKC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ymf3js2gud2h2rspqmcd6n7nmsdyk5zvvwyz9wk4vegy3df3r4sqgrepv5",
+    "name": "POOP",
+    "symbol": "POOP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10fs0sjuudj5suc5w0w6cfcak2w7y6t7wwaaflumh430x203dvn5s25q6yh",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra10fvqy25jyrr8uu5jw70vkshrnh8akzs534t0z9mrhdtw3lhth73qagl5zc",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra10lncq275lsf7jcw75p0mmcnv93zxwgeztyxa8dx0yy87rh3hsnkqa5t7k4",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra10smdczgk3cfay3hwahu9hwqp7ms66usty64n29dxprexd696uhuq4sd44n",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra12gly5yany57srs3m0qhae47h2jvpmdj6m73skwe0qfm0ywrmlk3qhpmpya",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra12jwxnguurh6dzhlwu0qag6fdwty5dh5uk0ldr5ycqrzm6kez080sufcemh",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra12uuqg783xejjds0t4f46ylxfl088pyw42wqtjcnupvgt02lgacyq4ta8ac",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra12wa9vvnffrady2yltzv6u20q37gg59w8qslmt4ufpqyprfe97aws5cyae3",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra137q26tg7gnjvu8lyqlkaffd343qfdzj9d7ynfm428eu7cc60vq2smkhn0w",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra13tzvgrp0zy5q5h50k9xlvdtwhs840pdyt5fyhhp8lskpgj0gsd2q8u5ng4",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra13w3073l43gwxw77tv2np2katn3jrvet87unyfevg8nrj755m3x7ql5xv0g",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra13wppqeqww2y42dlp7u30rwmekwjandzaxjvq3c503ak8fx5nvsyshercr5",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1454mwwpg5g0lqrsnh7gfr74avw8agm2snhawgf70cjectgcn6kssx7jl6e",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra14c7t4686jdtf9mf83hjwm0hqm9hawzzfjt93x77djfa0audx3dyqczda67",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra14dtlxyj2wqteq02293zt538rn39djdsahyt3hayyxm06ds7hn8hqdp54cv",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra14eut6f6mvdk8wpz6hsmuzgdujek5dnhd6dxx4py0gvxejzxwawdsksgtj4",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra14l6hpqyd2vqy0wn63wkep30wxmt62vjzlwzeeyhlkdkgm7grfl4qdf0enc",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra14tcq7cwrjtauqh6zwjd0zdaqg700dm42p5ja2a5fam9smnhn6t7qdek9jy",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1546pd7p449kej7rk2zgphxuymrqf90rlxu9tylyv0uf6dva4srfslhhu47",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra15qleygegrst8wke88m3fqzrsc7c6a45yqnqjlz64xqm94wd9zjaqw0z3an",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra15zsd9j5c3rzw5em6wqvzveek7cqx0ac3s2hzmee8qsdy37vwv7aq8w0fce",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1623wrqxv80s7tcg2ugp63tvygp58j6d4h0tuf8xewxmzv2gmrk5qze554q",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra164caf0wq3xl6fzpn2ek0ermwj3hyznr5dc7d920xsmq99h6auptq0jqujc",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra168nvfltz6z6dt3y8c38zr76p7hx2as32vwgy5hju7atcl7krxacq7yjsm8",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra16n6w0crnx7jskql6hgd2jg0tcafj60kwgp9k7nmpnfyt6j5dju3su923y7",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra17a5n5ln6zflcf23sf34va7ptes3u03vhftza47shqlfd2z04t75q3gkq6n",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra17d9vyjcnpn752dzxvgxn6lm28rn54p5t603q3t97dn5v92lyujlscdvqzj",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra17j6erkccpazwmzklkne96mf4kqwzs93mjxeqx7whxqmt4ha507pqe0a77t",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra17yzdugtznvecr5f7xhf9ralg0gg9l0pah9f6lhhv0xtwkj4aajks47cwtf",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra188ql9msm2g7r4lhm778w2gc5qfss8l4qtv235sz6wyslctmzmn4shg7k8e",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra188qt3hm9d3e50303hk04s4q9grfelfku74df7u5hpgrwgh2hhgeqhvj9t7",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra18cm52mt0c37yz7vutht0fvq37kkr8wgkvkwl6jn4kwx8uaa77d2qpa8ewd",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra18lteke6cy5t8dmc7ndzaj7mkp42acwplsm5f7vq3xmen360s2qxqafmvlf",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1924amcpgxksj7sz296kysxzn8u8lq8l0gvpnyrlx8pp42ryv00gq6k76ag",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19522js50q7gql2fcavcu2emw32lh6v4exypz0h3sm62hl37hmdgqjd69yp",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19664tmugwklf9z72f0nh3jjudzw0vfzjf4gmvttuppl60k9pvarswcmvj6",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra197fuwr564m6efgxdvau5j7j4nn0l8lau5qjcdzpv5cufzjzyjvgshcyd8x",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19evfm7pk6hxth52eq7949dddm64ug9u5xnpggpwg4nlfesahqdhqslrhtz",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19w83ezwxxc4qthcx2skfzre3qtamxzuhd3jj4r7h07c3rx4y9zlqnq9zw6",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1a05hpaqh4h5mkt9nnfpql7m0kjs2972pm0t4t88ezxgenp0xlg8sqfeeru",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1a2sfcfjvqh5hzstzek4flqmj2rcsn9dxgy7dfn3qalmajsuexmssvfdtfc",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1c7th2fkvtvsgy4w083nkzarmjayy4eqdn3qvagpa7sj723fvxprsf7yzgh",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ccrhywcdxwlkhgv74eu8mdmd32vawc3lt9htz4pvy4hv7p4xlewqteunm6",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1crp926elm6g765272tt6ky53k77klq9pvfyacupw3mjzc0d0pk9sxpphpf",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1cv2n08ak4vyywxuzu4sshp9vrwkddmjh6sf9lun9dyf37rtn3llsnd6rej",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1cv9cp72zx7mawt3vgct2x0vhsjp59uf9m007zz8rz9m4zxn6n8lsvvnudp",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1d569vm9mlka059qh8wr99gkt0zdrwrfgnsq3e0ms2nrjzk4pv97scuphsj",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1d8cyqqf958ztmtfm5zdak93j3ymj00xe3l5k47zhgjypykkku67q9epza8",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1dmvcpkkgeuf2n3zy26sfc8l7yhz2tydvhvz9ywa8mwjct6nj9yqqdhcs5h",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1edly287ft06dwp6atdd9528adg4kavfwrqutpyzq0pax499d6whqejghcj",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1et08h5f3kjmles2za0vrhf703pnq2958kjx83z6n2asqgs7zw33s6je5ha",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1etperyw4cne44rfzqz2d76cj9j6hg8gha68ag4uwwffx7qk355dsf7cqsy",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1f29qttj2d62adht0ay89fkxd79rmd538v4f3svdean2ftgr074jqurt6u8",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1f4hv5xl2h5lqwrjvlnsp4zhwtxc364l5w43qryxatv5de23xvmnqje4ck7",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1f754ns6leagk42dkexk6drsxkas2j0zsfsww7yumhuvzs6w9yx2qm3g3kk",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ffcttu9lxc0w2qqhavlchq824zswcnrva4vn4twclj7vpqwdtakqeg6sf2",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1fsdcnggcq05yvt4s6crkkn6yuv92qy6fv7vxwg3h5fm2tvj8rnzq8s6te8",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1fwf47kuhyvtzzm6l9sf7cwvk9lteed7g4fz63x4j26edquurc67q2kyx0u",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1h45p9vdfvv53f2pwne3apd8dw2yf6azqep766hw7rhlcem3t6x0spgmkmx",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1h8xhl9c5x78xnunag5chvlq4frs69t8l2a6tphu7txe23cryw6ps0zd0z2",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1hvmuxay55jngk94s3fcehktnu944ld0nt50phlpm39d77p3pw9wsq3rd95",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1hx08r5dt75txlyk9xcqwyga8zrnfhczcgkn9k6tg2sueadqkrn3sffdegg",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1hz8x8zkuerf3kjqqwv7ftvf6nm7ya6gkm78tquslzjkw6nznpf6qjdess2",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1jetsdecxkel6taay6hw34w7qkgp855mp496ks8hpv7uy9n8n8sussw05st",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1k3wvnmy6fwsqeguvtnta8guvaq2npmhr360mwucq9g9v3gc55nfqg726mt",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1k56kqqmnclet6lvk7mnrm2wpuey429ztlleg789alh3cvpyu6xtsars0cs",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1km4849s0a3vx7alp42ukd3psyxjhs6umwcx76rvcrrthznaftfhstl7p3z",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1kngra82083kv7n39ku4lhwlwwugxavh38fp44xyr99vftjg8502s8hm0k5",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1kt32q3539f0hgurekuda2yq6u2he9py4j3yv3663veqsyvc79uusje9c80",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ktru8mwg7q6ztuvy8906m2w8gj08fwerv38h20mm9gs53tx38uesf4hyzr",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1kymjy4xjsppjv0qd2xxj9cyx626w5ddgcsqkr29qshn7dfdmdghqll9pvr",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1l4cz9ak9rzjpra8tjqpsp2z4k3qguyccr40hej8uypcawp9sawys4yqjl9",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1lhdmrqq8gtfx3sxgvhnkcnkcsuw44mzqjhaa6r6pwjrhpvkguuuskjfz39",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1m2g4y2hs9almn7dayhu7mfk45xnhygpw9cckrywke3f9ucr2t83qq44gae",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1m9cg0gf5axy27pc4dcagejflsnve3c8y5vfuhdljl8kqflecckaqfgzr2c",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1mys8yflclfsg4jlzfwm60alwkjgq2hxq2n78ku5secx2g9hy2l4qc0gpsh",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1newq5r75d2seee7jh34h5g7r7puws66erxkdck62zkj27mn67x4qdejr0h",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1np06dk3p979t9qvu733r4v753zysev4c6jpl62r3n6e8dyea8q3qy3r5na",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1nrvntz7dp6xazrq94h4p6ugv5qqz4txqpk69ysaha4st2f3nwwkqw0j2jd",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1nz6rquzm8lxsp8tu834aq9ttegv80ru2gcls9lktvra5lrput8mst5ayyn",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1p0vnl6gns5wgjjjtqweszjwjuvnptlleztfp79lg4r7agkwgxt8qgey572",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1paqr8p29tazlvt25yhj4c9mnz5g7mj93svnwqeyjewkfz8nruwzsgcdk0z",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1pl9mq3zzk8fxjkjany0p2ewv9u40w6aggpu8m5kgqae3c7ynppgq2tjxjq",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1pulvlgx7cp4l3u4w35kux8sg9zn25n3xzn5cqvcvhkvy5nx0n7vspj3n4w",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1q3p4x32wqy7gyp347wktfxw42we4tdjuped0kuqfvvl07kgygh3s0v8nxn",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1qc2sa5a5rv7rd5jt6rdwy8tgfdh7xsv6dtrldnnkzk5rswk57zeslvxfxp",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1qdsjtafetdr83t97xjgewm6m6ddekjagfvhzsa5fp9mvc82892ds655chn",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1qghmdv9tmm575l6n9mmpp56m5ppyndve5apvj4fnz875yvf7ft0qynlppp",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1qxef85xd7dzqhyll3j0u6686ugvv0x9fke76rpcphyr680ls2c5qnx44ss",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1r4e3jexudvu72n9mxyjuvwedn03r6epjpankmkml44mktx5nvu9satrfd4",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1rajev0zks98jq2rw9jk0vy06nxv8eja564sxrw9fq7c2rvjw66ysrkex4l",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1rgffrrprdyuyjegz262pyz8sy2wd4u5jrza8wf37e7whgcdkq9tqf4n4sq",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1rvtgvc38sfd9zehtgsp3eh8k269naq949u5qdcqm3x35mjg2uctqp7f0yg",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1s9um3sdm0exu9yse43h3wh0zqngd9pg5dqa54pj76ea96uynfcrs5g97nm",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1sc23f03xe60m83jtkghsksapwlppjw65rlzpmvylkn8puhkrpessjlqupn",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1swggew3xu60py79d065zm4aqevt9sujgu06pm2ee64zw8yg7lzzqp4zlfz",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1t45w99d4te55es7lmw9kfmcc2y7549eg9vdfs9veec6zy54ehyzq7ja76l",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1tj89edfq20tdjay4q8aleqkus50lkd3evud82mc4l8lchy0qhh3qhldwvj",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1tm4xanlzde3uye0q5w4zwanpuk6fcr0vupkd7n3n2g7ctur5dres8zp7sv",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1tu3h0sa8s3tveyz8zkyzd9kras2s30qsumanwn5074zwj32qdeuqka5x95",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1tutagjumy6u40v0twxsuh5wsnwfpfwfju4lzw25w24hft3wm83xq72tzpk",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1uuhtyv2lqt95ml6krz824rnkrgt20lu8t5jw8dcl2vsmq49xwqpsn3zmzv",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ux3ku7uv7urkm7gvf2l8557208ewu0sr6gw6688dsm59jk80hgvqzy7fpd",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1uy440n36h8mhhm4kgljzcm0m9crayv9qym5844vm5n00yp63vcms6th2xj",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1vh6u6e7pjlt90lz8v9mtgm58jl4tw8s3mvtns0q2f4e2v26y37ns9ez8xc",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1wdacaf4y9h20k6zq0gfgctxeakkpjlntg8afklnny3dlfrujw4wqryrds3",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1wf5xh4qggdgjd7qkrkyemdflclu8gtjehuqtd0wgdj39pt6dc9wq4xjysr",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1wgp70lydsl4npqcd896d5pfzmdtt6p978ufmcfvwmezeu97leals83mx6u",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1wgq575juumk5fz2vrrrcf3drx7nk0d2t4lj7jrt6g95emsvdz6rs0fteay",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1wr9tck0efj5vkys2m9v6a7a0vayjzyqmv5zruy4hwep48a7r86ws3sq97f",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1wrsdfjyykd3laekus6umln5zy4y0xwgfrzypucn26epaszdaa0msarh9rx",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1x6t9p76dt0qgnz9c84lxg588hvkmkwcug3w6rg8vjmfff3jvj3zq8hyqa9",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1xex8hxw7zq0n02mc627trtrck887yc8jzpeaqhmnn08gjuug8h3qj93nd2",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1xuhyuwjxqk38gsd7cdsa0c7pqeswu3r8ua3epa30j7avdecte80qrqr9c6",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1xwuyf0eth3hvtdfmntgy6t6mj5tggswj4k7ev6dewqf4fa3qwwds3ryhrs",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1y3wr927vujk5037768w43mfm5g8wyp7e5nqyswvmyxkdkr94zpeqtnltvq",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1y6mwa3qy5374ueslr62da4nkt6pqfzv672x0yfm3tsvupye73zfsat37nc",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1z7hxqnd74r6syx3uuxrtvg4a04qzct64pqm2g7ayezrkhq37tl2s2rhu90",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1zqjzzuyrrhqdhrp8y9nt97yle2uvynvphu7wqr9juk0pqjrtzmps7a7hmr",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ztcgnl9fsmk5kw8n3rygvpjkwznmqxh7ec92ydgpeet0kehgsknq733gxc",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
     "id": "terra1rwqs9stqn9704hpynza5sgxzs6yqrtn9j25chrrhlheeesw95egszgjvlw",
     "name": "PPT (Wormhole)",
     "symbol": "PPT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pfnex5dy7wvz2kd26t44t5lzlryg05reskjy5rem8xj6fvdmqwuqvzde7a",
+    "name": "Princess Rockettes",
+    "symbol": "Prin",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1zy2vjzwrc5j3evkkhagstewqxjlsk4vjs04u9q6g2umzw6nkt0sq6y32s0",
+    "name": "Princess Rockettes",
+    "symbol": "Prin",
+    "decimals": "0"
+  },
+  {
+    "id": "terra12jz8a0eaqvwp3w3qc5v7zdr7az25e7xr5z3gxmqcsnns9pkl4a2qjed4f3",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12nlllhjz3s308gazwss9pst0aq63n9uuenw3usup5kffv572jhmq6zmgc3",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15p408hyj9mge2dwsgevvakssjuawdpuqhzeg8cdf7df0a2ndvf7q56zytz",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1aw3pwzqf8l4gnkdelynump5pv8y4frayucpzxdlt2cy5djylfu4s6z9tsg",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1efkg3msnu9nhvwp7t33fqw4309gyn6fzlt2fz7v6jk5ra5qwhewspe7s4h",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f7qn0jk6sg7275hq6dx74fjlcxm323y5yfyq5ewn8scd6uszf6psxgzwfv",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1g3kkzyl57ww3c0pu82n9ayz3pa3hrgvfnlg97t7lhsze5rgslp2sycxwcq",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gjvtunfr4zep4t043grh87cunxzry5wa4c2a4dldcztyat3g7y5qz6a4ds",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hrxrkslv9d4eu4suq33vndrn8flnyhs32qhy7plzugn2zgqmr4kqw4npe3",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hxg704fdvm5wm9re3tuvhjryqv3mte6hpep4eh643chge7cqjmdqk0hh4j",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jr28yjhpm6fqwgd8f972smcxpg0jk9zvxuwc7wskfet9mk28kldsncqpjg",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1knwcergcxqyxlwqr6guyc6luaha5smn3vuljunrf3xr9trqe06msvudm7r",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kzj8ep2tttwf9a08fmpk40dey9h6f0ygu75ltew5ky44chvn8pmqp2px0q",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lactake5rh3rnael696ha2fu7tm9us8jmgt4skaja9uy8u0djg7svxx366",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1n7xs7hc7j2hxy9a9m7y0y54qgc2vyukv9wg0xpfftjwlmvvhk33sklc6za",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rvdm2esamrsvx6ad3ldzlku8v0h5j9xc0dpguwr4vct9qh6nssjqfp779h",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1unyw7mtg36jhsxyf234ks36xfz6r7g787h4hul5z9aekrrrs7ghq08wvmr",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ux08rv849xtyacwagr29k2m68n4fela54q5pkwveusa2cp9hma7q4lhsjs",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vxpuaymecjk2473mapryd0lnr5jaf9uvercrpfwufdunmvs4n0hq2xnp97",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z7jgpvhhga8t737ed4qk55s7k92gf3fdmwa4vwjnerec3aa96j9s5ql2wc",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zq0gmevf5ty5aggasm72c70klkcj8g63y2yhjayydeqhwmhefcus9675aq",
+    "name": "principal",
+    "symbol": "pToken",
     "decimals": "6"
   },
   {
@@ -2384,10 +5490,112 @@
     "decimals": "6"
   },
   {
+    "id": "terra1lunpxecglpu5w4pr5xkx9rzyprxktdwwdcd6puxa0zfx6muqsfrqdhjww2",
+    "name": "Rainbow Rockets",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1sf2fftvjt4z75g4rshngdxn5fr6qsccl78fgsz52fefwemxzvmaqptdfnp",
+    "name": "RameNFT",
+    "symbol": "n/a",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1sn99ks9lgpmj6lqq9za7fu2s00063hy69rqux9cahtzlkvayx2cqzz48dc",
+    "name": "RandomEarth Social",
+    "symbol": "RE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1a8lnalg78u8zdcshjg27qnxma6hr3umxf2cuy253u97p3c4kc7rqxewc5y",
+    "name": "Rare Experience",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra188vepzwkt623tcuh6p73khm6fuwz0ez89e68jnzzhzpyucal6ens5ccfss",
+    "name": "Real",
+    "symbol": "REAL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hcv8pl2vtakegf2fd2vvc0j3fsl0p0ur46w8jc897kvp8zmz8hzq5yzkez",
+    "name": "Real",
+    "symbol": "REAL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pem93fgdkmt7vvlrnnjseru69qmfqpkmwg8smeacg69fmfgplcvqgq43d4",
+    "name": "Real",
+    "symbol": "REAL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qrgn84zf993s84kyhfsyhhspz4a5alea75pc0tfk07hyy26nvn6qe2hak5",
+    "name": "Real",
+    "symbol": "REAL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gpvpy8qn8xmwmjg2zhs9504y7ptdz9mhk9pdm6pmvjd6egterkrs0as5z9",
+    "name": "Red",
+    "symbol": "RED",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ph3zz8lq842kc0vt634f67qrz8hred0cn9duuufzhlk7a0sh33xsp7wldf",
+    "name": "Red",
+    "symbol": "RED",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hh9rgaxtmfqfkeqkruckwah6qc4ajlxgnweexyjeh4dsptkfnhmqeelzfl",
+    "name": "Redacted | RONINs",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra15wsew96nut3ckfqkynxjhmfkm67hxnzndmtzfragl46prgh9k6vse6lllu",
     "name": "renLUNA (Wormhole)",
     "symbol": "renLUNA",
     "decimals": "6"
+  },
+  {
+    "id": "terra14dwdssqhd9wlezr9tnyn2vktlk7f96n0wmdf3p6etj029fst7qxshcrsde",
+    "name": "Riri Cool Club (RCC)",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1lyz4sm8vgu4c9f9hxcv6enzpx0kxct827s4x7t2vc8n6djfw9geq9l5z4w",
+    "name": "Robonomix Series",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra10tc799vxuwwdmy2hxchf6cl4n2qhed3wdhpv6kj7xfzhnsucsd5q8su39g",
+    "name": "Rockettes",
+    "symbol": "Rock",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ulsw8hclj4quxzq8yut0uq3cq5wrvgz99fwvx4txdz25afzhjcpq3tgphp",
+    "name": "Rockettes",
+    "symbol": "Rock",
+    "decimals": "0"
+  },
+  {
+    "id": "terra17m4n3s8fj8g56aukpeneu6vyq6zj3u8alenv388ctjekyv6mzcwqt8kxrk",
+    "name": "Royal Token Society ",
+    "symbol": "RYLS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1987ddrcpwgwrpkxw44l73lgzhuldxmt7ue9nj9e5c5rm3w9pmx6qaqwvrv",
+    "name": "Sandy Chuchat Collection",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1x599eytp94hky39qardrpnc4qjrcplqlc6u6vh7pugk2s6nqqghq97qlc5",
@@ -2414,6 +5622,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra1zqthrqndchxp5ye443zdulhhh2938uak78q4ztthfrnkfltpgrpsu3c5xd",
+    "name": "SAYV-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra1q5y5kyacmmq3p32khe8y7qrumawyfqq0tnxjw4afl8mmedqra96q0jt425",
     "name": "SAYV-XSAY-LP",
     "symbol": "uLP",
@@ -2426,9 +5640,123 @@
     "decimals": "6"
   },
   {
+    "id": "terra1ytu6fskvcdsuzj48l42nwah72y0g8pughgamlt5k8786aslq6vrqnxq56k",
+    "name": "Sirmagiste NFT",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19899s4dtmr7ug7wgqdwtlu04u9863lnuur64u0ev30x6p4rjylpqu7dz9s",
+    "name": "Skeleton Punks",
+    "symbol": "SP",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1x7rf4nquswmmrjtzlxg6dk3d70ef69prth2q7vk3v9vdprepdh0sjxrvl7",
+    "name": "Skeleton Punks",
+    "symbol": "SP",
+    "decimals": "0"
+  },
+  {
+    "id": "terra16thequeddc2jc2pcc8xpsyng5lexqwx45ch6yvngs0e3qxtmc7yqv0t6h0",
+    "name": "soil-test",
+    "symbol": "SOIL",
+    "decimals": "0"
+  },
+  {
+    "id": "terra14jq0tvadkw3sd9yh8wqs5gdygek7cjn5kkp8htychwz4g7ygcassqcr2h2",
+    "name": "Solid",
+    "symbol": "SOLID",
+    "decimals": "6"
+  },
+  {
     "id": "terra1ksrvpykmhyj9ka3qv4hsd5hecu22cxwzdk8wqvufhcrmnjl8nhaq2443jl",
     "name": "solUST (Wormhole)",
     "symbol": "solUST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v765xt7pdpzcr8v9ffpqw0nk2e4776yqtnhgsnuvguhhenrkv9yqfumtem",
+    "name": "SominGaze",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1rhjm54rh2d58wwrj5gep0xa4vf2uakvqe4e3se7vr7gakwhljrysxhne6n",
+    "name": "Source",
+    "symbol": "SRC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1asuk3yas2rtlfdukfj80lguaghy6ad47fq6n7d45q5my826en7kqgn2jng",
+    "name": "Space Birds ",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra16f3l8cq99qenutzzuctp2lnghnz72yduxc7yc9cfwkec4n4rsclslyqnsy",
+    "name": "Space Pizza",
+    "symbol": "SPZ",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vn0qwkp9l53q73ajsrnexdw97ekzscexh2q5rduk2kajqrvzwtkqj4nc08",
+    "name": "Space Toadz",
+    "symbol": "TOAD",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1w2hzqaxdrdqn6wvk3ha5qwy2hxz7xevth6m505mv7y6xjjyu4qmqvrs6zu",
+    "name": "Space Traveler",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1nuxaxnpmu2dm9zt69egmzdyck03r8r8luyp0qg96yada9lpru9kq0zwss6",
+    "name": "Spaceloot",
+    "symbol": "SL",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1gxqzjk4pkyzpnxnrz7h486vntvv4lmaukcs24v9gcsmcm4tyre7qytcm5e",
+    "name": "Spectrum Astroport ampLUNA-LUNA LP cToken",
+    "symbol": "clpAmpLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra144mkz6p3mmnuqaenu73pg4jwayr3m28xzhaxedlfwfnyke45w6yqvf9ed6",
+    "name": "Spectrum Astroport ASTRO-axlUSDC LP cToken",
+    "symbol": "clpAstroUsdc",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ufpsjrvj5fkvdedx2ttslnrc2wxvrftf4zcsvu778cufvlh4m9dsmgcf6f",
+    "name": "Spectrum Astroport axlUSDC-axlUSDT LP cToken",
+    "symbol": "clpUsdcUsdt",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1erm54gtdtfqv2s4c7ple3kmret7eecuj02nk5w8h08jjnenjffzsynsp0u",
+    "name": "Spectrum Astroport axlUSDC-LUNA LP cToken",
+    "symbol": "clpUsdcLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1w6l7kjc6wu7an37wnnehcfc3tpksw9tde9u67743ew0caly0hdasv0ws79",
+    "name": "Spectrum Astroport bLUNA-LUNA LP cToken",
+    "symbol": "clpbLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qczgczguzmxpsqfwlcaqm5hpy3jrkgrkkkcdxhd4uf28t8l8j6qsgtd863",
+    "name": "Spectrum Astroport LunaX-LUNA LP cToken",
+    "symbol": "clpLunaX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1j9ggd8wf73ggsfet99wnjvn06f3l9w9lsf50uac43h6vclysfc9sp0nyfh",
+    "name": "Spectrum Astroport RED-LUNA LP cToken",
+    "symbol": "clpRedLuna",
     "decimals": "6"
   },
   {
@@ -2438,10 +5766,94 @@
     "decimals": "6"
   },
   {
+    "id": "terra1udwqynsmrme00ksrakkyerrfjdkw9p05557yrrw6ca6x94uuj2zs0vpqt2",
+    "name": "Spectrum Astroport TPT-LUNA LP cToken",
+    "symbol": "clpTptLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ha4yvzqnq4mpu205wcd430m6m7wjklpquwn87dq89g9zersuvryses7rua",
+    "name": "Spectrum Astroport VKR-axlUSDC LP cToken",
+    "symbol": "clpVkrUsdc",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jsd4c0nkchn6mdqamcduuc3kqrtfjjmta9f9vkjj0pqu2q3vpykqr5sdx0",
+    "name": "Spike's World",
+    "symbol": "SPIKE",
+    "decimals": "8"
+  },
+  {
     "id": "terra1nu0c3s69umqz862ltp6wytuztm0rrn6w5079g999u0hvwy62tf3q02qhmr",
     "name": "StableDao",
     "symbol": "SDO",
     "decimals": "6"
+  },
+  {
+    "id": "terra1s2lr8u69xammmg3s8hemegcz57y07ae0wa7c7d2adupp6du3neyqfukkaz",
+    "name": "Stader LunaX Token",
+    "symbol": "LunaX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pu5gewue3s70u0pgzsza9asfjhkgt5trkzd7xyd2gyrrdqmumensyn8qy4",
+    "name": "Stader LunaX Token (Wormhole)",
+    "symbol": "LunaX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1j8uqz4d48x5t5sf5tgfv7wtt2uvl7jsrr2ayftxpfy5shkjv793s5qqpsa",
+    "name": "Stader LunaX Token (Wormhole) (Wormhole)",
+    "symbol": "LunaX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ek4upyl20z7ah4xk3mpfgczkxrn9nrqme9njtszht50vwkqyt6cqvchxet",
+    "name": "Stader Token",
+    "symbol": "SDToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f8p6yc7he3393y8rrpqp3syev5dnqd56kzepx6f36yt7zydghnequtkztf",
+    "name": "Stader Token",
+    "symbol": "SDToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1twakgfn5ch4qefp4xzu3met26ae2rhcd9t8tj7hujry4n50xtw0qhzpjw3",
+    "name": "Stader Token",
+    "symbol": "SDToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zfx0wkel6sffhu8f9mrcfxs830cauvkqd6x2aqy6szlxlrx658lsasenss",
+    "name": "Stader Token",
+    "symbol": "SDToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1eygp4ps44jnch66r5sm60ky5l3mc9vl2s7qd5g9m9at0mggzwzssy4j5yg",
+    "name": "Starbucks Corporation (Wormhole)",
+    "symbol": "mSBUX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10c8y69yylnlwrhu32ralf08ekladhfknfqrjsy9yqc9ml8mlxpqq6esfh0",
+    "name": "Starbucks Corporation (Wormhole) (Wormhole)",
+    "symbol": "mSBUX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z2wr8jmxmpe8x3j25rl8360pfl4w9p3ry3dpss90yuek4je4wgxqefg56f",
+    "name": "STARDUST UST",
+    "symbol": "DUST",
+    "decimals": "2"
+  },
+  {
+    "id": "terra1mtsce8d3hyds76366lrdf3aplakxlzjnal2hwmxmg88fpu9ashpqzjx6j0",
+    "name": "StardustEvents",
+    "symbol": "STDEVNTS",
+    "decimals": "0"
   },
   {
     "id": "terra1qqw2vlmlr0gempsdytwujq67yusscwpxmry5jevdf05wfwcw5jkszp0r5f",
@@ -2450,10 +5862,66 @@
     "decimals": "6"
   },
   {
+    "id": "terra1emm9kdgdznjy37gyw6883m62fg8d3kke26c8n34n6yz2v9fwvm9sq3sqkp",
+    "name": "STEA-SOL-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra175232yuat84jr5yx74mtz243egyyp904l9n69fvdzzkplhru5juqlv8ah6",
+    "name": "Steady test",
+    "symbol": "STDYTEST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12y8dapy6zvwkxhnxgxf2jnmrr9qqhdc8dh6ez0cj4eywms695zrskyltgd",
+    "name": "SteadyLads",
+    "symbol": "SteadyLads",
+    "decimals": "6"
+  },
+  {
+    "id": "terra188dgygh5qzkc06afamst7sjfrcw2xt4rkr6m3j69f88cnkw4jfqqy9ymrg",
+    "name": "Steak Token",
+    "symbol": "STEAK",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ud6n3r3tczvmw9jg05jy0rw70z6362hrm6q0gzf0zjgg3xc0wv7qfw3vle",
+    "name": "Steak Token",
+    "symbol": "STEAK",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14z3laya7z6883np60l3wu6075s75xakm3kpuqr4w5ezeknuxj9fqmemmtg",
+    "name": "Steak Token (Wormhole)",
+    "symbol": "STEAK",
+    "decimals": "6"
+  },
+  {
+    "id": "ibc/0EFC7B44625187BFB60AF09FF28A25FA49B68B959A505CC5313DF0498D8CF528",
+    "name": "Stride",
+    "symbol": "STRD",
+    "decimals": "6",
+    "icon": "https://assets.terra.money/icon/svg/ibc/STRD.svg"
+  },
+  {
+    "id": "ibc/08095CEDEA29977C9DD0CE9A48329FDA622C183359D5F90CF04CC4FF80CBE431",
+    "name": "Stride LUNA",
+    "symbol": "stLUNA",
+    "decimals": "6",
+    "icon": "https://assets.terra.money/icon/svg/ibc/stLUNA.svg"
+  },
+  {
     "id": "terra1qpa5u2mwycsku0deum3a0jk8jsselv80xyqnpa5zw0agcumgw0jsuvm48w",
     "name": "STT (Wormhole)",
     "symbol": "STT",
     "decimals": "6"
+  },
+  {
+    "id": "terra1vrh8y6aa3v99ttpsfxdawluf8n77m3c6prxmq0dtlmtqdeah364qjzpds5",
+    "name": "T",
+    "symbol": "V",
+    "decimals": "0"
   },
   {
     "id": "terra1gwz4m0q6vq6nyunt88vlsf5u3ve0fv3qc40q0mdky58s4fjy4fcsqpkman",
@@ -2480,7 +5948,43 @@
     "decimals": "8"
   },
   {
+    "id": "terra10znl5emz4l6qmtr9gq35u0l7rchg8vh2x7wknlgsuzg4azsj6v7q2h0dzl",
+    "name": "Terra Aliens",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1lfrgu8r4nyplqql7507khmf79efpns7hz9qyruxwy3rcs32w4s3ql00frh",
+    "name": "Terra Launch Pad",
+    "symbol": "TLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10xr7pndwwmq6ua7nmg0ldfxsf29az9fk59w5dtwmgt2vwgdnwj3shc64d4",
+    "name": "Terra Lotto",
+    "symbol": "TLO",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1lxjw8retq4waja95e8jrxpqtalt95nj4xm6w2cyljae3vnh45tjs72cl82",
+    "name": "Terra Meta Royals",
+    "symbol": "TMR",
+    "decimals": "0"
+  },
+  {
+    "id": "terra14lzmdzaqw53sgm0lef8agnzck6n68yhmutasdu80w5j49v7kn4eq4c0mj8",
+    "name": "Terra Meta Royals: Golden Tickets",
+    "symbol": "GOLDEN",
+    "decimals": "0"
+  },
+  {
     "id": "terra17uwa8ppl9dxqkjvmr7eyusua4af9juxnanpax4h0p2v30spgddqsm7lced",
+    "name": "Terra Name Service (Wormhole)",
+    "symbol": "TNS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qa9mae32y64mn2srmypnr2qjw7x94dqry6wwyej6wxu4ffe9xqtqmakj9e",
     "name": "Terra Name Service (Wormhole)",
     "symbol": "TNS",
     "decimals": "6"
@@ -2498,7 +6002,145 @@
     "decimals": "6"
   },
   {
+    "id": "terra1z4lds4txngn5dt74trf4knd9xpxwmwmrhf90ft7es38pc6h0hp6swcdj9c",
+    "name": "terra-luna (Wormhole)",
+    "symbol": "terra-luna",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1sskn97j4jvchgcpsd4a4ev7smueamsesls2qfalja5gxqlvnn0gsdwp292",
+    "name": "Terra2Casinos.com",
+    "symbol": "COIN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15lvw2kczml269rl296y85qnnjxw0zvcns3aucsr87kkfldh6gmks3r6tfa",
+    "name": "TerraBots",
+    "symbol": "BOTS",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1zcafgvq74ef8zu5mc62njfprsf3cr33xvan7r4nja269t280djrqkyrjsx",
+    "name": "TerraBots",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra146ypndztcmmrmyxef7e20cul82gh43vjnw4uacwdvg5sp9kva7sqc9mjav",
+    "name": "TerraDoge",
+    "symbol": "TDOGE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jlzw6xal0n2c580g3wxs09tjhlzdht9y8dgszq3tupf8fhl7xjus30q76r",
+    "name": "TerraDoge",
+    "symbol": "TDOGE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qrwaatac4xvf4qnnagvsc93gcnv2x2t7mm575v3drzh2wcap9has6lcuky",
+    "name": "TerraDoge",
+    "symbol": "TDOGE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1d47r74v2kxezfy3hxchqv5r5d26uyvk2e0k7gx3k9awxwwwsl44s4cesrt",
+    "name": "TerraFloki (Wormhole)",
+    "symbol": "TFLOKI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1a2nng5e58drpr2canclarhc9n0g3v6wmrnwvlmmxnwxlxvfhklvqd4kqvp",
+    "name": "TERRALION BITS",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ghuqnsgn576srmtp5rfk5fd7u60d8urce0usyu6xc3jkesy6hrcqkvrtmh",
+    "name": "TERRAMOON",
+    "symbol": "MOON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19xcvyg8ezn8f8t2fpatzfsg9kknnm3c3jhz74n2pawfv5g6kqlvspvvkvp",
+    "name": "Terranauts",
+    "symbol": "TRNT",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1lndtteve63vp4xv0wnkzk69ngx8ul2jt2k26a2eqpjkym87cjpksjc5zhj",
+    "name": "Terranauts",
+    "symbol": "TRNT",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1x6yunc975rzyu7gx0f80cjwskky8q9ggw8l9em69hjnhf5yjm2vsl26fvt",
+    "name": "Terranauts Sectors",
+    "symbol": "SCTRS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1hngslv4p3gk8p9x7y9pc9t9e079mzxfg73mh5zgralq79hq3r9jsdj8utr",
+    "name": "TerraNova",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ay5guxt0st9eetxakcs58n350dhkttnnxu7d4zt9je5540hfsf9stpa3sz",
+    "name": "Terranova 3D",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ytctz49dtpn85fagwut7e2eaw2586j74dn49t3cyadwlpwufl72q70qv75",
+    "name": "Terrans",
+    "symbol": "TRRNS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1e66djga9ku8rcpd6v7ncpt5f0n7fwaw44m05cqrvqq7hv6kg2rjsjvwk4v",
+    "name": "TERRANS",
+    "symbol": "TRN",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1c5umwtky59ypk2ad2jr3c95jwz2rp9r8h2fyselzxsq84yjj95asly9aq2",
+    "name": "Terrans: Limited Edition",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1v04p5nzya7727th4eesmyj34sjwtvt78ht7q7uc8xsmxses75x4qhm0kyj",
+    "name": "Terrapins on Terra",
+    "symbol": "PINS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ncyaafj4kt5m50tj3pftga2auuq62zzguwlntk5mtl2mdusagpkst9gmgl",
+    "name": "Terrapins on Terra Eggs",
+    "symbol": "EGGS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1khf570xnp6g7lnf70ufwax69e9ll446avyhffqh22y4kssr02yds3522gj",
+    "name": "TerraPrints [MIR]",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra12hq58scmmx04vzjlw9sywal7zv6pm6wjjy2m7zwxc990pplc5rpq3ck6k7",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra13yp5jufdd2n5gez84fy26tujq540alr29cm4tpntcsaqg7h660cqwe8dx9",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra154lszr3g2cmstw7me6pmv57jjug3ddqy2lac87eyptv83z9ul25svefc2y",
     "name": "terraswap liquidity token",
     "symbol": "uLP",
     "decimals": "6"
@@ -2528,7 +6170,25 @@
     "decimals": "6"
   },
   {
+    "id": "terra1l8z9t0hny99z9ncumpn4uqvd7k6sk6l90m68pu9mgvddmyr4vrwqdqcrp7",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra1s80jffm4a5awzed0dfjvkjz79rcs25wfttezgefmpzju6rmgt5eq43x5l8",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wmqka38647dus86jxsscc8j87ltykwsysl76gs8gq2kqxzkwa2aszfz6em",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1x3ee5rwurm703j2dx0qgwanntszty4egpcylwz6de5jarlr080jsv4hc0r",
     "name": "terraswap liquidity token",
     "symbol": "uLP",
     "decimals": "6"
@@ -2540,10 +6200,58 @@
     "decimals": "6"
   },
   {
+    "id": "terra1ecaxgghq46wg0rr66ema6dp8thf5dn5n8e40p2uaqljx04sf8gjqnyqzf9",
+    "name": "terraswap liquidity token (Wormhole)",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tu96pg7j0affaqezmlspkeeqnvrkrtcmqhag0up8cm6z4k7wx5csg4ar5s",
+    "name": "terrausd (Wormhole)",
+    "symbol": "terrausd",
+    "decimals": "8"
+  },
+  {
     "id": "terra1gsd4wtmpkcdlmkr4kpm4c2fe9syx8qyv5r3qykx708kv4850vqssgtvx44",
     "name": "TerraUSD (Wormhole)",
     "symbol": "UST",
     "decimals": "6"
+  },
+  {
+    "id": "terra1g76gzatrn8jnhv7lhmx7aqm6afja4750rpmvypjp3vcw03amva5swskrs0",
+    "name": "TerraWhales",
+    "symbol": "WHALES",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1sffdl730nq509rv5k0dm62sc0taa3yk7va2v3ngqhhl34gsmfuhsca3jff",
+    "name": "Tesla (Wormhole)",
+    "symbol": "mTSLA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dm53vefj2g2trw5t8glyjzxthtfg7qhq57l5ky7l26flcnswprzq4x7fsy",
+    "name": "Test",
+    "symbol": "TTT",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ry68wdl4hgkt0ddg52m0gnj3d8l35nlers08p3lajl7gsn8tmj0qdt2k89",
+    "name": "Test",
+    "symbol": "TEST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16vajmyc2zc8nhy7c7z9lxym5rp7qw4lkptuccp4tfqqywkqppdsqc7zkat",
+    "name": "Test 2",
+    "symbol": "TTTT",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1dakfhvgv5rwxngh7wecennfpn7jfyd74nq6cuyfzx8f400nz244sfuzwch",
+    "name": "Test Col",
+    "symbol": "TESTIE",
+    "decimals": "0"
   },
   {
     "id": "terra1mma39sqn43aen4jh2sdmka84mv94uk7v7xw3ype2fdvlay6emrlqweyf5u",
@@ -2558,10 +6266,124 @@
     "decimals": "6"
   },
   {
+    "id": "terra128v4wvntlyskezlvjqyec89femjva5ksyxtpswxmt5680amlyy3sy3f84g",
+    "name": "test new UI",
+    "symbol": "TNU",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19ng225hv9jp4ty8gt7d3g0er4chga8z96tya5ksmsz68rllp268qry2jyt",
+    "name": "Test nft",
+    "symbol": "BH",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ycw04kktq9l0ywqr85suuvg9t80h3nr94juxxkuxhh4sha7r8fuscyxyqa",
+    "name": "Test nft",
+    "symbol": "BH",
+    "decimals": "0"
+  },
+  {
+    "id": "terra168csa8g2prpcthh0qx4wmdfndwq49ef347tf0asy9qasf3zadq0s0flscj",
+    "name": "Test Terra2 NFT",
+    "symbol": "TMT",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1kz9rs4gurgrsv7qsm4ekmqvwysphnpf043wqj2u4r8n9j9xv3egsmj9ft4",
+    "name": "test1",
+    "symbol": "test",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16wr7gqnzm0e9z4kz92gwaq9wqx2xuusfd02xrrjsks9y4zlyk66q4tt7md",
+    "name": "testdaotoken",
+    "symbol": "test",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ery8l6jquynn9a4cz2pff6khg8c68f7urt33l5n9dng2cwzz4c4qj3spm2",
+    "name": "Tether",
+    "symbol": "USDT",
+    "decimals": "6"
+  },
+  {
     "id": "terra12ezq5402h5n3skhdshjp4f49zzg0saxum8fvvhjhauzas2ezyyrqpznqny",
     "name": "Tether USD (Wormhole)",
     "symbol": "USDT",
     "decimals": "8"
+  },
+  {
+    "id": "terra1p2wm9d7lp4pf32pmwzm5ll59q9sqj48p0u66cnfavuzj78gusdeskdgms2",
+    "name": "Tether USD (Wormhole)",
+    "symbol": "USDT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14n3adwz0pstwqtfgxr62uvdvfqkyctyec8jahf6pl7hwqer80aksk0hwl5",
+    "name": "TFM",
+    "symbol": "TFM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qg5ega6dykkxc307y25pecuufrjkxkaggkkxh7nad0vhyhtuhw3slg2he2",
+    "name": "The 420 NFT",
+    "symbol": "420",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqgj2ctk",
+    "name": "The 69 NFT",
+    "symbol": "69",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1dcj2st2qhljnl0llxp64n0dex6xn7fusu0ku83ewxasqunzkwgqsz6wkzz",
+    "name": "The Crypto Drugs",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1sp32et72dz2yh4ny48txy637gz7drvkmpel29j8lunfzy7xh47vq6e2lka",
+    "name": "The Factory Lives",
+    "symbol": "TFL",
+    "decimals": "0"
+  },
+  {
+    "id": "terra130cpevp2eyqskcsh6xs3nrqkrkeczzfg95xykyp06zt52cdkyeaq4ahe6y",
+    "name": "The Fallen Guardians",
+    "symbol": "FG",
+    "decimals": "0"
+  },
+  {
+    "id": "terra13cja66m0429yp6s6knrn565weskxgmlgm9pwws8r8lvuc6twd25qxvy6fn",
+    "name": "The Gorilla Legue",
+    "symbol": "TGL",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19kpvm4ru3979lkkan2atjas9pdpr4s0w3tnlm02eew5yk8tmh6wqs3rh7h",
+    "name": "The Lab",
+    "symbol": "LAB",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1j0qdr5m3t87p05k93qsfrzcvtu6k2ht6wr3ntnksrqjup9l67j9smm73ut",
+    "name": "The Lab",
+    "symbol": "LAB",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1zm7fylkhyvhrvpnpdec8ak8wlugafrguxg0z8dw6ru7pkg3hvzjqh60gh7",
+    "name": "The Lab",
+    "symbol": "LAB",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1vang7yw0aywnlged2v4jh8xndguqhyr9gv38mqe3rsdjm077qznsu50qkz",
+    "name": "The very essence of Cantonese",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1w2958rqnrz4qh39m4sfh3y2xl8jf5js4rz8r7dug7nv2gw2damgsplw3z8",
@@ -2573,6 +6395,30 @@
     "id": "terra1x0u4zwpa0lmmez0adc7zt4amaz04wu6jryhefcav6cdzpqx8ht0svzdkf8",
     "name": "The Walt Disney Company (Wormhole)",
     "symbol": "mDIS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16xt3d7m8qhhvj9w8dpcf5qhq8wx0jdnhk4n3x5f9spauzxs9at7sgndjdl",
+    "name": "TimeTerra",
+    "symbol": "TMT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra177phs7fn4hq0apnv3usttn0r05pty573548glh5jqkr00hks0ewqf2ekjc",
+    "name": "TimeTerra",
+    "symbol": "TMX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17jfvm266af58rxtapch6gmrgv7zz8t45p46ftulsdk4m2nf85e2qusujaf",
+    "name": "TKNA-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mqp9jdghpmprs9sc6ujh0juw6h7k7sp2evs0weh6q2u37ys3lf2srxjclc",
+    "name": "TKNB-ULUN-LP",
+    "symbol": "uLP",
     "decimals": "6"
   },
   {
@@ -2594,10 +6440,47 @@
     "decimals": "6"
   },
   {
+    "id": "terra1ntgzf3mp5223jmv4452qx7lvgfga9q0x89zsm5y8kpktwjdsxyws6x8e67",
+    "name": "Toxic Labs Governance",
+    "symbol": "TLT",
+    "decimals": "6"
+  },
+  {
     "id": "terra150qtrrrta74ewt9glydumq2fz4463hrcqm087vex2ynv97xz95gsha38dl",
     "name": "TPT-BLUN-LP",
     "symbol": "uLP",
     "decimals": "6"
+  },
+  {
+    "id": "terra16h880ss964j75erdsctgy7eyp62e2ladtaqw3x0qapzae8wrgyjqmgnwqm",
+    "name": "TPT-ORNE-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lu6wy88xv5huk35yq55e2an9k5h2me4nad20cetqsr73ez6vs84quysx2y",
+    "name": "Tricky Dick",
+    "symbol": "NIXON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1c47hfvyk8pug2qj5wppzfndehptwm9vq2xrus66junwkxhjuucdqcfcmep",
+    "name": "TT DAO Token",
+    "symbol": "TTD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ludp8erwgrd7ytelkycfprhvcnz0y54vjmgp6dausuty0lqmw8nspk6vyv",
+    "name": "Tuna Money (Wormhole)",
+    "symbol": "TUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qx284aak0wl7vrvlsc6cwcsn6xwajragkh6cjqj87m9p34hx5l2s22p3cp",
+    "name": "Tuna Token",
+    "symbol": "TUNA",
+    "decimals": "6",
+    "icon": "https://s3.ap-southeast-2.wasabisys.com/tuna/tunatoken.png"
   },
   {
     "id": "terra1vz7sw3gd5yf4ak755jt9kvshp7jnjc9l3rv6gaf8fehud2xnnltsqtsq2u",
@@ -2624,10 +6507,40 @@
     "decimals": "6"
   },
   {
+    "id": "terra1gl7a3jvk5ajnxs2rrdyjqz5ea99wf56qjuxct7cjwzf5cs675wlse2qf6v",
+    "name": "ULUN-BTC-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra138fc79ldpkzgswzuuts49xr82y02x078hajjhlnav8982e7z7t7sg3rrf8",
+    "name": "ULUN-DINH-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra1f6lmzz9caag00uqssw4dlczrvlaeva4afn2yl3cxfd0ncawpelnqwmtj2d",
     "name": "ULUN-FRGY-LP",
     "symbol": "uLP",
     "decimals": "6"
+  },
+  {
+    "id": "terra1w33n04crhh843ly5nh0km58w8zhz5ygstm9taqw6wgwkv57zfaas4w78a8",
+    "name": "ULUN-YLUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17vaenrsjh76yt8dcnlwzn0856k9fzk6h252j32ghr3k898pjyrdq9h55h9",
+    "name": "uluna (Wormhole)",
+    "symbol": "uluna",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1cm09997cnkfylgjz4wg0mk6wj2vd77a5qed67wvhxra0h8smzkds38uzq4",
+    "name": "uluna (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "8"
   },
   {
     "id": "terra19glrs2vtgxaxww39cq5acxapgv2v8hyw562zmsk7ucn4yznmyv3sljewv9",
@@ -2648,9 +6561,51 @@
     "decimals": "6"
   },
   {
+    "id": "terra1dsxs0u8thjngph6k60k5cepfkv90jtt776hsx7eyvl9x5gnepjjsfjnwyn",
+    "name": "Unstables: Unstable Kwon",
+    "symbol": "UNSTB:3",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1p5ll4frszlw63d7apaf3ghyd2k28dz2phnu4t359ey04xwcra5vq7kuemk",
+    "name": "Unstables: Unstable Kwon",
+    "symbol": "UNSTB:3",
+    "decimals": "0"
+  },
+  {
     "id": "terra1q4r4zzde2tg52306qevhnaf3qw76a68hnyzw404uuvvzx09n3ckqe2ylrm",
     "name": "USD ",
     "symbol": "USD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ezxp0nhct6mqsctckujttfkcsknux2aktv7knn6fjtprl3np74js7tzeqt",
+    "name": "USD Coin (PoS) (Wormhole)",
+    "symbol": "USDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10eqslzgvzl5grau5zuhs0hv6v0c8pj8va6lclrgxgzs9mhvfc2zq5hsdmx",
+    "name": "USD Coin (Wormhole)",
+    "symbol": "USDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17em5mehxz6wj4ya65ns0kf28zgf0xlz8qp4n0ykd2favszalr63sydrwyl",
+    "name": "USD Coin (Wormhole)",
+    "symbol": "USDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cmsh9ju4hk58hhdtlv5k7cqu8dmu0eucpaw5n9ynpwzuw4jluptsvyz8eh",
+    "name": "USD Coin (Wormhole)",
+    "symbol": "USDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1uylw76ux3h502muaml8l32j3e7d9v2ne0npwsgt0s46d5l3hpz4swsv2fc",
+    "name": "USD Coin (Wormhole)",
+    "symbol": "USDC",
     "decimals": "6"
   },
   {
@@ -2660,9 +6615,45 @@
     "decimals": "8"
   },
   {
+    "id": "terra1tzaw5m79em9juj0lf4dxr6phxxht79jt770mn77ltvx5e6ww4vpss6hvnu",
+    "name": "USD stable ",
+    "symbol": "USDc",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15x3mm9gl5z89w9d96fgpsqds0pa2eqdsnyp47rat0vey826fjj8svgqthd",
+    "name": "USD Token(Wormhole) (Wormhole)",
+    "symbol": "USD",
+    "decimals": "8"
+  },
+  {
     "id": "terra1uc3r74qg44csdrl8hrm5muzlue9gf7umgkyv569pgazh7tudpr4qdtgqh6",
     "name": "USDC",
     "symbol": "USDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pgtc0jsag7ax6cyyd55ntcva3kfnh6t805jtwcnrdm7szkx35pdqvycak5",
+    "name": "USDT (Wormhole)",
+    "symbol": "USDT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rcmvfsn77pd6m04ctqj3wcu66pvrw9p265cdl72w4zarfup2rv7qjxhkzl",
+    "name": "USDT on terra2",
+    "symbol": "USDT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jznfc58qvl8f0dldhm4pl505srpz98mwedlullt5rhv6petxwdpqn97n6v",
+    "name": "ust",
+    "symbol": "ust",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zwv6feuzhy6a9wekh96cd57lsarmqlwxdypdsplw6zhfncqw6ftqynf7kp",
+    "name": "UST",
+    "symbol": "UST",
     "decimals": "6"
   },
   {
@@ -2684,6 +6675,48 @@
     "decimals": "6"
   },
   {
+    "id": "terra1vapchnf63wx972v07jkjl0kfunft0ztyjuf5kqxgj2xx3mxfuw8s3gprxs",
+    "name": "V Collection",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1xepgy0lp0lkt9dq89pfe3sqwnfyln29r2zj5qqkp75l2egthmmkqkn36vv",
+    "name": "Valkyrian Pass",
+    "symbol": "vVP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16qlqgly543fpnp5eg6v8elfz3762us49xqt89y86htkrs6t0pams7jy3y6",
+    "name": "Valkyrie Token (Wormhole)",
+    "symbol": "VKR",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1n993kulwk0hj0pe06nhp0n9ll97qynwh2swzcjek6y5qngz0qqhq3c2qsv",
+    "name": "VKR-BUSD-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xx87xd4wl496gm48e9s4wygehx69z6cwju22zu32dl672ufh2rlsznsu05",
+    "name": "VKR-VVP-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1c6pzq0s8lr4vwmah8vauhn6mje4uz5ta62wvcpgtp259pxx5qevsgsu3jr",
+    "name": "VoxeLPunk Cards Print #1",
+    "symbol": "VXLPNK",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1cfwepxxkhfnypztquswu2e5vu5x2wg0exzfln8gl48c9hfaj6u6qkht5su",
+    "name": "VoxeLPunks Card Game",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
     "id": "terra1uq59f5lhzg6ut605ntevvf2a8kg9t2xk2873lgx6pweagkw76r4sdzj6ap",
     "name": "W-boneLuna",
     "symbol": "wbLUNA",
@@ -2696,10 +6729,46 @@
     "decimals": "6"
   },
   {
+    "id": "terra1x0vlryaz27jr4ncxc7ufd735fvs8uwrprp2kmz7l3pxf2jhkgpysml0yz9",
+    "name": "Warp token",
+    "symbol": "WARP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y86ynggjnfp9xfjhcxhj3gexkgqzd3f0vcsf5nzh7jl5hu90tjgq3vws3p",
+    "name": "Warp token",
+    "symbol": "WARP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z85035h0fptflnn004dvaw8c2q754qrnulsd5qwhzen4rtzr9juq5ef6ny",
+    "name": "Warp token",
+    "symbol": "WARP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v8pm45c8mecaasuj73wemvl9z7394lh8n92xla5vetwaqtcqsshq8jum8n",
+    "name": "WETH-UETH-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra1z2vjfumarm9ea75ahlwxzxw5ya3x5hh7zjg372j05v9lvxgygqsquzl2w2",
     "name": "WHT (Wormhole)",
     "symbol": "WHT",
     "decimals": "6"
+  },
+  {
+    "id": "terra19ney3d0rgy2qw2sj4s4xjruvex0e098rnpdlmg4q4yj0km9aqn2s5smwgq",
+    "name": "Wicca",
+    "symbol": "WIC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1sxqeul6tr7902ru8x9tum55a7xgfv6l6z770cnpwya78rngfu8xszad92j",
+    "name": "Wicca Badge",
+    "symbol": "WB",
+    "decimals": "0"
   },
   {
     "id": "terra1psyhchq2u0lp66xu7rlrvdz4kwtjlf9rhwgad0d6mf7llx8ajrzsmk8hyj",
@@ -2732,6 +6801,24 @@
     "decimals": "6"
   },
   {
+    "id": "terra19hq58hctw2m2mj6262n97x8gevas75pzmtkucf7gvgu4a0mcswnswj6tjz",
+    "name": "Wrapped Bitcoin (Sollet) (Wormhole)",
+    "symbol": "BTC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yn9grhzsq2rqe3a4tccxhva8pxqgd66arhhanju8vfx0p86y2nuscpyn3r",
+    "name": "Wrapped BNB",
+    "symbol": "WBNB",
+    "decimals": "18"
+  },
+  {
+    "id": "terra14kg73j92u8af2uwdp76cd7wnr54ray55k0kmcd0qqg7cd2me8ugqzv387z",
+    "name": "Wrapped BNB (Wormhole)",
+    "symbol": "WBNB",
+    "decimals": "8"
+  },
+  {
     "id": "terra1xc7ynquupyfcn43sye5pfmnlzjcw2ck9keh0l2w2a4rhjnkp64uq4pr388",
     "name": "Wrapped BNB (Wormhole)",
     "symbol": "WBNB",
@@ -2750,15 +6837,237 @@
     "decimals": "8"
   },
   {
+    "id": "terra1f509skqv3aumpwkrgjhnjpyew4mhhxrm6h3ce6zs45r7zme9e8eqwjeqwa",
+    "name": "Wrapped Ethereum",
+    "symbol": "WETH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ufj34v4agxlazv6gv36fsdm5e8y4kclqgp0qt0l8ureql9pcwssspma238",
+    "name": "Wrapped LUNA",
+    "symbol": "WLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1he6juwnty79eys2lszamkznek9yf4qu302dqf8qfws0sn03vyk0qfd4cz2",
+    "name": "Wrapped LUNA 2.0 (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "8"
+  },
+  {
+    "id": "terra12rglpa9u5jcatztvjsr4wfcx9pvgpa4vtz4c6z3n3sx2ynggggdscnt94y",
+    "name": "Wrapped Luna 2.0 Token (Wormhole)",
+    "symbol": "LUNA2",
+    "decimals": "8"
+  },
+  {
+    "id": "terra14axlvgd5mawznhukwf0dq93xhtfjfzq5cpn7pyah7lk5wf4g87tqx5whjg",
+    "name": "Wrapped LUNA Token (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1fxlqv06d7efj8qa3g9r6fz5kel4a9n9d3xtd5ws6zsmm4d2wyp2q426p2g",
+    "name": "Wrapped LUNA Token (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1sfhku0xmw62t8aau3r5rudjxmfxecr8j0ekvpfes6wed2q97yjdqrdnv6n",
+    "name": "Wrapped LUNA Token (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "8"
+  },
+  {
+    "id": "terra12g9t09vv7gdj0qpz043shtqgug5u80l5mrxm57kwncmxts96vhtqvfw8ep",
+    "name": "Wrapped LUNA Token (Wormhole) (Wormhole)",
+    "symbol": "wLUNA",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1dnatg47sl457qz6p20mdcm4p3x5djsfysnyk955agkdst2nhpdqs70lmzw",
+    "name": "Wrapped ROSE (Wormhole)",
+    "symbol": "wROSE",
+    "decimals": "8"
+  },
+  {
     "id": "terra17udtzsrzsrtg2uhr73zf6xmd3whda2wfg3qt2wtfru4x8dgv2gkqc9axuy",
     "name": "Wrapped UST (Wormhole) (Wormhole)",
     "symbol": "wUST",
     "decimals": "8"
   },
   {
+    "id": "terra1j4jen7gtnaec6fqc0kf0c3ku2yahywz0djjhw07596nz5hj9fzrqyhza66",
+    "name": "Wrapped UST Token (PoS) (Wormhole)",
+    "symbol": "UST",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1pm6s5x770t27xajnj2qqkn6mku8s4k44ujs0m53h9epqqcarulnqwva8nt",
+    "name": "WW Vault uluna LP token",
+    "symbol": "uLP-uluna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wnceq4l76f50xgeatwrs8xvl9v7dzmuaxclrwd0jhzhj0z3lwlys8cgtja",
+    "name": "XAST-CLUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra122u87x6k75sa3p4ynsfvk7fs520v2gw4jrwfnupfuw57vcdqsdps6zjed5",
+    "name": "xSAYVE",
+    "symbol": "xSAYVE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z2y3vv5mn69ep3k5wu90cmwuh2t6e9vp565j59x35d4fq2rh06esqf37ek",
+    "name": "xSAYVE",
+    "symbol": "xSAYVE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10l76clm9psp4whuhzheqhcrng53lzgu9za8hxntpu89ahepr6zqsuq6p4e",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1328565ayxaxcqjmw000v3va943jafszxjcqe0nfz5gf4huavym4qmj39qw",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14q94v3fycwq6vmfyvd7200gx79483lhtp03wlhdwr6clu27jkxdqclzpuw",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19kf5647manlwql4kez5mwdlwfr4k9vsglcefyp0xxwce7aaztlrq55mu0y",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19wdfeem79sxej2j7rxqk744axlpfn6egfu6wg9w0j83a0twvuj5sr2ev8n",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1celav7mac6ues3737mfrpgrurqkvmx5xx2yvq3jw5e4fcjpktq3syumv48",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1crat0mf78vtdvf752nk349pr9kjxutuewnakxrp0n5f40z4lmzxsgarjtx",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1elwcevx5x8nstnn460dhxqnahfzfvnjp3ssmuxqrj0j839z20k6skmwdz0",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fanpvu7kefjl8mdlvjvnnxvq4wawtxxherkpycfrrzm23wjs4pasktjcdd",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1frmvm9fn4y67vgwx35qavs9ch69ly66y90qyp087cpftsp6zdrgquemc2v",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gs5fpkpgdlwtvs9wqthm6ayu5shynkphp8sqe5zhr8n6gr2rctqsczzv9r",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1h6d2s0qpdx6zd9t2utkhdqsyk2nmln3tg3mxnwcplu2uvzmwmfrq4fd3rc",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1h8y42ee6p7yk2qks09dafd32up2evz3vx8tjf52fshv5s7dz9q6ssy06x3",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hng4rdkphpr3cn5gghwj7ly8tjl29hcs2ellt9w7yymd62ljql3sh8qr2a",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hywcdx2qyjjpvfggcsvswn20uy8vxc8dy6vhuqq9szhlr3fm0efq56hvkx",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1js0uheej983dch0w804s53433ta8whngwkatv5kjyk8angw6u3eqlhy32z",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jwdkhxx8jwce2rex2aw98nj65twe4pnnr9frrqva8y6cavs8fats84w2dm",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1k32vua65agvr4am52f3gkrgjrx0svyacdw6kc4k74j6040tfs5ssfvhaey",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ntlycx2ar0xfcekxw7pkhahcun3dz4vdcxqyxqffk9javdccvsaqgfxaek",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qs6xr9uk3u2kpfqlkaera5evjrvnf7w4jxracpkncyawlv2r2r0sys0j2u",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v0x26p9ncyclu2ln5n6kh3wr5552se677k7q7f3d4sug87vxc48s04ggta",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lmkpcg09dan6ll6vkh84zd088fxl98nhm3a62a4gj74qvnwaennqpjsr89",
+    "name": "YourGirls",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra1zjqd9jey003003jl30jkvccqn99jt4hhyw7xjl60cvkydwvajvascetjyj",
     "name": "МT (Wormhole)",
     "symbol": "МT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1msjxnah55lv7f279pnnpklkm6sfauk2sj0y4yhr38axyk3d8j6dqylf8zm",
+    "name": "저스티스 킹스맨 다오",
+    "symbol": "JKD",
     "decimals": "6"
   }
 ]

--- a/terra/asset.json
+++ b/terra/asset.json
@@ -941,9 +941,7 @@
     "name": "Graviton",
     "symbol": "GRAV",
     "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/ibc/GRAV.svg",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/grav/",
-    "coingecko": "https://www.coingecko.com/en/coins/graviton"
+    "icon": "https://assets.terra.money/icon/svg/ibc/GRAV.svg"
   },
   {
     "id": "ibc/4CD525F166D32B0132C095F353F4C6F033B0FF5C49141470D1EFDA1D63303D04",

--- a/terra/asset.json
+++ b/terra/asset.json
@@ -908,7 +908,9 @@
     "name": "Cosmos",
     "symbol": "ATOM",
     "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/ibc/ATOM.svg"
+    "icon": "https://assets.terra.money/icon/svg/ibc/ATOM.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/cosmos-hub",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/cosmos/"
   },
   {
     "id": "ibc/B090DC21658BD57698522880590CA53947B8B09355764131AA94EC75517D46A5",
@@ -916,7 +918,8 @@
     "name": "Crescent Network",
     "symbol": "CRE",
     "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/ibc/CRE.svg"
+    "icon": "https://assets.terra.money/icon/svg/ibc/CRE.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/crescent-network"
   },
   {
     "id": "terra1ecgazyd0waaj3g7l9cmy5gulhxkps2gmxu9ghducvuypjq68mq2s5lvsct",
@@ -941,7 +944,9 @@
     "name": "Graviton",
     "symbol": "GRAV",
     "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/ibc/GRAV.svg"
+    "icon": "https://assets.terra.money/icon/svg/ibc/GRAV.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/graviton",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/grav/"
   },
   {
     "id": "ibc/4CD525F166D32B0132C095F353F4C6F033B0FF5C49141470D1EFDA1D63303D04",
@@ -949,7 +954,9 @@
     "name": "Juno",
     "symbol": "JUNO",
     "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/ibc/JUNO.svg"
+    "icon": "https://assets.terra.money/icon/svg/ibc/JUNO.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/juno-network",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/juno/"
   },
   {
     "id": "ibc/B22B4DD21586965DAEF42A7600BA371EA77C02E90FC8A7F2330BF9F9DE129B07",
@@ -997,7 +1004,9 @@
     "name": "Osmosis",
     "symbol": "OSMO",
     "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/ibc/OSMO.svg"
+    "icon": "https://assets.terra.money/icon/svg/ibc/OSMO.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/osmosis",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/osmosis/"
   },
   {
     "id": "terra167khnalh9aawqx9qynj7kk9y0n8hc30qe6s8cy7y5yu2azrc2edqyjprp9",
@@ -1119,7 +1128,9 @@
     "name": "Secret",
     "symbol": "SCRT",
     "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/ibc/SCRT.svg"
+    "icon": "https://assets.terra.money/icon/svg/ibc/SCRT.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/secret",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/secret/"
   },
   {
     "id": "terra1l23rtnsp0fcfgs2zlww4gcd8dlznkm580p5yrsangcen9jjjhuqstd2sle",
@@ -1143,7 +1154,9 @@
     "symbol": "LunaX",
     "decimals": "6",
     "circ_supply_api": "https://phoenix-lcd.terra.dev/cosmwasm/wasm/v1/contract/terra14xsm2wzvu7xaf567r693vgfkhmvfs08l68h4tjj5wjgyn5ky8e2qvzyanh/smart/eyJ0b2tlbl9pbmZvIjp7fX0=",
-    "icon": "https://raw.githubusercontent.com/stader-labs/assets/main/terra/LunaX_1.png"
+    "icon": "https://raw.githubusercontent.com/stader-labs/assets/main/terra/LunaX_1.png",
+    "coingecko": "https://www.coingecko.com/en/coins/stader-lunax",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/stader-lunax/"
   },
   {
     "id": "terra1xumzh893lfa7ak5qvpwmnle5m5xp47t3suwwa9s0ydqa8d8s5faqn6x7al",
@@ -1160,7 +1173,9 @@
     "symbol": "LUNA",
     "decimals": "6",
     "circ_supply_api": "https://phoenix-api.terra.dev/balance/circulating-supply",
-    "icon": "https://assets.terra.money/icon/svg/Luna.svg"
+    "icon": "https://assets.terra.money/icon/svg/Luna.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/terra",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-luna-v2/"
   },
   {
     "id": "terra13j2k5rfkg0qhk58vz63cze0uze4hwswlrfnm0fa4rnyggjyfrcnqcrs5z2",
@@ -1185,7 +1200,8 @@
     "name": "TerraFloki",
     "symbol": "TFLOKI",
     "decimals": "6",
-    "icon": "https://terrafloki.io/tf-logo.png"
+    "icon": "https://terrafloki.io/tf-logo.png",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terrafloki/"
   },
   {
     "id": "terra10nnsamvtc5yux6m9utwc6dtee20h8fe8gp06jfqy0ffqtxrk384s4l0rru",
@@ -1565,7 +1581,9 @@
     "symbol": "VKR",
     "decimals": "6",
     "circ_supply_api": "https://terra-api.valkyrieprotocol.com/partner/coinhall/circulating-supply",
-    "icon": "https://app.valkyrieprotocol.com/icon_vkr.png"
+    "icon": "https://app.valkyrieprotocol.com/icon_vkr.png",
+    "coingecko": "https://www.coingecko.com/en/coins/valkyrie-protocol",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/valkyrie-protocol/"
   },
   {
     "id": "terra1qmnxhecc3vnmhef9q7vap7spx9tgpnw9fqe8ljqfwrlz7rur9y5qu2dlp6",
@@ -1573,7 +1591,9 @@
     "name": "Wrapped AVAX (Wormhole)",
     "symbol": "WAVAX",
     "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/AVAX_wh.png"
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/AVAX_wh.png",
+    "coingecko": "https://www.coingecko.com/en/coins/wrapped-avax",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/wavax/"
   },
   {
     "id": "terra15hhqg8gyz04zapynqtk7uvlsp7lzay7etrt9ann0276v94yae63sxygeat",
@@ -1581,7 +1601,9 @@
     "name": "Wrapped Ether (Wormhole)",
     "symbol": "WETH",
     "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs/logo.png"
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs/logo.png",
+    "coingecko": "https://www.coingecko.com/en/coins/weth",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/weth/"
   },
   {
     "id": "terra1ctelwayk6t2zu30a8v9kdg3u2gr0slpjdfny5pjp7m3tuquk32ysugyjdg",
@@ -1589,7 +1611,9 @@
     "name": "Wrapped SOL (Wormhole)",
     "symbol": "SOL",
     "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png"
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png",
+    "coingecko": "https://www.coingecko.com/en/coins/wrapped-solana",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/wrapped-solana/"
   },
   {
     "id": "terra1dwtgrdjtgx3d3laypgx8ptch0kk20skh4p6ra3euy38x6n9s7kws4yzlgf",
@@ -2201,7 +2225,8 @@
     "id": "terra1p67lldutk5haqpmnk5thuhmhyff8ntf8axa37mzm87qq58082u0qqp9mmu",
     "name": "Apple (Wormhole)",
     "symbol": "mAAPL",
-    "decimals": "6"
+    "decimals": "6",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/mirrored-apple/"
   },
   {
     "id": "terra16hx93yrc3s7xlx8facausmtz3sfrgknd6mf70fhmzhjkej97g42qkflfs2",
@@ -2616,7 +2641,8 @@
     "id": "terra129zjaxquhh3h5upn0clqzdawnze43a9z34ktt4l6um2hf5w0xqjsta42u5",
     "name": "BUSD Token (Wormhole)",
     "symbol": "BUSD",
-    "decimals": "8"
+    "decimals": "8",
+    "coingecko": "https://www.coingecko.com/en/coins/binance-usd-wormhole"
   },
   {
     "id": "terra1aplktggys8uf3mm8rnx5nz2vz66jgu4pszpjg72nn6kst299y58qv46ajc",
@@ -4041,7 +4067,9 @@
     "name": "Luna Classic (Wormhole)",
     "symbol": "LUNC",
     "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/LUNC.svg"
+    "icon": "https://assets.terra.money/icon/svg/LUNC.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/terra-luna-classic",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-luna/"
   },
   {
     "id": "terra1fvdcu2j85nrlhwhy0rmhttst2caaxtf36ytjcngg47qkt8ndcu8sm6qff6",
@@ -4281,7 +4309,8 @@
     "id": "terra1s8u586k3s7xtvasxv4p6ldl0jrxht9w886v8ymkst6crg5hxue3sqn49r9",
     "name": "Microsoft Corporation (Wormhole)",
     "symbol": "mMSFT",
-    "decimals": "6"
+    "decimals": "6",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/mirrored-microsoft/"
   },
   {
     "id": "terra1y5e4plp8evsh2urycmhy35lrqxneqc8ewdqzjpvlu5z9wurpqw7sfj9u5x",
@@ -6311,7 +6340,8 @@
     "id": "terra12ezq5402h5n3skhdshjp4f49zzg0saxum8fvvhjhauzas2ezyyrqpznqny",
     "name": "Tether USD (Wormhole)",
     "symbol": "USDT",
-    "decimals": "8"
+    "decimals": "8",
+    "coingecko": "https://www.coingecko.com/en/coins/tether-usd-wormhole-from-ethereum"
   },
   {
     "id": "terra1p2wm9d7lp4pf32pmwzm5ll59q9sqj48p0u66cnfavuzj78gusdeskdgms2",
@@ -6612,7 +6642,8 @@
     "id": "terra1vzd98s9kqdkatahxs7rsd8m474lf2f8ct39zdgd6shj4nh5e6kuskaz2gy",
     "name": "USD Coin (Wormhole)",
     "symbol": "USDC",
-    "decimals": "8"
+    "decimals": "8",
+    "coingecko": "https://www.coingecko.com/en/coins/usd-coin-wormhole-from-ethereum"
   },
   {
     "id": "terra1tzaw5m79em9juj0lf4dxr6phxxht79jt770mn77ltvx5e6ww4vpss6hvnu",
@@ -6660,7 +6691,9 @@
     "id": "terra1rwg5kt6kcyxtz69acjgpeut7dgr4y3r7tvntdxqt03dvpqktrfxq4jrvpq",
     "name": "UST (Wormhole)",
     "symbol": "UST",
-    "decimals": "6"
+    "decimals": "6",
+    "coingecko": "https://www.coingecko.com/en/coins/terrausd-wormhole",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terrausd-wormhole/"
   },
   {
     "id": "terra10tclyxjfcx7u0wd0d0he4muqvhd6nn6d7lr2ktmga275tq0axamqs6gxnj",

--- a/terra/entity.json
+++ b/terra/entity.json
@@ -3,6 +3,21 @@
     "name": "alentejo.money"
   },
   {
+    "name": "Andromeda"
+  },
+  {
+    "name": "Aperture Finance"
+  },
+  {
+    "name": "ApolloDAO"
+  },
+  {
+    "name": "Arbie"
+  },
+  {
+    "name": "Astral Money"
+  },
+  {
     "name": "Astroport",
     "website": "https://t.co/ejYaePobxy",
     "telegram": "https://t.co/kiLJmew5Ls",
@@ -14,7 +29,34 @@
     "twitter": "https://twitter.com/axelarcore"
   },
   {
+    "name": "Binance"
+  },
+  {
+    "name": "Bithumb"
+  },
+  {
     "name": "boneLuna"
+  },
+  {
+    "name": "Builder Council"
+  },
+  {
+    "name": "Capapult"
+  },
+  {
+    "name": "Coinex"
+  },
+  {
+    "name": "Coinhall"
+  },
+  {
+    "name": "Coinone"
+  },
+  {
+    "name": "Core Distribution Module"
+  },
+  {
+    "name": "Core Staking Module"
   },
   {
     "name": "Cosmos",
@@ -29,18 +71,54 @@
     "twitter": "https://twitter.com/crescenthub"
   },
   {
+    "name": "Cyberdeck"
+  },
+  {
+    "name": "Edge"
+  },
+  {
+    "name": "Edge Protocol"
+  },
+  {
     "name": "Eris Protocol",
     "website": "https://www.erisprotocol.com/",
     "telegram": "https://t.co/cqfIpelqbk",
     "twitter": "https://twitter.com/eris_protocol"
   },
   {
+    "name": "FTX"
+  },
+  {
+    "name": "Galactic Punks"
+  },
+  {
     "name": "Gidorah"
+  },
+  {
+    "name": "Gravidao"
   },
   {
     "name": "Gravity Bridge",
     "website": "https://t.co/rSb0msPbRI",
     "twitter": "https://twitter.com/gravity_bridge"
+  },
+  {
+    "name": "Hallswap"
+  },
+  {
+    "name": "Hermes Protocol"
+  },
+  {
+    "name": "Hero NFT"
+  },
+  {
+    "name": "Huobi"
+  },
+  {
+    "name": "IBC Transfer Module"
+  },
+  {
+    "name": "Illiquid Labs"
   },
   {
     "name": "Juno",
@@ -49,13 +127,55 @@
     "twitter": "https://twitter.com/JunoNetwork"
   },
   {
+    "name": "Kado Money"
+  },
+  {
+    "name": "Knowhere"
+  },
+  {
+    "name": "Kraken"
+  },
+  {
+    "name": "Kucoin"
+  },
+  {
     "name": "Kujira"
+  },
+  {
+    "name": "Leap"
+  },
+  {
+    "name": "LFG"
   },
   {
     "name": "Lira Financial"
   },
   {
     "name": "Luna Bird"
+  },
+  {
+    "name": "Moonpay"
+  },
+  {
+    "name": "Nauticus"
+  },
+  {
+    "name": "Neptune Finance"
+  },
+  {
+    "name": "Newton"
+  },
+  {
+    "name": "NFTSwitch"
+  },
+  {
+    "name": "Obi"
+  },
+  {
+    "name": "OkCoin"
+  },
+  {
+    "name": "OKX"
   },
   {
     "name": "Orne"
@@ -67,18 +187,51 @@
     "twitter": "https://twitter.com/osmosiszone"
   },
   {
+    "name": "Outlet Finance"
+  },
+  {
+    "name": "Packs"
+  },
+  {
+    "name": "Pavo Finance"
+  },
+  {
+    "name": "PaywithTerra"
+  },
+  {
     "name": "Phoenix"
   },
   {
     "name": "portugal.protocol"
   },
   {
+    "name": "Prism"
+  },
+  {
+    "name": "Prism Protocol"
+  },
+  {
+    "name": "Pulsar Finance"
+  },
+  {
+    "name": "Random Earth"
+  },
+  {
+    "name": "Randomearth"
+  },
+  {
     "name": "Redacted Money"
+  },
+  {
+    "name": "Risk Harbor"
   },
   {
     "name": "Santerra",
     "website": "https://santerra.app/",
     "twitter": "https://twitter.com/Santerra_SANT"
+  },
+  {
+    "name": "Sayve"
   },
   {
     "name": "Sayve Protocol",
@@ -87,10 +240,25 @@
     "twitter": "https://twitter.com/sayve_protocol"
   },
   {
+    "name": "SCV Security"
+  },
+  {
     "name": "Secret Network",
     "website": "scrt.network",
     "telegram": "https://t.me/scrtCommunity",
     "twitter": "https://twitter.com/SecretNetwork"
+  },
+  {
+    "name": "Setten"
+  },
+  {
+    "name": "Skip Protocol"
+  },
+  {
+    "name": "Spectrum"
+  },
+  {
+    "name": "Spectrum Protocol"
   },
   {
     "name": "Stader Labs"
@@ -100,6 +268,9 @@
     "website": "https://app.steak.club/",
     "telegram": "https://t.me/+PadO-WwMDxNjMGEx",
     "twitter": "https://twitter.com/st4k3h0us3"
+  },
+  {
+    "name": "Talis"
   },
   {
     "name": "Terra Money",
@@ -114,13 +285,43 @@
     "twitter": "https://twitter.com/TP_TerraPoker"
   },
   {
+    "name": "Terrafirma"
+  },
+  {
     "name": "TerraFloki",
     "website": "https://terrafloki.io/",
     "telegram": "https://t.co/tFOOeLO45t",
     "twitter": "https://twitter.com/MetaFrens_"
   },
   {
+    "name": "Terran One"
+  },
+  {
+    "name": "Terrascope"
+  },
+  {
     "name": "Terraswap"
+  },
+  {
+    "name": "TFL"
+  },
+  {
+    "name": "TFM"
+  },
+  {
+    "name": "Tiiik"
+  },
+  {
+    "name": "Tix Protocol"
+  },
+  {
+    "name": "TrackTerra"
+  },
+  {
+    "name": "Upbit"
+  },
+  {
+    "name": "Validator DAO"
   },
   {
     "name": "Valkyrie Protocol",
@@ -129,8 +330,20 @@
     "twitter": "https://twitter.com/valkyrie_money"
   },
   {
+    "name": "White Whale"
+  },
+  {
+    "name": "Wicca Money"
+  },
+  {
     "name": "Wormhole",
     "website": "https://wormholenetwork.com/",
     "twitter": "https://twitter.com/wormholecrypto"
+  },
+  {
+    "name": "Y-Foundry DAO"
+  },
+  {
+    "name": "Zodiac Protocol"
   }
 ]

--- a/terra/pool.json
+++ b/terra/pool.json
@@ -1,2192 +1,2192 @@
 [
   {
     "id": "terra10w06e42fg2sre2quy24hv5l93djp3lrp80fu0n8k336r90vszddspfn7vx",
-    "lp_token_id": "terra1e9ge099thjrfx9y74aznq38esfkm55lpqvdvun078aw0nejdhu0qsn5n9d",
     "asset_ids": [
       "terra1ecgazyd0waaj3g7l9cmy5gulhxkps2gmxu9ghducvuypjq68mq2s5lvsct",
       "terra1xumzh893lfa7ak5qvpwmnle5m5xp47t3suwwa9s0ydqa8d8s5faqn6x7al"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1e9ge099thjrfx9y74aznq38esfkm55lpqvdvun078aw0nejdhu0qsn5n9d"
   },
   {
     "id": "terra13aaxn6ekd9fhz9lwrnfqx3ywk4w4eryurmuytdlhwfgp804qjkjst95kej",
-    "lp_token_id": "terra15hgjqvr89q5t4qmvyt0qnmmlx34dyyn7e6x9z3fnqn5wtgj6lllqa95dm8",
     "asset_ids": [
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
       "terra129zjaxquhh3h5upn0clqzdawnze43a9z34ktt4l6um2hf5w0xqjsta42u5"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra15hgjqvr89q5t4qmvyt0qnmmlx34dyyn7e6x9z3fnqn5wtgj6lllqa95dm8"
   },
   {
     "id": "terra16v9vyplltvc52qrr5xxyw5c20tswtfvpc0wgmfv9n3ew6hd4afsqy3k8ym",
-    "lp_token_id": "terra1yj078tseqc85x9r54u06jhektnqhvcxayxqwycg0y3yt9867pglqcuqym5",
     "asset_ids": [
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
       "terra1vzd98s9kqdkatahxs7rsd8m474lf2f8ct39zdgd6shj4nh5e6kuskaz2gy"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1yj078tseqc85x9r54u06jhektnqhvcxayxqwycg0y3yt9867pglqcuqym5"
   },
   {
     "id": "terra18fr4keh3afk9e84tf466xsdkk9t8amstycjw7c8e6gukjqjq875q9zdavy",
-    "lp_token_id": "terra1q6hpxkcx5a0g8u0m0n30cl6afafufpl5yl4lza2umk5up9tzerwqszqvr7",
     "asset_ids": [
       "terra1ecgazyd0waaj3g7l9cmy5gulhxkps2gmxu9ghducvuypjq68mq2s5lvsct",
       "terra14xsm2wzvu7xaf567r693vgfkhmvfs08l68h4tjj5wjgyn5ky8e2qvzyanh"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1q6hpxkcx5a0g8u0m0n30cl6afafufpl5yl4lza2umk5up9tzerwqszqvr7"
   },
   {
     "id": "terra19kaa5azm3tw6a2yd2p0chvfznt6rathpf0qy2twm5mgwrg0wrf8sletgyv",
-    "lp_token_id": "terra1ef5veuvpudt392jvwrzfw79e0glcdjthgq0cyj3xs8uc98p7x3tqg293tl",
     "asset_ids": [
       "terra1vzd98s9kqdkatahxs7rsd8m474lf2f8ct39zdgd6shj4nh5e6kuskaz2gy",
       "terra12ezq5402h5n3skhdshjp4f49zzg0saxum8fvvhjhauzas2ezyyrqpznqny"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1ef5veuvpudt392jvwrzfw79e0glcdjthgq0cyj3xs8uc98p7x3tqg293tl"
   },
   {
     "id": "terra1c7uyg2lq70awrm2thf2cfza0xz6e8g6v4eta7xscuupyh0f77zdqtkvwc8",
-    "lp_token_id": "terra1xnjmgzzukpnp92mlhsu9ghmlg29h5hdtrv8n34mhvgmsctug4prq9prw2l",
     "asset_ids": [
       "uluna",
       "terra1hspy32cecnj72wwpma59eldpmsmfndlrwqxnzx6awfdtarns66qqw5kn85"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1xnjmgzzukpnp92mlhsu9ghmlg29h5hdtrv8n34mhvgmsctug4prq9prw2l"
   },
   {
     "id": "terra1cr8dg06sh343hh4xzn3gxd3ayetsjtet7q5gp4kfrewul2kql8sqvhaey4",
-    "lp_token_id": "terra1cq22eugxwgp0x34cqfrxmd9jkyy43gas93yqjhmwrm7j0h5ecrqq5j7dgp",
     "asset_ids": [
       "uluna",
       "terra1ecgazyd0waaj3g7l9cmy5gulhxkps2gmxu9ghducvuypjq68mq2s5lvsct"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1cq22eugxwgp0x34cqfrxmd9jkyy43gas93yqjhmwrm7j0h5ecrqq5j7dgp"
   },
   {
     "id": "terra1dythudkvns73g2sx3qqehkkug2hhcs26cpx5q4wjmuh88qhw0dus4rmxvd",
-    "lp_token_id": "terra1mnysxy8lrsx0vzsgpnln8c6p40rm5z00umhpmks6he6utr0cw56scfpt48",
     "asset_ids": [
       "terra1vzd98s9kqdkatahxs7rsd8m474lf2f8ct39zdgd6shj4nh5e6kuskaz2gy",
       "terra129zjaxquhh3h5upn0clqzdawnze43a9z34ktt4l6um2hf5w0xqjsta42u5"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1mnysxy8lrsx0vzsgpnln8c6p40rm5z00umhpmks6he6utr0cw56scfpt48"
   },
   {
     "id": "terra1faheydctjeq59qnwcw9yfs6qth5dntfugppm2we5ayud38er9eyqq0sesk",
-    "lp_token_id": "terra1vuh08zt4qcsmmu0g4p8k62mpzkj2v3rff4dg4srzdd2xenlm5qeqlwjht3",
     "asset_ids": [
       "terra12ezq5402h5n3skhdshjp4f49zzg0saxum8fvvhjhauzas2ezyyrqpznqny",
       "terra129zjaxquhh3h5upn0clqzdawnze43a9z34ktt4l6um2hf5w0xqjsta42u5"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1vuh08zt4qcsmmu0g4p8k62mpzkj2v3rff4dg4srzdd2xenlm5qeqlwjht3"
   },
   {
     "id": "terra1h32epkd72x7st0wk49z35qlpsxf26pw4ydacs8acq6uka7hgshmq7z7vl9",
-    "lp_token_id": "terra1h3z2zv6aw94fx5263dy6tgz6699kxmewlx3vrcu4jjrudg6xmtyqk6vt0u",
     "asset_ids": [
       "terra17aj4ty4sz4yhgm08na8drc0v03v2jwr3waxcqrwhajj729zhl7zqnpc0ml",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1h3z2zv6aw94fx5263dy6tgz6699kxmewlx3vrcu4jjrudg6xmtyqk6vt0u"
   },
   {
     "id": "terra1hmm6wkt2uq973hpykg46rtae34y3maplyl8l9fhpm2vfftrew5uq5t6a0r",
-    "lp_token_id": "terra135t2lyz8638ad0l7nasth49agcm6cn36zdp9mtxd6gdxx0tzhlmqs3dq0q",
     "asset_ids": [
       "ibc/14ACCAD1750327C74BB35978AD0C3E97B184DAB9F0BF4BD876FBD1F782B57110",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra135t2lyz8638ad0l7nasth49agcm6cn36zdp9mtxd6gdxx0tzhlmqs3dq0q"
   },
   {
     "id": "terra1l2r2dxss8j8su2tj6sf4zntu3zghqe76ee8gyx3e5dppxavfhe7q7qlcc4",
-    "lp_token_id": "terra1paat6jjgnfvavhfncdxhx4djpzansv9h06vge5grf3daqn8suezql2t7gx",
     "asset_ids": [
       "terra1qx284aak0wl7vrvlsc6cwcsn6xwajragkh6cjqj87m9p34hx5l2s22p3cp",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1paat6jjgnfvavhfncdxhx4djpzansv9h06vge5grf3daqn8suezql2t7gx"
   },
   {
     "id": "terra1l4a4reyzrtu7ylrag7x3z8ejrfk58ts44hnqwck0y5p03xkltf7qnm6jkx",
-    "lp_token_id": "terra13qn86nhlj09kh6ea3pzvswj48yzyrh49rnhjwh9qv7gvu54qgq2qrmet53",
     "asset_ids": [
       "terra1qx284aak0wl7vrvlsc6cwcsn6xwajragkh6cjqj87m9p34hx5l2s22p3cp",
       "ibc/CBF67A2BCF6CAE343FDF251E510C8E18C361FC02B23430C121116E0811835DEF"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra13qn86nhlj09kh6ea3pzvswj48yzyrh49rnhjwh9qv7gvu54qgq2qrmet53"
   },
   {
     "id": "terra1mpj7j25fw5a0q5vfasvsvdp6xytaqxh006lh6f5zpwxvadem9hwsy6m508",
-    "lp_token_id": "terra1kggfd6z0ad2k9q8v24f7ftxyqush8fp9xku9nyrjcs2wv0e4kypszfrfd0",
     "asset_ids": [
       "uluna",
       "terra14xsm2wzvu7xaf567r693vgfkhmvfs08l68h4tjj5wjgyn5ky8e2qvzyanh"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1kggfd6z0ad2k9q8v24f7ftxyqush8fp9xku9nyrjcs2wv0e4kypszfrfd0"
   },
   {
     "id": "terra1pxm9qtnrchzy90d99clpa0rkx8fyztlc67wt5t999pc8yvsrx90snpfe4v",
-    "lp_token_id": "terra1yhpasjvjfc84ywwxl07tfy50zqqhh7l8k0280tfqyr8t5uu6gf4s6u0hxh",
     "asset_ids": [
       "terra13eekqp0zgj55arjuacpxqxzgqy2uydf5wzzqns9ddgpepj377afqflunf3",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1yhpasjvjfc84ywwxl07tfy50zqqhh7l8k0280tfqyr8t5uu6gf4s6u0hxh"
   },
   {
     "id": "terra1q0799zjacryduxw5hcxwaqc6jf3ls604afvm7gqjpvultvm88d4qhyhss8",
-    "lp_token_id": "terra1n9yykacl3ft9fw95sr0eckqsd6p9l62ehdhf5u6k6akmvupqr7as9ygupx",
     "asset_ids": [
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
       "terra1q4r4zzde2tg52306qevhnaf3qw76a68hnyzw404uuvvzx09n3ckqe2ylrm"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1n9yykacl3ft9fw95sr0eckqsd6p9l62ehdhf5u6k6akmvupqr7as9ygupx"
   },
   {
     "id": "terra1stnej96md342vzlcaw04ju89f9femg3w4ed0hky5rlj6awwz56vswsfhaj",
-    "lp_token_id": "terra15me9trrk8nrtmwcgx248n98unlgw4a65vef8942rk336tytynqysqc53pq",
     "asset_ids": [
       "ibc/14ACCAD1750327C74BB35978AD0C3E97B184DAB9F0BF4BD876FBD1F782B57110",
       "ibc/CBF67A2BCF6CAE343FDF251E510C8E18C361FC02B23430C121116E0811835DEF"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra15me9trrk8nrtmwcgx248n98unlgw4a65vef8942rk336tytynqysqc53pq"
   },
   {
     "id": "terra1sxdrn5efjuf3z2lzuwnew839zus4lm2dndwzw589t0kzku6kmhnsuhsxq3",
-    "lp_token_id": "terra16hnd8a8cy0z5u6t56mcv28yencp8dwv4rtjs4kftxmqn5mhnga3q0ceajp",
     "asset_ids": [
       "terra16h7keds26d52xj8rn9jfx6lj2x0ja79lt56yxnmlm4xsttf5mu5smq5f78",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra16hnd8a8cy0z5u6t56mcv28yencp8dwv4rtjs4kftxmqn5mhnga3q0ceajp"
   },
   {
     "id": "terra1tpm8tsf9dtmpkzup6lfadpfy5fewqtghhw5zs3wv3nf8wt6wl7xqtscvgg",
-    "lp_token_id": "terra19ugc0gmww0f94pckazqfa4elnvt3rlrd6wp23w0ry88j3dfuya5sm7nyns",
     "asset_ids": [
       "terra1rwg5kt6kcyxtz69acjgpeut7dgr4y3r7tvntdxqt03dvpqktrfxq4jrvpq",
       "ibc/14ACCAD1750327C74BB35978AD0C3E97B184DAB9F0BF4BD876FBD1F782B57110"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra19ugc0gmww0f94pckazqfa4elnvt3rlrd6wp23w0ry88j3dfuya5sm7nyns"
   },
   {
     "id": "terra1v89tl3f0m4pydhv6dm7u6rnpwmv20tdpes8d45xjcgrxrrcuve5smf6fe4",
-    "lp_token_id": "terra1px8kmqg3m6kvmuf39ewua8c9scvl5mypw4pczpt35t7t6rwadxxs53m8a7",
     "asset_ids": [
       "ibc/BCB139B1FB690E0AC1AD98EBAAD281949ECB341872E697717BCF95B67917C34F",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1px8kmqg3m6kvmuf39ewua8c9scvl5mypw4pczpt35t7t6rwadxxs53m8a7"
   },
   {
     "id": "terra1vzxatdcx3msz0lpvl7anu8raarhhyenjhnrnpdhvsnhhx7dew9ms0hdaz9",
-    "lp_token_id": "terra1v4ytr73tfkms7e5qhuy7qnmfkfgf6fs5ut9av6u78j9tv9ahwrlqazaycp",
     "asset_ids": [
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
       "terra12ezq5402h5n3skhdshjp4f49zzg0saxum8fvvhjhauzas2ezyyrqpznqny"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1v4ytr73tfkms7e5qhuy7qnmfkfgf6fs5ut9av6u78j9tv9ahwrlqazaycp"
   },
   {
     "id": "terra1y0dp7jzr38uenmd2rncpqw9uegcdq2yqp5kcxc277ezklqdg2tcsj92x5e",
-    "lp_token_id": "terra14qulp86csugtkn6mz2czdsf0rudwu8kt89ccrzdfrf5v9tt3jvxqnk94ce",
     "asset_ids": [
       "terra1mrdgys0e0hhq0n56zgy3e0htahcnwtdt4dy2ec9wcltcr6qjntmq0yen07",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra14qulp86csugtkn6mz2czdsf0rudwu8kt89ccrzdfrf5v9tt3jvxqnk94ce"
   },
   {
     "id": "terra1ygn5h8v8rm0v8y57j3mtu3mjr2ywu9utj6jch6e0ys2fc2pkyddqekwrew",
-    "lp_token_id": "terra1khsxwfnzuxqcyza2sraxf2ngkr3dwy9f7rm0uts0xpkeshs96ccsqtu6nv",
     "asset_ids": [
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
       "ibc/CBF67A2BCF6CAE343FDF251E510C8E18C361FC02B23430C121116E0811835DEF"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1khsxwfnzuxqcyza2sraxf2ngkr3dwy9f7rm0uts0xpkeshs96ccsqtu6nv"
   },
   {
     "id": "terra1z6azezq688a7pnrta3g855jsmwel492uvraty5zxv0zjn8rxz5yq8zdgah",
-    "lp_token_id": "terra1rw5h8yrwkemd7nqmr2k70az2pel8r875qutu03cwjkczve4fev5q9m024s",
     "asset_ids": [
       "terra13jlm0anpdd3hc0xctw9vtncmcfnrag8dh686s2juy7m226unwd4q0tmx2v",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1rw5h8yrwkemd7nqmr2k70az2pel8r875qutu03cwjkczve4fev5q9m024s"
   },
   {
     "id": "terra1074tgxqlxtav7ypzadkj30wkgrync9mm8s307r3u9hc3r2rjsjjsytp2cz",
-    "lp_token_id": "terra1cs9wyhlcdz7w5arfgs7c9u0x7l2ev8atd6vzqd8pl702zpe69ndqpln7ky",
     "asset_ids": [
       "terra15hhqg8gyz04zapynqtk7uvlsp7lzay7etrt9ann0276v94yae63sxygeat",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1cs9wyhlcdz7w5arfgs7c9u0x7l2ev8atd6vzqd8pl702zpe69ndqpln7ky"
   },
   {
     "id": "terra108psz4xadgpytu76dfztaytkldvrh6zl35nwdy6n2cltvn0dkt8qu26rde",
-    "lp_token_id": "terra1ljjau3mzxv2rpje5p67vfa2uc82uvct5l70z5cqegd0pnus3u26svpura9",
     "asset_ids": [
       "terra1rwg5kt6kcyxtz69acjgpeut7dgr4y3r7tvntdxqt03dvpqktrfxq4jrvpq",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ljjau3mzxv2rpje5p67vfa2uc82uvct5l70z5cqegd0pnus3u26svpura9"
   },
   {
     "id": "terra10elu2q9xnarjnr9509v9cwa0rsxd5kpylmhl247eqsneh4n5369qsf7g25",
-    "lp_token_id": "terra1f6lmzz9caag00uqssw4dlczrvlaeva4afn2yl3cxfd0ncawpelnqwmtj2d",
     "asset_ids": [
       "uluna",
       "terra10exkttsx4xq2j5k3uel9h4gvxy63yd90u46yt3qzn9vfcuh2utwqydz8rq"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1f6lmzz9caag00uqssw4dlczrvlaeva4afn2yl3cxfd0ncawpelnqwmtj2d"
   },
   {
     "id": "terra10xergcw3a994882ra9gpefjwc9wupzpvdck8cemxgc5p6cg5scvqgjkuax",
-    "lp_token_id": "terra19ruafuuna67knun0e4falancl0u39jtnar9euv8s3h08le46wyfq7lyn4u",
     "asset_ids": [
       "terra1x62mjnme4y0rdnag3r8rfgjuutsqlkkyuh4ndgex0wl3wue25uksau39q8",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19ruafuuna67knun0e4falancl0u39jtnar9euv8s3h08le46wyfq7lyn4u"
   },
   {
     "id": "terra127xnylapups3msndck3aky75m9k47hk4h8y7cwerd5ua86km9ffqrc703g",
-    "lp_token_id": "terra1njqfs4v35leu654394yx0lyccvcau3j9u5v0k4gnx0dcl55rkqrqxwswd6",
     "asset_ids": [
       "terra1qmnxhecc3vnmhef9q7vap7spx9tgpnw9fqe8ljqfwrlz7rur9y5qu2dlp6",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1njqfs4v35leu654394yx0lyccvcau3j9u5v0k4gnx0dcl55rkqrqxwswd6"
   },
   {
     "id": "terra12hcs6mkg3zhg2vdnrl8ep8yejjhnynyvz42uewpupdmg0ksmlcts5v4uvv",
-    "lp_token_id": "terra1eavy3qvhwcvmvah8hgru8x6sc3cnluxfyqlkctur0e4jkcqvwgxqxmc3hl",
     "asset_ids": [
       "terra1a2gdn43yjllg3jvna7xcv2zea0ppjchsww2fedd63l9k2azg6j7qg6v3pj",
       "terra1uc3r74qg44csdrl8hrm5muzlue9gf7umgkyv569pgazh7tudpr4qdtgqh6"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1eavy3qvhwcvmvah8hgru8x6sc3cnluxfyqlkctur0e4jkcqvwgxqxmc3hl"
   },
   {
     "id": "terra12sxh6tx923lk9jpkzsrqx3k2hcm4nl4hjpjj28n8at0s5pyrs8wsdzawz7",
-    "lp_token_id": "terra1n6sa5dykwq87w8v08xqr2jnhwv2r7kzznvvqz7dvhkqch8kapwjs6xtl5s",
     "asset_ids": [
       "terra13j2k5rfkg0qhk58vz63cze0uze4hwswlrfnm0fa4rnyggjyfrcnqcrs5z2",
       "terra1e9s5m6vrl9ms75q0862llq2vcsz8r43czm36s6xnn3vh8dfmwe0s3c86e8"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1n6sa5dykwq87w8v08xqr2jnhwv2r7kzznvvqz7dvhkqch8kapwjs6xtl5s"
   },
   {
     "id": "terra12t3t0f0ga6hv6cw274mytcwhh9038x448ugthz9j0tkvdnlgnc5qdz2ael",
-    "lp_token_id": "terra1yfm49ecnsaxjh83raczdxy6jgq2rykp8kc2pmlw62rxu3dyy4laq9fzmu2",
     "asset_ids": [
       "uluna",
       "terra1ee4g63c3sus9hnyyp3p2u3tulzdv5ag68l55q8ej64y4qpwswvus5mtag2"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1yfm49ecnsaxjh83raczdxy6jgq2rykp8kc2pmlw62rxu3dyy4laq9fzmu2"
   },
   {
     "id": "terra12zp2u3g82g7kje37xwk2jn05klxank0fr5ejl4jtlfmszzdpc8ws9uvcww",
-    "lp_token_id": "terra14hq8h7sjvkjv9dv90mcy3lt74fyevktrg9685rzeshx0y2vpkl9sg38zmv",
     "asset_ids": [
       "terra13e7da9f90m32s04kg4knlpsakmn50kqz2zx2rqypkahhp29gxdwqu4vy8q",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14hq8h7sjvkjv9dv90mcy3lt74fyevktrg9685rzeshx0y2vpkl9sg38zmv"
   },
   {
     "id": "terra13fcan0w3xywmutwpunwwmw3c7aazx6l8aqv97ekxh3ag7anp53usxzpje7",
-    "lp_token_id": "terra12857xqnmsxdcd73qvtl7cr92djguxs03mmpgmgksey0xxzmkzqvs29aadp",
     "asset_ids": [
       "ibc/CBF67A2BCF6CAE343FDF251E510C8E18C361FC02B23430C121116E0811835DEF",
       "terra1uc3r74qg44csdrl8hrm5muzlue9gf7umgkyv569pgazh7tudpr4qdtgqh6"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra12857xqnmsxdcd73qvtl7cr92djguxs03mmpgmgksey0xxzmkzqvs29aadp"
   },
   {
     "id": "terra13fpdg3sz2t5pfjmx4u7r95etxzv9mkfrlhsdh9e0l3tstk3q0tmswzrzl6",
-    "lp_token_id": "terra15sytd365u3nw8xku492cj9nec6pgn9py6w5qka83fd9d26yr8cgsu5apxc",
     "asset_ids": [
       "uluna",
       "terra17aj4ty4sz4yhgm08na8drc0v03v2jwr3waxcqrwhajj729zhl7zqnpc0ml"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra15sytd365u3nw8xku492cj9nec6pgn9py6w5qka83fd9d26yr8cgsu5apxc"
   },
   {
     "id": "terra13rj43lsucnel7z8hakvskr7dkfj27hd9aa06pcw4nh7t66fgt7qshrpmaw",
-    "lp_token_id": "terra1fs0p7gammucw7get7mq7rzdk6rexxgszp003zr3859qyfc02ur2sdha672",
     "asset_ids": [
       "uluna",
       "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fs0p7gammucw7get7mq7rzdk6rexxgszp003zr3859qyfc02ur2sdha672"
   },
   {
     "id": "terra13sdzrp36cj0akpwqwtajt0zndsswlyrrex673ppkdvh7vfealqeq3crc3y",
-    "lp_token_id": "terra1pqd0vm00z7urf8u8wmg4m4kpavr7g5myrcz9he4xzyq9etkafyds0hkkk9",
     "asset_ids": [
       "terra1uc3r74qg44csdrl8hrm5muzlue9gf7umgkyv569pgazh7tudpr4qdtgqh6",
       "terra1ly8vd2q69h3jlyjgnwqq0q4wngulmr2l2gr0lxd93tqle42596rsq5zz5d"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1pqd0vm00z7urf8u8wmg4m4kpavr7g5myrcz9he4xzyq9etkafyds0hkkk9"
   },
   {
     "id": "terra14cl5f0l6vpx49fu4s73dsyuwgmxrqj6a5476nnf7audhjzl605kqlgsh8e",
-    "lp_token_id": "terra1n3zc3fey96mnfm094jka7hmezu38sdnswz3mp3my9hjuryd5gxjqxhx4ut",
     "asset_ids": [
       "terra1jg848acg7rzt7tnz6zqaxzsc94w2yjhafad80d3uel9937grkmfsv8aycw",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1n3zc3fey96mnfm094jka7hmezu38sdnswz3mp3my9hjuryd5gxjqxhx4ut"
   },
   {
     "id": "terra14txm4x955kvsqazptqje4tdgcwcquufs90tjgvry4psvmkzs544qywwsmm",
-    "lp_token_id": "terra120c58hp4d6e4c5uksdvcfhqkruxxhm3fljlmywza5x25gdm45tts8f9jkg",
     "asset_ids": [
       "uluna",
       "terra12ezq5402h5n3skhdshjp4f49zzg0saxum8fvvhjhauzas2ezyyrqpznqny"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra120c58hp4d6e4c5uksdvcfhqkruxxhm3fljlmywza5x25gdm45tts8f9jkg"
   },
   {
     "id": "terra15l4dduhqhrn0c5844e9vhthd0gkwd4jmhspez3vzw5xnd7hkakmsc9ux2a",
-    "lp_token_id": "terra1psd6waufk7hnhquh82wgnpt6qhevplnsjkwp6vw3enk2czxkjvmqzmyvkr",
     "asset_ids": [
       "uluna",
       "terra129zjaxquhh3h5upn0clqzdawnze43a9z34ktt4l6um2hf5w0xqjsta42u5"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1psd6waufk7hnhquh82wgnpt6qhevplnsjkwp6vw3enk2czxkjvmqzmyvkr"
   },
   {
     "id": "terra15l5pqlp8q5d4z8tvermadvp429d8pfctg4j802t8edzkf8aavp7q59t7er",
-    "lp_token_id": "terra1ces6k6jp7qzkjpwsl6xg4f7zfwre0u23cglg69hhj3g20fhygtpsu24dsy",
     "asset_ids": [
       "terra13j2k5rfkg0qhk58vz63cze0uze4hwswlrfnm0fa4rnyggjyfrcnqcrs5z2",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ces6k6jp7qzkjpwsl6xg4f7zfwre0u23cglg69hhj3g20fhygtpsu24dsy"
   },
   {
     "id": "terra15pr9kz5tkj4a9d9vtpk9ntec33xfagmvzm38d6n3wr3rxncmy7dqr8q204",
-    "lp_token_id": "terra18cl4602q8gfaxgm5gvh254s5qf9xhrhmlntsdpmduqgxa2qg9dgqkraadh",
     "asset_ids": [
       "terra1a2gdn43yjllg3jvna7xcv2zea0ppjchsww2fedd63l9k2azg6j7qg6v3pj",
       "terra1q4r4zzde2tg52306qevhnaf3qw76a68hnyzw404uuvvzx09n3ckqe2ylrm"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra18cl4602q8gfaxgm5gvh254s5qf9xhrhmlntsdpmduqgxa2qg9dgqkraadh"
   },
   {
     "id": "terra1634dltmg6vrw8wxl6hfap5njqjchqjuwlpnumrp73x7vqsqhtjqsw0acsw",
-    "lp_token_id": "terra1g79v06mvtn0jm6q274axyyg00l2yv5lgrxhl53ht728sxr8ke4fs8pgazj",
     "asset_ids": [
       "terra1q4r4zzde2tg52306qevhnaf3qw76a68hnyzw404uuvvzx09n3ckqe2ylrm",
       "terra1uc3r74qg44csdrl8hrm5muzlue9gf7umgkyv569pgazh7tudpr4qdtgqh6"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1g79v06mvtn0jm6q274axyyg00l2yv5lgrxhl53ht728sxr8ke4fs8pgazj"
   },
   {
     "id": "terra16eaw8uw55u832mn6q6g9m7t2g4gcmxkurwgtyerwu8s5zrhylrwqlcseer",
-    "lp_token_id": "terra1jv3ulmux29vtp89hgnmn9847ww7w5a9p433l7lgjrpzuxfagcs0sc77g48",
     "asset_ids": [
       "terra1x62mjnme4y0rdnag3r8rfgjuutsqlkkyuh4ndgex0wl3wue25uksau39q8",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1jv3ulmux29vtp89hgnmn9847ww7w5a9p433l7lgjrpzuxfagcs0sc77g48"
   },
   {
     "id": "terra16gcy7pzae346t67rv3wlcfexp5alx5jht35rcgzvgharyakzdldsupr4aq",
-    "lp_token_id": "terra16arnls40rkd07japhu3g4hf5j9ypqfmtfvl9hp9egmtg2m9eenvsaj72xu",
     "asset_ids": [
       "terra1d4j9lsl453mkvtlg4ctw8y52rdkhafsaefug0hq0z06phczuvvvs7uq0vg",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra16arnls40rkd07japhu3g4hf5j9ypqfmtfvl9hp9egmtg2m9eenvsaj72xu"
   },
   {
     "id": "terra179a20595ssz3zxmg46t9jpwyq5vfhuvyelj5qnthq6dcah9tdu0sxpt0tm",
-    "lp_token_id": "terra1s3fy4zc643suxfz7wsvhhgvhd0zv8jwrcl8ugdfq6z6nl3nxkg0q3s9nl2",
     "asset_ids": [
       "terra1uv8ltv32tuq4qf6xspytpv058p0pef64s5xdncfywjexv22lfjzs7mul8s",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1s3fy4zc643suxfz7wsvhhgvhd0zv8jwrcl8ugdfq6z6nl3nxkg0q3s9nl2"
   },
   {
     "id": "terra17eqh24zl7v6j2cqf40u0flsqer5tcdwqeutdz98zlwyal24dgxlsqxa3ej",
-    "lp_token_id": "terra1r3v8yfhvkmx6gy2sa93d062sjf60c7atm3xage4pn3rsuum8ktvqesvl8h",
     "asset_ids": [
       "terra1rwg5kt6kcyxtz69acjgpeut7dgr4y3r7tvntdxqt03dvpqktrfxq4jrvpq",
       "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1r3v8yfhvkmx6gy2sa93d062sjf60c7atm3xage4pn3rsuum8ktvqesvl8h"
   },
   {
     "id": "terra18635cslpa0jlc239ckmkmng6k532xqkc4cecc87h7qyncw5twclsky8ezz",
-    "lp_token_id": "terra1s7q7vl49xfqheeskh8dxss473kuaxhgd3qtrx5rpg0u57fwt7zeqzm7u9t",
     "asset_ids": [
       "terra1ctelwayk6t2zu30a8v9kdg3u2gr0slpjdfny5pjp7m3tuquk32ysugyjdg",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1s7q7vl49xfqheeskh8dxss473kuaxhgd3qtrx5rpg0u57fwt7zeqzm7u9t"
   },
   {
     "id": "terra186mkvhcuwwzsrs4jh0ukhne3fu9hjs4xdqn46a0ckhw45f80zras4hx5fn",
-    "lp_token_id": "terra19lpvantkz339ze3wssmjxph7wqaj6ahs6qwdyz9cvf7szfczzmxs0u5hzz",
     "asset_ids": [
       "terra1kkpf3f049trkyscv0av2pa9ad02dzls7f6m8s24q07ehetggytesru7qqp",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19lpvantkz339ze3wssmjxph7wqaj6ahs6qwdyz9cvf7szfczzmxs0u5hzz"
   },
   {
     "id": "terra18a8f4q64tsa2r8s2cm95y8mmmgjtevh7qdf2t0x7mrvuw5l8z0wse3zk00",
-    "lp_token_id": "terra10e606vcy44er2p570a7g2dkugcvua4k0u0y3gvq9r606uemv3wus967av2",
     "asset_ids": [
       "terra1gy73st560m2j0esw5c5rjmr899hvtv4rhh4seeajt3clfhr4aupszjss4j",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra10e606vcy44er2p570a7g2dkugcvua4k0u0y3gvq9r606uemv3wus967av2"
   },
   {
     "id": "terra18eftnddz5vym2csxeszzkx8nl7sg9hjz0dpwzmgs3jzv0hm462asg7czxv",
-    "lp_token_id": "terra152ffgyevz7u3nu2a8s0tfur8m7w2uqd5asv9tlzpfnldeft6k2jqraps9l",
     "asset_ids": [
       "terra1uy87s853kqhlac6m7fdc7w2zx43ww5y20qv5llnuanj8fp9lek6q8djl75",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra152ffgyevz7u3nu2a8s0tfur8m7w2uqd5asv9tlzpfnldeft6k2jqraps9l"
   },
   {
     "id": "terra18hrusareag6jyfkgzlaam4nuc6f3np53ea6ejcwp0f7easske5dq23v2pv",
-    "lp_token_id": "terra12vc5agylj7g9xudc0lf06n76dfvplmqxcpcsuy9805sljrukhgxq3sfy5y",
     "asset_ids": [
       "uluna",
       "terra1q4r4zzde2tg52306qevhnaf3qw76a68hnyzw404uuvvzx09n3ckqe2ylrm"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra12vc5agylj7g9xudc0lf06n76dfvplmqxcpcsuy9805sljrukhgxq3sfy5y"
   },
   {
     "id": "terra192kkkdgdk58qcwtqql8qfvva9tnhhxgdcsqq30m5jknqtpj04lysjgyusl",
-    "lp_token_id": "terra1hva5lt2whpgav5hhsxfvegvkk2kjjshprzj7spe3cl24g4705asq4kx299",
     "asset_ids": [
       "terra1ecgazyd0waaj3g7l9cmy5gulhxkps2gmxu9ghducvuypjq68mq2s5lvsct",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1hva5lt2whpgav5hhsxfvegvkk2kjjshprzj7spe3cl24g4705asq4kx299"
   },
   {
     "id": "terra19zfuwg4l9u7wrsekpq2aumakgzc3g090almhl4taxmnu89weyavqz5t27g",
-    "lp_token_id": "terra1fw969f420dy50t4glu0nct9whdftsralf2sdywxh5zklzyj7350sp94ycs",
     "asset_ids": [
       "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
       "terra1uc3r74qg44csdrl8hrm5muzlue9gf7umgkyv569pgazh7tudpr4qdtgqh6"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fw969f420dy50t4glu0nct9whdftsralf2sdywxh5zklzyj7350sp94ycs"
   },
   {
     "id": "terra1a044rg849fdtzvkr8sgq7dzrktmxd93at8pf2nr56aydgm45h3fsj8w6lc",
-    "lp_token_id": "terra1857ysefuel7ywk2qhj2zqfa5z2vcpesys7h38v5jdtttatadm36sq0j8vz",
     "asset_ids": [
       "terra15hhqg8gyz04zapynqtk7uvlsp7lzay7etrt9ann0276v94yae63sxygeat",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1857ysefuel7ywk2qhj2zqfa5z2vcpesys7h38v5jdtttatadm36sq0j8vz"
   },
   {
     "id": "terra1a46adg628fjpm8xqvmskqar4d0m4ssyzwnx54mefm7hezafyt9vsm83f4m",
-    "lp_token_id": "terra1tquaelpx4tw6xnv9wh8xj8e48auhyyy888s756z699ssfqpq2wasz00fmx",
     "asset_ids": [
       "terra1kvpf2swxmc7kmmh6usnrqr2gd2p0nxnfywvche7vj77807km2f3q3aqvrp",
       "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1tquaelpx4tw6xnv9wh8xj8e48auhyyy888s756z699ssfqpq2wasz00fmx"
   },
   {
     "id": "terra1a8qzhz0rwn8zy6pwfx94hvd957gxyy4w5v4pwqeq4tm5gvgjt85s60ug2a",
-    "lp_token_id": "terra1y0hu67n6jq49a3ml43py4jzkr43a4qn38clvxsmd567rr4kdtj5sn4ehez",
     "asset_ids": [
       "terra1nchx6x3xtmme9sq6gxtj0tuux9l3mh05ce0hmmm7ge35vl8zsdeshkn7z5",
       "terra16er279t0mgumskzqp2eq5wju9ge68v6y7ylq4qju35rj5as6gwaqpf70xu"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1y0hu67n6jq49a3ml43py4jzkr43a4qn38clvxsmd567rr4kdtj5sn4ehez"
   },
   {
     "id": "terra1alzkrc6hkvs8g5a064cukfxnv0jj4l3l8vhgfypfxvysk78v6dgqsymgmv",
-    "lp_token_id": "terra18mcmlf4v23ehukkh7qxgpf5tznzg6893fxmf9ffmdt9phgf365zqvmlug6",
     "asset_ids": [
       "terra1gy73st560m2j0esw5c5rjmr899hvtv4rhh4seeajt3clfhr4aupszjss4j",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra18mcmlf4v23ehukkh7qxgpf5tznzg6893fxmf9ffmdt9phgf365zqvmlug6"
   },
   {
     "id": "terra1apzktjcuez96a2mhuuptnkphpevvn5m8rfjcwvnrpaaxmpv5mrasq2fgwk",
-    "lp_token_id": "terra153zpj7f0shmfrt95s2jmets2k7fuuclerxh295n7hltf0z7p9xdsdngtdr",
     "asset_ids": [
       "terra1564y9uxzhast8sk5n47teypy4mxy7fg5vne2msuztsft7qk3pj9sxxuxmc",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra153zpj7f0shmfrt95s2jmets2k7fuuclerxh295n7hltf0z7p9xdsdngtdr"
   },
   {
     "id": "terra1cduckhvafxrr2h49rufmkqgkku92pjnpnevgrcvjzxsqpgmtagcscgl2j6",
-    "lp_token_id": "terra14tu8x3hgzycpqlu6z87fm66uzthu409lk58u7uut5y9ev0swkxeq25axte",
     "asset_ids": [
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
       "terra1ee4g63c3sus9hnyyp3p2u3tulzdv5ag68l55q8ej64y4qpwswvus5mtag2"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14tu8x3hgzycpqlu6z87fm66uzthu409lk58u7uut5y9ev0swkxeq25axte"
   },
   {
     "id": "terra1ckta7a4qpxrr4dy2wzz7gguxhp2wenhlf9w6egfn6p8x0a6qd7ys3lqv3u",
-    "lp_token_id": "terra1pccqe4pufnw05wwl0xe9uc99lngnddpn8az48fe3svpeca0hq0tqrfeznp",
     "asset_ids": [
       "terra1q4r4zzde2tg52306qevhnaf3qw76a68hnyzw404uuvvzx09n3ckqe2ylrm",
       "terra1ly8vd2q69h3jlyjgnwqq0q4wngulmr2l2gr0lxd93tqle42596rsq5zz5d"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1pccqe4pufnw05wwl0xe9uc99lngnddpn8az48fe3svpeca0hq0tqrfeznp"
   },
   {
     "id": "terra1csqjyrdv2pkhhspskc3pjr0kn48ptwtp9dqenqwkkqyqdmyulvkq55k80s",
-    "lp_token_id": "terra1plcht4ueytcpwk6vh4c366g74p3dzrt7st4phszx4mjmsfh74y2sq04nw2",
     "asset_ids": [
       "terra1uelwtk27dq4luvyj0w0u8jvsejcw2l5fvy8n3kxurl69pleqkp5sl5t2rq",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1plcht4ueytcpwk6vh4c366g74p3dzrt7st4phszx4mjmsfh74y2sq04nw2"
   },
   {
     "id": "terra1cw6lvwkw3hz8c5gj33ecjma88kyp73mgep04m0rgg87yt5g5l4hsfpuhd4",
-    "lp_token_id": "terra1ysdymqfph9jwlkynm9rm8gskf38pulzc8p2t707wtu00j6n6w8vsyke4zp",
     "asset_ids": [
       "terra1e9s5m6vrl9ms75q0862llq2vcsz8r43czm36s6xnn3vh8dfmwe0s3c86e8",
       "terra1x62mjnme4y0rdnag3r8rfgjuutsqlkkyuh4ndgex0wl3wue25uksau39q8"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ysdymqfph9jwlkynm9rm8gskf38pulzc8p2t707wtu00j6n6w8vsyke4zp"
   },
   {
     "id": "terra1dm9e5dq2e2rll59d0fpypjgh25s3a5af47lkhpzqthyz0cmvv2kq9z29uf",
-    "lp_token_id": "terra1z3nctlwtasqshsagu2l4lj74pdm8hl7jhjyeepergtkny4cyka0se48n37",
     "asset_ids": [
       "terra1kkpf3f049trkyscv0av2pa9ad02dzls7f6m8s24q07ehetggytesru7qqp",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1z3nctlwtasqshsagu2l4lj74pdm8hl7jhjyeepergtkny4cyka0se48n37"
   },
   {
     "id": "terra1e67qwgxexherg4quj8l5297txq0awqr46y52nl8pywcz86n5rwlq82teeh",
-    "lp_token_id": "terra14a40x0uxgz3h76dk6l2u8qukkzsscrn3kdzv7ct85dltyrcqdpgs8uenjs",
     "asset_ids": [
       "terra1xe8umegahlqphtpvjsuwfzfvyjfvag5h8rffsx6ezm0el4xzsf8s7uzezk",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14a40x0uxgz3h76dk6l2u8qukkzsscrn3kdzv7ct85dltyrcqdpgs8uenjs"
   },
   {
     "id": "terra1ekaahva0msrcxdyyfrx6lt9c8rf4u682mrfpp8qstqpdwxk46ussup7enm",
-    "lp_token_id": "terra1cjz82w795jcsxp09dpps697qwx55aryprvypl3n07my4zwrxfchs34lqcc",
     "asset_ids": [
       "terra13j2k5rfkg0qhk58vz63cze0uze4hwswlrfnm0fa4rnyggjyfrcnqcrs5z2",
       "terra1ry9f6alqyf9dpj04u9ymq5u4whjndu485agh6gusn89dmqse3ggsnzducj"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1cjz82w795jcsxp09dpps697qwx55aryprvypl3n07my4zwrxfchs34lqcc"
   },
   {
     "id": "terra1en2a8cwke0f7drc80zphdgqnmtuh0zhgnqppwtwm8pkt5jtjm5dq4l5ex3",
-    "lp_token_id": "terra1fltdf8rkxz4ss06vtf2a4qt9tdplt52saefq650vyf47y4mt7q2qk0gtfv",
     "asset_ids": [
       "terra1nu0c3s69umqz862ltp6wytuztm0rrn6w5079g999u0hvwy62tf3q02qhmr",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fltdf8rkxz4ss06vtf2a4qt9tdplt52saefq650vyf47y4mt7q2qk0gtfv"
   },
   {
     "id": "terra1ep0pd629h5kqrmphep5z556hxdqz6tzxf0qyh975c4xrmyenxnyshkje0g",
-    "lp_token_id": "terra1xq08x97luxlraz7d79x240ntdaf8k8w0jtqmgtzr46drkz86xxqslh4fwt",
     "asset_ids": [
       "terra13jlm0anpdd3hc0xctw9vtncmcfnrag8dh686s2juy7m226unwd4q0tmx2v",
       "terra1mrdgys0e0hhq0n56zgy3e0htahcnwtdt4dy2ec9wcltcr6qjntmq0yen07"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1xq08x97luxlraz7d79x240ntdaf8k8w0jtqmgtzr46drkz86xxqslh4fwt"
   },
   {
     "id": "terra1ergk3vej7yu9ljvjsmejdpp0ae3p0zgue6lzmcuq73s6jnjaquzst8a3yq",
-    "lp_token_id": "terra18e6uqw3sx6xgg57t7rglstmqgqrm4ks9428am8crg2aeuqkxk37qzhq9xx",
     "asset_ids": [
       "terra1qx284aak0wl7vrvlsc6cwcsn6xwajragkh6cjqj87m9p34hx5l2s22p3cp",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra18e6uqw3sx6xgg57t7rglstmqgqrm4ks9428am8crg2aeuqkxk37qzhq9xx"
   },
   {
     "id": "terra1ex0yd688yz5yte6k4n82e20zvmveq7la0g5hdv9yqyv34utky9ws97f97r",
-    "lp_token_id": "terra13406847ntuyct7qgefrks05cfuca7jtf4u9zqnahud2c7vnarkysj2c8gj",
     "asset_ids": [
       "terra1ly8vd2q69h3jlyjgnwqq0q4wngulmr2l2gr0lxd93tqle42596rsq5zz5d",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra13406847ntuyct7qgefrks05cfuca7jtf4u9zqnahud2c7vnarkysj2c8gj"
   },
   {
     "id": "terra1eysmqlw77qeupvcnzvqjmf2rfvuay55p95v6nknykkdadnfyv6sqryf2gg",
-    "lp_token_id": "terra13f7dedzar82afsedw4kn388zvfg94r8uusefa8nj0zysrayqaszsvcje3e",
     "asset_ids": [
       "terra1plhefzma59lh6rjk5gfkq45pz2chfq35nm9xgdz4pcuhp3nnwekq8sthua",
       "terra1q4r4zzde2tg52306qevhnaf3qw76a68hnyzw404uuvvzx09n3ckqe2ylrm"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra13f7dedzar82afsedw4kn388zvfg94r8uusefa8nj0zysrayqaszsvcje3e"
   },
   {
     "id": "terra1fd68ah02gr2y8ze7tm9te7m70zlmc7vjyyhs6xlhsdmqqcjud4dql4wpxr",
-    "lp_token_id": "terra1ckmsqdhlky9jxcmtyj64crgzjxad9pvsd58k8zsxsnv4vzvwdt7qke04hl",
     "asset_ids": [
       "uluna",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ckmsqdhlky9jxcmtyj64crgzjxad9pvsd58k8zsxsnv4vzvwdt7qke04hl"
   },
   {
     "id": "terra1ffkw4u3uaa800a62jfxaf5wtjqk0mgl4e5ayxmus2n2tq0lfnffqva4xww",
-    "lp_token_id": "terra1kusqucsy7x5yhfl4lu064f0kyhdx7mhj67z7uclhhxr8mm3ayatq4zse64",
     "asset_ids": [
       "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
       "terra1xe8umegahlqphtpvjsuwfzfvyjfvag5h8rffsx6ezm0el4xzsf8s7uzezk"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1kusqucsy7x5yhfl4lu064f0kyhdx7mhj67z7uclhhxr8mm3ayatq4zse64"
   },
   {
     "id": "terra1fg8zgcxtc40zqttq3sk2dqjmaf9zw6qqaqpvn83e4tvy579hlqfq8vrpsh",
-    "lp_token_id": "terra1v7uxpztn2xk8v05y3ak8dkjlfrdsnyl9stv63np0kfp6yzh0rz8qph3upx",
     "asset_ids": [
       "terra1xumzh893lfa7ak5qvpwmnle5m5xp47t3suwwa9s0ydqa8d8s5faqn6x7al",
       "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1v7uxpztn2xk8v05y3ak8dkjlfrdsnyl9stv63np0kfp6yzh0rz8qph3upx"
   },
   {
     "id": "terra1fgry98nm8m94fqmmzkwzf7gr3fg4vh5vg8y78g7vzqwt29rwrcvqwlrcek",
-    "lp_token_id": "terra1ngp9lsp72hjjate0jlmhz27ra6mjap97ptg0r4nuytf3kuk2md6sz8twrv",
     "asset_ids": [
       "uluna",
       "terra1klxa4rxjgpg9xuaf5mwpgykpv7x9decrvgg3ejresupcne69cgdqzx5yhu"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ngp9lsp72hjjate0jlmhz27ra6mjap97ptg0r4nuytf3kuk2md6sz8twrv"
   },
   {
     "id": "terra1fwjgcqkeuzvyh40pq78m239ffdelrqxuzft7x5e4ezkxhxwt4ershfgtah",
-    "lp_token_id": "terra12lq8l9tc3z9h8cy4qt9khmalrzv2nszdu8rl2yfsmjvcn0vffnfqhznup3",
     "asset_ids": [
       "uluna",
       "terra177huv6k3gyqwxcd7n32ts56tvxt68dgll0fn56k56rcvy9zeke9s5gfn3c"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra12lq8l9tc3z9h8cy4qt9khmalrzv2nszdu8rl2yfsmjvcn0vffnfqhznup3"
   },
   {
     "id": "terra1ghrgxen482dag6777mp4pzkcafh995y9xp7jqsfvdaal5ld3d2hs4q0v5v",
-    "lp_token_id": "terra1v6z888r63vzc094w2cll9z42xjwc7kuf8feccyh9f5ehkqmwqcdst2afjf",
     "asset_ids": [
       "terra1uc3r74qg44csdrl8hrm5muzlue9gf7umgkyv569pgazh7tudpr4qdtgqh6",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1v6z888r63vzc094w2cll9z42xjwc7kuf8feccyh9f5ehkqmwqcdst2afjf"
   },
   {
     "id": "terra1gsqqskperwh8ssjqmz0v32hd7c0s0w0txhjdddyj8ldudatw34ns5mqkw7",
-    "lp_token_id": "terra1wrjl547wvaw7vm7e2vqvnvmaeszumfx9whpqdaw8xl5vh65cx24sf6jgap",
     "asset_ids": [
       "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
       "terra1uy87s853kqhlac6m7fdc7w2zx43ww5y20qv5llnuanj8fp9lek6q8djl75"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1wrjl547wvaw7vm7e2vqvnvmaeszumfx9whpqdaw8xl5vh65cx24sf6jgap"
   },
   {
     "id": "terra1gzlc06z7syc6znywepyf7uqc9ql5aj62lapp5quepz0t4kmks4tswvklvx",
-    "lp_token_id": "terra1tgjah63kfmsk38nmanckpf2j28qntdg6zp6vqx4v6mttaza0l3ls0ld7km",
     "asset_ids": [
       "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
       "terra17aj4ty4sz4yhgm08na8drc0v03v2jwr3waxcqrwhajj729zhl7zqnpc0ml"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1tgjah63kfmsk38nmanckpf2j28qntdg6zp6vqx4v6mttaza0l3ls0ld7km"
   },
   {
     "id": "terra1h4cakgms4ju3eryhrmw00xegtjxkgyv88yqllg9ryz9qxek4qz9sz3swn2",
-    "lp_token_id": "terra10ht5t5vzpt6lfh8r6lau6mtsha3rqeznhkw5whc65scgrtkqradq0zy9pa",
     "asset_ids": [
       "terra19p20mfnvwh9yvyr7aus3a6z6g6uk28fv4jhx9kmnc2m7krg27q2qkfenjw",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra10ht5t5vzpt6lfh8r6lau6mtsha3rqeznhkw5whc65scgrtkqradq0zy9pa"
   },
   {
     "id": "terra1h6xr89an8gh63wvju7rfrkstmf8wpxlzr2xa4l72rg8u9jp4clusqkkudk",
-    "lp_token_id": "terra1339twwfe6rqgj4ge7qe5mdzu238ke2farlnwm7k2allh9un96w9sywjsff",
     "asset_ids": [
       "terra1mma39sqn43aen4jh2sdmka84mv94uk7v7xw3ype2fdvlay6emrlqweyf5u",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1339twwfe6rqgj4ge7qe5mdzu238ke2farlnwm7k2allh9un96w9sywjsff"
   },
   {
     "id": "terra1h8qx27ty8gce8hvpc7dezzjkcj6m8e3gpj9nhmz78w3cpf7yeklqv35xrz",
-    "lp_token_id": "terra17ymsjrzhtz04wt6ftamthph5sfnuem0f0xgr4ajvas9uzjll6p0sdu36ff",
     "asset_ids": [
       "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
       "terra1q4r4zzde2tg52306qevhnaf3qw76a68hnyzw404uuvvzx09n3ckqe2ylrm"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17ymsjrzhtz04wt6ftamthph5sfnuem0f0xgr4ajvas9uzjll6p0sdu36ff"
   },
   {
     "id": "terra1h98qlgzmryy3av87w0e8yrqf95xknamfvq6qnn4u3aslra6ly7cqpcjcnc",
-    "lp_token_id": "terra13y6q5agfqdvd4mkrzzw9fadp500nk4spnd8rzyrkdls5fsqgurksa74uxz",
     "asset_ids": [
       "terra19p20mfnvwh9yvyr7aus3a6z6g6uk28fv4jhx9kmnc2m7krg27q2qkfenjw",
       "terra1xe8umegahlqphtpvjsuwfzfvyjfvag5h8rffsx6ezm0el4xzsf8s7uzezk"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra13y6q5agfqdvd4mkrzzw9fadp500nk4spnd8rzyrkdls5fsqgurksa74uxz"
   },
   {
     "id": "terra1hapant9z9454s0sl2pjwpct2apft4uxu6ypem0u290fe0626gvzqg4xzlp",
-    "lp_token_id": "terra1lgsccchaws9nnm74aj7uhdj289jd99893ngkv2am9j40cn0sza8sxkzc9r",
     "asset_ids": [
       "terra16h7keds26d52xj8rn9jfx6lj2x0ja79lt56yxnmlm4xsttf5mu5smq5f78",
       "terra1rwg5kt6kcyxtz69acjgpeut7dgr4y3r7tvntdxqt03dvpqktrfxq4jrvpq"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1lgsccchaws9nnm74aj7uhdj289jd99893ngkv2am9j40cn0sza8sxkzc9r"
   },
   {
     "id": "terra1j88tckt0uyq6enw5747ayf5yd77e89yr6ljda5sza6tmpp00tfxs4xjmza",
-    "lp_token_id": "terra1s5ywajpamm25ny872ek26a56a7y3368h6eu4su2eff5ua8jw8yyqlxmtwr",
     "asset_ids": [
       "ibc/14ACCAD1750327C74BB35978AD0C3E97B184DAB9F0BF4BD876FBD1F782B57110",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1s5ywajpamm25ny872ek26a56a7y3368h6eu4su2eff5ua8jw8yyqlxmtwr"
   },
   {
     "id": "terra1j9lyhksxqjyfmr0v8p70ghex5wpa45972c67aqdsvv5gdsznarhs99v3t5",
-    "lp_token_id": "terra1cpflqqkse0lljw4cekrh9sqdz0km9p9lzteqd55y5qd0yrdzxg8sytqdpk",
     "asset_ids": [
       "terra1c5qexuz3hx9rkac8tfa9ktytfgurg767qd5p08e7l7khkhtktk7sx84vdk",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1cpflqqkse0lljw4cekrh9sqdz0km9p9lzteqd55y5qd0yrdzxg8sytqdpk"
   },
   {
     "id": "terra1jpkrh5q5wcfatatuwlzqsl830f2ewsrk3urkxh4reqalr0nav4xq2d6jk9",
-    "lp_token_id": "terra14v6sh40tydg22c9ws2yhj8qgyhj8wsgand8uhmcvl4wad3209dzs0an099",
     "asset_ids": [
       "terra1z7xe8pjrr0tdguvsdxh2hj6u0gk3y93dxs2xncz00jsjzt8g6suq95lj5w",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14v6sh40tydg22c9ws2yhj8qgyhj8wsgand8uhmcvl4wad3209dzs0an099"
   },
   {
     "id": "terra1jynmf6gteg4rd03ztldan5j2dp78su4tc3hfvkve8dl068c2yppsk5uszc",
-    "lp_token_id": "terra182wam9eklls989k5qqrcv5s64a9cat6ctw4zr3paa6k79dxt4k0q4kd97a",
     "asset_ids": [
       "terra1xumzh893lfa7ak5qvpwmnle5m5xp47t3suwwa9s0ydqa8d8s5faqn6x7al",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra182wam9eklls989k5qqrcv5s64a9cat6ctw4zr3paa6k79dxt4k0q4kd97a"
   },
   {
     "id": "terra1k7aa2ngsfajxrtn2vy3q5jph8jc8xaeg75x80plhqg3ttre0pk9slh4ms6",
-    "lp_token_id": "terra1r2e983ghd0jsk7r6k36zw4lnqf8y9raghzdnrusgsg97465uuvfq8nuls7",
     "asset_ids": [
       "terra1ttspm8jgeylc6us3mlpwpmlwzr3rkesm70vn6zkfr07pz7e3rzkq73ah2j",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1r2e983ghd0jsk7r6k36zw4lnqf8y9raghzdnrusgsg97465uuvfq8nuls7"
   },
   {
     "id": "terra1lfldysmac4yhrn4ulrusvwgxg6yh7uffhrmetyghc7zm938d22kq209kvg",
-    "lp_token_id": "terra13qaz542ft2ve34jfdy8epp33v6gfd857vc98sjxapf86fh83p99spzqf0u",
     "asset_ids": [
       "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
       "terra10exkttsx4xq2j5k3uel9h4gvxy63yd90u46yt3qzn9vfcuh2utwqydz8rq"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra13qaz542ft2ve34jfdy8epp33v6gfd857vc98sjxapf86fh83p99spzqf0u"
   },
   {
     "id": "terra1lfpnr3k8l68c3cw248k07p9e4tresc8w52kqtu6q7a3gtm56jtzs5qjmx0",
-    "lp_token_id": "terra1zf35dfsvk69c5dgytka82762922l2r4cj3v24un0uycln9hy695qkwlpga",
     "asset_ids": [
       "terra1dzahfzk3vavwy4zqt0x49guswvwe6ef8jm60fpl2cqmq0yl7pp4qyrx3cr",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1zf35dfsvk69c5dgytka82762922l2r4cj3v24un0uycln9hy695qkwlpga"
   },
   {
     "id": "terra1lgnfv8tkh8wlqcs280nnpfcw7p5v6j8my4uga5t9d8dgw6nlx9qszjetaj",
-    "lp_token_id": "terra1wv46n9zggd8sx30d8gfgzeyu2a7rmdc8makk7cl4qgtlnw342kpq94faz0",
     "asset_ids": [
       "terra1uc3r74qg44csdrl8hrm5muzlue9gf7umgkyv569pgazh7tudpr4qdtgqh6",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1wv46n9zggd8sx30d8gfgzeyu2a7rmdc8makk7cl4qgtlnw342kpq94faz0"
   },
   {
     "id": "terra1lgqmzes782hp43ykdsdgd2fh2wywr5asmmw6v9fq9fru6lrppeusw7dxd6",
-    "lp_token_id": "terra150qtrrrta74ewt9glydumq2fz4463hrcqm087vex2ynv97xz95gsha38dl",
     "asset_ids": [
       "terra13j2k5rfkg0qhk58vz63cze0uze4hwswlrfnm0fa4rnyggjyfrcnqcrs5z2",
       "terra17aj4ty4sz4yhgm08na8drc0v03v2jwr3waxcqrwhajj729zhl7zqnpc0ml"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra150qtrrrta74ewt9glydumq2fz4463hrcqm087vex2ynv97xz95gsha38dl"
   },
   {
     "id": "terra1m3njul5my33cvfezqdujyt4wrw5y9z2z0mtesnpxsqh898mfdv3sk7qhsc",
-    "lp_token_id": "terra1ftd8l9xny6dhc2299m9rd59aknutl8fvrc7h9ywammxcus5se9ese03yfd",
     "asset_ids": [
       "terra1cmf8ytutcwrjrv08zskj9phuh46a3w3nkjax7en4hxezsrdr58lqvzy05q",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ftd8l9xny6dhc2299m9rd59aknutl8fvrc7h9ywammxcus5se9ese03yfd"
   },
   {
     "id": "terra1mlywfyhc85p84h32lpsx28gwq86xujar2rfn93f0cd7q4qgnj4rsn0z4as",
-    "lp_token_id": "terra1e6395r0qgvdg204kuvy96rd2tlf32hme4ksrk86zmpantxku9s5sp59n0t",
     "asset_ids": [
       "terra1z56spghy7kmvv6j9p7gv2hf569x57mnnex4gcqyx5m8m76d0awvqd6ywfj",
       "terra1y03yesqka4m799fdtnjp6p5w7n9rup9e5tucdsdqes6pr98t6pes9w6dcv"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1e6395r0qgvdg204kuvy96rd2tlf32hme4ksrk86zmpantxku9s5sp59n0t"
   },
   {
     "id": "terra1muhks8yr47lwe370wf65xg5dmyykrawqpkljfm39xhkwhf4r7jps0gwl4l",
-    "lp_token_id": "terra1wkcyh5l9204m6ef5aujdlnh3frswyhpl8xp7evr7rk0qmyqyhrkqg287g8",
     "asset_ids": [
       "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
       "terra1x62mjnme4y0rdnag3r8rfgjuutsqlkkyuh4ndgex0wl3wue25uksau39q8"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1wkcyh5l9204m6ef5aujdlnh3frswyhpl8xp7evr7rk0qmyqyhrkqg287g8"
   },
   {
     "id": "terra1my9v4lt55v6mg92wpq43gfyuvj5k0gll0epaj8u0tcarcjyp0qtsf6c9nw",
-    "lp_token_id": "terra1t906pc4s8ptgrr8gx8m52hvvse8ytq5za86fmudm2wr4vw2kyqzqyph4ml",
     "asset_ids": [
       "terra1xzkel96e5e8vfmqw7valzdzzv9hqasfyslclvnmvxdejvpda3xwsskxzus",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1t906pc4s8ptgrr8gx8m52hvvse8ytq5za86fmudm2wr4vw2kyqzqyph4ml"
   },
   {
     "id": "terra1ncrc7j5s80fz099nru5fajaa7k5wwxhc4nezlsn2ls7k40hqzshq5jzm38",
-    "lp_token_id": "terra1uuz0sfj2gauppp9p8sul50x97nu3jhtfj7y22x93wgte4kgs0jpqad4qmf",
     "asset_ids": [
       "terra1uelwtk27dq4luvyj0w0u8jvsejcw2l5fvy8n3kxurl69pleqkp5sl5t2rq",
       "terra1c5qexuz3hx9rkac8tfa9ktytfgurg767qd5p08e7l7khkhtktk7sx84vdk"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1uuz0sfj2gauppp9p8sul50x97nu3jhtfj7y22x93wgte4kgs0jpqad4qmf"
   },
   {
     "id": "terra1nem6em9a2twyx5tx42gmtyfa39d0t53kufaxcwj45d5etvq40pfqlr0s3z",
-    "lp_token_id": "terra1zhwjeh96z0ce0l7ze6veynuekmqkhatmawgnmvkfnutg3z4ymsass9cfev",
     "asset_ids": [
       "terra19p20mfnvwh9yvyr7aus3a6z6g6uk28fv4jhx9kmnc2m7krg27q2qkfenjw",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1zhwjeh96z0ce0l7ze6veynuekmqkhatmawgnmvkfnutg3z4ymsass9cfev"
   },
   {
     "id": "terra1nmrt8ppp7jtm0nmtgxg0qcv9x4ksgvpz20l25w6fyuj28v52v6rshgse5w",
-    "lp_token_id": "terra1ctkly6fuddqfpsq9fjjsqudx9zsl5crma0z4jl29zky3k8ezfe5s23gd7s",
     "asset_ids": [
       "ibc/CBF67A2BCF6CAE343FDF251E510C8E18C361FC02B23430C121116E0811835DEF",
       "terra1ee4g63c3sus9hnyyp3p2u3tulzdv5ag68l55q8ej64y4qpwswvus5mtag2"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ctkly6fuddqfpsq9fjjsqudx9zsl5crma0z4jl29zky3k8ezfe5s23gd7s"
   },
   {
     "id": "terra1nmz2advxvxt8z0kcpnds8f6jygz7855980duvh2q7nqnyxe57kxqck4gyx",
-    "lp_token_id": "terra1m06sj94uj26c9lscuyfvns5avk9jckehs7287zkfa9usctfpu5tq8y8fd8",
     "asset_ids": [
       "terra1uy87s853kqhlac6m7fdc7w2zx43ww5y20qv5llnuanj8fp9lek6q8djl75",
       "terra1gn3fwtw7k40gl465723phk4qgarthw32t962acxz5e5rjzgepwpsjysppv"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1m06sj94uj26c9lscuyfvns5avk9jckehs7287zkfa9usctfpu5tq8y8fd8"
   },
   {
     "id": "terra1nvtnf0j9pavdz59f2zpxt7eekjff7wvkrc58elvq99g2ds397vpqaupf7g",
-    "lp_token_id": "terra185r56sntq8cjem0ttcg93l5cwsx58f4vsl74uen0j8j8z2qnlf2sjgaaqt",
     "asset_ids": [
       "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
       "terra1c5qexuz3hx9rkac8tfa9ktytfgurg767qd5p08e7l7khkhtktk7sx84vdk"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra185r56sntq8cjem0ttcg93l5cwsx58f4vsl74uen0j8j8z2qnlf2sjgaaqt"
   },
   {
     "id": "terra1p4pun9gqzqemjwhhc59vfwx4kkm4j0nu96ys6yzvecdv06pnlznskqz5d6",
-    "lp_token_id": "terra1vpcj4fj0yxy4m928lxf8us7tk8kdqr3ny6q2gtx7g0s935awdreqppm7au",
     "asset_ids": [
       "terra1hspy32cecnj72wwpma59eldpmsmfndlrwqxnzx6awfdtarns66qqw5kn85",
       "terra1uc3r74qg44csdrl8hrm5muzlue9gf7umgkyv569pgazh7tudpr4qdtgqh6"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1vpcj4fj0yxy4m928lxf8us7tk8kdqr3ny6q2gtx7g0s935awdreqppm7au"
   },
   {
     "id": "terra1p4xx3nydj6th2e2ewk0j6xrzxeq4f3zm86pmv6hywnrl7d4vc9asgkmmru",
-    "lp_token_id": "terra12xcl4p6wmksle9a4vax4vr9umju30s4mv495pmnmkjj9587ugkrqg7jz3l",
     "asset_ids": [
       "terra1e0uch3fwned9rfhkaeehqv9mnfuwjh9jfhawd4gxw248czljdttsh22jkg",
       "terra1gk0y0tcxj8pr65tanqvc8zyzv3c8szkwf2kcmzgqj9jm2t9z3f9q4xcnfz"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra12xcl4p6wmksle9a4vax4vr9umju30s4mv495pmnmkjj9587ugkrqg7jz3l"
   },
   {
     "id": "terra1p6cxnzh29rafnm9mdr96lhgpw82scqpf43zcq4lgny9eds99cfvsjklz52",
-    "lp_token_id": "terra1p2n59z2dnx9rt8m8qnztpyw9jgwt0gypenf3q6q0wpkqjcypkqvsq8u3pf",
     "asset_ids": [
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
       "terra13j2k5rfkg0qhk58vz63cze0uze4hwswlrfnm0fa4rnyggjyfrcnqcrs5z2"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1p2n59z2dnx9rt8m8qnztpyw9jgwt0gypenf3q6q0wpkqjcypkqvsq8u3pf"
   },
   {
     "id": "terra1p6f29pqcjjhxmdj9zhpnjxdapd4qatmjv3jpadusva9df09pp84qy5ujlr",
-    "lp_token_id": "terra1tf2lj6lp4y29kw36ue6tjsa97ad4e5fha6te08h26pg6y4v7c23qhu2k4j",
     "asset_ids": [
       "terra1a2gdn43yjllg3jvna7xcv2zea0ppjchsww2fedd63l9k2azg6j7qg6v3pj",
       "terra1ly8vd2q69h3jlyjgnwqq0q4wngulmr2l2gr0lxd93tqle42596rsq5zz5d"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1tf2lj6lp4y29kw36ue6tjsa97ad4e5fha6te08h26pg6y4v7c23qhu2k4j"
   },
   {
     "id": "terra1pwsn9s8x7qt5x2s7n0l9wqkyuf0zz0hz09tat5ku80k5jgd4h5mq6u0e6m",
-    "lp_token_id": "terra1dpvp8xra378kadfmn0c93n9qvf942r04vkznh75c2s4cy3atq72sq3jetx",
     "asset_ids": [
       "terra1xumzh893lfa7ak5qvpwmnle5m5xp47t3suwwa9s0ydqa8d8s5faqn6x7al",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1dpvp8xra378kadfmn0c93n9qvf942r04vkznh75c2s4cy3atq72sq3jetx"
   },
   {
     "id": "terra1q2e7apwksvk3rwzzych67wapkaj55rhn33wzpswa39z2hhc6vdrqdrscqj",
-    "lp_token_id": "terra1mckjrtvxvsxtxvc5jttxmvheyh4wjcrlrnfy28xnln5a87qhxz6s4el0sy",
     "asset_ids": [
       "terra1hspy32cecnj72wwpma59eldpmsmfndlrwqxnzx6awfdtarns66qqw5kn85",
       "terra1ecgazyd0waaj3g7l9cmy5gulhxkps2gmxu9ghducvuypjq68mq2s5lvsct"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mckjrtvxvsxtxvc5jttxmvheyh4wjcrlrnfy28xnln5a87qhxz6s4el0sy"
   },
   {
     "id": "terra1q5xw5q8sqpaffuq867rjdl6ljaent9zlzv3t3hy90a24gttuts3sdjxduz",
-    "lp_token_id": "terra1l0dv709pqv2gcs86jr9w3k67jr7tk62vem0h8ntzzkpl443f27vsy47gsm",
     "asset_ids": [
       "terra1d4j9lsl453mkvtlg4ctw8y52rdkhafsaefug0hq0z06phczuvvvs7uq0vg",
       "terra1ry9f6alqyf9dpj04u9ymq5u4whjndu485agh6gusn89dmqse3ggsnzducj"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1l0dv709pqv2gcs86jr9w3k67jr7tk62vem0h8ntzzkpl443f27vsy47gsm"
   },
   {
     "id": "terra1qdv90q7rdg60tlpyeem93c88avp8lvnwa04sxr3yxsfcnccknnysft59tg",
-    "lp_token_id": "terra1alu4y2ncdyaamv9tgkxwefcazc433n5t9mpmpahnsy2dsng0m3rswmxpfp",
     "asset_ids": [
       "terra1s8u586k3s7xtvasxv4p6ldl0jrxht9w886v8ymkst6crg5hxue3sqn49r9",
       "terra1rwg5kt6kcyxtz69acjgpeut7dgr4y3r7tvntdxqt03dvpqktrfxq4jrvpq"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1alu4y2ncdyaamv9tgkxwefcazc433n5t9mpmpahnsy2dsng0m3rswmxpfp"
   },
   {
     "id": "terra1qewkdazkleddgauymdfzqrwqt6vh43cmv93g3w5muury20ugaz9szazg7q",
-    "lp_token_id": "terra10n8tq3hxa5rkgzwdjylehrl27alhlutyssqlrajr0h80vze46dfsye9y8v",
     "asset_ids": [
       "terra1c5qexuz3hx9rkac8tfa9ktytfgurg767qd5p08e7l7khkhtktk7sx84vdk",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra10n8tq3hxa5rkgzwdjylehrl27alhlutyssqlrajr0h80vze46dfsye9y8v"
   },
   {
     "id": "terra1qgyv6rqrqf0hlduuuhallj7eppsxjevwxldcjlejkcc9pn7fu33sg37j3u",
-    "lp_token_id": "terra1kytfl8v8e9pq0s5texq2vwcjy9k456ky44x0429yeh3cwj9m64cqdfpa9k",
     "asset_ids": [
       "terra1c5qexuz3hx9rkac8tfa9ktytfgurg767qd5p08e7l7khkhtktk7sx84vdk",
       "terra1gn3fwtw7k40gl465723phk4qgarthw32t962acxz5e5rjzgepwpsjysppv"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1kytfl8v8e9pq0s5texq2vwcjy9k456ky44x0429yeh3cwj9m64cqdfpa9k"
   },
   {
     "id": "terra1qvrgwcuqa8mlx8j408fajl23qxctkmx2wlx3nzh7xpgveqsgq22qrtjv99",
-    "lp_token_id": "terra15sad8j5wx8u0aptgfvmz7zwsjrl7mfuc207d3gljh9gdaxx0d0kqq8d7kc",
     "asset_ids": [
       "terra1uy87s853kqhlac6m7fdc7w2zx43ww5y20qv5llnuanj8fp9lek6q8djl75",
       "terra1uelwtk27dq4luvyj0w0u8jvsejcw2l5fvy8n3kxurl69pleqkp5sl5t2rq"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra15sad8j5wx8u0aptgfvmz7zwsjrl7mfuc207d3gljh9gdaxx0d0kqq8d7kc"
   },
   {
     "id": "terra1r74sez7xgv9d6fetzha63602w4350rp3szvr4urmn4lu6l0v7crqj9tlad",
-    "lp_token_id": "terra1eex8w4vqukz54pzzngt8xzmp4w9wz2mp5hcde7wwqhmepzm0ec9qarwx3v",
     "asset_ids": [
       "terra1l23rtnsp0fcfgs2zlww4gcd8dlznkm580p5yrsangcen9jjjhuqstd2sle",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1eex8w4vqukz54pzzngt8xzmp4w9wz2mp5hcde7wwqhmepzm0ec9qarwx3v"
   },
   {
     "id": "terra1rlu9nxc92rkmxjfysuxfn7gg8afm8ymvyfeq4h5xkn42er5ad25sy53qzv",
-    "lp_token_id": "terra18278qyznzktl8sxnepca4yw0cpdmxxjz54zf3xnn8sfh7au3uspq0ka994",
     "asset_ids": [
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
       "terra10exkttsx4xq2j5k3uel9h4gvxy63yd90u46yt3qzn9vfcuh2utwqydz8rq"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra18278qyznzktl8sxnepca4yw0cpdmxxjz54zf3xnn8sfh7au3uspq0ka994"
   },
   {
     "id": "terra1rne6vwma3nznlnc3ptef8zrqv9pj2fxtv8yzxg8ly9xd7mrjvrvsyhtfqf",
-    "lp_token_id": "terra18pr2eu0js9laz3u4k5tcwyuqfup484z8qm66vtkwcfeukmpgyapq70wj44",
     "asset_ids": [
       "terra1qmnxhecc3vnmhef9q7vap7spx9tgpnw9fqe8ljqfwrlz7rur9y5qu2dlp6",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra18pr2eu0js9laz3u4k5tcwyuqfup484z8qm66vtkwcfeukmpgyapq70wj44"
   },
   {
     "id": "terra1rngmfgctlmksmsusx7nrweq6tz5h4c33l3fs5szt3p9w38kxe80q3k72w9",
-    "lp_token_id": "terra1zjtpdke8qnqjflgeyyd8wrg2de32z3g2avk2utwlc4vzjw974jfs34nu08",
     "asset_ids": [
       "terra1gn3fwtw7k40gl465723phk4qgarthw32t962acxz5e5rjzgepwpsjysppv",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1zjtpdke8qnqjflgeyyd8wrg2de32z3g2avk2utwlc4vzjw974jfs34nu08"
   },
   {
     "id": "terra1rp6yty73lf08pu29jw36kgzq0tkf3jllk9hadv75w6zs73vd286s45ttkt",
-    "lp_token_id": "terra1aqu49fznmzfgxky72fd3f4rjewexueu9c7yzjs59z2hqxv6ktxpsfffw87",
     "asset_ids": [
       "terra1gd3ntqq04lvd623xs8ht6dly0s7n4gxnz7lmlw5ga0qnamg9wyrqcggn2h",
       "terra1l02355pejytcakcpq6g3n57ydwpqeysuw5nj679hlnrrsz3sc3wssxr69j"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1aqu49fznmzfgxky72fd3f4rjewexueu9c7yzjs59z2hqxv6ktxpsfffw87"
   },
   {
     "id": "terra1s9dfg4cg30jv6yma7k0qdhet3dwgx08mwvsy8da2cy63ztlwzd3q7dav89",
-    "lp_token_id": "terra1d8j3v5dg08mnw9yzh242nvdc2mznup400msx8d6hcgpd2ygv4uuqfy4v9p",
     "asset_ids": [
       "ibc/6CD39EACF052B761E3ADC709A11747CFCCA49F07DA23A26E61DB1CEF4D0CCC33",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1d8j3v5dg08mnw9yzh242nvdc2mznup400msx8d6hcgpd2ygv4uuqfy4v9p"
   },
   {
     "id": "terra1sd4wzqh4uefjt7nwgezdg7ahn9n6943rc3xq87mvtt270ev2ejcqyrsgga",
-    "lp_token_id": "terra1tr7355as8t6k9y94wru5humch34yacrv3mwz9n690fugwcc8mrvs296qz8",
     "asset_ids": [
       "terra17aj4ty4sz4yhgm08na8drc0v03v2jwr3waxcqrwhajj729zhl7zqnpc0ml",
       "terra1x62mjnme4y0rdnag3r8rfgjuutsqlkkyuh4ndgex0wl3wue25uksau39q8"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1tr7355as8t6k9y94wru5humch34yacrv3mwz9n690fugwcc8mrvs296qz8"
   },
   {
     "id": "terra1slvfamhstqgnaavadjxgvqqx08mx44sy986xtaldlm9hztlc9ejq57jlrr",
-    "lp_token_id": "terra1cysh639syvrhhg7mnsdl4vrhhvmefrzd5udxtd0jftscha2n3cjsnxsmnx",
     "asset_ids": [
       "terra1k57q7f7gh6rm4gyqpqygkxdgsh0d67nxngfuwj6n5d38jpd44psshn5gaq",
       "terra1sqxtvf93tpu08evzt6va072cefy45xuvjghutgmcv93pk2aaazgs220eev"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1cysh639syvrhhg7mnsdl4vrhhvmefrzd5udxtd0jftscha2n3cjsnxsmnx"
   },
   {
     "id": "terra1sr5gcuww0564lcf9mderzqq6xmn4rucv070qq55kx44x99j92k0qykgnfn",
-    "lp_token_id": "terra1qnxq4gjc72nraczff0gefthv0d83gxn3gzpqe70n9wynlvh2afjq86elkt",
     "asset_ids": [
       "terra1gk0y0tcxj8pr65tanqvc8zyzv3c8szkwf2kcmzgqj9jm2t9z3f9q4xcnfz",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qnxq4gjc72nraczff0gefthv0d83gxn3gzpqe70n9wynlvh2afjq86elkt"
   },
   {
     "id": "terra1tfxnza2panr47fgr6g28ns6zgvh4lcx99vs03vyjs4mh7jdeeqfqc87455",
-    "lp_token_id": "terra109sh4nxudwcqrq0v8gdna46sc3mhs9qh49jrv3m6546asc3kk87s3z28hr",
     "asset_ids": [
       "terra1ctelwayk6t2zu30a8v9kdg3u2gr0slpjdfny5pjp7m3tuquk32ysugyjdg",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra109sh4nxudwcqrq0v8gdna46sc3mhs9qh49jrv3m6546asc3kk87s3z28hr"
   },
   {
     "id": "terra1ucc2zgtx4e38zltfhxq5u82aqrxqkpcxc3azgs0pxrd0j6wfxdlse4qtrx",
-    "lp_token_id": "terra1u9amrmxnnhfwecku6ndaxk2034e73cddxau96avzg4r0xvta4wns2ckane",
     "asset_ids": [
       "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
       "terra13j2k5rfkg0qhk58vz63cze0uze4hwswlrfnm0fa4rnyggjyfrcnqcrs5z2"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1u9amrmxnnhfwecku6ndaxk2034e73cddxau96avzg4r0xvta4wns2ckane"
   },
   {
     "id": "terra1ulf4j2tqzgzwywn9yxm0759yuldmvjs26m9gdx0u9qywy0vjrejqsa6lpv",
-    "lp_token_id": "terra1kv246hnusfqh3d97ww0u59hgaqf335844hmj4mrsadvnjwaf2n0qtyhrg5",
     "asset_ids": [
       "terra16h7keds26d52xj8rn9jfx6lj2x0ja79lt56yxnmlm4xsttf5mu5smq5f78",
       "terra1hspy32cecnj72wwpma59eldpmsmfndlrwqxnzx6awfdtarns66qqw5kn85"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1kv246hnusfqh3d97ww0u59hgaqf335844hmj4mrsadvnjwaf2n0qtyhrg5"
   },
   {
     "id": "terra1uz03r5rk7p60aktxl8gm8np2kf9ur3dk3zp80uyztfse07xhnrusqdq8du",
-    "lp_token_id": "terra1ahr8gc72dht7s3fxhqp95xrnvn25uf3tw5elg3vfgtqm2qqk36yszxlcuq",
     "asset_ids": [
       "terra1zf90xr38pdgq0yjq2d56scclpfyu3ep4d720s9r2yw9gmwg7khaq0c30rl",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ahr8gc72dht7s3fxhqp95xrnvn25uf3tw5elg3vfgtqm2qqk36yszxlcuq"
   },
   {
     "id": "terra1vpd0qgmmg0euxdzrhdr3hqp97h90yhe0yzckflksf9fm73s597rsd4nalx",
-    "lp_token_id": "terra1l3r2z220fs6hfz8var4ms8w0tlxhw7aqdulslvgz9ur9g3g7mn9qd9mptr",
     "asset_ids": [
       "terra1xp9hrhthzddnl7j5du83gqqr4wmdjm5t0guzg9jp6jwrtpukwfjsjgy4f3",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1l3r2z220fs6hfz8var4ms8w0tlxhw7aqdulslvgz9ur9g3g7mn9qd9mptr"
   },
   {
     "id": "terra1w579ysjvpx7xxhckxewk8sykxz70gm48wpcuruenl29rhe6p6raslhj0m6",
-    "lp_token_id": "terra16esjk7qqlgh8w7p2a58yxhgkfk4ykv72p7ha056zul58adzjm6msvc674t",
     "asset_ids": [
       "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra16esjk7qqlgh8w7p2a58yxhgkfk4ykv72p7ha056zul58adzjm6msvc674t"
   },
   {
     "id": "terra1wfm57qavephsengsrjedvjgwrngvcvs0046fj3aq0mekjzq7gpcqt7sqrx",
-    "lp_token_id": "terra1vd0pgkrg0t0ekz5gefudvw0crlzvcqztc5ngec34memth5ft6mnqtjmd2m",
     "asset_ids": [
       "terra1rwg5kt6kcyxtz69acjgpeut7dgr4y3r7tvntdxqt03dvpqktrfxq4jrvpq",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1vd0pgkrg0t0ekz5gefudvw0crlzvcqztc5ngec34memth5ft6mnqtjmd2m"
   },
   {
     "id": "terra1wfqufuq7tky0c07cfrpnuwmz69rtew2ufh9dz7hac28qqce3m2wq683drn",
-    "lp_token_id": "terra17786erkmuydha7cwlgvvnler20cktz5egdea7pxs7ely9xu3v7eswdqa8h",
     "asset_ids": [
       "terra1gd3ntqq04lvd623xs8ht6dly0s7n4gxnz7lmlw5ga0qnamg9wyrqcggn2h",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17786erkmuydha7cwlgvvnler20cktz5egdea7pxs7ely9xu3v7eswdqa8h"
   },
   {
     "id": "terra1wvjp87g8mzm2a42efdrcgkj2swhswan9elx8fjkq3tw6n3nw67usz9wtr8",
-    "lp_token_id": "terra1zgtka8nyjvnet5v4xhecwl4afpmkv26mp7c22jegsavhp2pmpcrquhluuz",
     "asset_ids": [
       "ibc/BCB139B1FB690E0AC1AD98EBAAD281949ECB341872E697717BCF95B67917C34F",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1zgtka8nyjvnet5v4xhecwl4afpmkv26mp7c22jegsavhp2pmpcrquhluuz"
   },
   {
     "id": "terra1wx8h3grl9w79awkp5lefx2pewzner324dcq6vycxrrn3kj0lf0fqy74ple",
-    "lp_token_id": "terra1zweae4lq0p3pa493njmjexywk9wmr6cznhp6pz50hmyvelluf8qqq82mpg",
     "asset_ids": [
       "terra14xsm2wzvu7xaf567r693vgfkhmvfs08l68h4tjj5wjgyn5ky8e2qvzyanh",
       "terra1x62mjnme4y0rdnag3r8rfgjuutsqlkkyuh4ndgex0wl3wue25uksau39q8"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1zweae4lq0p3pa493njmjexywk9wmr6cznhp6pz50hmyvelluf8qqq82mpg"
   },
   {
     "id": "terra1x2tg9mhjlg9nwff0mum450gx9kejpkvxrufqet00e6ldsxfyhmks77rvz9",
-    "lp_token_id": "terra138k8ca3rn28zgek2ljdtwhzaqmtekazvrgl9yp07prtvlws2ygqq8sdgq3",
     "asset_ids": [
       "terra1xp9hrhthzddnl7j5du83gqqr4wmdjm5t0guzg9jp6jwrtpukwfjsjgy4f3",
       "ibc/CBF67A2BCF6CAE343FDF251E510C8E18C361FC02B23430C121116E0811835DEF"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra138k8ca3rn28zgek2ljdtwhzaqmtekazvrgl9yp07prtvlws2ygqq8sdgq3"
   },
   {
     "id": "terra1xalvww8ylaug2fhs0azxfpmh4scpc0uehk7p0j45heak302twz2sq9dvkg",
-    "lp_token_id": "terra1cfs2gjc96wca6ahq0hzjcj56wy37fj76slvtfq22hpfrly7vfzeqa9ruz7",
     "asset_ids": [
       "uluna",
       "terra1vzd98s9kqdkatahxs7rsd8m474lf2f8ct39zdgd6shj4nh5e6kuskaz2gy"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1cfs2gjc96wca6ahq0hzjcj56wy37fj76slvtfq22hpfrly7vfzeqa9ruz7"
   },
   {
     "id": "terra1xl5jlqjmzczugw0essagnum5a4wvhes0ggf44mxh6jmsalsyallsl0606j",
-    "lp_token_id": "terra1km69jdkp00zvsqya0pmyqn8e3thg7csuud2yw0v2a7jy87uh52qqz7rcq5",
     "asset_ids": [
       "terra1uelwtk27dq4luvyj0w0u8jvsejcw2l5fvy8n3kxurl69pleqkp5sl5t2rq",
       "terra1gn3fwtw7k40gl465723phk4qgarthw32t962acxz5e5rjzgepwpsjysppv"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1km69jdkp00zvsqya0pmyqn8e3thg7csuud2yw0v2a7jy87uh52qqz7rcq5"
   },
   {
     "id": "terra1yahrrps6tv6nsk8a8mcjynsty5yutryg5ctr0sp7t7hxnflnuwys74yysn",
-    "lp_token_id": "terra1qaudeq98hht76r9efvexhkf8k7waqq6cexqztgp5t6v0ptt7ljxq95nqlw",
     "asset_ids": [
       "terra1p67lldutk5haqpmnk5thuhmhyff8ntf8axa37mzm87qq58082u0qqp9mmu",
       "terra1rwg5kt6kcyxtz69acjgpeut7dgr4y3r7tvntdxqt03dvpqktrfxq4jrvpq"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qaudeq98hht76r9efvexhkf8k7waqq6cexqztgp5t6v0ptt7ljxq95nqlw"
   },
   {
     "id": "terra1yjekfa0d0z8jdj5jc0mv0k8lu023yzymmgkerjvhh4twtq6nhmzqa9s2v7",
-    "lp_token_id": "terra10rwjgm2nzweq04fqlqykld7azm4t0yhj8gwnyg9k7c4w4laht3aqrmwjyn",
     "asset_ids": [
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
       "terra1ry9f6alqyf9dpj04u9ymq5u4whjndu485agh6gusn89dmqse3ggsnzducj"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra10rwjgm2nzweq04fqlqykld7azm4t0yhj8gwnyg9k7c4w4laht3aqrmwjyn"
   },
   {
     "id": "terra1ynkgl2e7aphrc33pkx4tr4jc9vynddcesd750tg0cq0jrdudyy6sch4ka9",
-    "lp_token_id": "terra1w45txv24j32l27kmnj23rrrpz34c0hf2aj2tmqf466g758ndhgzsu5y42s",
     "asset_ids": [
       "terra1mma39sqn43aen4jh2sdmka84mv94uk7v7xw3ype2fdvlay6emrlqweyf5u",
       "terra1jqt5mmlpd6x3jtwfdsxwtrknvaczz2xmplukzc8h86xhupg7fe7q7nkzdp"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1w45txv24j32l27kmnj23rrrpz34c0hf2aj2tmqf466g758ndhgzsu5y42s"
   },
   {
     "id": "terra1ytv225amprdus06930pptnpxu0m7nhtjjwd4wf8r4x8wwhzj9uaqwyp38r",
-    "lp_token_id": "terra1gglgnmzuzfdu0v4v59c2442m9zj7sp7un256m0rvk6hg9jlh0wqsu4tsx3",
     "asset_ids": [
       "terra1d4j9lsl453mkvtlg4ctw8y52rdkhafsaefug0hq0z06phczuvvvs7uq0vg",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1gglgnmzuzfdu0v4v59c2442m9zj7sp7un256m0rvk6hg9jlh0wqsu4tsx3"
   },
   {
     "id": "terra1yx28vf8z0ph94h6mwxurfjuqzqcc6chzpd85ls8uvr0ajpkdvzhqrmp2sv",
-    "lp_token_id": "terra17rlm3qv3c9epnkpc2l3h3n9zjn3ldjugwhxtuuw6mhhm2vskjkws04xzza",
     "asset_ids": [
       "terra17gck626vgax9jpe6utm7dhx4vdzawfkt0jhru03l7a3dzu98wedsfad4sz",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17rlm3qv3c9epnkpc2l3h3n9zjn3ldjugwhxtuuw6mhhm2vskjkws04xzza"
   },
   {
     "id": "terra1zhq0rqermczklmw89ranmgz28zthsthw6u35umgvpykfwzlwtgcsylpqqf",
-    "lp_token_id": "terra1ua7uk7xvx89dg8tnr8k8smk5vermlaer50zsglmpx8plttaxvvtsem5fgy",
     "asset_ids": [
       "terra1xe8umegahlqphtpvjsuwfzfvyjfvag5h8rffsx6ezm0el4xzsf8s7uzezk",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ua7uk7xvx89dg8tnr8k8smk5vermlaer50zsglmpx8plttaxvvtsem5fgy"
   },
   {
     "id": "terra1zjfy562q4nw0fwhhp8hmck88td3trlj76wqhhkncal25qu4mck6sgpkau4",
-    "lp_token_id": "terra1sdajd4wfkxvwzd3em9h9qdpsf0mavuc9ukt8hpcxklp2znd7lrhsgkudn0",
     "asset_ids": [
       "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
       "terra1gy73st560m2j0esw5c5rjmr899hvtv4rhh4seeajt3clfhr4aupszjss4j"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1sdajd4wfkxvwzd3em9h9qdpsf0mavuc9ukt8hpcxklp2znd7lrhsgkudn0"
   },
   {
     "id": "terra1zxgtcuyktse6egmy7nnwu6gg5yg9lzg04unlyh2lva670rx5wwcsdpwcpw",
-    "lp_token_id": "terra1qqh6vpync8tylpdfv9mjemml02xutzmufetrp35na09k2cnlnl7qxh0lqy",
     "asset_ids": [
       "terra1ykxe98arwtahe97h9y5nck8gw88kxn2z73gfwlnx5twcd96ct98sqzcsrk",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qqh6vpync8tylpdfv9mjemml02xutzmufetrp35na09k2cnlnl7qxh0lqy"
   },
   {
     "id": "terra1zz8u4y9h0dw6l7kgfcaz7t5yxgmdkhxmqg7anmk0l393guflnvzqjhvtl7",
-    "lp_token_id": "terra1r8m2zuy0wmrv5p3uxzctmpltztwd8x4hh0sw05hs7q9y7qq0m3hqws0lty",
     "asset_ids": [
       "ibc/CBF67A2BCF6CAE343FDF251E510C8E18C361FC02B23430C121116E0811835DEF",
       "terra1rwg5kt6kcyxtz69acjgpeut7dgr4y3r7tvntdxqt03dvpqktrfxq4jrvpq"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1r8m2zuy0wmrv5p3uxzctmpltztwd8x4hh0sw05hs7q9y7qq0m3hqws0lty"
   },
   {
     "id": "terra19dt99rwu4zh5kwrtp4453czw90u8sgd7s8nf38psf0eflqml9jwqk8ftcp",
-    "lp_token_id": "terra13yp5jufdd2n5gez84fy26tujq540alr29cm4tpntcsaqg7h660cqwe8dx9",
     "asset_ids": [
       "terra1k57q7f7gh6rm4gyqpqygkxdgsh0d67nxngfuwj6n5d38jpd44psshn5gaq",
       "terra1kggfd6z0ad2k9q8v24f7ftxyqush8fp9xku9nyrjcs2wv0e4kypszfrfd0"
     ],
     "dex": "Nauticus",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra13yp5jufdd2n5gez84fy26tujq540alr29cm4tpntcsaqg7h660cqwe8dx9"
   },
   {
     "id": "terra19z5ugnppt7fu70mpuy9a6v0l32vnkrndu9z5qnvp9p85ep7dhq8scqpqs8",
-    "lp_token_id": "terra1s80jffm4a5awzed0dfjvkjz79rcs25wfttezgefmpzju6rmgt5eq43x5l8",
     "asset_ids": [
       "terra1z56spghy7kmvv6j9p7gv2hf569x57mnnex4gcqyx5m8m76d0awvqd6ywfj",
       "terra1kggfd6z0ad2k9q8v24f7ftxyqush8fp9xku9nyrjcs2wv0e4kypszfrfd0"
     ],
     "dex": "Nauticus",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1s80jffm4a5awzed0dfjvkjz79rcs25wfttezgefmpzju6rmgt5eq43x5l8"
   },
   {
     "id": "terra1fmfsqjv9xuk86waazkye0jqgf0r3dx28mu6s0cpuv47mxs3dewcqfyek3m",
-    "lp_token_id": "terra1fn29pxsueea3zt3xw909gpgjmzcwfxw7q55jgcsfh7v5rh4y3a6s2s69k8",
     "asset_ids": [
       "terra13g39gz8uv4s8h9a7pzmg2pezcmd46jz774lffhe2n9dqckn87mlqqg86nc",
       "terra1kggfd6z0ad2k9q8v24f7ftxyqush8fp9xku9nyrjcs2wv0e4kypszfrfd0"
     ],
     "dex": "Nauticus",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fn29pxsueea3zt3xw909gpgjmzcwfxw7q55jgcsfh7v5rh4y3a6s2s69k8"
   },
   {
     "id": "terra1gezc52xphwg0q646fy9hvk7f4ctgmxrzt8pppqcy6ww59yd86z0qr2k3w2",
-    "lp_token_id": "terra179w0ny7mv7qn5h5q4rz6k6jhvspeau5fmkuqpvmtn6qx6l36pu5qe06wr0",
     "asset_ids": [
       "terra1gk0y0tcxj8pr65tanqvc8zyzv3c8szkwf2kcmzgqj9jm2t9z3f9q4xcnfz",
       "terra1khsxwfnzuxqcyza2sraxf2ngkr3dwy9f7rm0uts0xpkeshs96ccsqtu6nv"
     ],
     "dex": "Nauticus",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra179w0ny7mv7qn5h5q4rz6k6jhvspeau5fmkuqpvmtn6qx6l36pu5qe06wr0"
   },
   {
     "id": "terra1qma7tzf0pul603hnqdfp37hvqvxr8c6vugagd4y8zyf7ju6j59fsy5yr2v",
-    "lp_token_id": "terra1gjmpaqvm5ns4pap0enqdtsm78m0rc9n3wxsecq8rsjxdv6chwvfqmpnwyn",
     "asset_ids": [
       "terra1k57q7f7gh6rm4gyqpqygkxdgsh0d67nxngfuwj6n5d38jpd44psshn5gaq",
       "terra1kggfd6z0ad2k9q8v24f7ftxyqush8fp9xku9nyrjcs2wv0e4kypszfrfd0"
     ],
     "dex": "Nauticus",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1gjmpaqvm5ns4pap0enqdtsm78m0rc9n3wxsecq8rsjxdv6chwvfqmpnwyn"
   },
   {
     "id": "terra1v3n36s6pfm7zznaz3n6jdvhf8dnh8ymz9y4wp8fuuf0g306rcmysqjc777",
-    "lp_token_id": "terra1yph6hsldjpc7up5q87jjqyzxnpfllpewzc89r0yk30t065ajv8nq5rz5mx",
     "asset_ids": [
       "terra13g39gz8uv4s8h9a7pzmg2pezcmd46jz774lffhe2n9dqckn87mlqqg86nc",
       "terra1kggfd6z0ad2k9q8v24f7ftxyqush8fp9xku9nyrjcs2wv0e4kypszfrfd0"
     ],
     "dex": "Nauticus",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1yph6hsldjpc7up5q87jjqyzxnpfllpewzc89r0yk30t065ajv8nq5rz5mx"
   },
   {
     "id": "terra1dm2jkvxqwgnez8llnut46837ky29rvzxy9kl69kqh30r78qdj8rs4rksl8",
-    "lp_token_id": "terra1s3zkg95yrmdl0nlxnynkunq3uqyeuu6mk3ca6vtcag0us9ejtjas0dv7em",
     "asset_ids": [
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
       "ibc/CBF67A2BCF6CAE343FDF251E510C8E18C361FC02B23430C121116E0811835DEF"
     ],
     "dex": "Phoenix",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1s3zkg95yrmdl0nlxnynkunq3uqyeuu6mk3ca6vtcag0us9ejtjas0dv7em"
   },
   {
     "id": "terra1z7705t2p5p6rel93fd7zrsh8a4luxyxz88a4zkmlctwf38yh520qt949n8",
-    "lp_token_id": "terra1dxd7vh4x6cf6n20p2x6syatxdv4jftzzs45n42wn7kutqc0xxj8sj3p0dc",
     "asset_ids": [
       "terra14xsm2wzvu7xaf567r693vgfkhmvfs08l68h4tjj5wjgyn5ky8e2qvzyanh",
       "uluna"
     ],
     "dex": "Phoenix",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1dxd7vh4x6cf6n20p2x6syatxdv4jftzzs45n42wn7kutqc0xxj8sj3p0dc"
   },
   {
     "id": "terra164w2vl7z7lpuvex6z3ru0v55fgq3dmvxuqt0aejp49w7fyc8g6ksfw55nh",
-    "lp_token_id": "terra1wwmlrhulv55ph6vnv8wlgma5sjca2p8k8ykrmkfyh9qj3kct9m7sez5cv8",
     "asset_ids": [
       "ibc/BC8A77AFBD872FDC32A348D3FB10CC09277C266CFE52081DE341C7EC6752E674",
       "uluna"
     ],
     "dex": "Phoenix",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1wwmlrhulv55ph6vnv8wlgma5sjca2p8k8ykrmkfyh9qj3kct9m7sez5cv8"
   },
   {
     "id": "terra1728806n8mgr3n25dwhnmlvgvkfqv9pfnjsqtdzqzk8xpr4h4rnnsttthnw",
-    "lp_token_id": "terra12ctxrpmkpqr0gzrndjwr2a8k0gp3stx94x4q5p7g7u30p9mnrezsc2sl3n",
     "asset_ids": [
       "terra14xsm2wzvu7xaf567r693vgfkhmvfs08l68h4tjj5wjgyn5ky8e2qvzyanh",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Phoenix",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra12ctxrpmkpqr0gzrndjwr2a8k0gp3stx94x4q5p7g7u30p9mnrezsc2sl3n"
   },
   {
     "id": "terra190alph3r79rm2ypefamglwk53ln2qr3ud09sa3mnxexxf0p8xv3qzume3r",
-    "lp_token_id": "terra14s6uknh7zc97m3zqfejfqkkzm90tx9zez6k4swqa3422xvgpy56s3tyn49",
     "asset_ids": [
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
       "uluna"
     ],
     "dex": "Phoenix",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14s6uknh7zc97m3zqfejfqkkzm90tx9zez6k4swqa3422xvgpy56s3tyn49"
   },
   {
     "id": "terra1gwnwqdwz7taadacdw45q7kwz3q7h0hfrc4f3xpxas4j869tqexxsxze6gz",
-    "lp_token_id": "terra1fqh5u2m7qs7vfz0ty8c8n9td74afgltrgg98ezqmxqg2dgqdfqrq2wy9r6",
     "asset_ids": [
       "ibc/CBF67A2BCF6CAE343FDF251E510C8E18C361FC02B23430C121116E0811835DEF",
       "uluna"
     ],
     "dex": "Phoenix",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fqh5u2m7qs7vfz0ty8c8n9td74afgltrgg98ezqmxqg2dgqdfqrq2wy9r6"
   },
   {
     "id": "terra1ll68rj627k4g88v9q45pp64zwv8gg6x2v8ev68c570tzhq253gcsu74qrl",
-    "lp_token_id": "terra167khnalh9aawqx9qynj7kk9y0n8hc30qe6s8cy7y5yu2azrc2edqyjprp9",
     "asset_ids": [
       "ibc/BC8A77AFBD872FDC32A348D3FB10CC09277C266CFE52081DE341C7EC6752E674",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Phoenix",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra167khnalh9aawqx9qynj7kk9y0n8hc30qe6s8cy7y5yu2azrc2edqyjprp9"
   },
   {
     "id": "terra1phz9fk5zrpj40el0px2h4rmnfyrlvxgwfz863nv96a0835tf3ljqpdsnru",
-    "lp_token_id": "terra14zymzz73zzmrpfujjxkv6drcqdjdve3jsz5rx00464x9jdld6ays06l0n3",
     "asset_ids": [
       "terra1ykxe98arwtahe97h9y5nck8gw88kxn2z73gfwlnx5twcd96ct98sqzcsrk",
       "uluna"
     ],
     "dex": "Phoenix",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14zymzz73zzmrpfujjxkv6drcqdjdve3jsz5rx00464x9jdld6ays06l0n3"
   },
   {
     "id": "terra1pue3acs2umsjryf8xmqvmuc02kav04k32gq8vc4h6hu3zfvwxkdst6ldm2",
-    "lp_token_id": "terra1w3vxxyvrq909w8nqrxypaeazqtt3ldyy3ucre3jwz23nyznnd3eql5hymn",
     "asset_ids": [
       "terra1xp9hrhthzddnl7j5du83gqqr4wmdjm5t0guzg9jp6jwrtpukwfjsjgy4f3",
       "uluna"
     ],
     "dex": "Phoenix",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1w3vxxyvrq909w8nqrxypaeazqtt3ldyy3ucre3jwz23nyznnd3eql5hymn"
   },
   {
     "id": "terra10tqe0qz0led62433muaxa00ehdr3ja4kgus3cn4pkst6vpxpw8qsydz956",
-    "lp_token_id": "terra1ugtkewkzkq26ya8ye6gfwkt9jpj08sw0737ddjj9h803ee4768xqwr56d4",
     "asset_ids": [
       "terra1jzl4telukvjx56l72zxuts0xm60gefgu3kla36fvfqlfxn0ckuvsgd6akd",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ugtkewkzkq26ya8ye6gfwkt9jpj08sw0737ddjj9h803ee4768xqwr56d4"
   },
   {
     "id": "terra10xuatumr0g345umf7qtn0svvy83k0wxmdyf698yrs9lkytyd6srs0g2vut",
-    "lp_token_id": "terra136ce352lvvlgs662hplc0rlf8tq8tvjrcaadp2ezzf2wf604gvsswflejp",
     "asset_ids": [
       "terra1cmf8ytutcwrjrv08zskj9phuh46a3w3nkjax7en4hxezsrdr58lqvzy05q",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra136ce352lvvlgs662hplc0rlf8tq8tvjrcaadp2ezzf2wf604gvsswflejp"
   },
   {
     "id": "terra128mfavj89an674grxygf7eyqwqc5y9z849nklvd2v65gs6g2r5hqpyht0u",
-    "lp_token_id": "terra1h7kgccvtdf6z2udech63qlvn5j06pw0vny9uq2wl8eqad63vt95q2pkmrq",
     "asset_ids": [
       "uluna",
       "terra12ezq5402h5n3skhdshjp4f49zzg0saxum8fvvhjhauzas2ezyyrqpznqny"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1h7kgccvtdf6z2udech63qlvn5j06pw0vny9uq2wl8eqad63vt95q2pkmrq"
   },
   {
     "id": "terra12jlsxqs89ytrtpm86mc0ey8yl902zhk2vy7e3h9xzfppk3mdd3qqdj9c5t",
-    "lp_token_id": "terra1qatnqunnama825l0xf6nmxgts6j27vqfhnzadwecld4mnlumhkkq9q7cn7",
     "asset_ids": [
       "terra1ee4g63c3sus9hnyyp3p2u3tulzdv5ag68l55q8ej64y4qpwswvus5mtag2",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qatnqunnama825l0xf6nmxgts6j27vqfhnzadwecld4mnlumhkkq9q7cn7"
   },
   {
     "id": "terra130w7wjnj4ngzwz2x3qd4w2pq99ynzgw9fdxrsjg0cqhg5pw0dphsqg2jtk",
-    "lp_token_id": "terra1qcax3h3cadtpqua2uev06euuse8wxsjzfrtlmt0nyp2aw0a7hctq0ww6p9",
     "asset_ids": [
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
       "terra12ezq5402h5n3skhdshjp4f49zzg0saxum8fvvhjhauzas2ezyyrqpznqny"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qcax3h3cadtpqua2uev06euuse8wxsjzfrtlmt0nyp2aw0a7hctq0ww6p9"
   },
   {
     "id": "terra13ce384pm3paufw9t3k4cdyqlutqrn09tve5sl5su5tuksqfyyxnq73ftyt",
-    "lp_token_id": "terra1xnudulcse7gp2rg0hpzxtx7cz72mg20pjqhzw87z0j3pk5y9lufqupgj22",
     "asset_ids": [
       "terra1d4j9lsl453mkvtlg4ctw8y52rdkhafsaefug0hq0z06phczuvvvs7uq0vg",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1xnudulcse7gp2rg0hpzxtx7cz72mg20pjqhzw87z0j3pk5y9lufqupgj22"
   },
   {
     "id": "terra13vxj8sffahcwjl02mkw065sydparj086q4vcnw4n5cvqg6wd4r8qd3ngnx",
-    "lp_token_id": "terra1nf8q6w0tl3hmnvs3llakr52f9gtlnyfmtt0ynmwweppx4g2y42dqxaqrek",
     "asset_ids": [
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
       "terra1vzd98s9kqdkatahxs7rsd8m474lf2f8ct39zdgd6shj4nh5e6kuskaz2gy"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1nf8q6w0tl3hmnvs3llakr52f9gtlnyfmtt0ynmwweppx4g2y42dqxaqrek"
   },
   {
     "id": "terra153vnf45phcnjg6ymmvexa0jr7t03xarcwefxgnz2xmvf3x6lttrsjs3kwg",
-    "lp_token_id": "terra1k6pf84kdfxqz6gmcl9w0wwphkvwxccuz3e9fryrgvlxepuw5qrhqp07sd9",
     "asset_ids": [
       "terra1693sgskk3tj24n8atssq5x7aq090awq6wy7hkmpew403vg6svzjq6x04nh",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1k6pf84kdfxqz6gmcl9w0wwphkvwxccuz3e9fryrgvlxepuw5qrhqp07sd9"
   },
   {
     "id": "terra15dpd6drrsxt785m4k8frxt088caelz37q3tkpveekh4lvt6j79kq3jrvqs",
-    "lp_token_id": "terra1nwju0tcdykx037phw8qh7jzwqal5uk7ekqjkxzpuymkpmc7a4sjs3d3t9a",
     "asset_ids": [
       "terra1ykxe98arwtahe97h9y5nck8gw88kxn2z73gfwlnx5twcd96ct98sqzcsrk",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1nwju0tcdykx037phw8qh7jzwqal5uk7ekqjkxzpuymkpmc7a4sjs3d3t9a"
   },
   {
     "id": "terra15svuxeq5w58l5g5qkd2yrmpalgp4uwzz0l86mcfg8z2e2nd7fu8scf4cl5",
-    "lp_token_id": "terra1sn3ee5c5ujczx9ksky8hn2x0jwqf2sc5hxgn9gch32933mxjjv7qtl53w5",
     "asset_ids": [
       "terra1ry9f6alqyf9dpj04u9ymq5u4whjndu485agh6gusn89dmqse3ggsnzducj",
       "terra1d4j9lsl453mkvtlg4ctw8y52rdkhafsaefug0hq0z06phczuvvvs7uq0vg"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1sn3ee5c5ujczx9ksky8hn2x0jwqf2sc5hxgn9gch32933mxjjv7qtl53w5"
   },
   {
     "id": "terra160lewlf0ygzvjkjar5n8wxulnh8phsu6vsq4sk8e3ln3pqz58juq22ywwy",
-    "lp_token_id": "terra1vz29w25qu5lzfghz89yy6cq7jaj5snjf5p66qcmp4hza87jcstfqylf5er",
     "asset_ids": [
       "terra1ee4g63c3sus9hnyyp3p2u3tulzdv5ag68l55q8ej64y4qpwswvus5mtag2",
       "ibc/CBF67A2BCF6CAE343FDF251E510C8E18C361FC02B23430C121116E0811835DEF"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1vz29w25qu5lzfghz89yy6cq7jaj5snjf5p66qcmp4hza87jcstfqylf5er"
   },
   {
     "id": "terra16m2fp6mlt2qtlgv30z4xln8q0grlxr9c0ylwelknnl7rklasw24qkag3za",
-    "lp_token_id": "terra14avgfstw3th676cy3mg7kwqd5a09yfwwk02uztqzq4lzu78e738saktxrk",
     "asset_ids": [
       "terra12ezq5402h5n3skhdshjp4f49zzg0saxum8fvvhjhauzas2ezyyrqpznqny",
       "terra129zjaxquhh3h5upn0clqzdawnze43a9z34ktt4l6um2hf5w0xqjsta42u5"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14avgfstw3th676cy3mg7kwqd5a09yfwwk02uztqzq4lzu78e738saktxrk"
   },
   {
     "id": "terra172v738ut05le2272gm6akv9hw2jqfwfkm7ej7ndy53skxq757s5sraz2ja",
-    "lp_token_id": "terra1rwx6w02alc4kaz7xpyg3rlxpjl4g63x5jq292mkxgg65zqpn5llq9etvsk",
     "asset_ids": [
       "uluna",
       "terra1rcmvfsn77pd6m04ctqj3wcu66pvrw9p265cdl72w4zarfup2rv7qjxhkzl"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1rwx6w02alc4kaz7xpyg3rlxpjl4g63x5jq292mkxgg65zqpn5llq9etvsk"
   },
   {
     "id": "terra173rx5nh86525mz7x6clgunnvumrf9nrkruvk6h8ev5mlc7r028xq8nsqrm",
-    "lp_token_id": "terra139djw4keg5vu2x2cwucapkxp4efst286rf0n9gh3cv3ptm65c80shy0fwl",
     "asset_ids": [
       "terra175232yuat84jr5yx74mtz243egyyp904l9n69fvdzzkplhru5juqlv8ah6",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra139djw4keg5vu2x2cwucapkxp4efst286rf0n9gh3cv3ptm65c80shy0fwl"
   },
   {
     "id": "terra17neqggggg4rlwh2ksk0ys8hjtxapfa4n0k5ppclw9arnh3cez93qkh4xyp",
-    "lp_token_id": "terra1dsy8ly4t2xtzlseflqlphg8cr47sgg3egmk8pktnnq5cd7hu04lqhp80mu",
     "asset_ids": [
       "terra1sdglum2dt4f3fmq7jrt2phf2tegmnudc7qqqqujkpqcm9ujuxxkqakv5u8",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1dsy8ly4t2xtzlseflqlphg8cr47sgg3egmk8pktnnq5cd7hu04lqhp80mu"
   },
   {
     "id": "terra18a2u6az6dzw528rptepfg6n49ak6hdzkf8ewf0n5r0nwju7gtdgqfag9xu",
-    "lp_token_id": "terra1hw5n2l4v5vz8lk4sj69j7pwdaut0kkn90mw09snlkdd3f7ckld0sutg4p7",
     "asset_ids": [
       "terra1ery8l6jquynn9a4cz2pff6khg8c68f7urt33l5n9dng2cwzz4c4qj3spm2",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1hw5n2l4v5vz8lk4sj69j7pwdaut0kkn90mw09snlkdd3f7ckld0sutg4p7"
   },
   {
     "id": "terra18z2zq3vyav0tyg2s3dm8ctftwjqd96f5pkfmp2qgn7fkq0uwaaysaxw3pu",
-    "lp_token_id": "terra1ka40j33h55z3vkr98etwd4l0v8htaup4883pa53ze4ncaa8z9vgqd49ngc",
     "asset_ids": [
       "terra1a7zeajhk6nnj7jzu2rxynwr3yvp58gj2ffxe9k4dneyte0v5kkeqnmzwvq",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ka40j33h55z3vkr98etwd4l0v8htaup4883pa53ze4ncaa8z9vgqd49ngc"
   },
   {
     "id": "terra19n9cmdamempsdhvw5x0zzm2txnttqedcdu7llh5g2dftad5jfusqvlnnuf",
-    "lp_token_id": "terra1xnxsxarhsj6v5xlrc2es2lw937z6jxat643p5uvqa3dllewl5s4qa7hwkw",
     "asset_ids": [
       "terra1ry9f6alqyf9dpj04u9ymq5u4whjndu485agh6gusn89dmqse3ggsnzducj",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1xnxsxarhsj6v5xlrc2es2lw937z6jxat643p5uvqa3dllewl5s4qa7hwkw"
   },
   {
     "id": "terra1ccxwgew8aup6fysd7eafjzjz6hw89n40h273sgu3pl4lxrajnk5st2hvfh",
-    "lp_token_id": "terra1eh2aulwsyc9m45ggeznav402xcck4ll0yn0xgtlxyf4zkwch7juqsxvfzr",
     "asset_ids": [
       "terra1ecgazyd0waaj3g7l9cmy5gulhxkps2gmxu9ghducvuypjq68mq2s5lvsct",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1eh2aulwsyc9m45ggeznav402xcck4ll0yn0xgtlxyf4zkwch7juqsxvfzr"
   },
   {
     "id": "terra1cndy6rcqgm45ssj6s9hkmftha89gu06ymecpx09pd4x0zxs4js5smpsvj2",
-    "lp_token_id": "terra13w89pfxhk5k62xp8ctckkhrjwwvq34czmltwkvsck0kvenyspk7q7cpcss",
     "asset_ids": [
       "terra1ee4g63c3sus9hnyyp3p2u3tulzdv5ag68l55q8ej64y4qpwswvus5mtag2",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra13w89pfxhk5k62xp8ctckkhrjwwvq34czmltwkvsck0kvenyspk7q7cpcss"
   },
   {
     "id": "terra1dtaakf99dllanxn0sg0ryft4j9fsewypgns5gavev6tz49mw0wds8cg89y",
-    "lp_token_id": "terra1q3647qp780u7y2zvau5fn748zqxsfm4kr6lcvr5jjev5a77kchxsjy2m4x",
     "asset_ids": [
       "terra1dtaqwlmzlk3jku5un6h6rfunttmwsqnfz7evvdf4pwr0wypsl68q6nuam0",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1q3647qp780u7y2zvau5fn748zqxsfm4kr6lcvr5jjev5a77kchxsjy2m4x"
   },
   {
     "id": "terra1eryp83n366l4583nk8ln5qv7lvdeejzsx7vekf32e6qj33cxwguqns2vxr",
-    "lp_token_id": "terra18fe2jdsll40rhfhfj34n0vlkysjsndwd20jecvezdxc3dp4kcr5s7uucd3",
     "asset_ids": [
       "terra1sdglum2dt4f3fmq7jrt2phf2tegmnudc7qqqqujkpqcm9ujuxxkqakv5u8",
       "terra1cmf8ytutcwrjrv08zskj9phuh46a3w3nkjax7en4hxezsrdr58lqvzy05q"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra18fe2jdsll40rhfhfj34n0vlkysjsndwd20jecvezdxc3dp4kcr5s7uucd3"
   },
   {
     "id": "terra1eud3zfx5q7eklahp3q9ar77gc432g7qa6lwm7z5zfg88qf80rvsshj29sg",
-    "lp_token_id": "terra1xj8h7gkdr4kalgqmvvpmdxd2rkn6u5amlg0j3zek523y4sz2nlfs5gcgyv",
     "asset_ids": [
       "terra1q8kfp0v9rhef0d3u44ds9shwvwcusjheh8nhye3n7gwjd95ze96sehyp6w",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1xj8h7gkdr4kalgqmvvpmdxd2rkn6u5amlg0j3zek523y4sz2nlfs5gcgyv"
   },
   {
     "id": "terra1gfv5f3r5e9ykhsgz92hx5qa5wtxc6222w7nnj5f26a9ekw3mdzmsa95h0v",
-    "lp_token_id": "terra1uvqk5vj9vn4gjemrp0myz4ku49aaemulgaqw7pfe0nuvfwp3gukq4rz3fj",
     "asset_ids": [
       "uluna",
       "terra129gzxm65ckt7p9tp3rnq8q0zvaz6m48e5l7qpxtmy2s3fnhcjd0sag3tm3"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1uvqk5vj9vn4gjemrp0myz4ku49aaemulgaqw7pfe0nuvfwp3gukq4rz3fj"
   },
   {
     "id": "terra1gmdgdku0dvn034cwry64vmrtp387tle6rtdjrngr56e0us4vphkqytu9lj",
-    "lp_token_id": "terra1pt6wkxlkga4fw2spxawd0ymqfdy63xk7y4tr6cawafmd06dfzgxqr9mwk8",
     "asset_ids": [
       "terra1ry9f6alqyf9dpj04u9ymq5u4whjndu485agh6gusn89dmqse3ggsnzducj",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1pt6wkxlkga4fw2spxawd0ymqfdy63xk7y4tr6cawafmd06dfzgxqr9mwk8"
   },
   {
     "id": "terra1gu75wek7kq8h4ee6eztmfu73nr3esl6al0qjawkhya3g57sz6jvsukpj3z",
-    "lp_token_id": "terra1a4hcacqpkqgmh94jpe290gekgv6f7euhfcl2fxm22s2r78uck9lqw33t99",
     "asset_ids": [
       "terra1qj5hs3e86qn4vm9dvtgtlkdp550r0rayk9wpay44mfw3gn3tr8nq5jw3dg",
       "terra1cmf8ytutcwrjrv08zskj9phuh46a3w3nkjax7en4hxezsrdr58lqvzy05q"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1a4hcacqpkqgmh94jpe290gekgv6f7euhfcl2fxm22s2r78uck9lqw33t99"
   },
   {
     "id": "terra1h3wqh8fdsd8rr6rlz3yfp9sm8849wrec8vqsmkwksx0ndkqaxkjqellq28",
-    "lp_token_id": "terra1gkg8cxha802dy8km0jldyegmtj384f69wp0c3cvtfq43gu8caa7swpe4kc",
     "asset_ids": [
       "uluna",
       "terra14xsm2wzvu7xaf567r693vgfkhmvfs08l68h4tjj5wjgyn5ky8e2qvzyanh"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1gkg8cxha802dy8km0jldyegmtj384f69wp0c3cvtfq43gu8caa7swpe4kc"
   },
   {
     "id": "terra1j08452mqwadp8xu25kn9rleyl2gufgfjnv0sn8dvynynakkjukcqsc244x",
-    "lp_token_id": "terra1ma0g752dl0yujasnfs9yrk6uew7d0a2zrgvg62cfnlfftu2y0egqjpj90v",
     "asset_ids": [
       "terra1zwv6feuzhy6a9wekh96cd57lsarmqlwxdypdsplw6zhfncqw6ftqynf7kp",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ma0g752dl0yujasnfs9yrk6uew7d0a2zrgvg62cfnlfftu2y0egqjpj90v"
   },
   {
     "id": "terra1k08qteme5x0gm4932usuet89zzcv3z9kp6jzzn8wgy4qgwk293sqjm09mz",
-    "lp_token_id": "terra1a0s7u0zej7jpzuq90yglms75ng5yvq9q20awu44h395hc9k249hsry5d2j",
     "asset_ids": [
       "terra1yetl2gafkhtanr6utpmxp0zqtkhkc05k4dgjg0zfyf86p9fzw3ssslv0fj",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1a0s7u0zej7jpzuq90yglms75ng5yvq9q20awu44h395hc9k249hsry5d2j"
   },
   {
     "id": "terra1lx77v34gd24krhmnqmhldc36lyanp3ajyx9zyd7qulslnujvcsqslrlspe",
-    "lp_token_id": "terra1adyqxpz0vseur93xct7k4sgfjfqf9drhrxt58k2z2p7vvsh4wt5qpmc8dg",
     "asset_ids": [
       "terra1xp9hrhthzddnl7j5du83gqqr4wmdjm5t0guzg9jp6jwrtpukwfjsjgy4f3",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1adyqxpz0vseur93xct7k4sgfjfqf9drhrxt58k2z2p7vvsh4wt5qpmc8dg"
   },
   {
     "id": "terra1mecfcj3fkmsgxqa4eaq5w285u6cn0wqtwzkp9gfhpm3dyt8e3cesrpg5hq",
-    "lp_token_id": "terra1gxnp98ghg5mqddw3n0ve6uw3ay9hnt0ks9r3dyucjn0y007u64vqw03d6f",
     "asset_ids": [
       "terra1y92wp8u58396mtaejwhtasz24vrcf0lhsznl7rj0nhw0khp8kchscuqgfs",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1gxnp98ghg5mqddw3n0ve6uw3ay9hnt0ks9r3dyucjn0y007u64vqw03d6f"
   },
   {
     "id": "terra1n9gqryt5sqlt9rexp569anwqw8end0tqj2jdauu7cwv4jrfkq7eqj70d0n",
-    "lp_token_id": "terra1zmlgklwyrzvhgvn5sfrq28fad69wcevjymkea7jgpz8gheuk6qas2w8krk",
     "asset_ids": [
       "uluna",
       "terra129zjaxquhh3h5upn0clqzdawnze43a9z34ktt4l6um2hf5w0xqjsta42u5"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1zmlgklwyrzvhgvn5sfrq28fad69wcevjymkea7jgpz8gheuk6qas2w8krk"
   },
   {
     "id": "terra1nfv5kddgfj2y77phtu0yumwnw5vz4m8anz2avaw4dpf2w0wlu02s9rkc56",
-    "lp_token_id": "terra1tewy0s0xydvh3l2wkpf238rp48n5mmd3xjfwp6j3cy603hvpgf2sztgvv8",
     "asset_ids": [
       "terra1spkm49wd9dqkranhrks4cupecl3rtgeqqljq3qrvrrts2ev2gw6sy5vz3k",
       "terra1cmf8ytutcwrjrv08zskj9phuh46a3w3nkjax7en4hxezsrdr58lqvzy05q"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1tewy0s0xydvh3l2wkpf238rp48n5mmd3xjfwp6j3cy603hvpgf2sztgvv8"
   },
   {
     "id": "terra1q6kpxy6ar5lkxqudjvryarrrttmakwsv32ahx8smkksp6dqq87msqsncny",
-    "lp_token_id": "terra1nc84knc0n7td5xqplwy0luh97zd8hv5mhvm9cdempc05xk0xvxyqjr6cyg",
     "asset_ids": [
       "terra146ypndztcmmrmyxef7e20cul82gh43vjnw4uacwdvg5sp9kva7sqc9mjav",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1nc84knc0n7td5xqplwy0luh97zd8hv5mhvm9cdempc05xk0xvxyqjr6cyg"
   },
   {
     "id": "terra1qe36wap4lrwx4yanhvst33lvvxfdryve8c6uwhvks36p07z5qvlq0cx202",
-    "lp_token_id": "terra10nnsamvtc5yux6m9utwc6dtee20h8fe8gp06jfqy0ffqtxrk384s4l0rru",
     "asset_ids": [
       "terra1564y9uxzhast8sk5n47teypy4mxy7fg5vne2msuztsft7qk3pj9sxxuxmc",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra10nnsamvtc5yux6m9utwc6dtee20h8fe8gp06jfqy0ffqtxrk384s4l0rru"
   },
   {
     "id": "terra1qg85dekl59jv723ce54s82v26rteknru5645lfm3n9eytr53570ssrz6js",
-    "lp_token_id": "terra1xgkjhtn4d5csgwchma73gtx5yzjxuq0eywz25lj56eqgq4d4r37sygw8wn",
     "asset_ids": [
       "terra1sdglum2dt4f3fmq7jrt2phf2tegmnudc7qqqqujkpqcm9ujuxxkqakv5u8",
       "terra1qj5hs3e86qn4vm9dvtgtlkdp550r0rayk9wpay44mfw3gn3tr8nq5jw3dg"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1xgkjhtn4d5csgwchma73gtx5yzjxuq0eywz25lj56eqgq4d4r37sygw8wn"
   },
   {
     "id": "terra1req03gy0eyeeg9e7nwjyn0pct6hdqtphy837j784492l4hcsh0vqx2n8az",
-    "lp_token_id": "terra1mpyp9t48q2dy6s4lkxwjpy8sgg4r823hwam2tap2ra86hmgrrqyqcf6ehy",
     "asset_ids": [
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
       "ibc/CBF67A2BCF6CAE343FDF251E510C8E18C361FC02B23430C121116E0811835DEF"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mpyp9t48q2dy6s4lkxwjpy8sgg4r823hwam2tap2ra86hmgrrqyqcf6ehy"
   },
   {
     "id": "terra1s0rpd42k4uv4amlr5z9fw2ha9kedwewpm33ma7awscmaq00402nsdu2w3f",
-    "lp_token_id": "terra1epvnlk847v85sa82ndvt730ndhkalq22lehkwrv3fwzy00kyydxqyk27m6",
     "asset_ids": [
       "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1epvnlk847v85sa82ndvt730ndhkalq22lehkwrv3fwzy00kyydxqyk27m6"
   },
   {
     "id": "terra1t5ddufyxl6yjedr6me5dusmm29jfgvmxstjk6ul57zk6d0trptjsju2xw2",
-    "lp_token_id": "terra14m6nt5dwnxsmvt6pv6am8dkmqrf263acgjq6ex00un3t0qdd9pts2fy2cq",
     "asset_ids": [
       "terra1vzd98s9kqdkatahxs7rsd8m474lf2f8ct39zdgd6shj4nh5e6kuskaz2gy",
       "terra12ezq5402h5n3skhdshjp4f49zzg0saxum8fvvhjhauzas2ezyyrqpznqny"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14m6nt5dwnxsmvt6pv6am8dkmqrf263acgjq6ex00un3t0qdd9pts2fy2cq"
   },
   {
     "id": "terra1twpp0zndevlxx3mfn047qmvl824zm5mnqwaye07ts6x5tqyyf9dqx9a63n",
-    "lp_token_id": "terra1nvd25azm56h9fk7qn9r0usjsn3g2n34w7dypw52gam8ytgvrcrfslrq2ff",
     "asset_ids": [
       "terra1vzd98s9kqdkatahxs7rsd8m474lf2f8ct39zdgd6shj4nh5e6kuskaz2gy",
       "terra129zjaxquhh3h5upn0clqzdawnze43a9z34ktt4l6um2hf5w0xqjsta42u5"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1nvd25azm56h9fk7qn9r0usjsn3g2n34w7dypw52gam8ytgvrcrfslrq2ff"
   },
   {
     "id": "terra1u3wd9gu7weezw6vwfaaa4q589zjlazg6wt6gyer3lc42tgqrpggqv90c2c",
-    "lp_token_id": "terra1w2l4w5p66l5t2nmrmsvz7k4cu50s7e8dc6h59gcxsnmp2tgy7q7smfaxql",
     "asset_ids": [
       "uluna",
       "ibc/CBF67A2BCF6CAE343FDF251E510C8E18C361FC02B23430C121116E0811835DEF"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1w2l4w5p66l5t2nmrmsvz7k4cu50s7e8dc6h59gcxsnmp2tgy7q7smfaxql"
   },
   {
     "id": "terra1u9hwyy9yjjhh03hr4sqvk9trzrgjnmjesql9m05t03pz4yjr52gqgjlv8s",
-    "lp_token_id": "terra1qzn7zc70c5npg5tyc6pvwrpvfp7p9utkpcwlaugn9avn6r49609suh5g0r",
     "asset_ids": [
       "uluna",
       "terra1wu5cts7zr3sfmwlxfh7an3nthrx9cuz8fx7xfesmdudg2kzcwmhsaw24r8"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qzn7zc70c5npg5tyc6pvwrpvfp7p9utkpcwlaugn9avn6r49609suh5g0r"
   },
   {
     "id": "terra1uedcdmxu48uncd7ssxqx4cg9a33nvdkwq2x3k2xx4aa66klq2rzqh5srww",
-    "lp_token_id": "terra1np60v3wfrdp232m765ulrmvcwqz5ymkfvflfw59enhftnnn3sceq9gt7f0",
     "asset_ids": [
       "terra1qx284aak0wl7vrvlsc6cwcsn6xwajragkh6cjqj87m9p34hx5l2s22p3cp",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1np60v3wfrdp232m765ulrmvcwqz5ymkfvflfw59enhftnnn3sceq9gt7f0"
   },
   {
     "id": "terra1vrxe77hvfl4k98n9rdv4n47u8hy59tqv9eyrvl0u445ym543g93svz89m3",
-    "lp_token_id": "terra1erku46zd9ac98ts6mzj0fxv3rv37c4al5afff4xejhx5cveqefrqa9js3n",
     "asset_ids": [
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
       "terra129zjaxquhh3h5upn0clqzdawnze43a9z34ktt4l6um2hf5w0xqjsta42u5"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1erku46zd9ac98ts6mzj0fxv3rv37c4al5afff4xejhx5cveqefrqa9js3n"
   },
   {
     "id": "terra1w8246pdk9tf9d2dnu4lty5m8v3ptjltrm46vh8kd6yhr8k4ad2yskdqs6x",
-    "lp_token_id": "terra1gdj85sxs0tqhap50pv6jr6vrku4vqfrx5k62x0fu4gxt4l66qjgqqyz386",
     "asset_ids": [
       "terra1spkm49wd9dqkranhrks4cupecl3rtgeqqljq3qrvrrts2ev2gw6sy5vz3k",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1gdj85sxs0tqhap50pv6jr6vrku4vqfrx5k62x0fu4gxt4l66qjgqqyz386"
   },
   {
     "id": "terra1wm9dlwgtufjnjzuuee8ftqy3t9vq728vhyxv0tuqgzk7dt3fmwwsecqh8j",
-    "lp_token_id": "terra18jq3nawedex6s67f2rwkz3e7a57a5nxq40r9905yvyran5x7dh6sm7krj2",
     "asset_ids": [
       "terra1spkm49wd9dqkranhrks4cupecl3rtgeqqljq3qrvrrts2ev2gw6sy5vz3k",
       "terra1qj5hs3e86qn4vm9dvtgtlkdp550r0rayk9wpay44mfw3gn3tr8nq5jw3dg"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra18jq3nawedex6s67f2rwkz3e7a57a5nxq40r9905yvyran5x7dh6sm7krj2"
   },
   {
     "id": "terra1wmdc884tjwyqexalt89lkrdddpuqhrnzgl9nuq9wh0wmg6ug37ksku43rt",
-    "lp_token_id": "terra1rwz4h4xqlmlt6h475ckllxks8t8gulrg9dpgj5tkm8udf5mgcy7sj2rtva",
     "asset_ids": [
       "terra10k0kuaxr2lrgqlp9wqc0xxs3u5lwx434ttg2avc0mtttavykzh2qssgtku",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1rwz4h4xqlmlt6h475ckllxks8t8gulrg9dpgj5tkm8udf5mgcy7sj2rtva"
   },
   {
     "id": "terra1xjv2pmf26yaz3wqft7caafgckdg4eflzsw56aqhdcjw58qx0v2mqux87t8",
-    "lp_token_id": "terra1ttaekgrc60xc3xcflq069m49lwu79m5t552rjcws48rzhxcr4g6shmdw2v",
     "asset_ids": [
       "terra1qj5hs3e86qn4vm9dvtgtlkdp550r0rayk9wpay44mfw3gn3tr8nq5jw3dg",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ttaekgrc60xc3xcflq069m49lwu79m5t552rjcws48rzhxcr4g6shmdw2v"
   },
   {
     "id": "terra1yu58twelefzpkgnzphc99q57kyqqyqhl6fmsc64cz6jy3s90gv8srlvtps",
-    "lp_token_id": "terra1hhjh8hj0zdx2qh70gsuse4efer0dq93rwggkwd6w2jqpafa5gw4qhzn047",
     "asset_ids": [
       "terra1rwg5kt6kcyxtz69acjgpeut7dgr4y3r7tvntdxqt03dvpqktrfxq4jrvpq",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1hhjh8hj0zdx2qh70gsuse4efer0dq93rwggkwd6w2jqpafa5gw4qhzn047"
   },
   {
     "id": "terra1zdpq84j8ex29wz9tmygqtftplrw87x8wmuyfh0rsy60uq7nadtsq5pjr7y",
-    "lp_token_id": "terra1gte4eejaw3hrs2d8pt0zhp0yfd34xp24qdgqumjul29jt5hwl5tsx3qmw7",
     "asset_ids": [
       "terra1xumzh893lfa7ak5qvpwmnle5m5xp47t3suwwa9s0ydqa8d8s5faqn6x7al",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1gte4eejaw3hrs2d8pt0zhp0yfd34xp24qdgqumjul29jt5hwl5tsx3qmw7"
   },
   {
     "id": "terra1zmv0qqangw0fp78xtzyzksmzl6weev5pm6d6y44k4z4lvszv6gqq04m2l0",
-    "lp_token_id": "terra1kzwl8dk45sn3nrfpangz73za32kzcyz4t6lq8jq9ctrwrzv07c4qda7sy8",
     "asset_ids": [
       "terra1spkm49wd9dqkranhrks4cupecl3rtgeqqljq3qrvrrts2ev2gw6sy5vz3k",
       "terra1sdglum2dt4f3fmq7jrt2phf2tegmnudc7qqqqujkpqcm9ujuxxkqakv5u8"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1kzwl8dk45sn3nrfpangz73za32kzcyz4t6lq8jq9ctrwrzv07c4qda7sy8"
   },
   {
     "id": "terra1zrajvdc5yx0fsp429j6ej4nvrq68jjv078n94r00nl67d8cj6kmsalxtwt",
-    "lp_token_id": "terra1ep6pquxwgfljxzvgs7l7d0epp8spx3erysymhd8m6u4x94ztjxhqyhmyrp",
     "asset_ids": [
       "uluna",
       "terra1vzd98s9kqdkatahxs7rsd8m474lf2f8ct39zdgd6shj4nh5e6kuskaz2gy"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ep6pquxwgfljxzvgs7l7d0epp8spx3erysymhd8m6u4x94ztjxhqyhmyrp"
   },
   {
     "id": "terra1zrs8p04zctj0a0f9azakwwennrqfrkh3l6zkttz9x89e7vehjzmqzg8v7n",
-    "lp_token_id": "terra1a0fyanyqm496fpgneqawhlsug6uqfvqg2epnw39q0jdenw3zs8zqlykdyd",
     "asset_ids": [
       "uluna",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1a0fyanyqm496fpgneqawhlsug6uqfvqg2epnw39q0jdenw3zs8zqlykdyd"
   },
   {
     "id": "terra1zuhretv42g0puey36tsefx8hqt5wpskkr8z5qw4w2q3feyamw8ks4l2e6z",
-    "lp_token_id": "terra19dgcuxy7vlu2u4lpv407kcrg7yeaj9an72r0gver20thkejgprksvd06yv",
     "asset_ids": [
       "terra1ey8nrqhufmj0lfcn33x345hf7zhggz03nss03keavs3nxcml0w8spl0w58",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19dgcuxy7vlu2u4lpv407kcrg7yeaj9an72r0gver20thkejgprksvd06yv"
   },
   {
     "id": "terra17l9xj8f6m8smumhn8wgpgnswr3mu60wfkcm6pjc69drxp0t398rs7335vn",
-    "lp_token_id": "terra17ly9laewec70qu6tl0e3qrwh2vhz9akpf2jd7mxqram63xg2n0rsj36xvr",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "White Whale",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17ly9laewec70qu6tl0e3qrwh2vhz9akpf2jd7mxqram63xg2n0rsj36xvr"
   },
   {
     "id": "terra1ck8nkz35sa8mmqez3lqrm77vh36n2gd2f0dxjde4uemkwsjt22pqgk49zj",
-    "lp_token_id": "terra1rlmjwapg7y3p39aucq2rq5rffyns7z94twm8acl59na4d9aehu9sl2dfkc",
     "asset_ids": [
       "uluna",
       "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4"
     ],
     "dex": "White Whale",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1rlmjwapg7y3p39aucq2rq5rffyns7z94twm8acl59na4d9aehu9sl2dfkc"
   },
   {
     "id": "terra1e6t37fgjkxrzdx2s95fyq6jdra5s82720vhtmxvx4yhcvnsrey4ssmrya6",
-    "lp_token_id": "terra19glrs2vtgxaxww39cq5acxapgv2v8hyw562zmsk7ucn4yznmyv3sljewv9",
     "asset_ids": [
       "uluna",
       "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26"
     ],
     "dex": "White Whale",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19glrs2vtgxaxww39cq5acxapgv2v8hyw562zmsk7ucn4yznmyv3sljewv9"
   },
   {
     "id": "terra1frfcj4xhvx0emkup4vel5jun9zun0797j5yhn7ant3r4jzy9mkxqzcwev6",
-    "lp_token_id": "terra1adp223mw8937arxcfl36acjjyn2dcf7wzp8h09jek5k0gw3vch8sqlq6su",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "uluna"
     ],
     "dex": "White Whale",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1adp223mw8937arxcfl36acjjyn2dcf7wzp8h09jek5k0gw3vch8sqlq6su"
   },
   {
     "id": "terra1p2xgcr2ewnetug8ahqms5y3k6rxyh2xglnzzx500ylh4420h9ucqz8w7x5",
-    "lp_token_id": "terra1avfsch3ee82wyrpwlawecyz6zktr9jln0zaxp58xuvmxyl5g305q3rwuj3",
     "asset_ids": [
       "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       "ibc/4CD525F166D32B0132C095F353F4C6F033B0FF5C49141470D1EFDA1D63303D04"
     ],
     "dex": "White Whale",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1avfsch3ee82wyrpwlawecyz6zktr9jln0zaxp58xuvmxyl5g305q3rwuj3"
   },
   {
     "id": "terra1qzux5j9he9nv95kq3unkuzy0hddf080um2t243raatg3f6requwsaahpqp",
-    "lp_token_id": "terra1lt586fhwyuccktk58v8k96ugzp9szurhqvmlnjxhyn6yapa6v2jsmc468d",
     "asset_ids": [
       "uluna",
       "terra14xsm2wzvu7xaf567r693vgfkhmvfs08l68h4tjj5wjgyn5ky8e2qvzyanh"
     ],
     "dex": "White Whale",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1lt586fhwyuccktk58v8k96ugzp9szurhqvmlnjxhyn6yapa6v2jsmc468d"
   }
 ]

--- a/terraclassic/asset.json
+++ b/terraclassic/asset.json
@@ -1150,8 +1150,8 @@
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
     "icon": "https://raw.githubusercontent.com/stader-labs/assets/main/terra/LunaX_1.png",
-    "coingecko": "https://www.coingecko.com/en/coins/stader",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/stader/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/stader/",
+    "coingecko": "https://www.coingecko.com/en/coins/stader"
   },
   {
     "id": "terra1ustvnmngueq0p4jd7gfnutgvdc6ujpsjhsjd02",
@@ -1533,8 +1533,8 @@
     "decimals": "6",
     "circ_supply_api": "https://api.anchorprotocol.com/api/v1/anc",
     "icon": "https://whitelist.anchorprotocol.com/logo/ANC.png",
-    "coingecko": "https://www.coingecko.com/en/coins/anchor-protocol",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/anchor-protocol/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/anchor-protocol/",
+    "coingecko": "https://www.coingecko.com/en/coins/anchor-protocol"
   },
   {
     "id": "terra1587zn7hagaylrp22x5edz25zpqfn6szfmvtym4",
@@ -2592,8 +2592,8 @@
     "symbol": "SB",
     "decimals": "6",
     "icon": "https://s2.coinmarketcap.com/static/img/coins/64x64/14451.png",
-    "coingecko": "https://www.coingecko.com/en/coins/dragonsb",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/dragonsb/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/dragonsb/",
+    "coingecko": "https://www.coingecko.com/en/coins/dragonsb"
   },
   {
     "id": "terra1nh6theuhf4pv67pcyqnz58czljr382mxrp2rdh",
@@ -3932,8 +3932,8 @@
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/luna",
     "icon": "https://assets.terra.money/icon/svg/LUNC.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/terra-luna",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-luna/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-luna/",
+    "coingecko": "https://www.coingecko.com/en/coins/terra-luna"
   },
   {
     "id": "terra1ex5age9gqd5em86wg8hu0ak5wrqez9yufvlrat",
@@ -4009,8 +4009,8 @@
     "decimals": "6",
     "circ_supply_api": "https://source.lunaverse.io/circulation",
     "icon": "https://lunaverse.io/assets/images/logo.png",
-    "coingecko": "https://www.coingecko.com/en/coins/lunaverse",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/lunaverse/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/lunaverse/",
+    "coingecko": "https://www.coingecko.com/en/coins/lunaverse"
   },
   {
     "id": "terra1kd4rfff04cvw7vae0szgawj0xye90fkchljv7y",
@@ -4043,8 +4043,8 @@
     "symbol": "LUNI",
     "decimals": "6",
     "icon": "https://d2s3n99uw51hng.cloudfront.net/static/100_100_LUNI_logo.png",
-    "coingecko": "https://www.coingecko.com/en/coins/luni",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/luni"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/luni",
+    "coingecko": "https://www.coingecko.com/en/coins/luni"
   },
   {
     "id": "terra1ykl7ee0dakfev97ektynnup8hscyuhc9kly9k4",
@@ -4117,8 +4117,8 @@
     "decimals": "6",
     "circ_supply_api": "https://api.marsprotocol.io/graphql",
     "icon": "https://marsprotocol.io/MARSTokenMini.svg",
-    "coingecko": "https://www.coingecko.com/en/coins/mars-protocol",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/mars-protocol/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/mars-protocol/",
+    "coingecko": "https://www.coingecko.com/en/coins/mars-protocol"
   },
   {
     "id": "terra1qs7h830ud0a4hj72yr8f7jmlppyx7z524f7gw6",
@@ -4321,8 +4321,8 @@
     "decimals": "6",
     "circ_supply_api": "https://graph.mirror.finance/graphql",
     "icon": "https://whitelist.mirror.finance/icon/MIR.png",
-    "coingecko": "https://www.coingecko.com/en/coins/mirror-protocol",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/mirror-protocol/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/mirror-protocol/",
+    "coingecko": "https://www.coingecko.com/en/coins/mirror-protocol"
   },
   {
     "id": "terra1h4hvry62zk4zh0udecqmatfg02phnyu6hq74xd",
@@ -4722,8 +4722,8 @@
     "decimals": "8",
     "circ_supply_api": "https://app.orion.money/circulating-supply.txt",
     "icon": "https://orion.money/assets/ORION-LOGO-2.1-GREEN@256x256.png",
-    "coingecko": "https://www.coingecko.com/en/coins/orion-money",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/orion-money/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/orion-money/",
+    "coingecko": "https://www.coingecko.com/en/coins/orion-money"
   },
   {
     "id": "terra1yhlhrea3rgyx2xdnsswsfakn28qa8z7yp5gmhd",
@@ -5070,8 +5070,8 @@
     "decimals": "6",
     "circ_supply_api": "https://api.pylon.money/api/mine/v1/overview",
     "icon": "https://assets.pylon.rocks/logo/MINE.png",
-    "coingecko": "https://www.coingecko.com/en/coins/pylon-protocol",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/pylon-protocol/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/pylon-protocol/",
+    "coingecko": "https://www.coingecko.com/en/coins/pylon-protocol"
   },
   {
     "id": "terra1u9hgxjw5k0aje9xjf0ejfu6uwmamc2k8ylzd7l",
@@ -5177,8 +5177,8 @@
     "decimals": "6",
     "circ_supply_api": "https://robohero-io-api.vercel.app/token/circulatingsupply",
     "icon": "https://i.ibb.co/nmhRXB9/token.png",
-    "coingecko": "https://www.coingecko.com/en/coins/robohero",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/robohero/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/robohero/",
+    "coingecko": "https://www.coingecko.com/en/coins/robohero"
   },
   {
     "id": "terra1gpwkclxwwuzd5wyjw2qn3km0r5ge4t4f4mnf0x",
@@ -5523,8 +5523,8 @@
     "decimals": "6",
     "circ_supply_api": "https://api.spec.finance/api/stat?format=txt&type=circulation",
     "icon": "https://terra.spec.finance/assets/SPEC.png",
-    "coingecko": "https://www.coingecko.com/en/coins/spectrum-token",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/spectrum-token/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/spectrum-token/",
+    "coingecko": "https://www.coingecko.com/en/coins/spectrum-token"
   },
   {
     "id": "terra1k9ltsdc6e4ay4g8f8nt8qd7my9yyd27m7eh82d",
@@ -5679,8 +5679,8 @@
     "decimals": "6",
     "circ_supply_api": "https://api.starterra.io/cmc?q=circulating",
     "icon": "https://starterra.io/assets/100x100_starterra.png",
-    "coingecko": "https://www.coingecko.com/en/coins/starterra",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/starterra/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/starterra/",
+    "coingecko": "https://www.coingecko.com/en/coins/starterra"
   },
   {
     "id": "terra146fhkmq8d7ae3e6jemufy4h5eq9zerftm8wzmt",
@@ -7448,8 +7448,8 @@
     "symbol": "whCREDI",
     "decimals": "8",
     "icon": "https://i.ibb.co/M7JKGWM/e1-Qb-Z4q-Q-400x400.jpg",
-    "coingecko": "https://www.coingecko.com/en/coins/credefi",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/credefi/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/credefi/",
+    "coingecko": "https://www.coingecko.com/en/coins/credefi"
   },
   {
     "id": "terra1efjugpjc50d8sha7lr8s48cr7wmsthz94eevcl",
@@ -7457,8 +7457,8 @@
     "symbol": "whDAO",
     "decimals": "8",
     "icon": "https://etherscan.io/token/images/daomaker_128.png",
-    "coingecko": "https://www.coingecko.com/en/coins/dao-maker",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/dao-maker/"
+    "coinmarketcap": "https://coinmarketcap.com/currencies/dao-maker/",
+    "coingecko": "https://www.coingecko.com/en/coins/dao-maker"
   },
   {
     "id": "terra1gtjr689cyaau20k8ezdxy8eup34tntun5xr9l2",

--- a/terraclassic/asset.json
+++ b/terraclassic/asset.json
@@ -1,76 +1,5 @@
 [
   {
-    "id": "terra1cmf8ytutcwrjrv08zskj9phuh46a3w3nkjax7en4hxezsrdr58lqvzy05q",
-    "entity": "alentejo.money",
-    "name": "alentejo.money",
-    "symbol": "Alem",
-    "decimals": "6",
-    "icon": "https://static.wixstatic.com/media/1e62a0_42c272173eb244a893daa63902538ffe~mv2.png/v1/fill/w_560,h_560,fp_0.50_0.50,enc_auto/1e62a0_42c272173eb244a893daa63902538ffe~mv2.png"
-  },
-  {
-    "id": "terra1ftd8l9xny6dhc2299m9rd59aknutl8fvrc7h9ywammxcus5se9ese03yfd",
-    "entity": "Astroport",
-    "name": "ALEM-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1q6hpxkcx5a0g8u0m0n30cl6afafufpl5yl4lza2umk5up9tzerwqszqvr7",
-    "entity": "Astroport",
-    "name": "AMPL-LUNA-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1e9ge099thjrfx9y74aznq38esfkm55lpqvdvun078aw0nejdhu0qsn5n9d",
-    "entity": "Astroport",
-    "name": "AMPL-STEA-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16esjk7qqlgh8w7p2a58yxhgkfk4ykv72p7ha056zul58adzjm6msvc674t",
-    "entity": "Astroport",
-    "name": "ASTR-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1kusqucsy7x5yhfl4lu064f0kyhdx7mhj67z7uclhhxr8mm3ayatq4zse64",
-    "entity": "Astroport",
-    "name": "ASTR-RED-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra17ymsjrzhtz04wt6ftamthph5sfnuem0f0xgr4ajvas9uzjll6p0sdu36ff",
-    "entity": "Astroport",
-    "name": "ASTR-USD-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1fw969f420dy50t4glu0nct9whdftsralf2sdywxh5zklzyj7350sp94ycs",
-    "entity": "Astroport",
-    "name": "ASTR-USDC-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1sdajd4wfkxvwzd3em9h9qdpsf0mavuc9ukt8hpcxklp2znd7lrhsgkudn0",
-    "entity": "Astroport",
-    "name": "ASTR-VKR-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1wkcyh5l9204m6ef5aujdlnh3frswyhpl8xp7evr7rk0qmyqyhrkqg287g8",
-    "entity": "Astroport",
-    "name": "ASTR-XAST-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
     "id": "terra17raumdxxxlm8smtx2pcxmqpz7qq9am4zfxzl8d",
     "entity": "Astroport",
     "name": "Astroport",
@@ -116,391 +45,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra19lpvantkz339ze3wssmjxph7wqaj6ahs6qwdyz9cvf7szfczzmxs0u5hzz",
-    "entity": "Astroport",
-    "name": "BGT-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1z3nctlwtasqshsagu2l4lj74pdm8hl7jhjyeepergtkny4cyka0se48n37",
-    "entity": "Astroport",
-    "name": "BGT-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1mckjrtvxvsxtxvc5jttxmvheyh4wjcrlrnfy28xnln5a87qhxz6s4el0sy",
-    "entity": "Astroport",
-    "name": "BLUN-AMPL-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1h3z2zv6aw94fx5263dy6tgz6699kxmewlx3vrcu4jjrudg6xmtyqk6vt0u",
-    "entity": "Astroport",
-    "name": "BLUN-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1tr7355as8t6k9y94wru5humch34yacrv3mwz9n690fugwcc8mrvs296qz8",
-    "entity": "Astroport",
-    "name": "BLUN-XAST-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra13f7dedzar82afsedw4kn388zvfg94r8uusefa8nj0zysrayqaszsvcje3e",
-    "entity": "Astroport",
-    "name": "BOND-USD-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1tf2lj6lp4y29kw36ue6tjsa97ad4e5fha6te08h26pg6y4v7c23qhu2k4j",
-    "entity": "Astroport",
-    "name": "BTC-UETH-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra18cl4602q8gfaxgm5gvh254s5qf9xhrhmlntsdpmduqgxa2qg9dgqkraadh",
-    "entity": "Astroport",
-    "name": "BTC-USD-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1eavy3qvhwcvmvah8hgru8x6sc3cnluxfyqlkctur0e4jkcqvwgxqxmc3hl",
-    "entity": "Astroport",
-    "name": "BTC-USDC-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14hq8h7sjvkjv9dv90mcy3lt74fyevktrg9685rzeshx0y2vpkl9sg38zmv",
-    "entity": "Astroport",
-    "name": "BURN-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1yhpasjvjfc84ywwxl07tfy50zqqhh7l8k0280tfqyr8t5uu6gf4s6u0hxh",
-    "entity": "Astroport",
-    "name": "CLUN-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra17rlm3qv3c9epnkpc2l3h3n9zjn3ldjugwhxtuuw6mhhm2vskjkws04xzza",
-    "entity": "Astroport",
-    "name": "DUST-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ahr8gc72dht7s3fxhqp95xrnvn25uf3tw5elg3vfgtqm2qqk36yszxlcuq",
-    "entity": "Astroport",
-    "name": "FATM-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1xq08x97luxlraz7d79x240ntdaf8k8w0jtqmgtzr46drkz86xxqslh4fwt",
-    "entity": "Astroport",
-    "name": "GEA-GEB-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1rw5h8yrwkemd7nqmr2k70az2pel8r875qutu03cwjkczve4fev5q9m024s",
-    "entity": "Astroport",
-    "name": "GEA-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14qulp86csugtkn6mz2czdsf0rudwu8kt89ccrzdfrf5v9tt3jvxqnk94ce",
-    "entity": "Astroport",
-    "name": "GEB-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1r2e983ghd0jsk7r6k36zw4lnqf8y9raghzdnrusgsg97465uuvfq8nuls7",
-    "entity": "Astroport",
-    "name": "GIDO-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra15hgjqvr89q5t4qmvyt0qnmmlx34dyyn7e6x9z3fnqn5wtgj6lllqa95dm8",
-    "entity": "Astroport",
-    "name": "IBC/-BUSD-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra135t2lyz8638ad0l7nasth49agcm6cn36zdp9mtxd6gdxx0tzhlmqs3dq0q",
-    "entity": "Astroport",
-    "name": "IBC/-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra15me9trrk8nrtmwcgx248n98unlgw4a65vef8942rk336tytynqysqc53pq",
-    "entity": "Astroport",
-    "name": "IBC/-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1khsxwfnzuxqcyza2sraxf2ngkr3dwy9f7rm0uts0xpkeshs96ccsqtu6nv",
-    "entity": "Astroport",
-    "name": "IBC/-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14tu8x3hgzycpqlu6z87fm66uzthu409lk58u7uut5y9ev0swkxeq25axte",
-    "entity": "Astroport",
-    "name": "IBC/-LIRA-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ctkly6fuddqfpsq9fjjsqudx9zsl5crma0z4jl29zky3k8ezfe5s23gd7s",
-    "entity": "Astroport",
-    "name": "IBC/-LIRA-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra10rwjgm2nzweq04fqlqykld7azm4t0yhj8gwnyg9k7c4w4laht3aqrmwjyn",
-    "entity": "Astroport",
-    "name": "IBC/-OPZA-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1p2n59z2dnx9rt8m8qnztpyw9jgwt0gypenf3q6q0wpkqjcypkqvsq8u3pf",
-    "entity": "Astroport",
-    "name": "IBC/-TPT-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1s5ywajpamm25ny872ek26a56a7y3368h6eu4su2eff5ua8jw8yyqlxmtwr",
-    "entity": "Astroport",
-    "name": "IBC/-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1n9yykacl3ft9fw95sr0eckqsd6p9l62ehdhf5u6k6akmvupqr7as9ygupx",
-    "entity": "Astroport",
-    "name": "IBC/-USD-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1yj078tseqc85x9r54u06jhektnqhvcxayxqwycg0y3yt9867pglqcuqym5",
-    "entity": "Astroport",
-    "name": "IBC/-USDC-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1v4ytr73tfkms7e5qhuy7qnmfkfgf6fs5ut9av6u78j9tv9ahwrlqazaycp",
-    "entity": "Astroport",
-    "name": "IBC/-USDT-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1r8m2zuy0wmrv5p3uxzctmpltztwd8x4hh0sw05hs7q9y7qq0m3hqws0lty",
-    "entity": "Astroport",
-    "name": "IBC/-UST-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1gglgnmzuzfdu0v4v59c2442m9zj7sp7un256m0rvk6hg9jlh0wqsu4tsx3",
-    "entity": "Astroport",
-    "name": "IDC-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1l0dv709pqv2gcs86jr9w3k67jr7tk62vem0h8ntzzkpl443f27vsy47gsm",
-    "entity": "Astroport",
-    "name": "IDC-OPZA-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16arnls40rkd07japhu3g4hf5j9ypqfmtfvl9hp9egmtg2m9eenvsaj72xu",
-    "entity": "Astroport",
-    "name": "IDC-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1t906pc4s8ptgrr8gx8m52hvvse8ytq5za86fmudm2wr4vw2kyqzqyph4ml",
-    "entity": "Astroport",
-    "name": "LOCA-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1s3fy4zc643suxfz7wsvhhgvhd0zv8jwrcl8ugdfq6z6nl3nxkg0q3s9nl2",
-    "entity": "Astroport",
-    "name": "LUBI-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1kv246hnusfqh3d97ww0u59hgaqf335844hmj4mrsadvnjwaf2n0qtyhrg5",
-    "entity": "Astroport",
-    "name": "LUNA-BLUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16hnd8a8cy0z5u6t56mcv28yencp8dwv4rtjs4kftxmqn5mhnga3q0ceajp",
-    "entity": "Astroport",
-    "name": "LUNA-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1lgsccchaws9nnm74aj7uhdj289jd99893ngkv2am9j40cn0sza8sxkzc9r",
-    "entity": "Astroport",
-    "name": "LUNA-UST-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1zweae4lq0p3pa493njmjexywk9wmr6cznhp6pz50hmyvelluf8qqq82mpg",
-    "entity": "Astroport",
-    "name": "LUNA-XAST-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qaudeq98hht76r9efvexhkf8k7waqq6cexqztgp5t6v0ptt7ljxq95nqlw",
-    "entity": "Astroport",
-    "name": "MAAP-UST-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qqh6vpync8tylpdfv9mjemml02xutzmufetrp35na09k2cnlnl7qxh0lqy",
-    "entity": "Astroport",
-    "name": "MINE-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1alu4y2ncdyaamv9tgkxwefcazc433n5t9mpmpahnsy2dsng0m3rswmxpfp",
-    "entity": "Astroport",
-    "name": "MMSF-UST-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1n3zc3fey96mnfm094jka7hmezu38sdnswz3mp3my9hjuryd5gxjqxhx4ut",
-    "entity": "Astroport",
-    "name": "MOON-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14v6sh40tydg22c9ws2yhj8qgyhj8wsgand8uhmcvl4wad3209dzs0an099",
-    "entity": "Astroport",
-    "name": "MUSK-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra10ht5t5vzpt6lfh8r6lau6mtsha3rqeznhkw5whc65scgrtkqradq0zy9pa",
-    "entity": "Astroport",
-    "name": "ORNE-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1zf35dfsvk69c5dgytka82762922l2r4cj3v24un0uycln9hy695qkwlpga",
-    "entity": "Astroport",
-    "name": "PCE-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra17786erkmuydha7cwlgvvnler20cktz5egdea7pxs7ely9xu3v7eswdqa8h",
-    "entity": "Astroport",
-    "name": "PLUN-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1aqu49fznmzfgxky72fd3f4rjewexueu9c7yzjs59z2hqxv6ktxpsfffw87",
-    "entity": "Astroport",
-    "name": "PLUN-YLUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qnxq4gjc72nraczff0gefthv0d83gxn3gzpqe70n9wynlvh2afjq86elkt",
-    "entity": "Astroport",
-    "name": "PN-U-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14a40x0uxgz3h76dk6l2u8qukkzsscrn3kdzv7ct85dltyrcqdpgs8uenjs",
-    "entity": "Astroport",
-    "name": "RED-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ua7uk7xvx89dg8tnr8k8smk5vermlaer50zsglmpx8plttaxvvtsem5fgy",
-    "entity": "Astroport",
-    "name": "RED-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1eex8w4vqukz54pzzngt8xzmp4w9wz2mp5hcde7wwqhmepzm0ec9qarwx3v",
-    "entity": "Astroport",
-    "name": "SD-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1fltdf8rkxz4ss06vtf2a4qt9tdplt52saefq650vyf47y4mt7q2qk0gtfv",
-    "entity": "Astroport",
-    "name": "SDO-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra109sh4nxudwcqrq0v8gdna46sc3mhs9qh49jrv3m6546asc3kk87s3z28hr",
-    "entity": "Astroport",
-    "name": "SOL-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1s7q7vl49xfqheeskh8dxss473kuaxhgd3qtrx5rpg0u57fwt7zeqzm7u9t",
-    "entity": "Astroport",
-    "name": "SOL-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
     "id": "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7",
     "entity": "Astroport",
     "name": "Staked Astroport",
@@ -515,41 +59,6 @@
     "symbol": "xASTRO",
     "decimals": "6",
     "icon": "https://app.astroport.fi/tokens/xAstro.png"
-  },
-  {
-    "id": "terra1v7uxpztn2xk8v05y3ak8dkjlfrdsnyl9stv63np0kfp6yzh0rz8qph3upx",
-    "entity": "Astroport",
-    "name": "STEA-ASTR-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1dpvp8xra378kadfmn0c93n9qvf942r04vkznh75c2s4cy3atq72sq3jetx",
-    "entity": "Astroport",
-    "name": "STEA-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra182wam9eklls989k5qqrcv5s64a9cat6ctw4zr3paa6k79dxt4k0q4kd97a",
-    "entity": "Astroport",
-    "name": "STEA-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1w45txv24j32l27kmnj23rrrpz34c0hf2aj2tmqf466g758ndhgzsu5y42s",
-    "entity": "Astroport",
-    "name": "TCW-AUTO-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1339twwfe6rqgj4ge7qe5mdzu238ke2farlnwm7k2allh9un96w9sywjsff",
-    "entity": "Astroport",
-    "name": "TCW-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
   },
   {
     "id": "null",
@@ -1462,394 +971,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra153zpj7f0shmfrt95s2jmets2k7fuuclerxh295n7hltf0z7p9xdsdngtdr",
-    "entity": "Astroport",
-    "name": "TFLO-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1y0hu67n6jq49a3ml43py4jzkr43a4qn38clvxsmd567rr4kdtj5sn4ehez",
-    "entity": "Astroport",
-    "name": "TKNA-TKNB-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1cjz82w795jcsxp09dpps697qwx55aryprvypl3n07my4zwrxfchs34lqcc",
-    "entity": "Astroport",
-    "name": "TPT-OPZA-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ces6k6jp7qzkjpwsl6xg4f7zfwre0u23cglg69hhj3g20fhygtpsu24dsy",
-    "entity": "Astroport",
-    "name": "TPT-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1n6sa5dykwq87w8v08xqr2jnhwv2r7kzznvvqz7dvhkqch8kapwjs6xtl5s",
-    "entity": "Astroport",
-    "name": "TPT-XTPT-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra13qn86nhlj09kh6ea3pzvswj48yzyrh49rnhjwh9qv7gvu54qgq2qrmet53",
-    "entity": "Astroport",
-    "name": "TUNA-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1paat6jjgnfvavhfncdxhx4djpzansv9h06vge5grf3daqn8suezql2t7gx",
-    "entity": "Astroport",
-    "name": "TUNA-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra18e6uqw3sx6xgg57t7rglstmqgqrm4ks9428am8crg2aeuqkxk37qzhq9xx",
-    "entity": "Astroport",
-    "name": "TUNA-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra13406847ntuyct7qgefrks05cfuca7jtf4u9zqnahud2c7vnarkysj2c8gj",
-    "entity": "Astroport",
-    "name": "UETH-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1cq22eugxwgp0x34cqfrxmd9jkyy43gas93yqjhmwrm7j0h5ecrqq5j7dgp",
-    "entity": "Astroport",
-    "name": "ULUN-AMPL-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1fs0p7gammucw7get7mq7rzdk6rexxgszp003zr3859qyfc02ur2sdha672",
-    "entity": "Astroport",
-    "name": "ULUN-ASTR-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra15sytd365u3nw8xku492cj9nec6pgn9py6w5qka83fd9d26yr8cgsu5apxc",
-    "entity": "Astroport",
-    "name": "ULUN-BLUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1xnjmgzzukpnp92mlhsu9ghmlg29h5hdtrv8n34mhvgmsctug4prq9prw2l",
-    "entity": "Astroport",
-    "name": "ULUN-BLUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1psd6waufk7hnhquh82wgnpt6qhevplnsjkwp6vw3enk2czxkjvmqzmyvkr",
-    "entity": "Astroport",
-    "name": "ULUN-BUSD-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra12lq8l9tc3z9h8cy4qt9khmalrzv2nszdu8rl2yfsmjvcn0vffnfqhznup3",
-    "entity": "Astroport",
-    "name": "ULUN-GIDO-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ngp9lsp72hjjate0jlmhz27ra6mjap97ptg0r4nuytf3kuk2md6sz8twrv",
-    "entity": "Astroport",
-    "name": "ULUN-HERO-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ckmsqdhlky9jxcmtyj64crgzjxad9pvsd58k8zsxsnv4vzvwdt7qke04hl",
-    "entity": "Astroport",
-    "name": "ULUN-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1yfm49ecnsaxjh83raczdxy6jgq2rykp8kc2pmlw62rxu3dyy4laq9fzmu2",
-    "entity": "Astroport",
-    "name": "ULUN-LIRA-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1kggfd6z0ad2k9q8v24f7ftxyqush8fp9xku9nyrjcs2wv0e4kypszfrfd0",
-    "entity": "Astroport",
-    "name": "ULUN-LUNA-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra12vc5agylj7g9xudc0lf06n76dfvplmqxcpcsuy9805sljrukhgxq3sfy5y",
-    "entity": "Astroport",
-    "name": "ULUN-USD-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1cfs2gjc96wca6ahq0hzjcj56wy37fj76slvtfq22hpfrly7vfzeqa9ruz7",
-    "entity": "Astroport",
-    "name": "ULUN-USDC-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra120c58hp4d6e4c5uksdvcfhqkruxxhm3fljlmywza5x25gdm45tts8f9jkg",
-    "entity": "Astroport",
-    "name": "ULUN-USDT-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1pccqe4pufnw05wwl0xe9uc99lngnddpn8az48fe3svpeca0hq0tqrfeznp",
-    "entity": "Astroport",
-    "name": "USD-UETH-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1g79v06mvtn0jm6q274axyyg00l2yv5lgrxhl53ht728sxr8ke4fs8pgazj",
-    "entity": "Astroport",
-    "name": "USD-USDC-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1mnysxy8lrsx0vzsgpnln8c6p40rm5z00umhpmks6he6utr0cw56scfpt48",
-    "entity": "Astroport",
-    "name": "USDC-BUSD-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1wv46n9zggd8sx30d8gfgzeyu2a7rmdc8makk7cl4qgtlnw342kpq94faz0",
-    "entity": "Astroport",
-    "name": "USDC-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1pqd0vm00z7urf8u8wmg4m4kpavr7g5myrcz9he4xzyq9etkafyds0hkkk9",
-    "entity": "Astroport",
-    "name": "USDC-UETH-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1v6z888r63vzc094w2cll9z42xjwc7kuf8feccyh9f5ehkqmwqcdst2afjf",
-    "entity": "Astroport",
-    "name": "USDC-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ef5veuvpudt392jvwrzfw79e0glcdjthgq0cyj3xs8uc98p7x3tqg293tl",
-    "entity": "Astroport",
-    "name": "USDC-USDT-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1vuh08zt4qcsmmu0g4p8k62mpzkj2v3rff4dg4srzdd2xenlm5qeqlwjht3",
-    "entity": "Astroport",
-    "name": "USDT-BUSD-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1r3v8yfhvkmx6gy2sa93d062sjf60c7atm3xage4pn3rsuum8ktvqesvl8h",
-    "entity": "Astroport",
-    "name": "UST-ASTR-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra19ugc0gmww0f94pckazqfa4elnvt3rlrd6wp23w0ry88j3dfuya5sm7nyns",
-    "entity": "Astroport",
-    "name": "UST-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ljjau3mzxv2rpje5p67vfa2uc82uvct5l70z5cqegd0pnus3u26svpura9",
-    "entity": "Astroport",
-    "name": "UST-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1vd0pgkrg0t0ekz5gefudvw0crlzvcqztc5ngec34memth5ft6mnqtjmd2m",
-    "entity": "Astroport",
-    "name": "UST-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra18mcmlf4v23ehukkh7qxgpf5tznzg6893fxmf9ffmdt9phgf365zqvmlug6",
-    "entity": "Astroport",
-    "name": "VKR-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra10e606vcy44er2p570a7g2dkugcvua4k0u0y3gvq9r606uemv3wus967av2",
-    "entity": "Astroport",
-    "name": "VKR-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra18pr2eu0js9laz3u4k5tcwyuqfup484z8qm66vtkwcfeukmpgyapq70wj44",
-    "entity": "Astroport",
-    "name": "WAVA-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1njqfs4v35leu654394yx0lyccvcau3j9u5v0k4gnx0dcl55rkqrqxwswd6",
-    "entity": "Astroport",
-    "name": "WAVA-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1cs9wyhlcdz7w5arfgs7c9u0x7l2ev8atd6vzqd8pl702zpe69ndqpln7ky",
-    "entity": "Astroport",
-    "name": "WETH-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1857ysefuel7ywk2qhj2zqfa5z2vcpesys7h38v5jdtttatadm36sq0j8vz",
-    "entity": "Astroport",
-    "name": "WETH-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1jv3ulmux29vtp89hgnmn9847ww7w5a9p433l7lgjrpzuxfagcs0sc77g48",
-    "entity": "Astroport",
-    "name": "XAST-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra19ruafuuna67knun0e4falancl0u39jtnar9euv8s3h08le46wyfq7lyn4u",
-    "entity": "Astroport",
-    "name": "XAST-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ysdymqfph9jwlkynm9rm8gskf38pulzc8p2t707wtu00j6n6w8vsyke4zp",
-    "entity": "Astroport",
-    "name": "XTPT-XAST-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra12xcl4p6wmksle9a4vax4vr9umju30s4mv495pmnmkjj9587ugkrqg7jz3l",
-    "entity": "Astroport",
-    "name": "YN-U-PN-U-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "ibc/2E9CD07D7A6572A4CDAABBF0FBB89F69A9A362818132221182654819E277220A",
-    "entity": "Axelar",
-    "name": "Axelar AAVE",
-    "symbol": "axlAAVE",
-    "decimals": "18",
-    "icon": "https://assets.terra.money/icon/svg/ibc/axlAAVE.svg"
-  },
-  {
-    "id": "ibc/1FD62537E1FBE67DF7574E0234112B4FE417B20AADC2F574026CB664EA9492C7",
-    "entity": "Axelar",
-    "name": "Axelar ChainLink",
-    "symbol": "axlLINK",
-    "decimals": "18",
-    "icon": "https://assets.terra.money/icon/svg/ibc/axlLINK.svg"
-  },
-  {
-    "id": "ibc/E46EF5449878F6B81219163F211E7329CC0729AA99DA8A589A865F82F754ADE8",
-    "entity": "Axelar",
-    "name": "Axelar DAI",
-    "symbol": "axlDAI",
-    "decimals": "18",
-    "icon": "https://assets.terra.money/icon/svg/ibc/axlDAI.svg"
-  },
-  {
-    "id": "ibc/2E435CEEEBA18CCB2719E0182BC5D142A364D6CCE9957DE6E1AC4D62127D2913",
-    "entity": "Axelar",
-    "name": "Axelar Frax",
-    "symbol": "axlFRAX",
-    "decimals": "18",
-    "icon": "https://assets.terra.money/icon/svg/ibc/axlFRAX.svg"
-  },
-  {
-    "id": "ibc/14E4FD1AB72DE9BF1D6725CBA18373C406CB9A7DA17955299F3F4DC5C6131A4E",
-    "entity": "Axelar",
-    "name": "Axelar Matic",
-    "symbol": "axlMATIC",
-    "decimals": "18",
-    "icon": "https://assets.terra.money/icon/svg/ibc/axlMATIC.svg"
-  },
-  {
-    "id": "ibc/6EFF21F9E65C9101370C38AA53049E4D1FF2B206A7C350B45F0ED3660E57AC75",
-    "entity": "Axelar",
-    "name": "Axelar Uniswap",
-    "symbol": "axlUNI",
-    "decimals": "18",
-    "icon": "https://assets.terra.money/icon/svg/ibc/axlUNI.svg"
-  },
-  {
-    "id": "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
-    "entity": "Axelar",
-    "name": "Axelar USD Coin",
-    "symbol": "axlUSDC",
-    "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/ibc/axlUSDC.svg"
-  },
-  {
-    "id": "ibc/CBF67A2BCF6CAE343FDF251E510C8E18C361FC02B23430C121116E0811835DEF",
-    "entity": "Axelar",
-    "name": "Axelar USD Tether",
-    "symbol": "axlUSDT",
-    "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/ibc/axlUSDT.svg"
-  },
-  {
-    "id": "ibc/05D299885B07905B6886F554B39346EA6761246076A1120B1950049B92B922DD",
-    "entity": "Axelar",
-    "name": "Axelar Wrapped Bitcoin",
-    "symbol": "axlWBTC",
-    "decimals": "8",
-    "icon": "https://assets.terra.money/icon/svg/ibc/axlWBTC.svg"
-  },
-  {
-    "id": "ibc/BC8A77AFBD872FDC32A348D3FB10CC09277C266CFE52081DE341C7EC6752E674",
-    "entity": "Axelar",
-    "name": "Axelar Wrapped Ethereum",
-    "symbol": "axlWETH",
-    "decimals": "18",
-    "icon": "https://assets.terra.money/icon/svg/ibc/axlETH.svg"
-  },
-  {
     "id": "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
     "entity": "boneLuna",
     "name": "Bonded Luna",
@@ -1859,23 +980,7 @@
     "icon": "https://whitelist.anchorprotocol.com/logo/bLUNA.png"
   },
   {
-    "id": "terra17aj4ty4sz4yhgm08na8drc0v03v2jwr3waxcqrwhajj729zhl7zqnpc0ml",
-    "entity": "boneLuna",
-    "name": "boneLuna",
-    "symbol": "bLUNA",
-    "decimals": "6",
-    "icon": "https://i.imgur.com/8CpJdcB.jpeg"
-  },
-  {
     "id": "ibc/18ABA66B791918D51D33415DA173632735D830E2E77E63C91C11D3008CFD5262",
-    "entity": "Cosmos",
-    "name": "Cosmos",
-    "symbol": "ATOM",
-    "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/ibc/ATOM.svg"
-  },
-  {
-    "id": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
     "entity": "Cosmos",
     "name": "Cosmos",
     "symbol": "ATOM",
@@ -1891,28 +996,12 @@
     "icon": "https://assets.terra.money/icon/svg/ibc/ATOM.svg"
   },
   {
-    "id": "ibc/B090DC21658BD57698522880590CA53947B8B09355764131AA94EC75517D46A5",
-    "entity": "Crescent Network",
-    "name": "Crescent Network",
-    "symbol": "CRE",
+    "id": "terra1ecgazyd0waaj3g7l9cmy5gulhxkps2gmxu9ghducvuypjq68mq2s5lvsct",
+    "entity": "Eris Protocol",
+    "name": "Eris Amplified LUNA",
+    "symbol": "ampLUNA",
     "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/ibc/CRE.svg"
-  },
-  {
-    "id": "terra1ttspm8jgeylc6us3mlpwpmlwzr3rkesm70vn6zkfr07pz7e3rzkq73ah2j",
-    "entity": "Gidorah",
-    "name": "Gidorah Token",
-    "symbol": "GIDO",
-    "decimals": "6",
-    "icon": "https://firebasestorage.googleapis.com/v0/b/wicca-c3bbe.appspot.com/o/app%2Fmainnet%2Ftoken%2FMIRhzK1keYKtJsRYg_oL9.jpeg?alt=media&token=5de0205f-d0f6-4a76-b765-e6dd59d7d47a"
-  },
-  {
-    "id": "ibc/4CD525F166D32B0132C095F353F4C6F033B0FF5C49141470D1EFDA1D63303D04",
-    "entity": "Juno",
-    "name": "Juno",
-    "symbol": "JUNO",
-    "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/ibc/JUNO.svg"
+    "icon": "https://www.erisprotocol.com/en-US/assets/ampLuna100.png"
   },
   {
     "id": "terra1vsl7etwe53vglc2xq2rdt7mujarcjy9j694hdk",
@@ -1974,22 +1063,6 @@
     "decimals": "6"
   },
   {
-    "id": "ibc/14ACCAD1750327C74BB35978AD0C3E97B184DAB9F0BF4BD876FBD1F782B57110",
-    "entity": "Kujira",
-    "name": "USK",
-    "symbol": "USK",
-    "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/ibc/USK.svg"
-  },
-  {
-    "id": "terra1ee4g63c3sus9hnyyp3p2u3tulzdv5ag68l55q8ej64y4qpwswvus5mtag2",
-    "entity": "Lira Financial",
-    "name": "Lira",
-    "symbol": "LIRA",
-    "decimals": "6",
-    "icon": "https://lira.financial/images/icons/lira.svg"
-  },
-  {
     "id": "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
     "entity": "Lira Financial",
     "name": "Lira",
@@ -1998,325 +1071,14 @@
     "icon": "https://lira.financial/images/icons/lira.svg"
   },
   {
-    "id": "terra1uv8ltv32tuq4qf6xspytpv058p0pef64s5xdncfywjexv22lfjzs7mul8s",
-    "entity": "Luna Bird",
-    "name": "Luna Bird",
-    "symbol": "LUBI",
-    "decimals": "6",
-    "icon": "https://www.lunabird.network/logo.png"
-  },
-  {
-    "id": "terra18ej5nsuu867fkx4tuy2aglpvqjrkcrjjslap3z",
-    "entity": "Mirror Protocol",
-    "name": "Advanced Micro Devices, Inc.",
-    "symbol": "mAMD",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra18ej5nsuu867fkx4tuy2aglpvqjrkcrjjslap3z/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/AMD.png"
-  },
-  {
-    "id": "terra1g4x2pzmkc9z3mseewxf758rllg08z3797xly0n",
-    "entity": "Mirror Protocol",
-    "name": "Airbnb Inc.",
-    "symbol": "mABNB",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1g4x2pzmkc9z3mseewxf758rllg08z3797xly0n/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/ABNB.png"
-  },
-  {
-    "id": "terra1w7zgkcyt7y4zpct9dw8mw362ywvdlydnum2awa",
-    "entity": "Mirror Protocol",
-    "name": "Alibaba Group Holding Limited",
-    "symbol": "mBABA",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1w7zgkcyt7y4zpct9dw8mw362ywvdlydnum2awa/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/BABA.png"
-  },
-  {
-    "id": "terra1h8arz2k547uvmpxctuwush3jzc8fun4s96qgwt",
-    "entity": "Mirror Protocol",
-    "name": "Alphabet Inc.",
-    "symbol": "mGOOGL",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1h8arz2k547uvmpxctuwush3jzc8fun4s96qgwt/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/GOOGL.png"
-  },
-  {
-    "id": "terra165nd2qmrtszehcfrntlplzern7zl4ahtlhd5t2",
-    "entity": "Mirror Protocol",
-    "name": "Amazon.com, Inc.",
-    "symbol": "mAMZN",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra165nd2qmrtszehcfrntlplzern7zl4ahtlhd5t2/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/AMZN.png"
-  },
-  {
-    "id": "terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy",
-    "entity": "Mirror Protocol",
-    "name": "AMC Entertainment Holdings Inc.",
-    "symbol": "mAMC",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/AMC.png"
-  },
-  {
-    "id": "terra1vxtwu4ehgzz77mnfwrntyrmgl64qjs75mpwqaz",
-    "entity": "Mirror Protocol",
-    "name": "Apple Inc.",
-    "symbol": "mAAPL",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1vxtwu4ehgzz77mnfwrntyrmgl64qjs75mpwqaz/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/AAPL.png"
-  },
-  {
-    "id": "terra1qqfx5jph0rsmkur2zgzyqnfucra45rtjae5vh6",
-    "entity": "Mirror Protocol",
-    "name": "ARK Innovation ETF",
-    "symbol": "mARKK",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1qqfx5jph0rsmkur2zgzyqnfucra45rtjae5vh6/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/ARKK.png"
-  },
-  {
-    "id": "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw",
-    "entity": "Mirror Protocol",
-    "name": "Bitcoin",
-    "symbol": "mBTC",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/BTC.png"
-  },
-  {
-    "id": "terra18wayjpyq28gd970qzgjfmsjj7dmgdk039duhph",
-    "entity": "Mirror Protocol",
-    "name": "Coinbase Global, Inc.",
-    "symbol": "mCOIN",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra18wayjpyq28gd970qzgjfmsjj7dmgdk039duhph/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/COIN.png"
-  },
-  {
-    "id": "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
-    "entity": "Mirror Protocol",
-    "name": "Ether",
-    "symbol": "mETH",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/ETH.png"
-  },
-  {
-    "id": "terra1mqsjugsugfprn3cvgxsrr8akkvdxv2pzc74us7",
-    "entity": "Mirror Protocol",
-    "name": "Facebook Inc.",
-    "symbol": "mFB",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1mqsjugsugfprn3cvgxsrr8akkvdxv2pzc74us7/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/FB.png"
-  },
-  {
-    "id": "terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls",
-    "entity": "Mirror Protocol",
-    "name": "Galaxy Digital Holdings Ltd",
-    "symbol": "mGLXY",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/GLXY.png"
-  },
-  {
-    "id": "terra1m6j6j9gw728n82k78s0j9kq8l5p6ne0xcc820p",
-    "entity": "Mirror Protocol",
-    "name": "GameStop Corp",
-    "symbol": "mGME",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1m6j6j9gw728n82k78s0j9kq8l5p6ne0xcc820p/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/GME.png"
-  },
-  {
-    "id": "terra137drsu8gce5thf6jr5mxlfghw36rpljt3zj73v",
-    "entity": "Mirror Protocol",
-    "name": "Goldman Sachs Group Inc.",
-    "symbol": "mGS",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra137drsu8gce5thf6jr5mxlfghw36rpljt3zj73v/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/GS.png"
-  },
-  {
-    "id": "terra1csk6tc7pdmpr782w527hwhez6gfv632tyf72cp",
-    "entity": "Mirror Protocol",
-    "name": "Invesco QQQ Trust",
-    "symbol": "mQQQ",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1csk6tc7pdmpr782w527hwhez6gfv632tyf72cp/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/QQQ.png"
-  },
-  {
-    "id": "terra10h7ry7apm55h4ez502dqdv9gr53juu85nkd4aq",
-    "entity": "Mirror Protocol",
-    "name": "iShares Gold Trust",
-    "symbol": "mIAU",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra10h7ry7apm55h4ez502dqdv9gr53juu85nkd4aq/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/IAU.png"
-  },
-  {
-    "id": "terra15hp9pr8y4qsvqvxf3m4xeptlk7l8h60634gqec",
-    "entity": "Mirror Protocol",
-    "name": "iShares Gold Trust (Delisted)",
-    "symbol": "mIAU",
-    "decimals": "6",
-    "icon": "https://whitelist.mirror.finance/icon/IAU.png"
-  },
-  {
-    "id": "terra1kscs6uhrqwy6rx5kuw5lwpuqvm3t6j2d6uf2lp",
-    "entity": "Mirror Protocol",
-    "name": "iShares Silver Trust",
-    "symbol": "mSLV",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1kscs6uhrqwy6rx5kuw5lwpuqvm3t6j2d6uf2lp/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/SLV.png"
-  },
-  {
-    "id": "terra1ptdxmj3xmmljzx02nr4auwfuelmj0cnkh8egs2",
-    "entity": "Mirror Protocol",
-    "name": "Johnson & Johnson",
-    "symbol": "mJNJ",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1ptdxmj3xmmljzx02nr4auwfuelmj0cnkh8egs2/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/JNJ.png"
-  },
-  {
-    "id": "terra1227ppwxxj3jxz8cfgq00jgnxqcny7ryenvkwj6",
-    "entity": "Mirror Protocol",
-    "name": "Microsoft Corporation",
-    "symbol": "mMSFT",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1227ppwxxj3jxz8cfgq00jgnxqcny7ryenvkwj6/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/MSFT.png"
-  },
-  {
-    "id": "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
-    "entity": "Mirror Protocol",
-    "name": "Mirror",
-    "symbol": "MIR",
-    "decimals": "6",
-    "circ_supply_api": "https://graph.mirror.finance/graphql",
-    "icon": "https://whitelist.mirror.finance/icon/MIR.png"
-  },
-  {
-    "id": "terra1jsxngqasf2zynj5kyh0tgq9mj3zksa5gk35j4k",
-    "entity": "Mirror Protocol",
-    "name": "Netflix, Inc.",
-    "symbol": "mNFLX",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1jsxngqasf2zynj5kyh0tgq9mj3zksa5gk35j4k/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/NFLX.png"
-  },
-  {
-    "id": "terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx",
-    "entity": "Mirror Protocol",
-    "name": "PayPal Holdings Inc",
-    "symbol": "mPYPL",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/PYPL.png"
-  },
-  {
-    "id": "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
-    "entity": "Mirror Protocol",
-    "name": "Polkadot",
-    "symbol": "mDOT",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/DOT.png"
-  },
-  {
-    "id": "terra19cmt6vzvhnnnfsmccaaxzy2uaj06zjktu6yzjx",
-    "entity": "Mirror Protocol",
-    "name": "ProShares VIX Short-Term Futures ETF",
-    "symbol": "mVIXY",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra19cmt6vzvhnnnfsmccaaxzy2uaj06zjktu6yzjx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/VIXY.png"
-  },
-  {
-    "id": "terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45",
-    "entity": "Mirror Protocol",
-    "name": "ProShares VIX Short-Term Futures ETF (Delisted)",
-    "symbol": "mVIXY",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/VIXY.png"
-  },
-  {
-    "id": "terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc",
-    "entity": "Mirror Protocol",
-    "name": "SPDR S&P 500",
-    "symbol": "mSPY",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/SPY.png"
-  },
-  {
-    "id": "terra1u43zu5amjlsgty5j64445fr9yglhm53m576ugh",
-    "entity": "Mirror Protocol",
-    "name": "Square, Inc.",
-    "symbol": "mSQ",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1u43zu5amjlsgty5j64445fr9yglhm53m576ugh/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/SQ.png"
-  },
-  {
-    "id": "terra1246zy658dfgtausf0c4a6ly8sc2e285q4kxqga",
-    "entity": "Mirror Protocol",
-    "name": "Starbucks Corporation",
-    "symbol": "mSBUX",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1246zy658dfgtausf0c4a6ly8sc2e285q4kxqga/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/SBUX.png"
-  },
-  {
-    "id": "terra14y5affaarufk3uscy2vr6pe6w6zqf2wpjzn5sh",
-    "entity": "Mirror Protocol",
-    "name": "Tesla, Inc.",
-    "symbol": "mTSLA",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra14y5affaarufk3uscy2vr6pe6w6zqf2wpjzn5sh/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/TSLA.png"
-  },
-  {
-    "id": "terra1cc3enj9qgchlrj34cnzhwuclc4vl2z3jl7tkqg",
-    "entity": "Mirror Protocol",
-    "name": "Twitter, Inc.",
-    "symbol": "mTWTR",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1cc3enj9qgchlrj34cnzhwuclc4vl2z3jl7tkqg/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/TWTR.png"
-  },
-  {
-    "id": "terra1lvmx8fsagy70tv0fhmfzdw9h6s3sy4prz38ugf",
-    "entity": "Mirror Protocol",
-    "name": "United States Oil Fund, LP",
-    "symbol": "mUSO",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1lvmx8fsagy70tv0fhmfzdw9h6s3sy4prz38ugf/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/USO.png"
-  },
-  {
-    "id": "terra19p20mfnvwh9yvyr7aus3a6z6g6uk28fv4jhx9kmnc2m7krg27q2qkfenjw",
-    "entity": "Orne",
-    "name": "Orne",
-    "symbol": "ORNE",
-    "decimals": "6",
-    "icon": "https://orne.io/img/token_icon.png"
-  },
-  {
     "id": "terra1hnezwjqlhzawcrfysczcxs6xqxu2jawn729kkf",
     "entity": "Orne",
     "name": "Orne",
     "symbol": "ORNE",
     "decimals": "6",
     "circ_supply_api": "https://orne.io/api/",
-    "icon": "https://orne.io/img/token_icon.png"
+    "icon": "https://orne.io/img/token_icon.png",
+    "coingecko": "https://www.coingecko.com/en/coins/orne"
   },
   {
     "id": "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B",
@@ -2325,95 +1087,6 @@
     "symbol": "OSMO",
     "decimals": "6",
     "icon": "https://assets.terra.money/icon/svg/ibc/OSMO.svg"
-  },
-  {
-    "id": "terra167khnalh9aawqx9qynj7kk9y0n8hc30qe6s8cy7y5yu2azrc2edqyjprp9",
-    "entity": "Phoenix",
-    "name": "IBC/-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1s3zkg95yrmdl0nlxnynkunq3uqyeuu6mk3ca6vtcag0us9ejtjas0dv7em",
-    "entity": "Phoenix",
-    "name": "IBC/-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14s6uknh7zc97m3zqfejfqkkzm90tx9zez6k4swqa3422xvgpy56s3tyn49",
-    "entity": "Phoenix",
-    "name": "IBC/-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1fqh5u2m7qs7vfz0ty8c8n9td74afgltrgg98ezqmxqg2dgqdfqrq2wy9r6",
-    "entity": "Phoenix",
-    "name": "IBC/-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1wwmlrhulv55ph6vnv8wlgma5sjca2p8k8ykrmkfyh9qj3kct9m7sez5cv8",
-    "entity": "Phoenix",
-    "name": "IBC/-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra12ctxrpmkpqr0gzrndjwr2a8k0gp3stx94x4q5p7g7u30p9mnrezsc2sl3n",
-    "entity": "Phoenix",
-    "name": "LUNA-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1dxd7vh4x6cf6n20p2x6syatxdv4jftzzs45n42wn7kutqc0xxj8sj3p0dc",
-    "entity": "Phoenix",
-    "name": "LUNA-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14zymzz73zzmrpfujjxkv6drcqdjdve3jsz5rx00464x9jdld6ays06l0n3",
-    "entity": "Phoenix",
-    "name": "MINE-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1spkm49wd9dqkranhrks4cupecl3rtgeqqljq3qrvrrts2ev2gw6sy5vz3k",
-    "entity": "portugal.protocol",
-    "name": "dinheiro",
-    "symbol": "Dinheiros",
-    "decimals": "0",
-    "icon": "https://static.wixstatic.com/media/1e62a0_04207897171e4f5c8931295172b3e34c~mv2.png"
-  },
-  {
-    "id": "terra1qj5hs3e86qn4vm9dvtgtlkdp550r0rayk9wpay44mfw3gn3tr8nq5jw3dg",
-    "entity": "portugal.protocol",
-    "name": "escudo",
-    "symbol": "Escudos",
-    "decimals": "6",
-    "icon": "https://static.wixstatic.com/media/1e62a0_37bd3a14b88646f987919ec4ea30533c~mv2.png"
-  },
-  {
-    "id": "terra1sdglum2dt4f3fmq7jrt2phf2tegmnudc7qqqqujkpqcm9ujuxxkqakv5u8",
-    "entity": "portugal.protocol",
-    "name": "real",
-    "symbol": "Reis",
-    "decimals": "6",
-    "icon": "https://static.wixstatic.com/media/1e62a0_89af25478e5144089de9292b990493e2~mv2.png"
-  },
-  {
-    "id": "terra1xe8umegahlqphtpvjsuwfzfvyjfvag5h8rffsx6ezm0el4xzsf8s7uzezk",
-    "entity": "Redacted Money",
-    "name": "Red",
-    "symbol": "RED",
-    "decimals": "6",
-    "circ_supply_api": "https://api-v2.redacted.money/circulating_supply",
-    "icon": "https://red.redacted.money/red.svg"
   },
   {
     "id": "terra1ye68rx8etwj7xylwc4nd4vp58zz236mlhk0cpx",
@@ -2437,23 +1110,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1q8kfp0v9rhef0d3u44ds9shwvwcusjheh8nhye3n7gwjd95ze96sehyp6w",
-    "entity": "Santerra",
-    "name": "Santerra SANT",
-    "symbol": "SANT",
-    "decimals": "6",
-    "icon": "https://santerra.app/sant_logo.svg"
-  },
-  {
-    "id": "terra1xp9hrhthzddnl7j5du83gqqr4wmdjm5t0guzg9jp6jwrtpukwfjsjgy4f3",
-    "entity": "Sayve Protocol",
-    "name": "Sayve Token",
-    "symbol": "SAYVE",
-    "decimals": "6",
-    "circ_supply_api": "https://raw.githubusercontent.com/sayveprotocol/web-assets/main/data/circulating-supply",
-    "icon": "https://raw.githubusercontent.com/sayveprotocol/web-assets/main/logos/sayve-logo.png"
-  },
-  {
     "id": "terra14v9wrjs55qsn9lkvylsqela3w2ytwxzkycqzcr",
     "entity": "Sayve Protocol",
     "name": "SAYVE Token",
@@ -2461,22 +1117,6 @@
     "decimals": "6",
     "circ_supply_api": "https://lcd.terra.dev/wasm/contracts/terra1c0ml4nvpapkuex28yuh40n38cq3zyugszsw59e/store?query_msg=%7B%22check_balance%22%3A%7B%22addr%22%3A+%22terra14v9wrjs55qsn9lkvylsqela3w2ytwxzkycqzcr%22%7D%7D",
     "icon": "https://i.ibb.co/5xC39ym/sayve.png"
-  },
-  {
-    "id": "terra16zc783wt2w5lvlt9u4as977lt39c3se427akkenrzyax5vtde70qa89ukv",
-    "entity": "Sayve Protocol",
-    "name": "xSAYVE",
-    "symbol": "xSAYVE",
-    "decimals": "6",
-    "icon": "https://raw.githubusercontent.com/sayveprotocol/web-assets/main/logos/xsayve-logo.png"
-  },
-  {
-    "id": "ibc/10BD6ED30BA132AB96F146D71A23B46B2FC19E7D79F52707DC91F2F3A45040AD",
-    "entity": "Secret Network",
-    "name": "Secret",
-    "symbol": "SCRT",
-    "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/ibc/SCRT.svg"
   },
   {
     "id": "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09",
@@ -2509,7 +1149,9 @@
     "symbol": "LunaX",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://raw.githubusercontent.com/stader-labs/assets/main/terra/LunaX_1.png"
+    "icon": "https://raw.githubusercontent.com/stader-labs/assets/main/terra/LunaX_1.png",
+    "coingecko": "https://www.coingecko.com/en/coins/stader",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/stader/"
   },
   {
     "id": "terra1ustvnmngueq0p4jd7gfnutgvdc6ujpsjhsjd02",
@@ -2518,6 +1160,14 @@
     "symbol": "SD",
     "decimals": "8",
     "icon": "https://raw.githubusercontent.com/stader-labs/assets/main/terra/whSD.png"
+  },
+  {
+    "id": "terra1xumzh893lfa7ak5qvpwmnle5m5xp47t3suwwa9s0ydqa8d8s5faqn6x7al",
+    "entity": "Steak",
+    "name": "STEAK Liquid Token",
+    "symbol": "STEAK",
+    "decimals": "6",
+    "icon": "https://liquidstaking.app/steak.png"
   },
   {
     "id": "terra1rl4zyexjphwgx6v3ytyljkkc4mrje2pyznaclv",
@@ -2537,22 +1187,6 @@
     "icon": "https://terra.poker/ico/ms-icon-310x310.png"
   },
   {
-    "id": "terra1e9s5m6vrl9ms75q0862llq2vcsz8r43czm36s6xnn3vh8dfmwe0s3c86e8",
-    "entity": "Terra Poker",
-    "name": "xTPT",
-    "symbol": "xTPT",
-    "decimals": "6",
-    "icon": "https://terra.poker/ico/ms-icon-310x310.png"
-  },
-  {
-    "id": "terra1564y9uxzhast8sk5n47teypy4mxy7fg5vne2msuztsft7qk3pj9sxxuxmc",
-    "entity": "TerraFloki",
-    "name": "TerraFloki",
-    "symbol": "TFLOKI",
-    "decimals": "6",
-    "icon": "https://terrafloki.io/tf-logo.png"
-  },
-  {
     "id": "terra1kx4y3y4pn32jssqr90cj0rw89ds98dc0t5eqfp",
     "entity": "TerraFloki",
     "name": "TerraFloki",
@@ -2566,7 +1200,8 @@
     "symbol": "TFLOKI",
     "decimals": "6",
     "circ_supply_api": "https://api.terrafloki.io/supply/circulating",
-    "icon": "https://terrafloki.io/terrafloki_logo.png"
+    "icon": "https://terrafloki.io/terrafloki_logo.png",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terrafloki/"
   },
   {
     "id": "terra1vl3khh0w2fydtd72ly03vjmlll4nr0ldcl9u4z",
@@ -2574,377 +1209,6 @@
     "name": "TerraFloki",
     "symbol": "TFLOKI",
     "decimals": "3"
-  },
-  {
-    "id": "terra10nnsamvtc5yux6m9utwc6dtee20h8fe8gp06jfqy0ffqtxrk384s4l0rru",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra136ce352lvvlgs662hplc0rlf8tq8tvjrcaadp2ezzf2wf604gvsswflejp",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra139djw4keg5vu2x2cwucapkxp4efst286rf0n9gh3cv3ptm65c80shy0fwl",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra13w89pfxhk5k62xp8ctckkhrjwwvq34czmltwkvsck0kvenyspk7q7cpcss",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14avgfstw3th676cy3mg7kwqd5a09yfwwk02uztqzq4lzu78e738saktxrk",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14m6nt5dwnxsmvt6pv6am8dkmqrf263acgjq6ex00un3t0qdd9pts2fy2cq",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra18fe2jdsll40rhfhfj34n0vlkysjsndwd20jecvezdxc3dp4kcr5s7uucd3",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra18jq3nawedex6s67f2rwkz3e7a57a5nxq40r9905yvyran5x7dh6sm7krj2",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra19dgcuxy7vlu2u4lpv407kcrg7yeaj9an72r0gver20thkejgprksvd06yv",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1a0fyanyqm496fpgneqawhlsug6uqfvqg2epnw39q0jdenw3zs8zqlykdyd",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1a0s7u0zej7jpzuq90yglms75ng5yvq9q20awu44h395hc9k249hsry5d2j",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1a4hcacqpkqgmh94jpe290gekgv6f7euhfcl2fxm22s2r78uck9lqw33t99",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1dsy8ly4t2xtzlseflqlphg8cr47sgg3egmk8pktnnq5cd7hu04lqhp80mu",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1eh2aulwsyc9m45ggeznav402xcck4ll0yn0xgtlxyf4zkwch7juqsxvfzr",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ep6pquxwgfljxzvgs7l7d0epp8spx3erysymhd8m6u4x94ztjxhqyhmyrp",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1epvnlk847v85sa82ndvt730ndhkalq22lehkwrv3fwzy00kyydxqyk27m6",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1erku46zd9ac98ts6mzj0fxv3rv37c4al5afff4xejhx5cveqefrqa9js3n",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1gdj85sxs0tqhap50pv6jr6vrku4vqfrx5k62x0fu4gxt4l66qjgqqyz386",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1gkg8cxha802dy8km0jldyegmtj384f69wp0c3cvtfq43gu8caa7swpe4kc",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1gte4eejaw3hrs2d8pt0zhp0yfd34xp24qdgqumjul29jt5hwl5tsx3qmw7",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1gxnp98ghg5mqddw3n0ve6uw3ay9hnt0ks9r3dyucjn0y007u64vqw03d6f",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1h7kgccvtdf6z2udech63qlvn5j06pw0vny9uq2wl8eqad63vt95q2pkmrq",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1hhjh8hj0zdx2qh70gsuse4efer0dq93rwggkwd6w2jqpafa5gw4qhzn047",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1hw5n2l4v5vz8lk4sj69j7pwdaut0kkn90mw09snlkdd3f7ckld0sutg4p7",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1k6pf84kdfxqz6gmcl9w0wwphkvwxccuz3e9fryrgvlxepuw5qrhqp07sd9",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ka40j33h55z3vkr98etwd4l0v8htaup4883pa53ze4ncaa8z9vgqd49ngc",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1kzwl8dk45sn3nrfpangz73za32kzcyz4t6lq8jq9ctrwrzv07c4qda7sy8",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ma0g752dl0yujasnfs9yrk6uew7d0a2zrgvg62cfnlfftu2y0egqjpj90v",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1mpyp9t48q2dy6s4lkxwjpy8sgg4r823hwam2tap2ra86hmgrrqyqcf6ehy",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1nc84knc0n7td5xqplwy0luh97zd8hv5mhvm9cdempc05xk0xvxyqjr6cyg",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1nf8q6w0tl3hmnvs3llakr52f9gtlnyfmtt0ynmwweppx4g2y42dqxaqrek",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1np60v3wfrdp232m765ulrmvcwqz5ymkfvflfw59enhftnnn3sceq9gt7f0",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1nvd25azm56h9fk7qn9r0usjsn3g2n34w7dypw52gam8ytgvrcrfslrq2ff",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1nwju0tcdykx037phw8qh7jzwqal5uk7ekqjkxzpuymkpmc7a4sjs3d3t9a",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1pt6wkxlkga4fw2spxawd0ymqfdy63xk7y4tr6cawafmd06dfzgxqr9mwk8",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1q3647qp780u7y2zvau5fn748zqxsfm4kr6lcvr5jjev5a77kchxsjy2m4x",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qatnqunnama825l0xf6nmxgts6j27vqfhnzadwecld4mnlumhkkq9q7cn7",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qcax3h3cadtpqua2uev06euuse8wxsjzfrtlmt0nyp2aw0a7hctq0ww6p9",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qzn7zc70c5npg5tyc6pvwrpvfp7p9utkpcwlaugn9avn6r49609suh5g0r",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1rwx6w02alc4kaz7xpyg3rlxpjl4g63x5jq292mkxgg65zqpn5llq9etvsk",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1rwz4h4xqlmlt6h475ckllxks8t8gulrg9dpgj5tkm8udf5mgcy7sj2rtva",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1sn3ee5c5ujczx9ksky8hn2x0jwqf2sc5hxgn9gch32933mxjjv7qtl53w5",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1tewy0s0xydvh3l2wkpf238rp48n5mmd3xjfwp6j3cy603hvpgf2sztgvv8",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ttaekgrc60xc3xcflq069m49lwu79m5t552rjcws48rzhxcr4g6shmdw2v",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ugtkewkzkq26ya8ye6gfwkt9jpj08sw0737ddjj9h803ee4768xqwr56d4",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1uvqk5vj9vn4gjemrp0myz4ku49aaemulgaqw7pfe0nuvfwp3gukq4rz3fj",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1vz29w25qu5lzfghz89yy6cq7jaj5snjf5p66qcmp4hza87jcstfqylf5er",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1w2l4w5p66l5t2nmrmsvz7k4cu50s7e8dc6h59gcxsnmp2tgy7q7smfaxql",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1xgkjhtn4d5csgwchma73gtx5yzjxuq0eywz25lj56eqgq4d4r37sygw8wn",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1xj8h7gkdr4kalgqmvvpmdxd2rkn6u5amlg0j3zek523y4sz2nlfs5gcgyv",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1xnudulcse7gp2rg0hpzxtx7cz72mg20pjqhzw87z0j3pk5y9lufqupgj22",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1xnxsxarhsj6v5xlrc2es2lw937z6jxat643p5uvqa3dllewl5s4qa7hwkw",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1zmlgklwyrzvhgvn5sfrq28fad69wcevjymkea7jgpz8gheuk6qas2w8krk",
-    "entity": "Terraswap",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
   },
   {
     "id": "terra1cx8rey3xpd7e7t6pkywvq6n9y98yq3wlfashpm",
@@ -2960,15 +1224,6 @@
     "symbol": "VKR",
     "decimals": "6",
     "circ_supply_api": "https://api.valkyrieprotocol.com/circulating-supply",
-    "icon": "https://app.valkyrieprotocol.com/icon_vkr.png"
-  },
-  {
-    "id": "terra1gy73st560m2j0esw5c5rjmr899hvtv4rhh4seeajt3clfhr4aupszjss4j",
-    "entity": "Valkyrie Protocol",
-    "name": "Valkyrie Token",
-    "symbol": "VKR",
-    "decimals": "6",
-    "circ_supply_api": "https://terra-api.valkyrieprotocol.com/partner/coinhall/circulating-supply",
     "icon": "https://app.valkyrieprotocol.com/icon_vkr.png"
   },
   {
@@ -2994,14 +1249,6 @@
     "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/AVAX_wh.png"
   },
   {
-    "id": "terra1qmnxhecc3vnmhef9q7vap7spx9tgpnw9fqe8ljqfwrlz7rur9y5qu2dlp6",
-    "entity": "Wormhole",
-    "name": "Wrapped AVAX (Wormhole)",
-    "symbol": "WAVAX",
-    "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/AVAX_wh.png"
-  },
-  {
     "id": "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
     "entity": "Wormhole",
     "name": "Wrapped Ether",
@@ -3010,211 +1257,15 @@
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs/logo.png"
   },
   {
-    "id": "terra15hhqg8gyz04zapynqtk7uvlsp7lzay7etrt9ann0276v94yae63sxygeat",
-    "entity": "Wormhole",
-    "name": "Wrapped Ether (Wormhole)",
-    "symbol": "WETH",
-    "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs/logo.png"
-  },
-  {
-    "id": "terra1ctelwayk6t2zu30a8v9kdg3u2gr0slpjdfny5pjp7m3tuquk32ysugyjdg",
-    "entity": "Wormhole",
-    "name": "Wrapped SOL (Wormhole)",
-    "symbol": "SOL",
-    "decimals": "8",
-    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png"
-  },
-  {
-    "id": "terra1dwtgrdjtgx3d3laypgx8ptch0kk20skh4p6ra3euy38x6n9s7kws4yzlgf",
-    "name": "  T (Wormhole)",
-    "symbol": "  T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1xcv6yvatcr9d5prd58d6d939c252l7zwcga9yfrscexekdnnfsmskk7rh5",
-    "name": " \\T (Wormhole)",
-    "symbol": " \\T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra19jtesa3t75krekhf62jjedtrk3y7l9phnkspfhyyrfqxz7c4jhusw5vlux",
-    "name": "__proto__ (Wormhole)",
-    "symbol": "__proto__",
-    "decimals": "8"
-  },
-  {
-    "id": "terra14vcfzv7f3ucedpmxsue9glsg6gnkw38js7srjynmmu60zpn3w3ys2ukckv",
-    "name": "__proto__.__proto__ (Wormhole)",
-    "symbol": "__proto__.__proto__",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1zk5vshetgylrptlr8x5swd9kp5jprtuhxp9axc6tc6ds30vsj72ss4yee3",
-    "name": "__proto__.admin = true; (Wormhole)",
-    "symbol": "__proto__.admin = true;",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1wzp5fl2jdca9xlqgl6wmncuuylfz44y29tg7y8fe77ljc73hedlsaquqay",
-    "name": "__T (Wormhole)",
-    "symbol": "__T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra19092gh8hswt696qy9d649azg0lsu0drth40uw7udhuxuk8uymcws638z94",
-    "name": "_-T (Wormhole)",
-    "symbol": "_-T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1aaav9c766djrgaadwcnwfxals3gqmq5rtmryff4gga82rwqmy9tsx6nujl",
-    "name": "--T (Wormhole)",
-    "symbol": "--T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16x6ymtdpru5pfmpjdcx3te9dtmz4almzqy5ur4ghth06023udrqqfdea99",
-    "name": ":::::::::::::::::::::::::::::::: (Wormhole)",
-    "symbol": "::::::::::::::::::::::::::::::::",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1lls0emf6ra0gjtc7ym35f7eaaf9f9u5cd92t9u9wjzuw40aru4ds0j34km",
-    "name": ":::::::::::::::::::::::::::::::: (Wormhole)",
-    "symbol": "::::::::::::::::::::::::::::::::",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1vk5efw9sdx09hkzfatpvxzk2jse5t0gj2w8hgnk8m2f0rk5zeazsnuyv3r",
-    "name": ":::::::::::::::::::::::::::::::: (Wormhole)",
-    "symbol": "::::::::::::::::::::::::::::::::",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1wwz4299eputh34ya8jp25kc3m5f7d3kql0ydvh8kj3fku3sayyas7r64wv",
-    "name": ":::::::::::::::::::::::::::::::: (Wormhole)",
-    "symbol": "::::::::::::::::::::::::::::::::",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1cmvf7863w80wykszfy5xj8s4asy8urv3u6sfup6wvzezd0alqhsq2ak99c",
-    "name": "::T (Wormhole)",
-    "symbol": "::T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1g9e7gkztzzp0ke2jw8cwp538470lxs65esdsz2dxt3upnt2klrgsj3j4el",
-    "name": "''T (Wormhole)",
-    "symbol": "''T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra180pk9zdn0xjk6vcsc7tgye7qxf37mc5ja0jj72wvq86mp0qjw6uqrk9mph",
-    "name": "\"\"T (Wormhole)",
-    "symbol": "\"\"T",
-    "decimals": "6"
-  },
-  {
     "id": "terra1s56hsyhyvq4xxxvnz8qr0pnktm2dadsm4gkl45",
     "name": "[REDACTED] Governance",
     "symbol": "RDCTD",
     "decimals": "6"
   },
   {
-    "id": "terra1nw80nxy20lg2xtkragal0785jregaqeqgeyypn7cacfxt3cqdwtsds64u3",
-    "name": "@darky_daria art",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1rnaz3celr57g5z06qz2qlzrjvlga6zk7wtjdwyltx4tc9tc9nnpq2pr3a2",
-    "name": "/\\T (Wormhole)",
-    "symbol": "/\\T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14mfxv7fgx9fkf8pwgq4n8vkt5hr5f7vjflxduspnjkzc57wcpdes9ys48s",
-    "name": "\\'T (Wormhole)",
-    "symbol": "\\'T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1z6gxfprq5h7qw82jwjfcx6kt4arh2klz27e8rzup9vzf2nldhr3qvfc2m3",
-    "name": "\\/T (Wormhole)",
-    "symbol": "\\/T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra17mh4p9t0cf59tyzeyeqt5wmnkpztdgavl7497w6y9u4hs8w0fktq0verp3",
-    "name": "\\\\T (Wormhole)",
-    "symbol": "\\\\T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1fjnfcpcey8x7h3yh45thr86ug32f8dux3llllcpyglxkyg8qpy0qjxl7vz",
-    "name": "\\\\T (Wormhole)",
-    "symbol": "\\\\T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1fpz8xnkpn3j5r34zgyz0td6wcqw3xggjr5g0e70hjzf3xq474vzs242dlj",
-    "name": "\\\\T (Wormhole)",
-    "symbol": "\\\\T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1myac7574328jxy0ylgnntzl0vd62yhaqv3g68vdccuz9h7msvh4q7x6far",
-    "name": "\\\\T (Wormhole)",
-    "symbol": "\\\\T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra15gn9456wttxvcxv7csgn9njqz3lnlf5jxqtrwjwm6dvwgd58ql9q97wem7",
-    "name": "\\`T (Wormhole)",
-    "symbol": "\\`T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16j8wmvu3cynnp4qqpg6z2ksh4zpngrszcne59svq8mz35jtq84cqdsrdpv",
-    "name": "\\`T (Wormhole)",
-    "symbol": "\\`T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qrgeuwxl8etjwjasvumrjmgat70d8m4la6jkng5tfc0gvgwu2xcs8fvddw",
-    "name": "\\ET (Wormhole)",
-    "symbol": "\\ET",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1hd30kzycu4hu04u2rdkyt3pjqadgk4hgvauetm8pul0ps4swdswq37gs7f",
-    "name": "`'T (Wormhole)",
-    "symbol": "`'T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ncn2xqfksmsjqv4xwzk0s8ryfcp4epp3qu74n6dx7rnkyrefjutsx6ek72",
-    "name": "``T (Wormhole)",
-    "symbol": "``T",
-    "decimals": "6"
-  },
-  {
-    "id": "terra17n8dqgaal20u6pux7jpdhus8zxa45u69xhpedkrlcw40gcfkw05q4zqkh0",
-    "name": "<>T (Wormhole)",
-    "symbol": "<>T",
-    "decimals": "6"
-  },
-  {
     "id": "terra1dwyd6vds479kv54f7kucevny97lge20c3s9w2k",
     "name": "<Big Green Dildo>",
     "symbol": "BGD",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1825g0pmvp2c0wq66n2g4lksjc3zf9a3s53dsyzslcc2k5k440p7q0uxmdx",
-    "name": "><T (Wormhole)",
-    "symbol": "><T",
     "decimals": "6"
   },
   {
@@ -3266,42 +1317,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra13xc83q58y74qplhwstu9er6axycapdjmnfrw288kndt3gdukxtmq8hedc2",
-    "name": "10% Angel LP",
-    "symbol": "AngelLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra172mepny4gzvseeunw3wu0acywk0r9hzyzn5gzqxgssfhnw9p36gsf7uz3e",
-    "name": "10% Burn LP",
-    "symbol": "BurnLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra12nkef0actgu77mzl2ywt6gratctps8mheq7n3uvagzeffyhusnrq7rc77x",
-    "name": "10% Spaces LP",
-    "symbol": "SpacesLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qdujz3vtn6nsc0lyf2jzukwzvpqa8mwfcl6mgdhkp07hkpwlyr6q3a6qfn",
-    "name": "100% Angel LP",
-    "symbol": "AngelLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1y0yajkqm3dfa2mcyq5cdffhk9dn6v40d6qm67gde7vaj40cmx9uq0qncja",
-    "name": "100% Burn LP",
-    "symbol": "BurnLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1lz689avwnzzthqer5nw9xsv5pu7pxe9z5ajml8hea3he33zpsysqll5h87",
-    "name": "100% Spaces LP",
-    "symbol": "SpacesLP",
-    "decimals": "6"
-  },
-  {
     "id": "terra12qeh8p79q6jrnlmw09hvtytv9e99yl2077cmgz",
     "name": "100BIL",
     "symbol": "HUNDBIL",
@@ -3332,24 +1347,6 @@
     "decimals": "3"
   },
   {
-    "id": "terra1ahzlzgvcf8879da55es9mly2vrr750na6vksyuu26wxm6g6xw4xqz88lka",
-    "name": "20% Angel LP",
-    "symbol": "AngelLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ghpf3cwp0exaq685yrkxfzpjyr69lstm2yakrzm25emng0xvqs0sq5q5r5",
-    "name": "20% Burn LP",
-    "symbol": "BurnLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra18st042rg72wm60z7vjcufnej64kdr57qpemmkjtmkrv5laxlh3hq558sqy",
-    "name": "20% Spaces LP",
-    "symbol": "SpacesLP",
-    "decimals": "6"
-  },
-  {
     "id": "terra1866wzpwzmrnmh0s267twyhr8c4tc47tqj5aths",
     "name": "247Payments",
     "symbol": "PAY",
@@ -3362,81 +1359,9 @@
     "decimals": "6"
   },
   {
-    "id": "terra1hqg5nfwdkm6858tm0sxgplkh87f66ry0jgrc84nd8yj5mtxn7d7quwspmg",
-    "name": "30% Angel LP",
-    "symbol": "AngelLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra13t6ndytpw7td2yjls6ln64062x8vxywsclzd0gytmd87pecg8ursdw43p8",
-    "name": "30% Burn LP",
-    "symbol": "BurnLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1chgx4qzdgsa5rykng5nwhm82gld9au6jkwg4ueayt2dkm8skhfssgwe63r",
-    "name": "30% Spaces LP",
-    "symbol": "SpacesLP",
-    "decimals": "6"
-  },
-  {
     "id": "terra1qt0j6rzqrc0rxpxxlyrvljmjkxrss2frsef5n0",
     "name": "300 Terrans",
     "symbol": "TERRANS",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1pmdjqw6cuql7e4wakcvte4xh8ltvkky7rzn8gqwpcx9vfst46g3q7c04w4",
-    "name": "40% Angel LP",
-    "symbol": "AngelLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1yff2t0wdhftjmy67ydjhyv6h4f3kz4sc3sn3ff4tje0axs82lpvs24ykqa",
-    "name": "40% Burn LP",
-    "symbol": "BurnLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1zu389vgu4pkpqrulfz3yk3jm870fwrd2hs0pes5en4rjwrsqx54sven5em",
-    "name": "40% Spaces LP",
-    "symbol": "SpacesLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1vf4z3lys8awmcxcclxsu8d9lwxv0wzhxtzkkfg0ntth4kks7pu2sv45ku8",
-    "name": "50% Angel LP",
-    "symbol": "AngelLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1l420mu6pkgffqhsxz9w42lxls80l7yg7f7la5ajdz99g07u94xhqdxlv9l",
-    "name": "50% Burn LP",
-    "symbol": "BurnLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1d9k26t24afcq3gha076yg39y4eg0hcayg9xzlskheluq59l5ut4s75qjuf",
-    "name": "50% Spaces LP",
-    "symbol": "SpacesLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1f8yude2jpdyfhx3f4p99nnreelx09950hkqcd263mpr9w9jykkmq58xsae",
-    "name": "60% Angel LP",
-    "symbol": "AngelLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1mt942r7k6c9wlkk32nzt2ewhs5p5y0haxkx5nepwk2astr6e2uxqkta3ps",
-    "name": "60% Burn LP",
-    "symbol": "BurnLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1z5x2rzk79eljmjnjfpt262hf2alnsph4eq8vr6vgl3dmn3q6k7nqvyqc6a",
-    "name": "60% Spaces LP",
-    "symbol": "SpacesLP",
     "decimals": "6"
   },
   {
@@ -3452,100 +1377,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra1p0x4c5r6n9dz4lm0mqssee8s8j4lafpwf46vvqyclputftcnh0rq3mueus",
-    "name": "70% Angel LP",
-    "symbol": "AngelLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1axg4x9pgx7xhlslcza9el0xqsyxd8fl69svs83895ycl0v22dv8styklnx",
-    "name": "70% Burn LP",
-    "symbol": "BurnLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16uun4j2ajew6pxz095d6nglswed6kjruevus9rn6y63djtrlkkeqx6cx4u",
-    "name": "70% Spaces LP",
-    "symbol": "SpacesLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1xmj3ln6hyfyzc4ky4vh9cl5x8tv8f5hx7lwmy0xgar069kqnehcq6fe3xs",
-    "name": "80% Angel LP",
-    "symbol": "AngelLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1pj8ng6reunzed6f0z26k7hfpd03g73z8jdhsnx8reu8uqsyapydqnjk50m",
-    "name": "80% Burn LP",
-    "symbol": "BurnLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14504gwrp7gvhd42l7qny4ld67xaqrnrvk6dm33xp37rls3ert9cs7c43f5",
-    "name": "80% Spaces LP",
-    "symbol": "SpacesLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ftpzlskr027fulju0mj9sz83zysy55whtspqghhxx2kjtu2mgqqsewnjkz",
-    "name": "90% Angel LP",
-    "symbol": "AngelLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1wf9gd0yuszsuqqxkm0gu0rzgnkr3yp5awzm8clurv4ljyc34j9vqamar9p",
-    "name": "90% Burn LP",
-    "symbol": "BurnLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14a7sujcak07xe90axfrplc3qd2uykt0snq3huastvu7jffdwpnlsqe5lyz",
-    "name": "90% Spaces LP",
-    "symbol": "SpacesLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1s53ze5358jeq0rggeuf8pqvt4y7fpe23w4hepl8g6zlkzklc374qllh09v",
-    "name": "90s PUNKS",
-    "symbol": "9PKS",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1e88qgtfw4c5zmgv9zhwsy569jwwsav4gukz64l5ewyxa3xaqckksc0z3hc",
-    "name": "A Space Doodle",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra17nyvdvmm2hjdajldme6x3y3nle6kp9wtn8qfmajw76hkk7g5tpuqgpkum5",
-    "name": "A Spooky Doodle",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1mdsnqpzj558p5qkujywpx6e59cmm68hkctfzm39zlgnlxfl738dqq2g47a",
-    "name": "A-Folkalypse",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1h48d3ccyaf50pzef0zc3v40vnv9zkq6mmslgm3gwl9s5s66cz42qz9enxe",
-    "name": "A-Team Lunaside ",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra1wlhgvtult73t5vpeng4sw9qmsq5jlujfm98gg2",
     "name": "AAA",
     "symbol": "AAA",
     "decimals": "6"
-  },
-  {
-    "id": "terra1zdwggjn7rkrpgz8ukm77yeh7a4gsallhq67f9dxjd9pmklve2gksc23gc2",
-    "name": "AAAA NFT Collection",
-    "symbol": "ADFC",
-    "decimals": "0"
   },
   {
     "id": "terra1dyptd3795l57lencr2eltut973kum8wgu36f7p",
@@ -3554,16 +1389,12 @@
     "decimals": "3"
   },
   {
-    "id": "terra1x4lm86rnw376xtuca3jux27yqwwnc9gu76vt4gggzp54hrxnegtqhz57e4",
-    "name": "ABCMETA Token (Wormhole)",
-    "symbol": "META",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1f7lvy8xrm4xnue6vtzkerzuwhszne5gqekmxx7y3fx7m603jzm8qjh2xsg",
-    "name": "Adventure of Homies",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
+    "id": "terra18ej5nsuu867fkx4tuy2aglpvqjrkcrjjslap3z",
+    "name": "Advanced Micro Devices, Inc.",
+    "symbol": "mAMD",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra18ej5nsuu867fkx4tuy2aglpvqjrkcrjjslap3z/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/AMD.png"
   },
   {
     "id": "terra12qxyx2l90c37kylw4jqe8t40ppnrnu8wqmx940",
@@ -3572,28 +1403,32 @@
     "decimals": "6"
   },
   {
+    "id": "terra1g4x2pzmkc9z3mseewxf758rllg08z3797xly0n",
+    "name": "Airbnb Inc.",
+    "symbol": "mABNB",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1g4x2pzmkc9z3mseewxf758rllg08z3797xly0n/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/ABNB.png"
+  },
+  {
     "id": "terra1xc5ll57yu269x8ysxvdpjmvxmac3js7pst5ddr",
     "name": "Alameda Research DAO",
     "symbol": "ARD",
     "decimals": "3"
   },
   {
-    "id": "terra1693sgskk3tj24n8atssq5x7aq090awq6wy7hkmpew403vg6svzjq6x04nh",
-    "name": "alentejo.money",
-    "symbol": "alem",
-    "decimals": "6"
+    "id": "terra1w7zgkcyt7y4zpct9dw8mw362ywvdlydnum2awa",
+    "name": "Alibaba Group Holding Limited",
+    "symbol": "mBABA",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1w7zgkcyt7y4zpct9dw8mw362ywvdlydnum2awa/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/BABA.png"
   },
   {
     "id": "terra14xulq5g99rfmrm6qkgzmrrspvknupajdqyd92k",
     "name": "Alibaba Group Holdings Ltd ADR",
     "symbol": "mBABA",
     "decimals": "6"
-  },
-  {
-    "id": "terra10330cpst4uvum97nvrqcrt3wachznh0akxgtzfxn20kvn0y7ue7qv2m5s3",
-    "name": "All i END 2.0",
-    "symbol": "AIE2",
-    "decimals": "0"
   },
   {
     "id": "terra1ukk89gn25p7xseqc4s4d45yarjlwychrwx7umv",
@@ -3609,18 +1444,6 @@
     "icon": "https://raw.githubusercontent.com/allbridge-io/media/main/token.svg"
   },
   {
-    "id": "terra15rqxf0fdmja0vxay3q7jspmkxd3yh6mcqf5jyppme5ue459csshqnm57cc",
-    "name": "Alpha Ark Test",
-    "symbol": "ALPHA_ARK_TEST",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1zvm0y8x4pxq7dhpvuevv3v3cdkvlcxtv99e67lcrtfayrr9glpns3fjara",
-    "name": "Alpha Ark Test",
-    "symbol": "ALPHA_ARK_TEST",
-    "decimals": "0"
-  },
-  {
     "id": "terra1366wmr8t8rrkh6mag8fagqxntmf2qe4kyte784",
     "name": "Alpha Pack Token",
     "symbol": "aLOT",
@@ -3628,10 +1451,12 @@
     "icon": "https://ipfs.playlot.io/icon/profile-logo.png"
   },
   {
-    "id": "terra1rpsh2wzwupdkp9ka5muq43fdnh9vkw8ee4uzznpy46ety0e56h2qk8407d",
-    "name": "Alphabreedies",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
+    "id": "terra1h8arz2k547uvmpxctuwush3jzc8fun4s96qgwt",
+    "name": "Alphabet Inc.",
+    "symbol": "mGOOGL",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1h8arz2k547uvmpxctuwush3jzc8fun4s96qgwt/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/GOOGL.png"
   },
   {
     "id": "terra17azgr4x2gz20uquy7vdacfdgjjkgd0h9lm377v",
@@ -3660,106 +1485,26 @@
     "decimals": "6"
   },
   {
-    "id": "terra1g79985x9uyqqynn8ckynk32rj04juqxecjqtmxazz7dq3weywz2swen6s3",
-    "name": "ALUN-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1m7rxu2099cdglmlz46ldqhkxtk26lwjgydszrq2v8ffauzmg5saq0n7rcc",
-    "name": "AMAZE",
-    "symbol": "AMG",
-    "decimals": "6"
-  },
-  {
     "id": "terra1tthplnk67e7tvga2dh49jk6l6cn4furuuffu9x",
     "name": "Amazon.com",
     "symbol": "mAMZN",
     "decimals": "6"
   },
   {
-    "id": "terra1e5vchf97lakl6sulztkn54aapekzfzsa6amdt88exvwmu25s3z0sg6hplq",
-    "name": "amp-ASTR-IBC/-LP",
-    "symbol": "ampLP",
-    "decimals": "6"
+    "id": "terra165nd2qmrtszehcfrntlplzern7zl4ahtlhd5t2",
+    "name": "Amazon.com, Inc.",
+    "symbol": "mAMZN",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra165nd2qmrtszehcfrntlplzern7zl4ahtlhd5t2/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/AMZN.png"
   },
   {
-    "id": "terra16akp34qkh3v6537gra4ypqj4z208fmesdpzp9vgx3w3luruplgmse5rvku",
-    "name": "amp-BLUN-ULUN-LP",
-    "symbol": "ampLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1cgtn7dnlexpqdzr44srt7t5edxlwjqae970prfmlzywjhttae99sche4v8",
-    "name": "amp-IBC/-IBC/-LP",
-    "symbol": "ampLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1xxyr0tduxlggrujcsqmnllu74dmg4697heyjmvvyv6tj3q0hh0qqqq8d6h",
-    "name": "amp-RED-ULUN-LP",
-    "symbol": "ampLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1rlfuqcq935j6avrwsurzn6altrq6htet0ggz3hv86kueeewfzunqj2u6lw",
-    "name": "amp-SAYV-ULUN-LP",
-    "symbol": "ampLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1m9fvkwjpwd4ddgkxd5ddvc2jst9wtv33u7kj89tq2wr0tjm34j8qyfmpwm",
-    "name": "amp-TPT-ULUN-LP",
-    "symbol": "ampLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ymwcpz20lcaue5kkawj3t2fe7et4xd7xkxtuxzc43at0dvcywrsqcuunk2",
-    "name": "amp-ULUN-AMPL-LP",
-    "symbol": "ampLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1as76h247wvey3aqmw22mlkq8g6vj8zj7qw4wywwn388s2mjt0rtqpp570z",
-    "name": "amp-ULUN-IBC/-LP",
-    "symbol": "ampLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1kle8kd6gwx9fwpav6spj8zg25uhftsm87gdss4ssmej4pnee2rtshhyct4",
-    "name": "amp-ULUN-LUNA-LP",
-    "symbol": "ampLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1nrzw3c28h5sq9q7pw9umc0882607exz8he5uj9yx2yw22m3mhrmsxw2lql",
-    "name": "amp-VKR-IBC/-LP",
-    "symbol": "ampLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1hva5lt2whpgav5hhsxfvegvkk2kjjshprzj7spe3cl24g4705asq4kx299",
-    "name": "AMPL-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ppjw8uh4d7mpp8ymutfdtv4ch0acgll7rrs059y3ghhvrs4jgm2szjp74n",
-    "name": "ampLuna Pool",
-    "symbol": "ptAmpLuna",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qxfq924wkxpx0vwy7eudxlumkn3k96e37eynvxdmhje96ftv0h8qykyyrv",
-    "name": "ampLuna Pool",
-    "symbol": "ptAmpLuna",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1wu5cts7zr3sfmwlxfh7an3nthrx9cuz8fx7xfesmdudg2kzcwmhsaw24r8",
-    "name": "ANC",
-    "symbol": "ANC",
-    "decimals": "6"
+    "id": "terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy",
+    "name": "AMC Entertainment Holdings Inc.",
+    "symbol": "mAMC",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/AMC.png"
   },
   {
     "id": "terra1fx6ffswrmgyuf5nsxruce5gertr8vgsm7krrp7",
@@ -3774,24 +1519,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1gwdxyqtu75es0x5l6cd9flqhh87zjtj7qdankayyr0vtt7s9w4ssm7ds8m",
-    "name": "Anchor Terra axlUSD",
-    "symbol": "aaxlUSDT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qgwcdwsk9hg064l5elnxmn84ll03ps0022mndxs87mt25wpj7tfqmt3mdq",
-    "name": "Anchor Terra axlUSD",
-    "symbol": "aaxlUSDT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1tyacsyss53dmsss5fj8rv7fzu2nm55p2pyre0ylz9wfjgzp9z3yqsarc8m",
-    "name": "Anchor Terra axlUSD",
-    "symbol": "aaxlUSDT",
-    "decimals": "6"
-  },
-  {
     "id": "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
     "name": "Anchor Terra USD",
     "symbol": "aUST",
@@ -3800,18 +1527,14 @@
     "icon": "https://whitelist.anchorprotocol.com/logo/aUST.png"
   },
   {
-    "id": "terra16j2duml4u8rlmggc26w4nz8ctxpk3h55l25fgz7u6zjg5evs4suqkc3uws",
-    "name": "Anchor Terra USD (Wormhole)",
-    "symbol": "aUST",
-    "decimals": "6"
-  },
-  {
     "id": "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
     "name": "Anchor Token",
     "symbol": "ANC",
     "decimals": "6",
     "circ_supply_api": "https://api.anchorprotocol.com/api/v1/anc",
-    "icon": "https://whitelist.anchorprotocol.com/logo/ANC.png"
+    "icon": "https://whitelist.anchorprotocol.com/logo/ANC.png",
+    "coingecko": "https://www.coingecko.com/en/coins/anchor-protocol",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/anchor-protocol/"
   },
   {
     "id": "terra1587zn7hagaylrp22x5edz25zpqfn6szfmvtym4",
@@ -3832,42 +1555,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1gs5k436vrwd38rqeanlnacl25swv8gmljgg0zej2ccvdmzr3lpdqmfxrl2",
-    "name": "Anchor Token (Wormhole)",
-    "symbol": "ANC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra15yw86743jryfe890fkuuz8egx22j5te7wat6j76gfm4pgywd0erqaxsr65",
-    "name": "Anchor Token (Wormhole) (Wormhol (Wormhole)",
-    "symbol": "ANC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1g5ghrkqcc5h6cg7ppjljlmx3gcwqzae4a5dwyaajwck2wzyl7p5sgr9tvc",
-    "name": "Anchor Token (Wormhole) (Wormhol (Wormhole)",
-    "symbol": "ANC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1zfhdvjkejtpp639emz9jyre3pp90zq35snrlypyv84x3qrza4xzs5cykdt",
-    "name": "Anchor Token (Wormhole) (Wormhol (Wormhole)",
-    "symbol": "ANC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1vppkxz6706zmd0qq037sv76qhlr4sw8wxyrhr99upmsfez3a576sj7g6wk",
-    "name": "And Enjoy",
-    "symbol": "ENJOY",
-    "decimals": "6"
-  },
-  {
-    "id": "terra19zz9g0lze6s2hjtslhr96h8hn9kl7zktmrx200cqpywrun9z4a0sktfxwr",
-    "name": "Android 51",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra1pujanvsuhqsqf8vc7r3ky9ghr8sgeg4e3ngjun",
     "name": "Angel Protocol",
     "symbol": "HALO",
@@ -3879,18 +1566,6 @@
     "symbol": "HALO",
     "decimals": "6",
     "icon": "https://i.ibb.co/q9krLwC/halo-token.png"
-  },
-  {
-    "id": "terra12ew4cuffqj20l8cz35lzngtk6x2f278dk77wm8pfpc28wle5pd6q88yrp0",
-    "name": "Ankr Reward Bearing BNB (Wormhole)",
-    "symbol": "ankrBNB",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1vj8jwvu0896hhq34r37krtqpfknfm3vway8vghygnrnr7kfzmncqurnvvl",
-    "name": "Ankr Reward Earning BNB (Wormhole)",
-    "symbol": "aBNBb",
-    "decimals": "8"
   },
   {
     "id": "terra15xf5wqprgzl59ckfyjtgavh7rqtxcju7gn57rc",
@@ -3931,10 +1606,12 @@
     "decimals": "6"
   },
   {
-    "id": "terra1p67lldutk5haqpmnk5thuhmhyff8ntf8axa37mzm87qq58082u0qqp9mmu",
-    "name": "Apple (Wormhole)",
+    "id": "terra1vxtwu4ehgzz77mnfwrntyrmgl64qjs75mpwqaz",
+    "name": "Apple Inc.",
     "symbol": "mAAPL",
-    "decimals": "6"
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1vxtwu4ehgzz77mnfwrntyrmgl64qjs75mpwqaz/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/AAPL.png"
   },
   {
     "id": "terra1vyusa796w86yh99l67dpd5g3hfva759vyuhn5z",
@@ -3943,22 +1620,12 @@
     "decimals": "6"
   },
   {
-    "id": "terra16hx93yrc3s7xlx8facausmtz3sfrgknd6mf70fhmzhjkej97g42qkflfs2",
-    "name": "Aptos Coin (Wormhole)",
-    "symbol": "APT",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1plhefzma59lh6rjk5gfkq45pz2chfq35nm9xgdz4pcuhp3nnwekq8sthua",
-    "name": "APY 365%",
-    "symbol": "BOND",
-    "decimals": "6"
-  },
-  {
-    "id": "terra12xzq4mpgzp357yh5pwpztr3j66aaqph5xucttt24f9qw0hf9lg3q686kru",
-    "name": "ARGO TOKEN",
-    "symbol": "ARGO",
-    "decimals": "6"
+    "id": "terra1qqfx5jph0rsmkur2zgzyqnfucra45rtjae5vh6",
+    "name": "ARK Innovation ETF",
+    "symbol": "mARKK",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1qqfx5jph0rsmkur2zgzyqnfucra45rtjae5vh6/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/ARKK.png"
   },
   {
     "id": "terra1yjlqptvn3al5402jp600l7n3l5yl8man8d4kex",
@@ -3967,118 +1634,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra19yuxlwnndlayj4p4d2ue0cpdw0wlhgvekshefar5vvxgkt8rsnlqst9wdx",
-    "name": "ARTerraLand - Mar de Pulpi",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra10fjq3tt0gzffek4099uwtrdv3acaeh69l86j0xycqr54qxyq98nqpj46lg",
-    "name": "Artistic Alphabots",
-    "symbol": "AABT",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1aukmt9xg0857dtzky3pd6cl83ken8dtgagntykytg7yfz9elrccsatlr4z",
-    "name": "Artistic Alphabots",
-    "symbol": "AABZ",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1c3kcc689kuexyx6ylgy6dj0ha3f8vfyhsruntuhj3xsnkcawfmvs6qsgy7",
-    "name": "Artistic Alphabots",
-    "symbol": "AABT",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1kcr0ymnr02ffn2amk3kd6wwdp5c90x5utqpwe4847c55ws634eqst53k24",
-    "name": "Artistic Alphabots",
-    "symbol": "ARLBOTS",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1p7nwjxm2mjjys9vxg4gkvl2jjjf3qqqtvpkysptf5s833nvv96xsxaelq5",
-    "name": "Artistic Alphabots",
-    "symbol": "AABT",
-    "decimals": "0"
-  },
-  {
     "id": "terra129796y06jrejsk9hjmvhkhat92mxt76k6qpyfw",
     "name": "Asan King Token",
     "symbol": "AKT",
     "decimals": "6"
-  },
-  {
-    "id": "terra1s9gdu78jm0yg8e8ceeefcn2j8upmxuf7f6zku4lkwtsngdct6yuqd289yd",
-    "name": "asd",
-    "symbol": "asdsad",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1mrg8rzx2mc43grmzveulyqxpw3enh2uvzlv7vv7ue28gv2d7wcgsap9cag",
-    "name": "ASPARAGOID",
-    "symbol": "MOUSE",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1tgjah63kfmsk38nmanckpf2j28qntdg6zp6vqx4v6mttaza0l3ls0ld7km",
-    "name": "ASTR-BLUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1wrjl547wvaw7vm7e2vqvnvmaeszumfx9whpqdaw8xl5vh65cx24sf6jgap",
-    "name": "ASTR-BRGR-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra185r56sntq8cjem0ttcg93l5cwsx58f4vsl74uen0j8j8z2qnlf2sjgaaqt",
-    "name": "ASTR-DRMR-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra13qaz542ft2ve34jfdy8epp33v6gfd857vc98sjxapf86fh83p99spzqf0u",
-    "name": "ASTR-FRGY-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1e8panxssahk726tf0uualyl7z3n8x9w80lxz6nmdqflm806rs3jq6f7wwm",
-    "name": "ASTR-IDC-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1u9amrmxnnhfwecku6ndaxk2034e73cddxau96avzg4r0xvta4wns2ckane",
-    "name": "ASTR-TPT-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1w4j2zjmam5c2cnclq4tr0v09dncw493y73fttf7hh9fgf3jpxx8szecyaw",
-    "name": "ASTR-WAVA-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1w47prn6mgznc0crx57ckg676kt93y8tr6ts6va5el02juf6rdydskf5spy",
-    "name": "Astro Herro",
-    "symbol": "Astro",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1m2s0tezk5y56cryqnvh7d8zt526th20my5hs02f5eaaya020kmvs0el8nk",
-    "name": "Astroport (Wormhole)",
-    "symbol": "ASTRO",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1pkw7a047dna36hc7kxce90f9v3trszjamr2swzun0cfmc0k2jxdqahzf9c",
-    "name": "Astroport Lockdrop NFT",
-    "symbol": "n/a",
-    "decimals": "0"
   },
   {
     "id": "terra1kdfsdm3c4reun9j3m4mk3nmyw4a4ns7mj24q3j",
@@ -4086,24 +1645,6 @@
     "symbol": "PUG",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/astropug/astropug-world/master/logo.png"
-  },
-  {
-    "id": "terra1pm0gpgsqmjk3rgy43m8z5edmjjx80r738mq4enyswgfz9uhppg4s849crt",
-    "name": "Astroverse #01",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1ur483uv42hht0dz73ammau4wav7mlxuxgtxvmgqx7swy9lg94qhqxjfhzx",
-    "name": "Astroverse #02",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra16968kw24zy3uayaexe6prht89e9zvntcgjuz6a4tf4ujewwfm4ls4jsfp4",
-    "name": "Astroverse x Vinboy",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
   },
   {
     "id": "terra1cl7whtrqmz5ldr553q69qahck8xvk80fm33qjx",
@@ -4147,18 +1688,6 @@
     "icon": "https://assets.terra.money/icon/60/AUT.png"
   },
   {
-    "id": "terra1jh37p2akmwprfwr2235kjyt3wuz0s2sfenhtytg9cajsxnxfvdasnaurdp",
-    "name": "Auto",
-    "symbol": "AUTO",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1jqt5mmlpd6x3jtwfdsxwtrknvaczz2xmplukzc8h86xhupg7fe7q7nkzdp",
-    "name": "Auto TOKEN",
-    "symbol": "AUTO",
-    "decimals": "6"
-  },
-  {
     "id": "terra13x03uqz06gkam3dq4dgx0tj89dpw3vs2nlftjq",
     "name": "AWDw Token",
     "symbol": "AWDw",
@@ -4168,48 +1697,6 @@
     "id": "terra14q0a4tfmdkwrvzakv7nq9jg2d36w8uj9jkhgee",
     "name": "AWESOME Money",
     "symbol": "AWE",
-    "decimals": "6"
-  },
-  {
-    "id": "terra19cx22u6uxzdv4mn7ga8g039wm5yzfe4k7rg4an4f5hwst9vjpxfqt5qfd4",
-    "name": "Axelar Wrapped LUNA (Wormhole)",
-    "symbol": "LUNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra15wg4cwcar39mxq0yg3zlpgcsm5s75sptrp9f57deycmvu30gh5nsshktux",
-    "name": "Axelar Wrapped USDC (Wormhole)",
-    "symbol": "axlUSDC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16dqd7fy7z9rxn0ytue6xjz0flwqyux00vnyqnjlv8j4fya8jeuzq3vs4jk",
-    "name": "Axelar Wrapped USDC (Wormhole)",
-    "symbol": "axlUSDC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1q9rn56280frulg8h9qmv2r2zjxqhx04fdls322egged43n4308xqsxe3pd",
-    "name": "Axelar Wrapped UST (Wormhole)",
-    "symbol": "UST",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qma34k8hxsl65vqf9anrhnr7muvwamhpj7f6u0azwxvvx6uv3exsz2ru8u",
-    "name": "Axelar Wrapped UST (Wormhole)",
-    "symbol": "UST",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1j7ckshknp3px4vggcews2ezp9llqkw65v7f383t2lhqvdvdgkngsgp0npu",
-    "name": "AXL INU (Wormhole)",
-    "symbol": "AXL",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1kkrplzf5hfz04l6pey44s0wd6nctdpv0nrsx47a5ts5s2wagsjcsly7cn4",
-    "name": "AXT (Wormhole)",
-    "symbol": "AXT",
     "decimals": "6"
   },
   {
@@ -4231,36 +1718,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1v4u6kjlc0m6lq089tczfpve2vwpw5cqvrdklcc55xyws2qphqctqp3tp4g",
-    "name": "Bag of D*cks",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1km69jdkp00zvsqya0pmyqn8e3thg7csuud2yw0v2a7jy87uh52qqz7rcq5",
-    "name": "BASI-DRC-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1uuz0sfj2gauppp9p8sul50x97nu3jhtfj7y22x93wgte4kgs0jpqad4qmf",
-    "name": "BASI-DRMR-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1plcht4ueytcpwk6vh4c366g74p3dzrt7st4phszx4mjmsfh74y2sq04nw2",
-    "name": "BASI-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1uelwtk27dq4luvyj0w0u8jvsejcw2l5fvy8n3kxurl69pleqkp5sl5t2rq",
-    "name": "Basic",
-    "symbol": "Basic",
-    "decimals": "6"
-  },
-  {
     "id": "terra1apxgj5agkkfdm2tprwvykug0qtahxvfmugnhx2",
     "name": "Basic Attention Token (Portal)",
     "symbol": "BAT",
@@ -4268,29 +1725,11 @@
     "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/BAT_wh.png"
   },
   {
-    "id": "terra10k0kuaxr2lrgqlp9wqc0xxs3u5lwx434ttg2avc0mtttavykzh2qssgtku",
-    "name": "BAZ",
-    "symbol": "BAZ",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1a7zeajhk6nnj7jzu2rxynwr3yvp58gj2ffxe9k4dneyte0v5kkeqnmzwvq",
-    "name": "BAZ",
-    "symbol": "BAZ",
-    "decimals": "6"
-  },
-  {
     "id": "terra1vsyyg4rs483uzd7jzw5fqqlm2q5n2yd37yylfc",
     "name": "BAZ",
     "symbol": "BAZ",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/BAZustc/BAZ-CORE/main/BAZ.png"
-  },
-  {
-    "id": "terra1xaqh7av93gwvuf2jj0n9sk3fju5pkclh033r8g5phtzawmu5hzusahf5r2",
-    "name": "BAZ",
-    "symbol": "BAZ",
-    "decimals": "6"
   },
   {
     "id": "terra1g36mr60pqf8x4hr3ulpsptrg84w088m0eunsw0",
@@ -4317,12 +1756,6 @@
     "symbol": "wasAVAX",
     "decimals": "8",
     "icon": "https://benqi.fi/images/assets/savax.svg"
-  },
-  {
-    "id": "terra1gyg0pys40ex2f6a4dytd3ewpx2xfrsnt3rdc2t4j3s3jc9qx8kqsrd5c0p",
-    "name": "bETH (Wormhole) (Wormhole)",
-    "symbol": "bETH",
-    "decimals": "8"
   },
   {
     "id": "terra1p2enl6vfmhdfj7ud32p3fkgns22sg62ls9mh2e",
@@ -4367,10 +1800,12 @@
     "decimals": "6"
   },
   {
-    "id": "terra18sv25lxt8v2z2zueatehtchjzv6f67qwsqah9anjyjzntf2rkkxqe9hnd7",
+    "id": "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw",
     "name": "Bitcoin",
-    "symbol": "BTC",
-    "decimals": "6"
+    "symbol": "mBTC",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/BTC.png"
   },
   {
     "id": "terra1vpehfldr2u2m2gw38zaryp4tfw7fe2kw2lryjf",
@@ -4379,23 +1814,12 @@
     "decimals": "6"
   },
   {
-    "id": "terra1urs3y9w7rsk3ysshtftkqtmx90dwxen59j8e0gj79m0wcpygy24ql7flqh",
-    "name": "Bitcoin (Wormhole)",
-    "symbol": "mBTC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra147kkv9tdq4lcuksu2u2h38ucp2rc9sk783wr5zhuxq3p709funpqrl0hk7",
-    "name": "BitLift",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra193c42lfwmlkasvcw22l9qqzc5q2dx208tkd7wl",
     "name": "Bitlocus Token",
     "symbol": "BTL",
     "decimals": "6",
-    "icon": "https://bitlocus.com/assets/btl-token.png"
+    "icon": "https://bitlocus.com/assets/btl-token.png",
+    "coingecko": "https://www.coingecko.com/en/coins/bitlocus"
   },
   {
     "id": "terra1ss460ny4hl5zew0tlvywnw38rsy2ql3n420lv2",
@@ -4416,12 +1840,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1nfgjhx7yh7j0qzw5uz24kr5q2wtneuya9ahs8cet2e0kcetu2seqh46nnu",
-    "name": "Blocks By Artog",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra1r7qpupdxkkh58vw9u8y9n9wjp6d9lr08u39j0z",
     "name": "BLUE TREE",
     "symbol": "TREE",
@@ -4431,24 +1849,6 @@
     "id": "terra1x95tutcwe4tjxcdvtgrjg5jxkf24sm74xz3leq",
     "name": "BLUESKY",
     "symbol": "SKY",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1vpcj4fj0yxy4m928lxf8us7tk8kdqr3ny6q2gtx7g0s935awdreqppm7au",
-    "name": "BLUN-USDC-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra173yxt55wz7aemm7xf2v83ttpnvtwxsaa4q53xp4jdz7m8g97plmsnv2duv",
-    "name": "bLuna",
-    "symbol": "bLuna",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1hspy32cecnj72wwpma59eldpmsmfndlrwqxnzx6awfdtarns66qqw5kn85",
-    "name": "bLuna",
-    "symbol": "bLuna",
     "decimals": "6"
   },
   {
@@ -4485,12 +1885,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra16tvjldrp7mgudk5sn6m7yhady8dg30lw9x4sa07exv2l65gtce8s5835nt",
-    "name": "Bonded Luna (Wormhole)",
-    "symbol": "BLUNA",
-    "decimals": "6"
-  },
-  {
     "id": "terra1c00vskhyzdv0z63z2tyetzx2qma67n2z3vzyn0",
     "name": "Bonded SOL",
     "symbol": "bSOL",
@@ -4502,18 +1896,6 @@
     "name": "Bonded UST",
     "symbol": "BUST",
     "decimals": "3"
-  },
-  {
-    "id": "terra14rpyyhc6vgrachny6ycu4evjyx06j7f46w5gh8ckhay7ueecukss43m2vx",
-    "name": "Bone Luna",
-    "symbol": "bLuna",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1kl3kqkmfe8cdu42y6gdl0stwuckegvxdm8td7jndtj025zxelp6skktt0t",
-    "name": "boneLuna",
-    "symbol": "bLuna",
-    "decimals": "6"
   },
   {
     "id": "terra1s0y8aldsy3t6wtg5tpwe8xzq3lyet5e9grwmlz",
@@ -4534,40 +1916,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra1dpsvhwqqnyllpg40l9ylttnhj3z4wqmwhsjn2u4s8lwvxs6zln3s89ezn8",
-    "name": "Bored Brat Squad 1st Collections ",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1czc4z2r4xvj90xr537e664et7pq9xs2c4vkdwxlk3hdhzxwc4cqsmmarah",
-    "name": "Bored SkullPIX Club",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra18wzq25g7cfleaca0rypsrz5dnu73agjqk7j3lg2uj4c9vtp29efseldtqj",
-    "name": "Bored Skullz",
-    "symbol": "BS",
-    "decimals": "0"
-  },
-  {
     "id": "terra1a07n2cp4wd49ezxdgm9xgtfrnpmxfcdp4yrdnv",
     "name": "BORG Token",
     "symbol": "BORG",
     "decimals": "6"
-  },
-  {
-    "id": "terra1fenpr826qpr42a6u5qwp9lktvzx84cq8dnmpm05fl3d65t75q84sf2yx78",
-    "name": "Born Sinner",
-    "symbol": "LUNA",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1syksjwl88dhetkzfw9snr8f8sg0spsmlvm9h4jq6y7sd6axjd9yqxu3w5u",
-    "name": "Born Sinner",
-    "symbol": "LUNA",
-    "decimals": "0"
   },
   {
     "id": "terra1d6vy3aueuucu3sf5qkrccnq7v58uwegh9m9x74",
@@ -4576,46 +1928,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra15mygj54nztctlmq0g7hfjaetsd2zryjnmctws9v2mjdteppp5znqusylxa",
-    "name": "Brand Governance Token",
-    "symbol": "BGT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1kkpf3f049trkyscv0av2pa9ad02dzls7f6m8s24q07ehetggytesru7qqp",
-    "name": "Brand Governance Token",
-    "symbol": "BGT",
-    "decimals": "6"
-  },
-  {
     "id": "terra1zp4xkexmng539vylktxkf45hxjg68ufx673x8p",
     "name": "BRDG Luna - FTM",
     "symbol": "BRLF",
     "decimals": "3"
-  },
-  {
-    "id": "terra15sad8j5wx8u0aptgfvmz7zwsjrl7mfuc207d3gljh9gdaxx0d0kqq8d7kc",
-    "name": "BRGR-BASI-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1m06sj94uj26c9lscuyfvns5avk9jckehs7287zkfa9usctfpu5tq8y8fd8",
-    "name": "BRGR-DRC-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ul4xg7ddcppfyl405rqyhxcsgp4kg2zfwk40lc5tx433x4tzlsysga3kre",
-    "name": "BRGR-DRMR-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra152ffgyevz7u3nu2a8s0tfur8m7w2uqd5asv9tlzpfnldeft6k2jqraps9l",
-    "name": "BRGR-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
   },
   {
     "id": "terra1ltcad0e9cgf2jgtzqwg82n9k54fre68wdddfll",
@@ -4645,30 +1961,6 @@
     "icon": "https://c2x.world/c2x-station/icon/BSTfancard.png"
   },
   {
-    "id": "terra1a2gdn43yjllg3jvna7xcv2zea0ppjchsww2fedd63l9k2azg6j7qg6v3pj",
-    "name": "BTC",
-    "symbol": "BTC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1pjpkzmnsuupnchte5vz8svwyf4vgr74hdtw7h8vqhd3hcts2ttpskkjeax",
-    "name": "BTC boys",
-    "symbol": "BB",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1uy87s853kqhlac6m7fdc7w2zx43ww5y20qv5llnuanj8fp9lek6q8djl75",
-    "name": "Burger",
-    "symbol": "BRGR",
-    "decimals": "12"
-  },
-  {
-    "id": "terra13e7da9f90m32s04kg4knlpsakmn50kqz2zx2rqypkahhp29gxdwqu4vy8q",
-    "name": "BURN",
-    "symbol": "BURN",
-    "decimals": "6"
-  },
-  {
     "id": "terra13zs7w76g0u4qgagcen6vq92wxuvgfucr3dy4tm",
     "name": "Burn game token",
     "symbol": "BURN",
@@ -4678,42 +1970,6 @@
     "id": "terra1f9h22l730vxxj5jmrakuwh3neuhdynwy42ezvv",
     "name": "BURNED TERRA",
     "symbol": "FIRE",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1z0fvc52jy3630rx36vcya4u3qmnxf9jdjqq40hsumddme8rjpdfsxvhlxk",
-    "name": "Burnt LUNC Using MM Pool",
-    "symbol": "BLUMP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra129zjaxquhh3h5upn0clqzdawnze43a9z34ktt4l6um2hf5w0xqjsta42u5",
-    "name": "BUSD Token (Wormhole)",
-    "symbol": "BUSD",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1aplktggys8uf3mm8rnx5nz2vz66jgu4pszpjg72nn6kst299y58qv46ajc",
-    "name": "BushMills",
-    "symbol": "MILLS",
-    "decimals": "6"
-  },
-  {
-    "id": "terra13y658n8mssa6sesrnqcz05mmxfd7ucma6gg04vwkd2862a2ptexssar2h7",
-    "name": "BushMills2",
-    "symbol": "MILLSTWO",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1xmn82g2e6pch8fwfrxfc90gquek93n6glf38z450mx3hxl8fteasluup20",
-    "name": "BushMills3",
-    "symbol": "MILLSTHREE",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ndlsnn3lcc8s2arj9t5x9qqj8vxsqd4r2rt60zzg7cldwr4askpqlza99x",
-    "name": "BWT (Wormhole)",
-    "symbol": "BWT",
     "decimals": "6"
   },
   {
@@ -4728,12 +1984,6 @@
     "symbol": "C2X",
     "decimals": "6",
     "icon": "https://c2x.world/c2x-station/icon/C2X.png"
-  },
-  {
-    "id": "terra1szqw035afuqmdc42tr2sxd6z5ady0ap9k97fhadzt8mdh46ts2ms2lmsqg",
-    "name": "Cactus MetaGloria",
-    "symbol": "GLORIA",
-    "decimals": "0"
   },
   {
     "id": "terra16ea8pnh3hu69kzqqps5gqw0zdd94hgul9tfnzw",
@@ -4760,12 +2010,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1l3uautulwdvn0v4pl928merxhh40fj46v8vgtpv0yymtk5t3n95s509m0z",
-    "name": "Canvas Worlds",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
     "id": "terra13fs83g5atgjwuh7c5ydzh6n7gecel6xyhhy2t5",
     "name": "CAPITRADE TOKEN",
     "symbol": "CDE",
@@ -4779,30 +2023,12 @@
     "decimals": "6"
   },
   {
-    "id": "terra15cqf7tdtef7umt9tm7lwf72qg4rdxf2wug0pdqznjduam0c9v9rq0rsw6x",
-    "name": "Captain Cookies",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1cyaaw5d03vqp20j0lttlqsnx2ey6e7jgc226fys2q6fnc48mlzwqrdfrdz",
-    "name": "Captive Insurance DAO",
-    "symbol": "CID",
-    "decimals": "6"
-  },
-  {
     "id": "ucad",
     "name": "CAT",
     "symbol": "CAT",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/cat",
     "icon": "https://assets.terra.money/icon/60/CAT.png"
-  },
-  {
-    "id": "terra17n96e2maa553se4u6ntmyzaqan93y6r4q33hwhwr5p386fulk0qqer6jj0",
-    "name": "Catching Fire",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
   },
   {
     "id": "terra1laqzmwrpyrd5tumpx5hs638tzhle4nc42k9jak",
@@ -4817,52 +2043,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra14zhee4jgeage596qhcwzx7u49yguwud9dn80sesa98r878ly3f6sjleq3m",
-    "name": "Cavern Bonded Luna",
-    "symbol": "aLUNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra170e8mepwmndwfgs5897almdewrt6phnkksktlf958s90eh055xvsrndvku",
-    "name": "Cavern Bonded Luna",
-    "symbol": "aLUNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1avs8kkqal38smrr8wwd0rjggz8yltay0hshefnzns8gwh964l6yslkdaae",
-    "name": "Cavern Bonded Luna",
-    "symbol": "aLUNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1cadlgv6qes2ee94qj8d8uyll3ujr4qdl8u3u3rsww2ezyutfjnmsqwr8sw",
-    "name": "Cavern Protocol Documents",
-    "symbol": "CAVDOCS",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1cx38qvyv4mj9hrn6p6m4fj7vhj726t5dg3ldpeupkkgel495ngnq5rtplq",
-    "name": "Cavern Protocol Documents",
-    "symbol": "CAVDOCS",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1v30xmf35gw2lh4rxc8a26ltt65h6ej99fqxmcaxed78uex8ygctstd7864",
-    "name": "Cavern Protocol Documents",
-    "symbol": "CAVDOCS",
-    "decimals": "0"
-  },
-  {
     "id": "terra1cvsfc32dkdvmla6urrscrtfceztecj0u5tvlvz",
     "name": "CBM Token",
     "symbol": "CBM",
     "decimals": "6"
-  },
-  {
-    "id": "terra1w9j54nkyuc4733tp2fz52md27k3qe95y7dfq0x39rcuk6nsjj5sqpmarhl",
-    "name": "Celo native asset (Wormhole)",
-    "symbol": "CELO",
-    "decimals": "8"
   },
   {
     "id": "terra1hppnw4jppmrzzga4yvd8s87y3dwkhe27xwwl5d",
@@ -4884,24 +2068,6 @@
     "symbol": "weLINK",
     "decimals": "8",
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2wpTofQ8SkACrkZWrZDjXPitYa8AwWgX8AfxdeBRRVLX/logo.png"
-  },
-  {
-    "id": "terra1thjqc88nra6sv9c702qpxgjs4n4mdje526uyfal5z2zzf03k9qcq83evd5",
-    "name": "ChainLink Token (Wormhole)",
-    "symbol": "LINK",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1m4anzhza4w5jf78f298f45s0wm2hzjpjfnn3v4xrax3yfvfjhxqqe0xqy3",
-    "name": "Charlie's Crew",
-    "symbol": "Crew",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1273k2c654p6jdu36mel90rxs2cdu7lk5tj9n3wfgkun2rll6pm2qypnu6y",
-    "name": "Chatmasala",
-    "symbol": "Chm",
-    "decimals": "0"
   },
   {
     "id": "terra1spe82hmc9j2y2vjl6urue78zhrn9r9xyydkyx4",
@@ -4932,12 +2098,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1r9sy95elmdvur3et4xgkx6scgfmcaywlnvjsq7eatwnhjqc6hwaq3j660v",
-    "name": "CLUN-LUNA-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
     "id": "terra13eekqp0zgj55arjuacpxqxzgqy2uydf5wzzqns9ddgpepj377afqflunf3",
     "name": "cLUNA",
     "symbol": "cLUNA",
@@ -4951,12 +2111,6 @@
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/cnt",
     "icon": "https://assets.terra.money/icon/60/CNT.png"
-  },
-  {
-    "id": "terra1hsqqj2namaepxt9h80snquszljxlsygl7kr32k5wyr424zs3j8zsl76l9d",
-    "name": "COAL",
-    "symbol": "COAL",
-    "decimals": "6"
   },
   {
     "id": "terra1yuvwz0wzd49mjlvh24g23jst89dllua0nc3knt",
@@ -4979,16 +2133,18 @@
     "decimals": "6"
   },
   {
-    "id": "terra1u4caj7h7f89w9jzudr9ryy3aq9kr6skwa9gf2k764wpzqjj0k55s0nsp2e",
-    "name": "Coffee Planets",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7",
     "name": "Coin Swap",
     "symbol": "SWAP",
     "decimals": "6"
+  },
+  {
+    "id": "terra18wayjpyq28gd970qzgjfmsjj7dmgdk039duhph",
+    "name": "Coinbase Global, Inc.",
+    "symbol": "mCOIN",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra18wayjpyq28gd970qzgjfmsjj7dmgdk039duhph/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/COIN.png"
   },
   {
     "id": "terra1n8awtfqa0wphx90pd2zc9v8vccc65f0gvv6rq5",
@@ -5027,34 +2183,10 @@
     "decimals": "3"
   },
   {
-    "id": "terra1dkkpnzmq88fsl4gfah4r6k9445vtpeqsucxpu34x6lp2cnkgu4lsae6d27",
-    "name": "colinB",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra1tvs43r9ry6s6g6j5mnmruw97s3fjhqxpc540hu",
     "name": "Connect Labs",
     "symbol": "CONNECT",
     "decimals": "6"
-  },
-  {
-    "id": "terra10l5yur0teqfllu296sd86y86xxmh49wgy3sahws2yt3t3xh45g8q0zwqdp",
-    "name": "Cool Ape Punk",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1j2qpcu8c3rgwtnq4azh0lpn035phmw9ummds7g3llrjuj5xvksjs6epy6t",
-    "name": "Cool Jerry Gang",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra19pwawxl2xzve0k06uehl5pl8fhvcykxuc0yfpzqy2pv39jv03fpqha5uwe",
-    "name": "Cool Teenager ",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
   },
   {
     "id": "terra1u02lqdhuhdfwph8wsl9yx9r0jupfdsd22q60tc",
@@ -5075,52 +2207,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra1s28fv278avrpazql4ktsstgymj8un6ua8t4yjehcr3kj2qm2ns8splxk40",
-    "name": "CrazyGhostsss",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1vkzknym2gw2xe59vsn8lf20lvdd0zrduew8km49fwjvn7a223kfserjsgy",
-    "name": "CRT (Wormhole)",
-    "symbol": "CRT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1hparjahcp0yrthrae7vhu07ynqy2fj09n8p46y3epn8xr3g9jvwsnr27yw",
-    "name": "CRT (Wormhole) (Wormhole) (Wormhole)",
-    "symbol": "CRT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1s53wmnfeu5zj394jfc4p5uhgzlkc6wjgva7w8ksv5gc3avg9jhps8xlqle",
-    "name": "CrudeArt: Wildcard",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra14kzm7p634852h2k2qqg2cr3zvaqvn796lejflycg53sfkmgq02fsmlnj6n",
-    "name": "Crypto Compass",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra1tewnpkjdtqq37udf5c5wjfrtkpegthfmls8lp7",
     "name": "Crypto Dev",
     "symbol": "CYD",
     "decimals": "6"
-  },
-  {
-    "id": "terra1ew4g9l5gh9tgls7yd9uz3lyue9m2u0u6z0jtw7s0fgvq8gvl693s07wepu",
-    "name": "Crypto Donkeys",
-    "symbol": "CDK",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1yqacrx2jvrnede4x87w370g4qgsstq3qjnqaqy77ypx3fqeynrjqfaa023",
-    "name": "Crypto King",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
   },
   {
     "id": "terra1qsjs0a02jmyfhvaeul4zax22sayx5e8dl8527g",
@@ -5133,18 +2223,6 @@
     "name": "CryptoBonds",
     "symbol": "BRLF",
     "decimals": "3"
-  },
-  {
-    "id": "terra1akahwercw3vmmd6ac4hudum9kj3tlvuw28ku064tj3gnk00d5w0qg2j6vs",
-    "name": "CryptoGlobe",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra16aq0p35g346xe3h60yuhkns3rhj6k66wwtz6czwgep7fwvmyjxqqw5gktz",
-    "name": "Cryptoismyjam",
-    "symbol": "JADE",
-    "decimals": "0"
   },
   {
     "id": "terra1hqr3l4je2yvn3l790ly0y6r0vgfs7yukwwj0ak",
@@ -5187,18 +2265,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1a3kqxlfgqnlmzrx6c22w7g94ucxlhcmnyafr8d8sldjzgplk66gq35fdtk",
-    "name": "Cute Corgi Crew",
-    "symbol": "CCC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1gdxwdrezs9dcrwgyjha9a0dwypumragsxqwm3x6hv7tfea8zzqtshsm5f4",
-    "name": "Cute Fat Chonky White Cats",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra1jju99w456sm6w2snkmatm00gve7cvvzda0j6pn",
     "name": "CUTE HAPPY",
     "symbol": "CAT",
@@ -5211,28 +2277,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra1q4l8zelhlcte9l496spty7wxdmlp74vvxjyqdjjw063x9qqc4udsyd29we",
-    "name": "Cuties of the Terra Universe",
-    "symbol": "WOOF",
-    "decimals": "0"
-  },
-  {
     "id": "terra1mely4fttd94g5kgjmz05dmclgdahq45xnv5n22",
     "name": "CVRG Token",
     "symbol": "CVRG",
     "decimals": "6"
-  },
-  {
-    "id": "terra1g2xx0jjngyahfhh4j2zdp5hwt8l0runfl9td6fx8l8vdx82rc8yqqy9hww",
-    "name": "cw-plus:cw20_base",
-    "symbol": "TEST",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1490pnjx2g7tce3ywcrzn3detm6r8w0jm5vzcc6kxvgzvg2eplgwqewl349",
-    "name": "Cyberdeck: First Settlers",
-    "symbol": "CBD",
-    "decimals": "0"
   },
   {
     "id": "terra1dxt75lk0m5g0wpucg0mz905akta99fjhuhafqa",
@@ -5254,28 +2302,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra16vdmyrgc344tsj3p5sz25wtx608nx97wl65w96x98s8x9we84dasnlpxdw",
-    "name": "danku_r | WAGMIstones",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra1d8uw3zddfrexn06f80nz6hx2cd3f32a7p45agf",
     "name": "DAO Shiba Inu",
     "symbol": "DSI",
     "decimals": "3"
-  },
-  {
-    "id": "terra1jva62gxl46aga43p8pfpp2xrujw73g37605334m7cng9mus39qksurqsdn",
-    "name": "Dark Waters - EP",
-    "symbol": "TESDW",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1w6szmq0vwlc8wlqt59fyrucw96xlptwrvejz3amhlp3ejdeuc5dqcuxjyq",
-    "name": "Dark Waters - EP",
-    "symbol": "TESDW",
-    "decimals": "0"
   },
   {
     "id": "terra1nzvqd5mr0jn58cvam9j06k9kry4myu0vp7a9ug",
@@ -5315,48 +2345,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra133ehn057cmupzcnk5l5rmgzqn90wfe6qemj2mj9r4mlh0l5slgfsznda3t",
-    "name": "demo_token",
-    "symbol": "udemo",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1zre8uunucxf7g3gyxnmntj4e723wjad0phmj9xtar5g67kcep73s9qlqsk",
-    "name": "demo_token",
-    "symbol": "udemo",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1hfg2yzqnvaplc04mnhu9cwff7llwxvhq2fjh50449q7kh9u4xuxsdcngfs",
-    "name": "Dengue's Fever",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra19j7859076jveetfhdskc6hwjnr7cpt2t78llp8nz9qnaqtgvj8ns0qgp9j",
-    "name": "Depeg Nation",
-    "symbol": "DPEG",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1kad44vp08yqcz9ec366krj89yvsvs6nmauvhqu6sl93jjw5ugw2qd3xdnw",
-    "name": "Depeg Nation - Tales of dUST ",
-    "symbol": "DPEGC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra17gck626vgax9jpe6utm7dhx4vdzawfkt0jhru03l7a3dzu98wedsfad4sz",
-    "name": "Depegged UST",
-    "symbol": "dUST",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1n3j3l0w2eclpv3me28yxzjesfa9cqt4m0e2d3xhxjk03pch2uxqsds9fud",
-    "name": "Depegged UST",
-    "symbol": "dUST",
-    "decimals": "6"
-  },
-  {
     "id": "terra1jusuf8pcuw56pmj0len5tcsdu9dm4xpqwqk48p",
     "name": "Derby Stars",
     "symbol": "DRBY",
@@ -5369,18 +2357,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1p648gcmx8zmjfqqk095zp6jxr5c4an0mdgl5rlrs8r82rp33yngsxw4qs2",
-    "name": "Día de Muertos",
-    "symbol": "Dia",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1rfr0epuuk5adhlp7qay7fxy6sdf78u492epen2jfs844cfxcqltqze6jmz",
-    "name": "Día de Muertos",
-    "symbol": "Dia",
-    "decimals": "0"
-  },
-  {
     "id": "terra18zqpuua4d8u9q9d6zsn8fqtjj5k8hk845prz9v",
     "name": "Diamond Club",
     "symbol": "DVC",
@@ -5391,19 +2367,8 @@
     "name": "Digipharm",
     "symbol": "DPH",
     "decimals": "6",
-    "icon": "https://digipharm.io/wp-content/uploads/2021/02/digipharm_etherscan_logo.png"
-  },
-  {
-    "id": "terra1vnzcsvy7ytan9tnjnzzhg8k7hpg0f30seg26xe6c66t4e8p0d84sqls0w0",
-    "name": "Dinheiros",
-    "symbol": "Dinheiros",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1hm53sx43hhdaad8uhvuz8gnh9zq7ukr7au7257adevcwpn267zashyfcjr",
-    "name": "Dino Hodl Crew",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
+    "icon": "https://digipharm.io/wp-content/uploads/2021/02/digipharm_etherscan_logo.png",
+    "coingecko": "https://www.coingecko.com/en/coins/digipharm"
   },
   {
     "id": "udkk",
@@ -5412,24 +2377,6 @@
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/dkt",
     "icon": "https://assets.terra.money/icon/60/DKT.png"
-  },
-  {
-    "id": "terra17ytwg38lx24x4nhker06er64sa2tvr9h6ppdc9ewupnswgqxxjpqq0q2fl",
-    "name": "DKT (Wormhole)",
-    "symbol": "DKT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1xvxmxw8rsywqzxmlzpw9wu9ddtxts5hwwusayya95fva7up4577slfmp55",
-    "name": "DN",
-    "symbol": "DN",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1sdvvdhaeusr96sq5yunkkn78uvlwr4uuaasctjq85gh5sy6f7w2sqqqzhq",
-    "name": "Do Klown Kwonzi Inu",
-    "symbol": "KLOWNZI",
-    "decimals": "6"
   },
   {
     "id": "terra1akwn8y34upderjyw07hgepunte8mza00vafzfd",
@@ -5455,12 +2402,6 @@
     "name": "DogCat",
     "symbol": "DOGCAT",
     "decimals": "6"
-  },
-  {
-    "id": "terra183tzpzemhgjdsfh6ahsvkc43s6xajd58qgppd2r2rrc0afetzftq624xw8",
-    "name": "Doge",
-    "symbol": "DOGE",
-    "decimals": "0"
   },
   {
     "id": "terra18cs7aktav46v3pwxr8r2hfkl9pdfmrthcn58qf",
@@ -5584,27 +2525,9 @@
     "decimals": "1"
   },
   {
-    "id": "terra1j6l6q3cnwqgpldf2k92mce2cd888wtecz3fun7yffcpghw3wn9qsgl52nv",
-    "name": "Doodle Baby Ape",
-    "symbol": "DBA",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1usnq8smssvxfjcdt2jdl0f6vc0wxssjy8vdx698mlyluy25ejrzslq3t5x",
-    "name": "DoodlesXXX",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra1uv3298xevlfdcjthfv4me7tn7gjxd3drv6ejvt",
     "name": "Doom NFT",
     "symbol": "DOOM",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1nm3hvfs4g6l48zrnxp75js39dvmdvjt85eh0pzz20mhvf92ler3qrrspek",
-    "name": "DOSCOIN",
-    "symbol": "DOSCOIN",
     "decimals": "6"
   },
   {
@@ -5640,12 +2563,6 @@
     "decimals": "3"
   },
   {
-    "id": "terra1tqpzf2f5ll3zmm53nwczatp8fzlu2stzrlxwrjgqsx3wxqwxw8uskh9qfp",
-    "name": "DOUN",
-    "symbol": "DOUN",
-    "decimals": "6"
-  },
-  {
     "id": "terra1ry60wuc8a7a4ujt3tmrp3upxzf6a4awj88eys3",
     "name": "DoWillBuy",
     "symbol": "DWB",
@@ -5674,7 +2591,9 @@
     "name": "DragonSB",
     "symbol": "SB",
     "decimals": "6",
-    "icon": "https://s2.coinmarketcap.com/static/img/coins/64x64/14451.png"
+    "icon": "https://s2.coinmarketcap.com/static/img/coins/64x64/14451.png",
+    "coingecko": "https://www.coingecko.com/en/coins/dragonsb",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/dragonsb/"
   },
   {
     "id": "terra1nh6theuhf4pv67pcyqnz58czljr382mxrp2rdh",
@@ -5683,45 +2602,9 @@
     "decimals": "6"
   },
   {
-    "id": "terra1zjtpdke8qnqjflgeyyd8wrg2de32z3g2avk2utwlc4vzjw974jfs34nu08",
-    "name": "DRC-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
     "id": "terra1elkjjsg4vm5u4tnesqcj3dzgvhanzld48lkqv2",
     "name": "DREAM PROTOCOL",
     "symbol": "DREAM",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1c5qexuz3hx9rkac8tfa9ktytfgurg767qd5p08e7l7khkhtktk7sx84vdk",
-    "name": "Dreamer",
-    "symbol": "DRMR",
-    "decimals": "18"
-  },
-  {
-    "id": "terra1gn3fwtw7k40gl465723phk4qgarthw32t962acxz5e5rjzgepwpsjysppv",
-    "name": "DreamersCubed",
-    "symbol": "DRC",
-    "decimals": "18"
-  },
-  {
-    "id": "terra1kytfl8v8e9pq0s5texq2vwcjy9k456ky44x0429yeh3cwj9m64cqdfpa9k",
-    "name": "DRMR-DRC-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1cpflqqkse0lljw4cekrh9sqdz0km9p9lzteqd55y5qd0yrdzxg8sytqdpk",
-    "name": "DRMR-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra10n8tq3hxa5rkgzwdjylehrl27alhlutyssqlrajr0h80vze46dfsye9y8v",
-    "name": "DRMR-ULUN-LP",
-    "symbol": "uLP",
     "decimals": "6"
   },
   {
@@ -5821,12 +2704,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra13cdqlhz4z7ml27y792xx4rnf93u05y4m49jmfh7jn7cglg7qn7cqggt7dq",
-    "name": "dUST",
-    "symbol": "dUST",
-    "decimals": "6"
-  },
-  {
     "id": "terra1pzjd5axw303jt40l4pmakfa88d0jpjf8rpmj8n",
     "name": "DWONS BIG DONG",
     "symbol": "DBD",
@@ -5845,81 +2722,9 @@
     "decimals": "6"
   },
   {
-    "id": "terra1uegpgqzy3aqwzpkfeyp7e8ljs0m3jm9upq77g4f7kv7jcfrd9lcslayred",
-    "name": "eCash (Wormhole)",
-    "symbol": "XEC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1d9ac0uug25qdu00te7mlsam608aqy7608k9ay406kz3zz60f23csq058vv",
-    "name": "Edge AxlUSDC",
-    "symbol": "eaxlUSDC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1fjane47sgaaljgm0qe0ysjwtuqjlp493ar4gwt8rez45qaazf9gsfgc6af",
-    "name": "Edge AxlUSDC",
-    "symbol": "eaxlUSDC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1gpcn0jvm6rv2zxce7dlgmh0k3l8zns72m5l2u47m44ehyxgar2dq6v8p75",
-    "name": "Edge AxlUSDC",
-    "symbol": "eaxlUSDC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1v6v4rcut5tsyufktp6da4vnn0a7jgm8e83ypdndsgykev5fu8uvqg5x2q7",
-    "name": "Edge AxlUSDC",
-    "symbol": "eaxlUSDC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra15a409g7juszev4k88pvvvh80654903k7q00qtlddjasqynhjj45qzvk893",
-    "name": "Edge LUNA",
-    "symbol": "eLUNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra18p9qapupd23gv7pf5k0n4ce5staqq39p7msl6vcvntrr3kgm54xqkrhffh",
-    "name": "Edge LUNA",
-    "symbol": "eLUNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1texwq26vke5vqem2lljwteqvyd9azy7x4mm0nxfgq7kleg8k5ukquvnqft",
-    "name": "Edge LUNA",
-    "symbol": "eLUNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1zd49uw3gd3z2v4tujlxyapsdw62e3g0n29gm2kpn5crl0y5zfg7slhxykm",
-    "name": "Edge LUNA",
-    "symbol": "eLUNA",
-    "decimals": "6"
-  },
-  {
     "id": "terra1x5mhyxzmy8da89rh7dnt3v289qz988hclyl6kk",
     "name": "EEE Token",
     "symbol": "EEE",
-    "decimals": "6"
-  },
-  {
-    "id": "terra10mdchp7kmpj8v5maqk902pwnm0ynj39shme66krac6nm2cw9zh4qxvvcx9",
-    "name": "EGA",
-    "symbol": "EGA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1e427e4zp7unnpr2677wkegqjdxqx9w7mtdenewjyg755ell0238qz27c6z",
-    "name": "EGA-EGB-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1v0g6jel2c5rf00yw5szjw38fn527w5p6szujmw44n2x9azkfumcqpv4j9s",
-    "name": "EGB",
-    "symbol": "EGB",
     "decimals": "6"
   },
   {
@@ -5959,12 +2764,6 @@
     "decimals": "8"
   },
   {
-    "id": "terra1md6qktuqpa0uat6gk7glh8lfxs87t04ym2pmy4uvxg83jwxdcmasrcxt90",
-    "name": "EMIYA",
-    "symbol": "EMD",
-    "decimals": "0"
-  },
-  {
     "id": "terra19pz3ehx9f2thr9t9jk5y89aalxmhzuq9j8ak99",
     "name": "Enter The Matrix",
     "symbol": "MATRIX",
@@ -5978,34 +2777,18 @@
     "icon": "https://www.erisprotocol.com/assets/ampLunc100.png"
   },
   {
-    "id": "terra1w0ajeq6pu757yy0uxkvg4g0ayssdvx4r570d9a93u88ax2uau7wstvhywy",
-    "name": "Eris Amplified LUNC (Wormhole)",
-    "symbol": "ampLUNC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1t4m5lcffscupfuzthf06s30w5ghkzupyfnknsh8f4rwtm69x6fsqrxrhme",
-    "name": "Escudo",
-    "symbol": "ESCUDO",
-    "decimals": "6"
-  },
-  {
     "id": "terra1h0jk42weh0urhgdtjql93rrvgdccspnp7vyf49",
     "name": "ESS Token",
     "symbol": "ESS",
     "decimals": "6"
   },
   {
-    "id": "terra1ly8vd2q69h3jlyjgnwqq0q4wngulmr2l2gr0lxd93tqle42596rsq5zz5d",
-    "name": "ETH  in USDC",
-    "symbol": "uETH",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ggefs7qz3spjmkmjk9k37xycljlf8525ea6sf4d356vufnrn9z0s7hrjy5",
-    "name": "Ethereum (Wormhole)",
-    "symbol": "ETH",
-    "decimals": "8"
+    "id": "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
+    "name": "Ether",
+    "symbol": "mETH",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/ETH.png"
   },
   {
     "id": "ueur",
@@ -6016,87 +2799,23 @@
     "icon": "https://assets.terra.money/icon/60/EUT.png"
   },
   {
-    "id": "terra1m24v9uumvuuhqu27xjlcqyzt8v78766vuu9sae5gt83u4xffam9s57vq6k",
-    "name": "EUT (Wormhole)",
-    "symbol": "EUT",
-    "decimals": "6"
-  },
-  {
     "id": "terra1aaqzva7adgwtzfkt9nmrmuvkg9s6lmsgtkg3jd",
     "name": "EXP",
     "symbol": "EXPEDITION",
     "decimals": "6"
   },
   {
-    "id": "terra1uhepfcw3va42nd8uwjymtjykuqs24y2jxgrjcfh69nd3gzwxj2ws5s8xf8",
-    "name": "FAFA",
-    "symbol": "FAFA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra19m0l67v6atfmu4cfmu9dw3hvum3rju6gt4jcw2ecpc6qr5lln2gsjs0439",
-    "name": "Fake Punk",
-    "symbol": "FP",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1jyfsmyzgk54gwjqcvvmq5xxaruada40hnfzvfzlt3njt7y72a0zqng56p8",
-    "name": "Fake Punk",
-    "symbol": "FP",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1v8787ruq4sgy2ple8pq5r4v5gsrjytnutxeseuknqjqpjxh555esar9wzs",
-    "name": "Fake Punk",
-    "symbol": "FP",
-    "decimals": "0"
-  },
-  {
-    "id": "terra142rnaaef6m5085p8kexfs0gfzky0evq47zffst7leezgdtsksrrqytxaaz",
-    "name": "Fallen Guardians",
-    "symbol": "WHALE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra19eg7fk4aw0muwe57lnawjpu6gvxe0e7naewnkgh8ytx686te2gks59sg28",
-    "name": "Falling Squares",
-    "symbol": "FLS",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1vmqa8hls3axrk8vqwqcztuu02t5w5hkrx6mzt7pn7jrhnx5xkxcs7lk6rg",
-    "name": "FAT (Wormhole)",
-    "symbol": "FAT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1dtaqwlmzlk3jku5un6h6rfunttmwsqnfz7evvdf4pwr0wypsl68q6nuam0",
-    "name": "FatManTerra",
-    "symbol": "FATMAN",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1zf90xr38pdgq0yjq2d56scclpfyu3ep4d720s9r2yw9gmwg7khaq0c30rl",
-    "name": "FatManTerra",
-    "symbol": "FATMAN",
-    "decimals": "6"
+    "id": "terra1mqsjugsugfprn3cvgxsrr8akkvdxv2pzc74us7",
+    "name": "Facebook Inc.",
+    "symbol": "mFB",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1mqsjugsugfprn3cvgxsrr8akkvdxv2pzc74us7/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/FB.png"
   },
   {
     "id": "terra17nekftv2yp8n4lsex85008sphchs4t3rnfcqzf",
     "name": "FFER Token",
     "symbol": "FFER",
-    "decimals": "6"
-  },
-  {
-    "id": "terra129w4tcrmzxk8u37qqtc0hezp66mkef45m3d9atnvlz09dar9a50qv30u04",
-    "name": "FIFI",
-    "symbol": "FIFI",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1xpwvt75aqj69kxcez0mm4z2fty40gaxc2ed0vzdy0y47qnswpxhq3d4wpg",
-    "name": "FIFI",
-    "symbol": "FIFI",
     "decimals": "6"
   },
   {
@@ -6286,12 +3005,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra10exkttsx4xq2j5k3uel9h4gvxy63yd90u46yt3qzn9vfcuh2utwqydz8rq",
-    "name": "Froggy",
-    "symbol": "FRGY",
-    "decimals": "6"
-  },
-  {
     "id": "terra1m2ar36pnymh6h4n0p7l2w4uxswc70e9auyvxh6",
     "name": "FROM EARTH TO THE MOON",
     "symbol": "FETM",
@@ -6317,22 +3030,12 @@
     "icon": "https://crytpo11.s3.eu-central-1.amazonaws.com/FANFURY_logo.png"
   },
   {
-    "id": "terra1p08zvpe4qr53w26fjjs2sjsh7tuhdfmuz5s3eltr7t6htmc6vh5qslqfga",
-    "name": "Galactic Cat Club",
-    "symbol": "GCC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra16ds898j530kn4nnlc7xlj6hcxzqpcxxk4mj8gkcl3vswksu6s3zszs8kp2",
-    "name": "Galactic Punks",
-    "symbol": "GP",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1dpryq9v7aqdzgkjkn9tgxstw7mclj78evh7zegupek4jjwsgt0wq7r26wp",
-    "name": "Galactic Punks",
-    "symbol": "GP",
-    "decimals": "0"
+    "id": "terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls",
+    "name": "Galaxy Digital Holdings Ltd",
+    "symbol": "mGLXY",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/GLXY.png"
   },
   {
     "id": "terra1hytrupk3argcrsl5x7dv55gyda0tn7f2qqlwkl",
@@ -6347,22 +3050,12 @@
     "decimals": "3"
   },
   {
-    "id": "terra1cmz3jsnf0r6z5f5zsxjsgspeyqdn06w4sr9jmtuvm544s400a8dsc8jtrx",
-    "name": "GAMMA aUST (Wormhole)",
-    "symbol": "gaUST",
-    "decimals": "8"
-  },
-  {
-    "id": "terra16eryf4yctfe39ppa48507a40dl2dka4psm33tasg0c3ra2n57jxstf6za6",
-    "name": "GavertC",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1f7zfr8j7etlmcypgm2aw6mky3sqfq4hn8au4kulj5puxkls6wvkqm5gy8y",
-    "name": "GavertC",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
+    "id": "terra1m6j6j9gw728n82k78s0j9kq8l5p6ne0xcc820p",
+    "name": "GameStop Corp",
+    "symbol": "mGME",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1m6j6j9gw728n82k78s0j9kq8l5p6ne0xcc820p/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/GME.png"
   },
   {
     "id": "ugbp",
@@ -6373,51 +3066,9 @@
     "icon": "https://assets.terra.money/icon/60/GBT.png"
   },
   {
-    "id": "terra105eh7wgzv9k39unzre6yfey9tvzdex737uc6ylk6phpmtfepylpqy6v6nw",
-    "name": "GBT (Wormhole)",
-    "symbol": "GBT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra13jlm0anpdd3hc0xctw9vtncmcfnrag8dh686s2juy7m226unwd4q0tmx2v",
-    "name": "GEA",
-    "symbol": "GEA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1m496u7arteks5hg29dea8gd64f9jvtg3rlg8we8rese6v70ggvpqjt4e60",
-    "name": "GEA-GEB-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1asmlnmhg7kua2ceyaedyjh54hs6w9wu28dlqu8a2rqw0d49ya5lqqptjfz",
-    "name": "GEA-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1v5j5azhyxl54h78udlt9n9vs24flvw4h0syfnpj6fr4v23tukzssgz9yys",
-    "name": "GEA-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1mrdgys0e0hhq0n56zgy3e0htahcnwtdt4dy2ec9wcltcr6qjntmq0yen07",
-    "name": "GEB",
-    "symbol": "GEB",
-    "decimals": "6"
-  },
-  {
     "id": "terra1k5hx3egz7jnzqs7n2ze0d93mce80y4cndd5saj",
     "name": "GGG",
     "symbol": "GGG",
-    "decimals": "6"
-  },
-  {
-    "id": "terra177huv6k3gyqwxcd7n32ts56tvxt68dgll0fn56k56rcvy9zeke9s5gfn3c",
-    "name": "Gidorah",
-    "symbol": "gido",
     "decimals": "6"
   },
   {
@@ -6425,24 +3076,6 @@
     "name": "GigaChadToken",
     "symbol": "GCT",
     "decimals": "8"
-  },
-  {
-    "id": "terra14phr0v3x8spgxwp64lxckzwzdlcfqtel3ynn5zcv6k7ded67pe6qk2my2r",
-    "name": "GIRL FROME KNOWHERE ",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1at27manc5tsujxfulas6rucuh24tsrkrr5spl5k7xryxlfd62ylsjpg6s4",
-    "name": "Girl's on Illustration.",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1y8z5urkg2e0ludtghuvrkspluzy2a5a7dwyv7n2pkw5heuczjavq3nrpqj",
-    "name": "Girls in kimono",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
   },
   {
     "id": "terra1cp02hkhu2nq7zznz04shwfvh9hdsp3y5334n6t",
@@ -6509,12 +3142,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1q8e48hqgqr6kkrxyf0x2e4ngy5pxfq832nqr3md54wgpk4gnf9esrh6fw9",
-    "name": "Goblin Punks",
-    "symbol": "GP",
-    "decimals": "0"
-  },
-  {
     "id": "terra1hw6q5ecr0gp09v668szzx3qz86w08jru9rqyq7",
     "name": "GOD",
     "symbol": "JESUS",
@@ -6539,10 +3166,12 @@
     "decimals": "3"
   },
   {
-    "id": "terra1u8z5eyklvsuutcmrxf7szr6u099e7c7phrm7jhywnplqkdxxgj9s0ked3h",
-    "name": "gold luna",
-    "symbol": "gold luna",
-    "decimals": "0"
+    "id": "terra137drsu8gce5thf6jr5mxlfghw36rpljt3zj73v",
+    "name": "Goldman Sachs Group Inc.",
+    "symbol": "mGS",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra137drsu8gce5thf6jr5mxlfghw36rpljt3zj73v/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/GS.png"
   },
   {
     "id": "terra1d633fx8wlpgqnns9j4xw66cq6ypdy4u8r0rr7j",
@@ -6563,42 +3192,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra139xv68tuktzq68u6fuv3snfk8tc34z8y3xgv7jw3kmcztuzmc3uq6dd32m",
-    "name": "Gorilla Haus",
-    "symbol": "GHS",
-    "decimals": "0"
-  },
-  {
-    "id": "terra123sjspx2v6hf2yjms3npz6nkmnx4vcxa9arce5q4n7w7k07wz0uspvsfgf",
-    "name": "Gorilla Haus Alpha",
-    "symbol": "GHA2",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1latd9ny36pdpehr3eukyq26jgm2c89ledpyg7es5e8muz5rul0lshstszh",
-    "name": "Gorilla Haus Alpha",
-    "symbol": "GHA2",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1ryy9h3zn6yrs6m2et3drkgszjfzjutfkmajytp98dq7xr8uqwfxs80zfut",
-    "name": "Gorilla Haus v2",
-    "symbol": "GH2",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1wez7n48nvcvw6wr6hctery68zzvfcerqks9phv2nat7ttpkesumqsa5ghv",
-    "name": "GORILLA HAUS v2",
-    "symbol": "GH2",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1ekfzeqk8mhvndg0npe9fcuhr06p8c9uv9h8czryheprgma8avmfq2s354e",
-    "name": "Gorilla League Members",
-    "symbol": "GLM",
-    "decimals": "0"
-  },
-  {
     "id": "terra1xs3pv5rd2xu36w9vg05shkgxcrxkvz40fhnfsv",
     "name": "GRAY",
     "symbol": "GRY",
@@ -6611,28 +3204,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra19cqs4lhwtq5uz037w0w7w5kjszyjrj6n0d0js7p5nmhnlzegxpxsvea3nk",
-    "name": "Green Autonomous Society",
-    "symbol": "GAS",
-    "decimals": "9"
-  },
-  {
     "id": "terra19m0xqgdaltwkesdt6m383jkqh3m9xyxwtp0f6f",
     "name": "Green Dragon",
     "symbol": "GRDR",
     "decimals": "3"
-  },
-  {
-    "id": "terra1hqemjht73a5zwuspk36gdrf4e05t30kcmckfh4lpy2fqv5rgyw3sgh5qpe",
-    "name": "Groovy Lunacy",
-    "symbol": "GROOVY",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1swdw97vxj3895nj88d0jhdu0acem6gy2cchcxzlhwfq2pz2p0cksqt50t2",
-    "name": "Groovy Lunacy",
-    "symbol": "GROOVY",
-    "decimals": "0"
   },
   {
     "id": "terra1tc7tcg8u54p3t2r5yfufgf4z340ggwpvlc2rwt",
@@ -6641,29 +3216,11 @@
     "decimals": "1"
   },
   {
-    "id": "terra1kv690w4w7ad2d6st3edmwd9y5zxj5j0ckqtnfywwut555jpw68pq0kz5p6",
-    "name": "GT Capital",
-    "symbol": "GTC",
-    "decimals": "6"
-  },
-  {
     "id": "terra15pkdjxv2ewjzn9x665y26pfz2h6ymak4d4e8se",
     "name": "Gtps.Finance",
     "symbol": "GFI",
     "decimals": "18",
     "icon": "https://img1.wsimg.com/blobby/go/f561f953-0bdd-48bf-a39b-982ecbd1698b/downloads/GtpsFinance225x225.png?ver=1649021019248"
-  },
-  {
-    "id": "terra1mzexcawct0dle4h2pced5efj5zk7gs3dgfulrlxewkaawm2anmes8hfzrf",
-    "name": "Guess who's back",
-    "symbol": "BCK",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1zlls6m9t2eg60t2wmw58aatt6umrh0xw93947kzt2rczkrcejcxsxf6u2d",
-    "name": "Guess Who's Back",
-    "symbol": "GWB",
-    "decimals": "0"
   },
   {
     "id": "terra1z55rhw0ut70jxdmpvge98mvj0rkwcz74q77z0u",
@@ -6727,54 +3284,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1klxa4rxjgpg9xuaf5mwpgykpv7x9decrvgg3ejresupcne69cgdqzx5yhu",
-    "name": "HERO",
-    "symbol": "HERO",
-    "decimals": "6"
-  },
-  {
-    "id": "terra13cdhq2uhsfe3p74jm28j5jf7ap3emj60v6cgmezy2er7hs6zh72sh3rxs4",
-    "name": "Hero Classic",
-    "symbol": "HERO",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1qlpzs5v95dk3f4n8v5nyf5shyq3sye4wecvgjntdxkurrgfrxgpsut38xr",
-    "name": "Hex Gorilla Alpha Terra",
-    "symbol": "HGAT",
-    "decimals": "0"
-  },
-  {
-    "id": "terra18mkl3dmcpa2uc6fr0hcct476jf62k7904puuzv70l99ffwdg5dds229q20",
-    "name": "Hex Gorilla Collab Collection",
-    "symbol": "HCC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1zqjcslj503p4j9svq6hfskzruetn2xtgqsyjmw4qljy2nwhsdmsssahppu",
-    "name": "Hex Gorilla Collab Collection",
-    "symbol": "HCC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1mvf9q3r84rhm3l52xmumluqfj5qvk4n422ycrvgt9z4w8df2f6dsaz4wf2",
-    "name": "Hex Gorilla Faces",
-    "symbol": "HGF",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1sg6wz6h3qngjjreeq96mlcffmu8v40gmgmhrm7l68v7w8zruddws2x54dm",
-    "name": "Hex Gorilla Genesis",
-    "symbol": "HEX",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1sq2ykswasmt352tarwqwn0g32w3rnm2maptryqe5mcdssn27mxgqzwt9kx",
-    "name": "Hex Gorilla Season One",
-    "symbol": "HEXO",
-    "decimals": "0"
-  },
-  {
     "id": "terra10en35kwlud79z2nljssvhp85ep5kx9k0ezzz8s",
     "name": "Hey Jude",
     "symbol": "HEY",
@@ -6807,159 +3316,15 @@
     "decimals": "6"
   },
   {
-    "id": "terra1tf4h7aytval74gk54amuwh45cmztu3fkh2jtkna60wum8mz3pqxqtdyxgu",
-    "name": "HODL ME CLUB",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra1wfau60yqgdtrqay0cdtcp5rre3l50khacyyhhz",
     "name": "HOHO",
     "symbol": "HOHO",
     "decimals": "3"
   },
   {
-    "id": "terra155lgyldnjskt687h9dtk5gfzamzqkt6t9zcjfamwrzj22mn945vqdgvyxp",
-    "name": "Hot Heather Animals Help Crypto",
-    "symbol": "HAC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra13f7jnzh7yjfpakahzrup5uxnpdxz5vcng5m96jxskhfs5lwlq8aqcgv4ds",
-    "name": "HOT WEATHER ANIMAL HELP CRYPTO ",
-    "symbol": "HAC",
-    "decimals": "6"
-  },
-  {
     "id": "terra16hwgds2089kktskluq8dh5ntw7eu5e4q4z6ud4",
     "name": "howtest",
     "symbol": "howtest",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1lnk3sukea5heg6gjaf7328xez85ta0a60glzrj6zvdsfy65cyaasycn479",
-    "name": "Hudpire Token",
-    "symbol": "hud",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1k94scguypw7ggah8w7t7ly8kxk00wnry3s40a9npdfegtrg76fusmpzlqf",
-    "name": "Hxxk's Airdrops",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1z7ft787p3m94yjch3uhkcydjhmrxz4yccn70uq4e55u2y0jfukkslhdlyt",
-    "name": "Hyper Testing Token",
-    "symbol": "HYTT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1lg5wyah066tc679ehp4d9d9cuk82grxk7vd7u73vpq6md8qzm9fq35lx7v",
-    "name": "IBC/-AAXL-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra17arxq8nn63u7zghp53kh33alkvuad743d8h77tc6psnq570zuupslmdgur",
-    "name": "IBC/-CLUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1yehzc2k78ywgckv2sn2lvaslquffdlf8aypytgt8gcv8ettaxmdqfaslw6",
-    "name": "IBC/-DUST-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra18278qyznzktl8sxnepca4yw0cpdmxxjz54zf3xnn8sfh7au3uspq0ka994",
-    "name": "IBC/-FRGY-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1px8kmqg3m6kvmuf39ewua8c9scvl5mypw4pczpt35t7t6rwadxxs53m8a7",
-    "name": "IBC/-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1uv507zlee8j5u4dzaxd6wekyqjuqqjkva94w7p26qxf8u62jjh0q4rlf6k",
-    "name": "IBC/-LUNA-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1lmjj99vmu5pxt8rv0taknr4j9v5evv2llk6sulmyexce4vr76gjsvj792v",
-    "name": "IBC/-PN-U-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14n22zd24nath0tf8fwn468nz7753rjuks67ppddrcqwq37x2xsxsddqxqc",
-    "name": "IBC/-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1d8j3v5dg08mnw9yzh242nvdc2mznup400msx8d6hcgpd2ygv4uuqfy4v9p",
-    "name": "IBC/-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1g6466sm9recxrmxhpu2aw79vdh4ahhkswjwq3tpq4mfdawd9nj6s8cxx3n",
-    "name": "IBC/-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1zgtka8nyjvnet5v4xhecwl4afpmkv26mp7c22jegsavhp2pmpcrquhluuz",
-    "name": "IBC/-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1fxh9c0v6vpvjrlxnywjq6k545yd09vyjdg536eafqk9ngd23l5vq4lfcgu",
-    "name": "IBC/-USD-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra12857xqnmsxdcd73qvtl7cr92djguxs03mmpgmgksey0xxzmkzqvs29aadp",
-    "name": "IBC/-USDC-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1j3q7gcxsp20hkrggh2eqa305asmjnsvgzjdc0jjz9rajg0q8shwqpzqhdy",
-    "name": "IBC/-VKR-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra15spkcas6jj2jrevvff5r0g7ht2s6h3mal7u8fmnjngk7k82rzt9s4gtnmj",
-    "name": "IBC/-YLUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1avfsch3ee82wyrpwlawecyz6zktr9jln0zaxp58xuvmxyl5g305q3rwuj3",
-    "name": "ibc/2739...5EB2-ibc/4CD5...3D04-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra17ly9laewec70qu6tl0e3qrwh2vhz9akpf2jd7mxqram63xg2n0rsj36xvr",
-    "name": "ibc/2739...5EB2-ibc/B350...C9E4-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1adp223mw8937arxcfl36acjjyn2dcf7wzp8h09jek5k0gw3vch8sqlq6su",
-    "name": "ibc/2739...5EB2-uluna-LP",
-    "symbol": "uLP",
     "decimals": "6"
   },
   {
@@ -6972,30 +3337,6 @@
     "id": "terra1n2rujfc5lscglry30zaptfgncfc0gq4n8my0gv",
     "name": "ID TOKEN ONE",
     "symbol": "ITO",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1l7z4lddtwstgmag6u7pu6jlthqrapk39wrlczm7vp0tjfxh6e84s4d055r",
-    "name": "IDC",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1w7ryjz65q6l48ydht9nnrc687p84jwt8qk5z4afj7z6unf5greas0z4qup",
-    "name": "IDC-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra10d4ss2p86v5caxjzsnlsexepjw78f98dqjxvjj66l5dp4qdp2f7s5j7g6y",
-    "name": "IDC-TPT-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14qsj3px3g3nfwhdp36nml33flfqy6hkgurcanae7t6sfl3yu4duq8xlppd",
-    "name": "IDC-WETH-LP",
-    "symbol": "uLP",
     "decimals": "6"
   },
   {
@@ -7043,48 +3384,12 @@
     "decimals": "6"
   },
   {
-    "id": "terra1lt30ry90758wz7mugmagkjr7ehn5t3pk7amlytd3c639sqddwz4qmrgmde",
-    "name": "Initiates of the Flame",
-    "symbol": "FIRE",
-    "decimals": "4"
-  },
-  {
-    "id": "terra1c5urwcswu23k40q640klugf3sz7dlh0m3nxxs07u40xpahtqrwgsrax3gq",
-    "name": "Inspiring Artists",
-    "symbol": "Insp",
-    "decimals": "0"
-  },
-  {
     "id": "uinr",
     "name": "INT",
     "symbol": "INT",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/int",
     "icon": "https://assets.terra.money/icon/60/INT.png"
-  },
-  {
-    "id": "terra1sxnyuh2dxzqrx75e9x62fw0pns7tvcyjkjsdkl0yvzdac7myjgeqep5mel",
-    "name": "INT (Wormhole)",
-    "symbol": "INT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14dadch35htr43e6fu5ra7vxzdq7a8w6jzgx6ksm5awg55aw9wzeqwnpjg7",
-    "name": "Inter galaxy colli by 12yo son",
-    "symbol": "IGLX",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1d4j9lsl453mkvtlg4ctw8y52rdkhafsaefug0hq0z06phczuvvvs7uq0vg",
-    "name": "INTERCHAIN DAO COIN",
-    "symbol": "IDC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1f7w3h99varl067u5qlsnpuss4etktcelv53at9jcyppsgkp3je4qajud0c",
-    "name": "INTERCHAIN DAO COIN",
-    "symbol": "IDC",
-    "decimals": "6"
   },
   {
     "id": "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf",
@@ -7094,10 +3399,12 @@
     "icon": "https://gateway.pinata.cloud/ipfs/Qmd3ussNvHvHhLSqZcZfkT7p6irQ6a2fNSW8jsRPi6uiro"
   },
   {
-    "id": "terra10h2zxfgap3ld4evqc6jczhpn6vjcdfhny4gx0k82c0xc658z9dnsepkndm",
-    "name": "InterNFT",
-    "symbol": "n/a",
-    "decimals": "0"
+    "id": "terra1csk6tc7pdmpr782w527hwhez6gfv632tyf72cp",
+    "name": "Invesco QQQ Trust",
+    "symbol": "mQQQ",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1csk6tc7pdmpr782w527hwhez6gfv632tyf72cp/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/QQQ.png"
   },
   {
     "id": "terra1enj2np0785hw3vt2gn2yga9y75306g6e9lq799",
@@ -7106,51 +3413,38 @@
     "decimals": "6"
   },
   {
+    "id": "terra10h7ry7apm55h4ez502dqdv9gr53juu85nkd4aq",
+    "name": "iShares Gold Trust",
+    "symbol": "mIAU",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra10h7ry7apm55h4ez502dqdv9gr53juu85nkd4aq/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/IAU.png"
+  },
+  {
     "id": "terra12lvpnlphqh3q0cxp8y47e5km8k2ad5ydw5asu4",
     "name": "iShares Gold Trust",
     "symbol": "mIAU",
     "decimals": "6"
   },
   {
+    "id": "terra15hp9pr8y4qsvqvxf3m4xeptlk7l8h60634gqec",
+    "name": "iShares Gold Trust (Delisted)",
+    "symbol": "mIAU",
+    "decimals": "6",
+    "icon": "https://whitelist.mirror.finance/icon/IAU.png"
+  },
+  {
+    "id": "terra1kscs6uhrqwy6rx5kuw5lwpuqvm3t6j2d6uf2lp",
+    "name": "iShares Silver Trust",
+    "symbol": "mSLV",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1kscs6uhrqwy6rx5kuw5lwpuqvm3t6j2d6uf2lp/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/SLV.png"
+  },
+  {
     "id": "terra1td527f09l7lgf55fqtr0zvtx5ek0yl0fdrx574",
     "name": "iShares Silver Trust",
     "symbol": "mSLV",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1087lrvk5zulanrjhdtcfrf49udx70dxqt7erhn4qssu5k60vz92qcrpv8w",
-    "name": "ITO Token",
-    "symbol": "ITO",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14fh69r7jvjmzkna7ucssdusufjmgc5y834ua6k5zgd3d4279f88q54w09g",
-    "name": "ITO Token",
-    "symbol": "ITO",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1c5vpgnu4kjzxehmvh8adx08ljcappve3jcqcvxha5klqpxc0pguszglelw",
-    "name": "ITO Token",
-    "symbol": "ITO",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1f9znhfh3uhzrs3rrmt9m2a4f0f5u7jcxuxr3a63wknlxre4vks8s30ljmf",
-    "name": "ITO Token",
-    "symbol": "ITO",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ncstskapt4ccg94glnkkylnlgdknpelwf82s5us4xyxj3pmpc54qd7gtky",
-    "name": "ITO Token",
-    "symbol": "ITO",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1u3dcmvrdnutlx5rtvw079fgesucwfav5znpv9d4z584nxmnnn6eqydajhm",
-    "name": "ITO-ULUN-LP",
-    "symbol": "uLP",
     "decimals": "6"
   },
   {
@@ -7165,12 +3459,6 @@
     "symbol": "JEFE",
     "decimals": "8",
     "icon": "https://s2.coinmarketcap.com/static/img/coins/64x64/16800.png"
-  },
-  {
-    "id": "terra1q6gqwja73tlz0jvatvdaassp5czam533vkcvewqyl2kg5tcm96yqdk3hpk",
-    "name": "JEFE TOKEN (Wormhole)",
-    "symbol": "JEFE",
-    "decimals": "8"
   },
   {
     "id": "terra19k974ngjsml8dtmk56cdhuy6pplr94rxqdt95p",
@@ -7203,10 +3491,12 @@
     "decimals": "3"
   },
   {
-    "id": "terra1afyue93pvg6dq2hmqfhnvawn9q4qpvmfe5aj3e5h0rrcjqcg0l8q3qql79",
-    "name": "Joeken",
-    "symbol": "JOE",
-    "decimals": "0"
+    "id": "terra1ptdxmj3xmmljzx02nr4auwfuelmj0cnkh8egs2",
+    "name": "Johnson & Johnson",
+    "symbol": "mJNJ",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1ptdxmj3xmmljzx02nr4auwfuelmj0cnkh8egs2/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/JNJ.png"
   },
   {
     "id": "terra1t5y4xm7xdc7csud2j2aezxs6e4uuj3lqpqk7jy",
@@ -7241,23 +3531,11 @@
     "decimals": "6"
   },
   {
-    "id": "terra1ajcht9tj6ujkpw3vyaadasslz85rp2geppu90yehz2gz6z4depaq0f7fqv",
-    "name": "Justice Kingsman",
-    "symbol": "100",
-    "decimals": "0"
-  },
-  {
     "id": "terra1l6nqyv78m3kj8v4wa7r5fr3vhp0qzrauwkx5av",
     "name": "Juta Club Token",
     "symbol": "JUTA",
     "decimals": "2",
     "icon": "https://raw.githubusercontent.com/terraswap/terraswap-web-app/main/public/images/CW20/JUTA.png"
-  },
-  {
-    "id": "terra1ppjlgcuk70yzexfnnwarcalz9ur0v4yay8h6s3tfc78vyc3q0y8shmaenc",
-    "name": "JUXTAPOSITIONS  ▞",
-    "symbol": "MSC",
-    "decimals": "0"
   },
   {
     "id": "terra1kujvztl5p8a45k56u42fq39jxldxcvuejtpfq5",
@@ -7278,12 +3556,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1cm5tgyvtrr383xp39z4dhz8xwrcsut3gw0nzqs3z2ugpa5pxmh5qtrfetz",
-    "name": "KateEatsPizza",
-    "symbol": "KATEPIZZA",
-    "decimals": "6"
-  },
-  {
     "id": "terra1a8an0aqzjghcukqrdgnkt3ygzhmaaqza03mc3h",
     "name": "Kernel Token",
     "symbol": "KVT",
@@ -7293,12 +3565,6 @@
     "id": "terra17efcrd3glln324tqke56w5wgnfkfn5emz4um8j",
     "name": "Kiba Inu",
     "symbol": "KIBA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1fjlj3twnm3yyt2utd738tsrx7fcerkx3xtpgn3x70yp9tak8ufdq0el8x8",
-    "name": "KIKI",
-    "symbol": "KIKI",
     "decimals": "6"
   },
   {
@@ -7329,12 +3595,6 @@
     "icon": "https://kingsmandao.com/wp-content/uploads/2021/10/kingsman-logo-transparent_1@0.5x.png"
   },
   {
-    "id": "terra1qnfwdkcm92l8ecefz7ypnwlx9xsd63n0mlqtcdavy6trhm8xr2tqlh3mws",
-    "name": "KingsmanDAO Art",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra1c5fr3wdf2trj3dkxcckhmzzxlnnpepqn8cu8f8",
     "name": "Kishu Inu Need 🌗💵 ",
     "symbol": "KINU",
@@ -7345,12 +3605,6 @@
     "name": "Kishu Inu Need to swap from PEPE ufxd 🌗💵 ",
     "symbol": "KINU",
     "decimals": "3"
-  },
-  {
-    "id": "terra1wwehdgkm6aa7vtuzhc3rs39txve0vv00mkhknru4m6ew0fazhfcsuk0zsc",
-    "name": "Knowhere NFT Contest ",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
   },
   {
     "id": "terra1545laqy9s6jcej2pgts32rhqy6dzq62umk8g9q",
@@ -7367,12 +3621,6 @@
     "icon": "https://assets.terra.money/icon/60/KRT.png"
   },
   {
-    "id": "terra1ndslkk6vfv5dc53chrlsl3k8qzympt4rrynjjttyl72jhuqyqy7s6am3lt",
-    "name": "KRT (Wormhole)",
-    "symbol": "KRT",
-    "decimals": "6"
-  },
-  {
     "id": "terra1l670q2m9j3npltmsqe428mwu0msw336m8jtq00",
     "name": "KRX",
     "symbol": "KRX",
@@ -7385,12 +3633,6 @@
     "symbol": "KRXfancard",
     "decimals": "0",
     "icon": "https://c2x.world/c2x-station/icon/KRXfancard.png"
-  },
-  {
-    "id": "terra10n6dj60zrndyru0udh85elvj7wzy6wtjw3t3gepvnxkexv9deztq8j3z86",
-    "name": "Kuji (Wormhole)",
-    "symbol": "KUJI",
-    "decimals": "6"
   },
   {
     "id": "terra1qrq5r95txaregxpa2c7mhf549u5jkm28rzmvt5",
@@ -7423,12 +3665,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1s9aew7kfrkn0feqpcau5pxjzyrgx58fyhpq2v7jk3tnld237l6gqr39jlk",
-    "name": "Las Caras en Blanco",
-    "symbol": "LCB",
-    "decimals": "0"
-  },
-  {
     "id": "terra1thhm2u93m2stytzynhsxh5h3jrtg540x4punqy",
     "name": "LCT Fancard Token",
     "symbol": "LCTfancard",
@@ -7441,18 +3677,6 @@
     "symbol": "LCT",
     "decimals": "6",
     "icon": "https://c2x.world/c2x-station/icon/LCT.png"
-  },
-  {
-    "id": "terra1pn7uq2wtv93rlpuemv5ulppf5p37ff8z5m4a2lc6kt0aek2cej9q37vwxv",
-    "name": "LDAO",
-    "symbol": "LDAO",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1c5h92xmgl6gjp4pq6ka6p8avsjkr23vatr05pulmzdvtcd38vvqs4epenh",
-    "name": "League Of Gorillas",
-    "symbol": "LOG",
-    "decimals": "0"
   },
   {
     "id": "terra1hwcnalcf35p48lvj3wt7tztkzh5szmpnxwyvdc",
@@ -7527,142 +3751,10 @@
     "decimals": "3"
   },
   {
-    "id": "terra1tquaelpx4tw6xnv9wh8xj8e48auhyyy888s756z699ssfqpq2wasz00fmx",
-    "name": "LIQ-ASTR-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1c66atrs8gg2ym7g4rp3clar0vxzssjuwdhu09mk9uun37cv8qt9qtm4uhn",
-    "name": "LIQ-BRGR-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qjpzejp4aeugxnxdg8n9j5rh6ls5n3etytkcg9jxc90fmp85agusdwe5uc",
-    "name": "LIQ-DRMR-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1pzrt6f3g8tdfra54tga49swaac97gskya9e2qfa39d4kpsy8ldrqyux70s",
-    "name": "LIQ-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1usz457mcs432pf6fm84zux4t584es8pfvqcp09jxcqs7qc5gcvcsar3q62",
-    "name": "LIQ-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1kvpf2swxmc7kmmh6usnrqr2gd2p0nxnfywvche7vj77807km2f3q3aqvrp",
-    "name": "Liquidity",
-    "symbol": "LIQ",
-    "decimals": "18"
-  },
-  {
-    "id": "terra1cd64uj7mhtgdncx3s62p7f02zvk4w7umtn85hkeemwf244075j4qe2eu9v",
-    "name": "Lira",
-    "symbol": "LIRA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ekn2a5h298endnvf7sryt3ec8pwraqpphxte0xpuhgdd3ngn3y8qezatcj",
-    "name": "Lira",
-    "symbol": "LIRA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1mfmfcet8l7khfwq68jxsqnerv246gv4ztpunjsgdj8ulwe3r0x0s5xa8r0",
-    "name": "Lira",
-    "symbol": "LIRA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1n6k0pg6hh5k2qd2u3tw9fr48vcl2q6a7zrt27anqjajnrm63vldq4a23vt",
-    "name": "Lira",
-    "symbol": "LIRA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1q8hcpc4atfpq8743kk3xq6uux9y20krd383995gye4c7qxy2y6ls79eemw",
-    "name": "Lira",
-    "symbol": "LIRA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1v9yne0lvwxfv2um36rqwutphgwxznr2suwl5ml9h6xzn2u29vz7q28ez0p",
-    "name": "Lira",
-    "symbol": "LIRA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1c45hdhurx9jaz86z9hrt83ddut9nqsz46p2sgey5ewf7vqz0kqvssrhecp",
-    "name": "Lira (Wormhole)",
-    "symbol": "LIRA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1njtkekd6dqxgz9vlrs52pf9lfd2mna9vgh2r0mf0wvp5gg6zu3lqf78fqu",
-    "name": "Lira (Wormhole) (Wormhole)",
-    "symbol": "LIRA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1z2e3mh27wuynd9whzsvm3rfyhcv8g4753ev8qfdd46esrcm4unxq374wy8",
-    "name": "Lira (Wormhole) (Wormhole)",
-    "symbol": "LIRA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1prcysrw4ys9kp53m3s3dhx4psus4yj7lyakxr5f68zm7640ss03sccdeqs",
-    "name": "Lira (Wormhole) (Wormhole) (Worm (Wormhole)",
-    "symbol": "LIRA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1s5uwl6gaxyj9mjtkwze4vwadc5jqtmqrkcxcave9c09frm5uzxpsjzjzy7",
-    "name": "Lira (Wormhole) (Wormhole) (Worm (Wormhole)",
-    "symbol": "LIRA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1uqauk8jrgzdp7zy700g6g6mw3txy3u2j9rtp00wven7prkqsc4rsafk4qg",
-    "name": "Lira (Wormhole) (Wormhole) (Worm (Wormhole)",
-    "symbol": "LIRA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1xdg4gtzsdacv8svusarsmndpsqpnafxhmdfqlhse7rk05ys3326s8f5pc5",
-    "name": "Lira (Wormhole) (Wormhole) (Worm (Wormhole)",
-    "symbol": "LIRA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1k8vt0lrm0ah37fpd3t5d0jc969khc200twsg5pqaf8xpg9sy5fnst0p7ka",
-    "name": "Lira (Wormhole) (Wormhole) (Wormhole)",
-    "symbol": "LIRA",
-    "decimals": "6"
-  },
-  {
     "id": "terra1m9fuqymdz03umd88guyc79083hd7vppzu74vck",
     "name": "Little Terra",
     "symbol": "LTT",
     "decimals": "6"
-  },
-  {
-    "id": "terra1rjsmxyv46ashe8hlzsesyawltd6c9ftxkpglf5g688xn08g66v0q0ny2zs",
-    "name": "Little Whale",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1c4tcf7xfaer6rk47s25skqy358jgwhs8jrgxkq3nr7dzmcrtsqxssln0s3",
-    "name": "Livia Testes",
-    "symbol": "liviatestes",
-    "decimals": "3"
   },
   {
     "id": "terra1p0w9hh9aea5mg26mjnx7tl695ldwxfksvw4yn4",
@@ -7671,59 +3763,11 @@
     "decimals": "6"
   },
   {
-    "id": "terra16a6qkmxpqzeyez8gh3w7qhrk7x3xe3arlv9nwfg944y8vzg9smrqntark3",
-    "name": "lns",
-    "symbol": "lns",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1fdea6s9g2w740ml0jmzr3szhwp85c2lg9hjgth70vzst43nz8yzqcyqaxg",
-    "name": "lns",
-    "symbol": "lns",
-    "decimals": "0"
-  },
-  {
-    "id": "terra19gsaaq8wyvgf5l5aaqtr6et83sunsu07dmhklhaghmtw8glwt63s9sdcaj",
-    "name": "Local Alentejo Coin",
-    "symbol": "LACO",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1f0rhjvayf6ea79jf9ls6zhwm36wjy8wvqtuu2gpq8z5ddnwd3saq9ytkev",
-    "name": "Local Alentejo Coin",
-    "symbol": "LACO",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1prnyz7ezw85dt9zeyjcdufldjcf6h4lxxzmvl5ctspyj50w7mt5syn69t8",
-    "name": "Local Alentejo Coin",
-    "symbol": "LACO",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1x5332um7nvaudzsgklnujepmdzz28grhn8h0yrl9djpvxva5agvsyaqn8x",
-    "name": "Local Alentejo Coin",
-    "symbol": "LACO",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1yetl2gafkhtanr6utpmxp0zqtkhkc05k4dgjg0zfyf86p9fzw3ssslv0fj",
-    "name": "Local Alentejo Coin",
-    "symbol": "LACO",
-    "decimals": "6"
-  },
-  {
     "id": "terra1vchw83qt25j89zqwdpmdzj722sqxthnckqzxxp",
     "name": "Local Terra Token",
     "symbol": "LOCAL",
     "decimals": "6",
     "icon": "https://localterra.money/local-logo-dark.png"
-  },
-  {
-    "id": "terra1xzkel96e5e8vfmqw7valzdzzv9hqasfyslclvnmvxdejvpda3xwsskxzus",
-    "name": "Local Terra Token (Wormhole)",
-    "symbol": "LOCAL",
-    "decimals": "6"
   },
   {
     "id": "terra14s3g6jmytjjg2jcxmmaj6k837vcr6h98muxc07",
@@ -7753,29 +3797,11 @@
     "icon": "https://loop.markets/token/logo3.png"
   },
   {
-    "id": "terra1h4me76lqd2450e8jnduewen2vpyfrxlekhtql9aed6kt48thkqqqu00vjq",
-    "name": "Lootopian Items",
-    "symbol": "LOOTITEMS",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1c649ctpkwqa9h65g6xmplrncc55d5nzqgz30zhtkcysedkd63zcq02uhs8",
-    "name": "Lootopians",
-    "symbol": "LOOTOPIANS",
-    "decimals": "0"
-  },
-  {
     "id": "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr",
     "name": "LoTerra",
     "symbol": "LOTA",
     "decimals": "6",
     "icon": "https://loterra.io/LOTA.png"
-  },
-  {
-    "id": "terra1jv9h8w29drd2r4fugsvsdnkrsl99wpr2xmn3wn5ukn6acv6g9esqf0uh9x",
-    "name": "LOVE",
-    "symbol": "TERRA",
-    "decimals": "6"
   },
   {
     "id": "terra182740uw8nh6tk3yjfcf7gu5phg3kqryhtuxp0p",
@@ -7882,66 +3908,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1ed0k9whkuc0upf65znurquqqvhchdawzv3fp9vum496tumwa60rqktjsy0",
-    "name": "Luna (Wormhole)",
-    "symbol": "Luna",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1leavh38n7ycjh5xed5us2s8f576zmpj48ec0nhjs25r0wq5au9lqw3kdqz",
-    "name": "Luna (Wormhole)",
-    "symbol": "LUNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1fqxs98wj9eeenq95093gkfqzq3emfzxe88hvdr87p46ymyu4agaql5hhv8",
-    "name": "LUNA (Wormhole)",
-    "symbol": "uluna",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1teycrt4svt52jfmhkwywgk5gg9thrvgz87qm3edc8u63kte23djqlv5u0t",
-    "name": "LUNA (Wormhole)",
-    "symbol": "__proto__",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1ukv6djf73m9g459a3pwhq6c8jvuy832gpv8ck4eyyeaj2rptxkvqyxlz43",
-    "name": "LUNA (Wormhole)",
-    "symbol": "LUNA",
-    "decimals": "8"
-  },
-  {
-    "id": "terra173scyqe32fh2cec7ctmy5jnxtqpghhlrw69p3z84vk9huzn9s8yqggvjzj",
-    "name": "Luna (Wormhole) (Wormhole)",
-    "symbol": "LUNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra18ywl0l4z3u6rjcxg4rwtjhztj89k8nneqfz96jg9tgh9c7tgxjns93v75d",
-    "name": "LUNA (Wormhole) (Wormhole)",
-    "symbol": "LUNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1f0rcrwut62l0fvnrn2mzg6m6zmq2ls6wgd9w3jjayzssahf74kfskn6ya3",
-    "name": "LUNA (Wormhole) (Wormhole)",
-    "symbol": "LUNA",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1sdr0trqyfjh3469a5j0fvga4u7ged6u4m56jskv0llz9zkm2twyqcgr4ez",
-    "name": "LUNA (Wormhole) (Wormhole)",
-    "symbol": "LUNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1rq683n66vng4hqp5fuq8jja0z9wdfvem204ckyvwf0r02nvr8xuqgrwglu",
-    "name": "Luna (Wormhole) (Wormhole) (Worm (Wormhole)",
-    "symbol": "LUNA",
-    "decimals": "6"
-  },
-  {
     "id": "terra12a39fn0k0duteqefme6zgr5efg0g5ya7eglvyu",
     "name": "LUNA 100 Dollars December 2021",
     "symbol": "LUNAMOON",
@@ -7952,12 +3918,6 @@
     "name": "LUNA 2.0",
     "symbol": "tLUNA",
     "decimals": "6"
-  },
-  {
-    "id": "terra17vysjt8ws64v8w696mavjpqs8mksf8s993qghlust9yey8qcmppqnhgw0e",
-    "name": "Luna Ape Club",
-    "symbol": "LAPEC",
-    "decimals": "0"
   },
   {
     "id": "terra1tm2jhnfh6hmnpvzsyfteqhcn6h5uw2qafr48yh",
@@ -7971,26 +3931,9 @@
     "symbol": "LUNC",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/luna",
-    "icon": "https://assets.terra.money/icon/svg/LUNC.svg"
-  },
-  {
-    "id": "terra16h7keds26d52xj8rn9jfx6lj2x0ja79lt56yxnmlm4xsttf5mu5smq5f78",
-    "name": "Luna Classic (Wormhole)",
-    "symbol": "LUNC",
-    "decimals": "6",
-    "icon": "https://assets.terra.money/icon/svg/LUNC.svg"
-  },
-  {
-    "id": "terra1fvdcu2j85nrlhwhy0rmhttst2caaxtf36ytjcngg47qkt8ndcu8sm6qff6",
-    "name": "Luna Classic (Wormhole)",
-    "symbol": "LUNC",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1y9guyavsd5cjz4hh9jxlsu4th2ce95kjqurc3aprkrgrwg4cj7hqx25p6v",
-    "name": "Luna Classic (Wormhole)",
-    "symbol": "LUNC",
-    "decimals": "8"
+    "icon": "https://assets.terra.money/icon/svg/LUNC.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/terra-luna",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-luna/"
   },
   {
     "id": "terra1ex5age9gqd5em86wg8hu0ak5wrqez9yufvlrat",
@@ -7999,70 +3942,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra1m20djcturk5yxv8u84s0t6xh5evjx98pmlc3xj8u99qeuwy79hrq5l9dz2",
-    "name": "Luna Crash Survivooors",
-    "symbol": "LCS",
-    "decimals": "0"
-  },
-  {
-    "id": "terra16nfcvfcfd8fnurp6m20xpa2d8c5y3v47g4y0r9jqzr7t6auersxqxd2jf9",
-    "name": "Luna Doodle Bears",
-    "symbol": "LDB",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1rwwtz3aac6w9yxmxa32hzggn0j7swt7e2lrs9838wmygq9wlnl9sdhq3wc",
-    "name": "Luna Doodle Bears",
-    "symbol": "LDB",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1crxcd4m9wvr35j7gjcgwquum6lxtz2f3dssd7f9959xn5jq5lu3q5dyrgh",
-    "name": "Luna Fight Club",
-    "symbol": "LFC",
-    "decimals": "0"
-  },
-  {
     "id": "terra1r5c53q49wu2vqerecdvua2zpvy9k8vlw7cnx25",
     "name": "Luna Game Guild",
     "symbol": "LGGD",
     "decimals": "3"
-  },
-  {
-    "id": "terra1dddhkvrdwjd30xgmamld3zdtvfmjlpeh2u49mluqjx65wgnwarcs882qme",
-    "name": "Luna Kiddy",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1fcqy0khmxkap332srawukpsqc2p9uaujv9us368pkvnpxwzz6r2s8trv6d",
-    "name": "Luna Kiddy Collection X - Hello Moon",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1swldwd2jaj6ewxyckhxu9cdjlhwvsky55rhd02jszfmsgvjcq6hsp04jx5",
-    "name": "Luna Moonz",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1gutsrmwdls9pva4jv8tghe29qt4rfmhnplx8qvy9h9l5f0y9l0xqestddh",
-    "name": "Luna optimizer token",
-    "symbol": "OPZA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ry9f6alqyf9dpj04u9ymq5u4whjndu485agh6gusn89dmqse3ggsnzducj",
-    "name": "Luna optimizer token",
-    "symbol": "OPZA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ldhrtdqhfffrg67q65rgnk9exwrjyv5rpk3p77hrcndg3vu8d9ws2h93nv",
-    "name": "Luna Saver",
-    "symbol": "LUSA",
-    "decimals": "6"
   },
   {
     "id": "terra1zpz6dfn24cnykwausjt7qwfdqf87kny0trn94k",
@@ -8077,12 +3960,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1ace6qznlfmng9ucmf3s02qa4j4jau702dz0mzjktacqr5yx4hulqysvs3r",
-    "name": "LUNA-Swap.io (Wormhole)",
-    "symbol": "LUNA",
-    "decimals": "8"
-  },
-  {
     "id": "terra1j4kt7mns290trwlwyxrun5n7nlfkxxcak57ck2",
     "name": "LunaApe",
     "symbol": "APE",
@@ -8095,64 +3972,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra1vh3djwh20p34y5xla3a8c45n7z2xgvyejy0kp2eke5xgtax7fmrs8a3g77",
-    "name": "LUNABIRD",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1tu3fljc4ksy785l4j7cwj387hvfwxp88avrc6rwxc0clckrjalvq0ctr3j",
-    "name": "LunaGorilla",
-    "symbol": "LG",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1p4z3k297lvxtc8awfewf5g63gjgunakgknh5wj2pnarydltlwz8qx93mmf",
-    "name": "LunaKittys",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra1e3s670y5lns7vlq3gxdcn9rv8mdpydhd89jdwz",
     "name": "LunaKwon Terra",
     "symbol": "LKWON",
     "decimals": "6"
-  },
-  {
-    "id": "terra1525vl2n9zh3w4yx22u96j8jua6mt4rmuy5tuclc9d8yjsekjxnrsnfr7wn",
-    "name": "LunaLapin",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1lxlm3dhchddr0gs9rw0s87c0prhw8xvmzjqh2s920v7pxtzqy9sqwsyqc0",
-    "name": "LUNANA",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1hvjl89vxv6lk5nmwl4tnz70pe7t24plgw7xa4r2yps0l2uytt8xscmhud5",
-    "name": "LunaPunks",
-    "symbol": "LunaPunks",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1ntnkf7k3twr4j7j2h6y4k95rz0nfhcx9e3e0ke957vjvpzwynd6qas43zl",
-    "name": "LunaPunks",
-    "symbol": "LunaPunks",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1ew0rx3lgecmkeh8qscz92kvw2268flpr0r49k7m44xk3musg4a6spw8yj7",
-    "name": "Lunar Assistant: The Giving",
-    "symbol": "LAV2",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1t5934pztkw2j983azhsgkvkvfp2vgfpgvzrpy58h88krr4uvph6sevnsdm",
-    "name": "Lunar Boots",
-    "symbol": "BOOTS",
-    "decimals": "0"
   },
   {
     "id": "terra1g0pm8xm5c2dq4qtv8j9a80hg4mhe5ndy8qad07",
@@ -8160,24 +3983,6 @@
     "symbol": "ARTS",
     "decimals": "6",
     "icon": "https://i.ibb.co/K9Q53VQ/lunart.png"
-  },
-  {
-    "id": "terra1723fcqetu8dxjqe3as7djqtmzyjwcp7k6rs5mv2jrsytjer032kqvr0vtq",
-    "name": "LUNASKULLS",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra196uh50ak5h6m8zffjpc0uv3vfu56q4lmcwh6hetyzvaldu6yy3gqkmpw23",
-    "name": "Lunatic ConDoms",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1hf3c5ryyk90spej29h8eyxvqkvvl6834x497ruedh9q8ej0v54gq08jmsu",
-    "name": "Lunatic Punks",
-    "symbol": "LP",
-    "decimals": "0"
   },
   {
     "id": "terra1fj06x3hq2xum56htlrdeame70knzl765cq4txr",
@@ -8198,24 +4003,14 @@
     "decimals": "8"
   },
   {
-    "id": "terra1ew6ve6nuq8rf33vfnkj7jfsygq4au9gkkkapr2xnp6vhrl30484s99ph5x",
-    "name": "Lunatics Punks",
-    "symbol": "LNP",
-    "decimals": "0"
-  },
-  {
-    "id": "terra19ersf68qqnpc4vu93l3fr4t3e0dwg7v374ynv0k75hk2ggad693q3y9p6z",
-    "name": "LunaV2.io (Luna Token) (Wormhole)",
-    "symbol": "LunaV2.io (Luna Token)",
-    "decimals": "8"
-  },
-  {
     "id": "terra15k5r9r8dl8r7xlr29pry8a9w7sghehcnv5mgp6",
     "name": "Lunaverse",
     "symbol": "LUV",
     "decimals": "6",
     "circ_supply_api": "https://source.lunaverse.io/circulation",
-    "icon": "https://lunaverse.io/assets/images/logo.png"
+    "icon": "https://lunaverse.io/assets/images/logo.png",
+    "coingecko": "https://www.coingecko.com/en/coins/lunaverse",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/lunaverse/"
   },
   {
     "id": "terra1kd4rfff04cvw7vae0szgawj0xye90fkchljv7y",
@@ -8227,42 +4022,6 @@
     "id": "terra16x6mn6ulxzg4pgg7gpachkkgrkuac59vl7xgyl",
     "name": "Lunaverse LUV Token",
     "symbol": "LUV",
-    "decimals": "6"
-  },
-  {
-    "id": "terra13su0l0gx7r52ttqc5srxhg3keu575eyq3admtz39m0c2k0yv499smrty24",
-    "name": "LunaX Pool",
-    "symbol": "ptLunaX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra168x6eryjuwkwdnqkksps0a6e0dr65mjpfclmhswxyurztyqy345qv6y39e",
-    "name": "LunaX Pool",
-    "symbol": "SMBL",
-    "decimals": "6"
-  },
-  {
-    "id": "terra10vz23p5agfdmryj62mh8srx9lcctlulnmg28upx2e8x47k6dmc4ssvahhf",
-    "name": "LUNC (Wormhole)",
-    "symbol": "LUNC",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1pujwphjvqww94vvefkhuq7vdlmxqunf5shnlf2zvpdeu8n3suces0r9lta",
-    "name": "LUNC (Wormhole) (Wormhole)",
-    "symbol": "LUNC",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1ulr678u52qwt27dsgxrftthq20a8v8t9s8f3hz5z8s62wsu6rslqyezul4",
-    "name": "LUNC Burn Token",
-    "symbol": "LBUN",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16fk7y0rn7fxdxv44gzv86uq4w3uq4v57y84v5tm6xmklu2v77tes2gwsy0",
-    "name": "LUNC Holocracy Token",
-    "symbol": "HOLO",
     "decimals": "6"
   },
   {
@@ -8279,29 +4038,13 @@
     "decimals": "6"
   },
   {
-    "id": "terra1897y20wkvefn994e5jx0vtmcyu6nkxdsnlg4kfg6uefe0s6ct8hshtakjh",
-    "name": "Lunc Trains",
-    "symbol": "LuncTrains",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1m22wjsm4vyuf5s9mpcczdckhqyqw5jmspxkdftju9v0u9tg8smxq9wdd23",
-    "name": "Lunciferrium - Invaders",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
     "id": "terra1m3tdguf59xq3pa2twk5fjte5g6szj5y9x5npy7",
     "name": "LUNI",
     "symbol": "LUNI",
     "decimals": "6",
-    "icon": "https://d2s3n99uw51hng.cloudfront.net/static/100_100_LUNI_logo.png"
-  },
-  {
-    "id": "terra1vfme2h5ffueendzymf0n4hs0g898ncp6ww5n09z8uw5rn8cfwhxq7qnk86",
-    "name": "LUNITA",
-    "symbol": "LUNITA",
-    "decimals": "0"
+    "icon": "https://d2s3n99uw51hng.cloudfront.net/static/100_100_LUNI_logo.png",
+    "coingecko": "https://www.coingecko.com/en/coins/luni",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/luni"
   },
   {
     "id": "terra1ykl7ee0dakfev97ektynnup8hscyuhc9kly9k4",
@@ -8309,12 +4052,6 @@
     "symbol": "LTVN",
     "decimals": "3",
     "icon": "https://luntivo.finance/images/coin.png"
-  },
-  {
-    "id": "terra1as057wvx6vjqefawk2cql39k90v62fltn03tuw4262dcqtzppv6qrh897m",
-    "name": "Lylith Iconic Woman",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
   },
   {
     "id": "terra1u02kfjra4q9272p0ckq8yjtfc5qq6584amvrnm",
@@ -8362,12 +4099,6 @@
     "icon": "https://marsprotocol.io/mars_logo_colored.svg"
   },
   {
-    "id": "terra1pupw8tmlgf7fgz5w9jn4876zkxw03es23jpm8v0207m2g7dpjtqsmdylpv",
-    "name": "MARS (Wormhole)",
-    "symbol": "MARS",
-    "decimals": "6"
-  },
-  {
     "id": "terra1z3ejshh0vwkdr35wt9eyxetsqm6mnraya8myxs",
     "name": "Mars Protocol",
     "symbol": "MARS",
@@ -8380,18 +4111,14 @@
     "decimals": "6"
   },
   {
-    "id": "terra15gykrtjfdxfy5q52v3jvdaqa0e7sw84nymvxltc4a4jfelvhspgqfwx4w0",
-    "name": "Mars Protocol Token (Wormhole)",
-    "symbol": "MARS",
-    "decimals": "8"
-  },
-  {
     "id": "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n",
     "name": "Mars Token",
     "symbol": "MARS",
     "decimals": "6",
     "circ_supply_api": "https://api.marsprotocol.io/graphql",
-    "icon": "https://marsprotocol.io/MARSTokenMini.svg"
+    "icon": "https://marsprotocol.io/MARSTokenMini.svg",
+    "coingecko": "https://www.coingecko.com/en/coins/mars-protocol",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/mars-protocol/"
   },
   {
     "id": "terra1qs7h830ud0a4hj72yr8f7jmlppyx7z524f7gw6",
@@ -8524,21 +4251,17 @@
     "decimals": "6"
   },
   {
+    "id": "terra1227ppwxxj3jxz8cfgq00jgnxqcny7ryenvkwj6",
+    "name": "Microsoft Corporation",
+    "symbol": "mMSFT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1227ppwxxj3jxz8cfgq00jgnxqcny7ryenvkwj6/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/MSFT.png"
+  },
+  {
     "id": "terra1yrch507vhsmd9rue6q3v8pz4pe445jl09nrvz6",
     "name": "Microsoft Corporation",
     "symbol": "mMSFT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1s8u586k3s7xtvasxv4p6ldl0jrxht9w886v8ymkst6crg5hxue3sqn49r9",
-    "name": "Microsoft Corporation (Wormhole)",
-    "symbol": "mMSFT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1y5e4plp8evsh2urycmhy35lrqxneqc8ewdqzjpvlu5z9wurpqw7sfj9u5x",
-    "name": "Mine",
-    "symbol": "Mine",
     "decimals": "6"
   },
   {
@@ -8592,14 +4315,18 @@
     "decimals": "6"
   },
   {
-    "id": "terra1h4hvry62zk4zh0udecqmatfg02phnyu6hq74xd",
+    "id": "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
     "name": "Mirror",
     "symbol": "MIR",
-    "decimals": "6"
+    "decimals": "6",
+    "circ_supply_api": "https://graph.mirror.finance/graphql",
+    "icon": "https://whitelist.mirror.finance/icon/MIR.png",
+    "coingecko": "https://www.coingecko.com/en/coins/mirror-protocol",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/mirror-protocol/"
   },
   {
-    "id": "terra1q2mc9srv908j0jt3mpevdvpqsmy4s8tt0vwgwvae7r6d9cvklfwqgzwk4d",
-    "name": "Mirror (Wormhole)",
+    "id": "terra1h4hvry62zk4zh0udecqmatfg02phnyu6hq74xd",
+    "name": "Mirror",
     "symbol": "MIR",
     "decimals": "6"
   },
@@ -8636,31 +4363,13 @@
     "icon": "https://assets.terra.money/icon/60/MNT.png"
   },
   {
-    "id": "terra120lhfhg7rwvzwfs5extsj89urmupsdhvghg24g25rvthfma3gxjqnluur5",
-    "name": "MNT (Wormhole)",
-    "symbol": "MNT",
-    "decimals": "6"
-  },
-  {
     "id": "terra19cxwwhtkpp4qvf4tvjmhh8lnh8lle7uw7ndqjw",
     "name": "mocart",
     "symbol": "mcrt",
     "decimals": "3"
   },
   {
-    "id": "terra1saxy7j45avta7z6q8qv3j08p4t0qz0nfsyxwhraejek90eege6asumnl5f",
-    "name": "moon",
-    "symbol": "moon",
-    "decimals": "6"
-  },
-  {
     "id": "terra16p7wv0m0upx763r5aux6qatzyve44ezdyqpq5m",
-    "name": "MOON",
-    "symbol": "MOON",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1jg848acg7rzt7tnz6zqaxzsc94w2yjhafad80d3uel9937grkmfsv8aycw",
     "name": "MOON",
     "symbol": "MOON",
     "decimals": "6"
@@ -8691,34 +4400,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra1jzl4telukvjx56l72zxuts0xm60gefgu3kla36fvfqlfxn0ckuvsgd6akd",
-    "name": "MuskTerra",
-    "symbol": "Musk",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1y92wp8u58396mtaejwhtasz24vrcf0lhsznl7rj0nhw0khp8kchscuqgfs",
-    "name": "MuskTerra",
-    "symbol": "MUSK",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1z7xe8pjrr0tdguvsdxh2hj6u0gk3y93dxs2xncz00jsjzt8g6suq95lj5w",
-    "name": "MuskTerra",
-    "symbol": "Musk",
-    "decimals": "6"
-  },
-  {
     "id": "terra1j874eyvev9pm7uxm0h9l82raswe3qwcug8wxuf",
     "name": "My Awesome Token",
     "symbol": "MAT",
     "decimals": "6"
-  },
-  {
-    "id": "terra12rh4v7lwszqwcf73k38yxv05j78vntckczngh4ym8a9dqtzqc08sucptw9",
-    "name": "My Get Rich Token (Wormhole)",
-    "symbol": "MGRT",
-    "decimals": "8"
   },
   {
     "id": "terra16ygrvq7q2zxw7jj3f96racur50w0g7r0mj6e2y",
@@ -8739,90 +4424,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1gd3ntqq04lvd623xs8ht6dly0s7n4gxnz7lmlw5ga0qnamg9wyrqcggn2h",
-    "name": "Nauticus Luna Principal 042923",
-    "symbol": "pLuna",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1l02355pejytcakcpq6g3n57ydwpqeysuw5nj679hlnrrsz3sc3wssxr69j",
-    "name": "Nauticus Luna Yield 042923",
-    "symbol": "yLuna",
-    "decimals": "6"
-  },
-  {
-    "id": "terra13g39gz8uv4s8h9a7pzmg2pezcmd46jz774lffhe2n9dqckn87mlqqg86nc",
-    "name": "Nauticus Principal: LUNA/LUNAX LP Astro",
-    "symbol": "pLUNA-LUNAX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1gqe4qzemuhj8nxn5f3fj9tcscszy90klrapxsjpr2td2a0fnlxmq2klheq",
-    "name": "Nauticus Principal: LUNA/LUNAX LP Astro",
-    "symbol": "pLUNA-LUNAX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1hkcahx3u4742adhlx4zx2ya3sxmm7a0xpk5nwkf4ze4j2akg0sns0ydt6l",
-    "name": "Nauticus Principal: LUNA/LUNAX LP Astro",
-    "symbol": "pLUNA-LUNAX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1k57q7f7gh6rm4gyqpqygkxdgsh0d67nxngfuwj6n5d38jpd44psshn5gaq",
-    "name": "Nauticus Principal: LUNA/LUNAX LP Astro",
-    "symbol": "pLUNA-LUNAX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1z56spghy7kmvv6j9p7gv2hf569x57mnnex4gcqyx5m8m76d0awvqd6ywfj",
-    "name": "Nauticus Principal: LUNA/LUNAX LP Astro",
-    "symbol": "pLUNA-LUNAX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1gk0y0tcxj8pr65tanqvc8zyzv3c8szkwf2kcmzgqj9jm2t9z3f9q4xcnfz",
-    "name": "Nauticus Principal: USDC/USDT LP Astro",
-    "symbol": "pN-USDC-USDT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra157n39w0p0ux2wcec2fwyn30rywfd9tunxjc40qm22z6g5sdlr9uqcv8rza",
-    "name": "Nauticus Yield: LUNA/LUNAX LP Astro",
-    "symbol": "yLUNA-LUNAX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1mecwgl3p77l57lv5ksn7zet0p97rjd6c6cdk4vmvrl52m680pk3qgf5y2u",
-    "name": "Nauticus Yield: LUNA/LUNAX LP Astro",
-    "symbol": "yLUNA-LUNAX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1sqxtvf93tpu08evzt6va072cefy45xuvjghutgmcv93pk2aaazgs220eev",
-    "name": "Nauticus Yield: LUNA/LUNAX LP Astro",
-    "symbol": "yLUNA-LUNAX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1wjzwg8megt6zsfsr2tduwklh8sx3mpptquqcm7h0krxuzwc5n86sn2xh9a",
-    "name": "Nauticus Yield: LUNA/LUNAX LP Astro",
-    "symbol": "yLUNA-LUNAX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1y03yesqka4m799fdtnjp6p5w7n9rup9e5tucdsdqes6pr98t6pes9w6dcv",
-    "name": "Nauticus Yield: LUNA/LUNAX LP Astro",
-    "symbol": "yLUNA-LUNAX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1e0uch3fwned9rfhkaeehqv9mnfuwjh9jfhawd4gxw248czljdttsh22jkg",
-    "name": "Nauticus Yield: USDC/USDT LP Astro",
-    "symbol": "yN-USDC-USDT",
-    "decimals": "6"
-  },
-  {
     "id": "terra1hgseash9ctvscp09trutsh8utt34z46lj2n96k",
     "name": "Nebula Token",
     "symbol": "NEB",
@@ -8837,22 +4438,18 @@
     "icon": "https://assets.neb.money/icons/NEB.png"
   },
   {
-    "id": "terra10z9tu85rpzhk7crljs3atqcknyedkyys40a9sj6u7fcqqmky7tmscc6eza",
-    "name": "neo",
-    "symbol": "neo",
-    "decimals": "6"
-  },
-  {
     "id": "terra1cczv3ck2r909w64n9rdqs3gh5gsmwumh4utz49",
     "name": "Netflix",
     "symbol": "mNFLX",
     "decimals": "6"
   },
   {
-    "id": "terra1hw6ymqhxla8a5wk7xjjfqhxnvewvzqgdv5c5gfhlateg7sfhtymq6ccfuc",
-    "name": "Netflix (Wormhole) (Wormhole)",
+    "id": "terra1jsxngqasf2zynj5kyh0tgq9mj3zksa5gk35j4k",
+    "name": "Netflix, Inc.",
     "symbol": "mNFLX",
-    "decimals": "6"
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1jsxngqasf2zynj5kyh0tgq9mj3zksa5gk35j4k/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/NFLX.png"
   },
   {
     "id": "terra1nagqpmyw55yjphea4rhntlfv87ugmeaj8ym756",
@@ -8860,18 +4457,6 @@
     "symbol": "cnETH",
     "decimals": "6",
     "icon": "https://terra.nexusprotocol.app/cnETH.svg"
-  },
-  {
-    "id": "terra1w3fjl2nuhpqwwu6mkaarkgnvpugs25t5sd4pj02ktdjn0ayw08ys50lepk",
-    "name": "NETONE",
-    "symbol": "NTO",
-    "decimals": "6"
-  },
-  {
-    "id": "terra10804tj9tsguuhe5k3yt0xm2h6wdtn8zhea4mj9v8s04w6enstf0sgf0mtq",
-    "name": "New Community Luna (Wormhole)",
-    "symbol": "cLuna",
-    "decimals": "8"
   },
   {
     "id": "terra1f659ez3nysf06765jjjqnl7m65urrqaxx2t40h",
@@ -8980,18 +4565,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1ymkvnzclutwd8plps056479wl26cw4m7ynelg2fxwnswlrct5syse9725q",
-    "name": "NFA",
-    "symbol": "NFA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra10cev4e2n2xjen5eqwx2454zusej5yvzfcd8ymzldtaujecwxpxcschl3et",
-    "name": "NFaTman",
-    "symbol": "NFAT",
-    "decimals": "0"
-  },
-  {
     "id": "terra17zeqmepm87d9g4dujjsctqjrfhz4xjkup26t03",
     "name": "NFT Kwon Terra",
     "symbol": "NKWON",
@@ -9022,12 +4595,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra17gg9tteke98elqlfgcy2m4ymx3hzqzs2efdmtvutjml03gxvanpqmzne87",
-    "name": "NICOL DAO COIN",
-    "symbol": "NDC",
-    "decimals": "6"
-  },
-  {
     "id": "terra17ana8hvzea0q7w367dm0dw48sxwql39qekpt7g",
     "name": "NIKE, Inc.",
     "symbol": "mNKE",
@@ -9049,12 +4616,6 @@
     "symbol": "cnLuna",
     "decimals": "6",
     "icon": "https://terra.nexusprotocol.app/cnLuna.svg"
-  },
-  {
-    "id": "terra1tejajvl4y8f9remfdtlpl555zmr7ltqq2rvvs2vrmx3ke98twepsyutyu2",
-    "name": "no-name-yet",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
   },
   {
     "id": "terra1zzfhavsjlhhx42rnjfvwk6u7taplh4qxqmhgfa",
@@ -9099,12 +4660,6 @@
     "decimals": "3"
   },
   {
-    "id": "terra1ey8nrqhufmj0lfcn33x345hf7zhggz03nss03keavs3nxcml0w8spl0w58",
-    "name": "NUSANTARA",
-    "symbol": "NUSA",
-    "decimals": "6"
-  },
-  {
     "id": "terra1drsjzvzej4h4qlehcfwclxg4w5l3h5tuvd3jd8",
     "name": "NVIDIA Corporation",
     "symbol": "mNVDA",
@@ -9133,18 +4688,6 @@
   {
     "id": "terra1zawrkv57eh7rne45zjta7s876jqc59slrev9xy",
     "name": "ONLY TERRANS",
-    "symbol": "ONLY",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14kxhyva49afm4hzurmwgzxf5qftrmtlqap6yyty29rgvzt9f0dkszt5de8",
-    "name": "ONLY-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1zd27zxxn976s0ygqa7h2cmgzq0emcuy2h4dk04a6s8jm5a346dfs3zc6u2",
-    "name": "OnlyFeet",
     "symbol": "ONLY",
     "decimals": "6"
   },
@@ -9178,7 +4721,9 @@
     "symbol": "ORION",
     "decimals": "8",
     "circ_supply_api": "https://app.orion.money/circulating-supply.txt",
-    "icon": "https://orion.money/assets/ORION-LOGO-2.1-GREEN@256x256.png"
+    "icon": "https://orion.money/assets/ORION-LOGO-2.1-GREEN@256x256.png",
+    "coingecko": "https://www.coingecko.com/en/coins/orion-money",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/orion-money/"
   },
   {
     "id": "terra1yhlhrea3rgyx2xdnsswsfakn28qa8z7yp5gmhd",
@@ -9186,30 +4731,6 @@
     "symbol": "orionASTRO",
     "decimals": "6",
     "icon": "https://orion.money/assets/orionASTRO-LOGO@256x256.png"
-  },
-  {
-    "id": "terra1xvfaprudv2nwh4kcz3rx4hurwfqgxwdencuf5ull6dt8q092ph0q9m7s20",
-    "name": "Orne (Wormhole)",
-    "symbol": "ORNE",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1s3uyn9nakk9ht6hq455vj89r34y6twc6nejgl63swqyz8ushwtwsg7zh8q",
-    "name": "ORNE-ASTR-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1zhwjeh96z0ce0l7ze6veynuekmqkhatmawgnmvkfnutg3z4ymsass9cfev",
-    "name": "ORNE-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra13y6q5agfqdvd4mkrzzw9fadp500nk4spnd8rzyrkdls5fsqgurksa74uxz",
-    "name": "ORNE-RED-LP",
-    "symbol": "uLP",
-    "decimals": "6"
   },
   {
     "id": "terra1ts6qq7va0msf0se3cwjsppt3vkumkh3t6n4d8a",
@@ -9236,34 +4757,10 @@
     "decimals": "2"
   },
   {
-    "id": "terra14mvqh98pklf3h9e0ug6tr4h5kpkn4hxqcqkhqvvedszjmef5vzqs9kkn0f",
-    "name": "Ozone Vault 1 01/27",
-    "symbol": "OZ-VaultOne",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16phy60cckrwcl9memglr0m25tp4p50av26n2cnnf2h4kre3gvffsd99kpx",
-    "name": "Ozone Vault 1 01/27",
-    "symbol": "OZ-VaultOne",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1saegtxk5vym89ydrfrfw75smhpfg7202mkje2f4gwx4tvh5m54cqz9xscy",
-    "name": "Ozone Vault 1 04/31",
-    "symbol": "OZ-VaultOne",
-    "decimals": "6"
-  },
-  {
     "id": "terra1v58klw3jakaeas2dkppqdh4y4dzd52kzda2fgf",
     "name": "Pace Token",
     "symbol": "PACE",
     "decimals": "6"
-  },
-  {
-    "id": "terra12562rn6zu6n54gat6nsv83xetexe6kjs50a3mulhmsv8lqwxgaxq5paym4",
-    "name": "Pacha X DCentralize",
-    "symbol": "DCENT",
-    "decimals": "0"
   },
   {
     "id": "terra1xvqlpjl2dxyel9qrp6qvtrg04xe3jh9cyxc6av",
@@ -9292,22 +4789,12 @@
     "decimals": "8"
   },
   {
-    "id": "terra1dzahfzk3vavwy4zqt0x49guswvwe6ef8jm60fpl2cqmq0yl7pp4qyrx3cr",
-    "name": "Pce",
-    "symbol": "Pce",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16zlyx8s596gfrswryazttjtvae2qwc72j27vuvnefcezc2qlazssjmmdn6",
-    "name": "PCE-ASTR-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1e89c3swfuyykycw0gkqnwdvuwd0lxsg55tqydf3367dwhp73mrqqad6u4f",
-    "name": "PEG",
-    "symbol": "PEG",
-    "decimals": "6"
+    "id": "terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx",
+    "name": "PayPal Holdings Inc",
+    "symbol": "mPYPL",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/PYPL.png"
   },
   {
     "id": "terra1rjf3c4ayvx2d6pej6fanjhe54a2ds8dlh9f69s",
@@ -9333,18 +4820,6 @@
     "name": "PHZ",
     "symbol": "PHZ",
     "decimals": "6"
-  },
-  {
-    "id": "terra1h7g332d4r6chhv63umey9y2g5g5dq3h88s5az6xzpj6mrdefwcgswv558v",
-    "name": "Pinx Ladies",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1kxeefnas9zsgz8dpequcdp85t0mlxshcjd3sar9889z5wwnwad5seexp60",
-    "name": "Pla-net Universe",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
   },
   {
     "id": "terra1nq9epqtswmj7uaymsw59w9n5h5e78k9rwduets",
@@ -9385,40 +4860,10 @@
     "icon": "https://i.ibb.co/Snt8gXx/Projekt-bez-tytu-u-3.png"
   },
   {
-    "id": "terra18enrpukca3tnun2qstkdnwy27xc326d75fjj682yevzmwe58mqkqcl27n3",
-    "name": "PlayNity token (Wormhole)",
-    "symbol": "PLY",
-    "decimals": "6"
-  },
-  {
     "id": "terra1kdkcxnsldqmj50ll77gmq5x26u69z8m69hdas6",
     "name": "PLEASE DONT BUY",
     "symbol": "PDB",
     "decimals": "2"
-  },
-  {
-    "id": "terra1cysh639syvrhhg7mnsdl4vrhhvmefrzd5udxtd0jftscha2n3cjsnxsmnx",
-    "name": "PLUN-YLUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1e6395r0qgvdg204kuvy96rd2tlf32hme4ksrk86zmpantxku9s5sp59n0t",
-    "name": "PLUN-YLUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1n5392a80qr69ee2waudrtrqrwufk0vjavd42q5ea9nut3hlfscpswx7t80",
-    "name": "PLUN-YLUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16ptks602wpdjqtmd0qg5kpulkm7qf3wr2h6t5hatgrec6cl3l3jsxnkt7r",
-    "name": "PN-U-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
   },
   {
     "id": "terra10yycj46tjfnfhkk5d6er49gvcn28jpqk0spthr",
@@ -9433,16 +4878,12 @@
     "decimals": "6"
   },
   {
-    "id": "terra1axc098v7zqalr4rgt9dxcw9zh3la4sgcwwlj40easet7yjs00e7q6mn3lf",
-    "name": "Poki Cube",
-    "symbol": "PKC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ymf3js2gud2h2rspqmcd6n7nmsdyk5zvvwyz9wk4vegy3df3r4sqgrepv5",
-    "name": "POOP",
-    "symbol": "POOP",
-    "decimals": "6"
+    "id": "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
+    "name": "Polkadot",
+    "symbol": "mDOT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/DOT.png"
   },
   {
     "id": "terra130fhr9jz0nylzhdvuwcpp3hne2s5qlft6hfzgv",
@@ -9451,873 +4892,9 @@
     "decimals": "6"
   },
   {
-    "id": "terra10fs0sjuudj5suc5w0w6cfcak2w7y6t7wwaaflumh430x203dvn5s25q6yh",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra10fvqy25jyrr8uu5jw70vkshrnh8akzs534t0z9mrhdtw3lhth73qagl5zc",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra10lncq275lsf7jcw75p0mmcnv93zxwgeztyxa8dx0yy87rh3hsnkqa5t7k4",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra10smdczgk3cfay3hwahu9hwqp7ms66usty64n29dxprexd696uhuq4sd44n",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra12gly5yany57srs3m0qhae47h2jvpmdj6m73skwe0qfm0ywrmlk3qhpmpya",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra12jwxnguurh6dzhlwu0qag6fdwty5dh5uk0ldr5ycqrzm6kez080sufcemh",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra12uuqg783xejjds0t4f46ylxfl088pyw42wqtjcnupvgt02lgacyq4ta8ac",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra12wa9vvnffrady2yltzv6u20q37gg59w8qslmt4ufpqyprfe97aws5cyae3",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra137q26tg7gnjvu8lyqlkaffd343qfdzj9d7ynfm428eu7cc60vq2smkhn0w",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra13tzvgrp0zy5q5h50k9xlvdtwhs840pdyt5fyhhp8lskpgj0gsd2q8u5ng4",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra13w3073l43gwxw77tv2np2katn3jrvet87unyfevg8nrj755m3x7ql5xv0g",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra13wppqeqww2y42dlp7u30rwmekwjandzaxjvq3c503ak8fx5nvsyshercr5",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1454mwwpg5g0lqrsnh7gfr74avw8agm2snhawgf70cjectgcn6kssx7jl6e",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra14c7t4686jdtf9mf83hjwm0hqm9hawzzfjt93x77djfa0audx3dyqczda67",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra14dtlxyj2wqteq02293zt538rn39djdsahyt3hayyxm06ds7hn8hqdp54cv",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra14eut6f6mvdk8wpz6hsmuzgdujek5dnhd6dxx4py0gvxejzxwawdsksgtj4",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra14l6hpqyd2vqy0wn63wkep30wxmt62vjzlwzeeyhlkdkgm7grfl4qdf0enc",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra14tcq7cwrjtauqh6zwjd0zdaqg700dm42p5ja2a5fam9smnhn6t7qdek9jy",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1546pd7p449kej7rk2zgphxuymrqf90rlxu9tylyv0uf6dva4srfslhhu47",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra15qleygegrst8wke88m3fqzrsc7c6a45yqnqjlz64xqm94wd9zjaqw0z3an",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra15zsd9j5c3rzw5em6wqvzveek7cqx0ac3s2hzmee8qsdy37vwv7aq8w0fce",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1623wrqxv80s7tcg2ugp63tvygp58j6d4h0tuf8xewxmzv2gmrk5qze554q",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra164caf0wq3xl6fzpn2ek0ermwj3hyznr5dc7d920xsmq99h6auptq0jqujc",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra168nvfltz6z6dt3y8c38zr76p7hx2as32vwgy5hju7atcl7krxacq7yjsm8",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra16n6w0crnx7jskql6hgd2jg0tcafj60kwgp9k7nmpnfyt6j5dju3su923y7",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra17a5n5ln6zflcf23sf34va7ptes3u03vhftza47shqlfd2z04t75q3gkq6n",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra17d9vyjcnpn752dzxvgxn6lm28rn54p5t603q3t97dn5v92lyujlscdvqzj",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra17j6erkccpazwmzklkne96mf4kqwzs93mjxeqx7whxqmt4ha507pqe0a77t",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra17yzdugtznvecr5f7xhf9ralg0gg9l0pah9f6lhhv0xtwkj4aajks47cwtf",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra188ql9msm2g7r4lhm778w2gc5qfss8l4qtv235sz6wyslctmzmn4shg7k8e",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra188qt3hm9d3e50303hk04s4q9grfelfku74df7u5hpgrwgh2hhgeqhvj9t7",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra18cm52mt0c37yz7vutht0fvq37kkr8wgkvkwl6jn4kwx8uaa77d2qpa8ewd",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra18lteke6cy5t8dmc7ndzaj7mkp42acwplsm5f7vq3xmen360s2qxqafmvlf",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1924amcpgxksj7sz296kysxzn8u8lq8l0gvpnyrlx8pp42ryv00gq6k76ag",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra19522js50q7gql2fcavcu2emw32lh6v4exypz0h3sm62hl37hmdgqjd69yp",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra19664tmugwklf9z72f0nh3jjudzw0vfzjf4gmvttuppl60k9pvarswcmvj6",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra197fuwr564m6efgxdvau5j7j4nn0l8lau5qjcdzpv5cufzjzyjvgshcyd8x",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra19evfm7pk6hxth52eq7949dddm64ug9u5xnpggpwg4nlfesahqdhqslrhtz",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra19w83ezwxxc4qthcx2skfzre3qtamxzuhd3jj4r7h07c3rx4y9zlqnq9zw6",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1a05hpaqh4h5mkt9nnfpql7m0kjs2972pm0t4t88ezxgenp0xlg8sqfeeru",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1a2sfcfjvqh5hzstzek4flqmj2rcsn9dxgy7dfn3qalmajsuexmssvfdtfc",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1c7th2fkvtvsgy4w083nkzarmjayy4eqdn3qvagpa7sj723fvxprsf7yzgh",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1ccrhywcdxwlkhgv74eu8mdmd32vawc3lt9htz4pvy4hv7p4xlewqteunm6",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1crp926elm6g765272tt6ky53k77klq9pvfyacupw3mjzc0d0pk9sxpphpf",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1cv2n08ak4vyywxuzu4sshp9vrwkddmjh6sf9lun9dyf37rtn3llsnd6rej",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1cv9cp72zx7mawt3vgct2x0vhsjp59uf9m007zz8rz9m4zxn6n8lsvvnudp",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1d569vm9mlka059qh8wr99gkt0zdrwrfgnsq3e0ms2nrjzk4pv97scuphsj",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1d8cyqqf958ztmtfm5zdak93j3ymj00xe3l5k47zhgjypykkku67q9epza8",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1dmvcpkkgeuf2n3zy26sfc8l7yhz2tydvhvz9ywa8mwjct6nj9yqqdhcs5h",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1edly287ft06dwp6atdd9528adg4kavfwrqutpyzq0pax499d6whqejghcj",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1et08h5f3kjmles2za0vrhf703pnq2958kjx83z6n2asqgs7zw33s6je5ha",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1etperyw4cne44rfzqz2d76cj9j6hg8gha68ag4uwwffx7qk355dsf7cqsy",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1f29qttj2d62adht0ay89fkxd79rmd538v4f3svdean2ftgr074jqurt6u8",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1f4hv5xl2h5lqwrjvlnsp4zhwtxc364l5w43qryxatv5de23xvmnqje4ck7",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1f754ns6leagk42dkexk6drsxkas2j0zsfsww7yumhuvzs6w9yx2qm3g3kk",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1ffcttu9lxc0w2qqhavlchq824zswcnrva4vn4twclj7vpqwdtakqeg6sf2",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1fsdcnggcq05yvt4s6crkkn6yuv92qy6fv7vxwg3h5fm2tvj8rnzq8s6te8",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1fwf47kuhyvtzzm6l9sf7cwvk9lteed7g4fz63x4j26edquurc67q2kyx0u",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1h45p9vdfvv53f2pwne3apd8dw2yf6azqep766hw7rhlcem3t6x0spgmkmx",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1h8xhl9c5x78xnunag5chvlq4frs69t8l2a6tphu7txe23cryw6ps0zd0z2",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1hvmuxay55jngk94s3fcehktnu944ld0nt50phlpm39d77p3pw9wsq3rd95",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1hx08r5dt75txlyk9xcqwyga8zrnfhczcgkn9k6tg2sueadqkrn3sffdegg",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1hz8x8zkuerf3kjqqwv7ftvf6nm7ya6gkm78tquslzjkw6nznpf6qjdess2",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1jetsdecxkel6taay6hw34w7qkgp855mp496ks8hpv7uy9n8n8sussw05st",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1k3wvnmy6fwsqeguvtnta8guvaq2npmhr360mwucq9g9v3gc55nfqg726mt",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1k56kqqmnclet6lvk7mnrm2wpuey429ztlleg789alh3cvpyu6xtsars0cs",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1km4849s0a3vx7alp42ukd3psyxjhs6umwcx76rvcrrthznaftfhstl7p3z",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1kngra82083kv7n39ku4lhwlwwugxavh38fp44xyr99vftjg8502s8hm0k5",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1kt32q3539f0hgurekuda2yq6u2he9py4j3yv3663veqsyvc79uusje9c80",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1ktru8mwg7q6ztuvy8906m2w8gj08fwerv38h20mm9gs53tx38uesf4hyzr",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1kymjy4xjsppjv0qd2xxj9cyx626w5ddgcsqkr29qshn7dfdmdghqll9pvr",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1l4cz9ak9rzjpra8tjqpsp2z4k3qguyccr40hej8uypcawp9sawys4yqjl9",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1lhdmrqq8gtfx3sxgvhnkcnkcsuw44mzqjhaa6r6pwjrhpvkguuuskjfz39",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1m2g4y2hs9almn7dayhu7mfk45xnhygpw9cckrywke3f9ucr2t83qq44gae",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1m9cg0gf5axy27pc4dcagejflsnve3c8y5vfuhdljl8kqflecckaqfgzr2c",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1mys8yflclfsg4jlzfwm60alwkjgq2hxq2n78ku5secx2g9hy2l4qc0gpsh",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1newq5r75d2seee7jh34h5g7r7puws66erxkdck62zkj27mn67x4qdejr0h",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1np06dk3p979t9qvu733r4v753zysev4c6jpl62r3n6e8dyea8q3qy3r5na",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1nrvntz7dp6xazrq94h4p6ugv5qqz4txqpk69ysaha4st2f3nwwkqw0j2jd",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1nz6rquzm8lxsp8tu834aq9ttegv80ru2gcls9lktvra5lrput8mst5ayyn",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1p0vnl6gns5wgjjjtqweszjwjuvnptlleztfp79lg4r7agkwgxt8qgey572",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1paqr8p29tazlvt25yhj4c9mnz5g7mj93svnwqeyjewkfz8nruwzsgcdk0z",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1pl9mq3zzk8fxjkjany0p2ewv9u40w6aggpu8m5kgqae3c7ynppgq2tjxjq",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1pulvlgx7cp4l3u4w35kux8sg9zn25n3xzn5cqvcvhkvy5nx0n7vspj3n4w",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1q3p4x32wqy7gyp347wktfxw42we4tdjuped0kuqfvvl07kgygh3s0v8nxn",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1qc2sa5a5rv7rd5jt6rdwy8tgfdh7xsv6dtrldnnkzk5rswk57zeslvxfxp",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1qdsjtafetdr83t97xjgewm6m6ddekjagfvhzsa5fp9mvc82892ds655chn",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1qghmdv9tmm575l6n9mmpp56m5ppyndve5apvj4fnz875yvf7ft0qynlppp",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1qxef85xd7dzqhyll3j0u6686ugvv0x9fke76rpcphyr680ls2c5qnx44ss",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1r4e3jexudvu72n9mxyjuvwedn03r6epjpankmkml44mktx5nvu9satrfd4",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1rajev0zks98jq2rw9jk0vy06nxv8eja564sxrw9fq7c2rvjw66ysrkex4l",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1rgffrrprdyuyjegz262pyz8sy2wd4u5jrza8wf37e7whgcdkq9tqf4n4sq",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1rvtgvc38sfd9zehtgsp3eh8k269naq949u5qdcqm3x35mjg2uctqp7f0yg",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1s9um3sdm0exu9yse43h3wh0zqngd9pg5dqa54pj76ea96uynfcrs5g97nm",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1sc23f03xe60m83jtkghsksapwlppjw65rlzpmvylkn8puhkrpessjlqupn",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1swggew3xu60py79d065zm4aqevt9sujgu06pm2ee64zw8yg7lzzqp4zlfz",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1t45w99d4te55es7lmw9kfmcc2y7549eg9vdfs9veec6zy54ehyzq7ja76l",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1tj89edfq20tdjay4q8aleqkus50lkd3evud82mc4l8lchy0qhh3qhldwvj",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1tm4xanlzde3uye0q5w4zwanpuk6fcr0vupkd7n3n2g7ctur5dres8zp7sv",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1tu3h0sa8s3tveyz8zkyzd9kras2s30qsumanwn5074zwj32qdeuqka5x95",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1tutagjumy6u40v0twxsuh5wsnwfpfwfju4lzw25w24hft3wm83xq72tzpk",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1uuhtyv2lqt95ml6krz824rnkrgt20lu8t5jw8dcl2vsmq49xwqpsn3zmzv",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1ux3ku7uv7urkm7gvf2l8557208ewu0sr6gw6688dsm59jk80hgvqzy7fpd",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1uy440n36h8mhhm4kgljzcm0m9crayv9qym5844vm5n00yp63vcms6th2xj",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1vh6u6e7pjlt90lz8v9mtgm58jl4tw8s3mvtns0q2f4e2v26y37ns9ez8xc",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1wdacaf4y9h20k6zq0gfgctxeakkpjlntg8afklnny3dlfrujw4wqryrds3",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1wf5xh4qggdgjd7qkrkyemdflclu8gtjehuqtd0wgdj39pt6dc9wq4xjysr",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1wgp70lydsl4npqcd896d5pfzmdtt6p978ufmcfvwmezeu97leals83mx6u",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1wgq575juumk5fz2vrrrcf3drx7nk0d2t4lj7jrt6g95emsvdz6rs0fteay",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1wr9tck0efj5vkys2m9v6a7a0vayjzyqmv5zruy4hwep48a7r86ws3sq97f",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1wrsdfjyykd3laekus6umln5zy4y0xwgfrzypucn26epaszdaa0msarh9rx",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1x6t9p76dt0qgnz9c84lxg588hvkmkwcug3w6rg8vjmfff3jvj3zq8hyqa9",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1xex8hxw7zq0n02mc627trtrck887yc8jzpeaqhmnn08gjuug8h3qj93nd2",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1xuhyuwjxqk38gsd7cdsa0c7pqeswu3r8ua3epa30j7avdecte80qrqr9c6",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1xwuyf0eth3hvtdfmntgy6t6mj5tggswj4k7ev6dewqf4fa3qwwds3ryhrs",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1y3wr927vujk5037768w43mfm5g8wyp7e5nqyswvmyxkdkr94zpeqtnltvq",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1y6mwa3qy5374ueslr62da4nkt6pqfzv672x0yfm3tsvupye73zfsat37nc",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1z7hxqnd74r6syx3uuxrtvg4a04qzct64pqm2g7ayezrkhq37tl2s2rhu90",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1zqjzzuyrrhqdhrp8y9nt97yle2uvynvphu7wqr9juk0pqjrtzmps7a7hmr",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1ztcgnl9fsmk5kw8n3rygvpjkwznmqxh7ec92ydgpeet0kehgsknq733gxc",
-    "name": "Portfolio",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1rwqs9stqn9704hpynza5sgxzs6yqrtn9j25chrrhlheeesw95egszgjvlw",
-    "name": "PPT (Wormhole)",
-    "symbol": "PPT",
-    "decimals": "6"
-  },
-  {
     "id": "terra133r6snp000sw0qhuspkua39fjc4c6pux82cnxh",
     "name": "Pre TGE SAYVE Token",
     "symbol": "PSAYVE",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1pfnex5dy7wvz2kd26t44t5lzlryg05reskjy5rem8xj6fvdmqwuqvzde7a",
-    "name": "Princess Rockettes",
-    "symbol": "Prin",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1zy2vjzwrc5j3evkkhagstewqxjlsk4vjs04u9q6g2umzw6nkt0sq6y32s0",
-    "name": "Princess Rockettes",
-    "symbol": "Prin",
-    "decimals": "0"
-  },
-  {
-    "id": "terra12jz8a0eaqvwp3w3qc5v7zdr7az25e7xr5z3gxmqcsnns9pkl4a2qjed4f3",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra12nlllhjz3s308gazwss9pst0aq63n9uuenw3usup5kffv572jhmq6zmgc3",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra15p408hyj9mge2dwsgevvakssjuawdpuqhzeg8cdf7df0a2ndvf7q56zytz",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1aw3pwzqf8l4gnkdelynump5pv8y4frayucpzxdlt2cy5djylfu4s6z9tsg",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1efkg3msnu9nhvwp7t33fqw4309gyn6fzlt2fz7v6jk5ra5qwhewspe7s4h",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1f7qn0jk6sg7275hq6dx74fjlcxm323y5yfyq5ewn8scd6uszf6psxgzwfv",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1g3kkzyl57ww3c0pu82n9ayz3pa3hrgvfnlg97t7lhsze5rgslp2sycxwcq",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1gjvtunfr4zep4t043grh87cunxzry5wa4c2a4dldcztyat3g7y5qz6a4ds",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1hrxrkslv9d4eu4suq33vndrn8flnyhs32qhy7plzugn2zgqmr4kqw4npe3",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1hxg704fdvm5wm9re3tuvhjryqv3mte6hpep4eh643chge7cqjmdqk0hh4j",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1jr28yjhpm6fqwgd8f972smcxpg0jk9zvxuwc7wskfet9mk28kldsncqpjg",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1knwcergcxqyxlwqr6guyc6luaha5smn3vuljunrf3xr9trqe06msvudm7r",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1kzj8ep2tttwf9a08fmpk40dey9h6f0ygu75ltew5ky44chvn8pmqp2px0q",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1lactake5rh3rnael696ha2fu7tm9us8jmgt4skaja9uy8u0djg7svxx366",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1n7xs7hc7j2hxy9a9m7y0y54qgc2vyukv9wg0xpfftjwlmvvhk33sklc6za",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1rvdm2esamrsvx6ad3ldzlku8v0h5j9xc0dpguwr4vct9qh6nssjqfp779h",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1unyw7mtg36jhsxyf234ks36xfz6r7g787h4hul5z9aekrrrs7ghq08wvmr",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ux08rv849xtyacwagr29k2m68n4fela54q5pkwveusa2cp9hma7q4lhsjs",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1vxpuaymecjk2473mapryd0lnr5jaf9uvercrpfwufdunmvs4n0hq2xnp97",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1z7jgpvhhga8t737ed4qk55s7k92gf3fdmwa4vwjnerec3aa96j9s5ql2wc",
-    "name": "principal",
-    "symbol": "pToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1zq0gmevf5ty5aggasm72c70klkcj8g63y2yhjayydeqhwmhefcus9675aq",
-    "name": "principal",
-    "symbol": "pToken",
     "decimals": "6"
   },
   {
@@ -10415,6 +4992,22 @@
     "decimals": "6"
   },
   {
+    "id": "terra19cmt6vzvhnnnfsmccaaxzy2uaj06zjktu6yzjx",
+    "name": "ProShares VIX Short-Term Futures ETF",
+    "symbol": "mVIXY",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra19cmt6vzvhnnnfsmccaaxzy2uaj06zjktu6yzjx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/VIXY.png"
+  },
+  {
+    "id": "terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45",
+    "name": "ProShares VIX Short-Term Futures ETF (Delisted)",
+    "symbol": "mVIXY",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/VIXY.png"
+  },
+  {
     "id": "terra128pe5jpempxu0nws5lw28se9zknhsr78626cpn",
     "name": "pStake Bonded ATOM (Wormhole)",
     "symbol": "webATOM",
@@ -10476,7 +5069,9 @@
     "symbol": "MINE",
     "decimals": "6",
     "circ_supply_api": "https://api.pylon.money/api/mine/v1/overview",
-    "icon": "https://assets.pylon.rocks/logo/MINE.png"
+    "icon": "https://assets.pylon.rocks/logo/MINE.png",
+    "coingecko": "https://www.coingecko.com/en/coins/pylon-protocol",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/pylon-protocol/"
   },
   {
     "id": "terra1u9hgxjw5k0aje9xjf0ejfu6uwmamc2k8ylzd7l",
@@ -10485,46 +5080,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra1ykxe98arwtahe97h9y5nck8gw88kxn2z73gfwlnx5twcd96ct98sqzcsrk",
-    "name": "Pylon MINE Token",
-    "symbol": "MINE",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1wpmnfxlysju3pq7plc0qljqwyztlh7g0jqdvh3xsy7tt94vg8zjs8tzfcd",
-    "name": "Pylon MINE Token (Wormhole)",
-    "symbol": "MINE",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1lunpxecglpu5w4pr5xkx9rzyprxktdwwdcd6puxa0zfx6muqsfrqdhjww2",
-    "name": "Rainbow Rockets",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1sf2fftvjt4z75g4rshngdxn5fr6qsccl78fgsz52fefwemxzvmaqptdfnp",
-    "name": "RameNFT",
-    "symbol": "n/a",
-    "decimals": "0"
-  },
-  {
     "id": "terra158gqaxafjche7vtew0f4zk9g80224qr07kwfsk",
     "name": "RandomEarth",
     "symbol": "rEarth",
     "decimals": "6"
-  },
-  {
-    "id": "terra1sn99ks9lgpmj6lqq9za7fu2s00063hy69rqux9cahtzlkvayx2cqzz48dc",
-    "name": "RandomEarth Social",
-    "symbol": "RE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1a8lnalg78u8zdcshjg27qnxma6hr3umxf2cuy253u97p3c4kc7rqxewc5y",
-    "name": "Rare Experience",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
   },
   {
     "id": "terra1ht5sepn28z999jx33sdduuxm9acthad507jg9q",
@@ -10554,48 +5113,6 @@
     "icon": "https://reactor.money/assets/logo.svg"
   },
   {
-    "id": "terra188vepzwkt623tcuh6p73khm6fuwz0ez89e68jnzzhzpyucal6ens5ccfss",
-    "name": "Real",
-    "symbol": "REAL",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1hcv8pl2vtakegf2fd2vvc0j3fsl0p0ur46w8jc897kvp8zmz8hzq5yzkez",
-    "name": "Real",
-    "symbol": "REAL",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1pem93fgdkmt7vvlrnnjseru69qmfqpkmwg8smeacg69fmfgplcvqgq43d4",
-    "name": "Real",
-    "symbol": "REAL",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qrgn84zf993s84kyhfsyhhspz4a5alea75pc0tfk07hyy26nvn6qe2hak5",
-    "name": "Real",
-    "symbol": "REAL",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1gpvpy8qn8xmwmjg2zhs9504y7ptdz9mhk9pdm6pmvjd6egterkrs0as5z9",
-    "name": "Red",
-    "symbol": "RED",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ph3zz8lq842kc0vt634f67qrz8hred0cn9duuufzhlk7a0sh33xsp7wldf",
-    "name": "Red",
-    "symbol": "RED",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1hh9rgaxtmfqfkeqkruckwah6qc4ajlxgnweexyjeh4dsptkfnhmqeelzfl",
-    "name": "Redacted | RONINs",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra1tdc7hmydg3es6lmn2asfwfgs8ykq7xa0nz9rkh",
     "name": "Refinable",
     "symbol": "Fine",
@@ -10605,12 +5122,6 @@
     "id": "terra19cnnyaah7c32hhcdt5m83pvdxa7ts64caarcm8",
     "name": "REKT",
     "symbol": "REKT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra15wsew96nut3ckfqkynxjhmfkm67hxnzndmtzfragl46prgh9k6vse6lllu",
-    "name": "renLUNA (Wormhole)",
-    "symbol": "renLUNA",
     "decimals": "6"
   },
   {
@@ -10640,12 +5151,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra14dwdssqhd9wlezr9tnyn2vktlk7f96n0wmdf3p6etj029fst7qxshcrsde",
-    "name": "Riri Cool Club (RCC)",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra1cdg2m5swqzatvzuvseef9xcxpwqylx2h983hm4",
     "name": "RIS Token",
     "symbol": "RIS",
@@ -10671,7 +5176,9 @@
     "symbol": "ROBO",
     "decimals": "6",
     "circ_supply_api": "https://robohero-io-api.vercel.app/token/circulatingsupply",
-    "icon": "https://i.ibb.co/nmhRXB9/token.png"
+    "icon": "https://i.ibb.co/nmhRXB9/token.png",
+    "coingecko": "https://www.coingecko.com/en/coins/robohero",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/robohero/"
   },
   {
     "id": "terra1gpwkclxwwuzd5wyjw2qn3km0r5ge4t4f4mnf0x",
@@ -10698,24 +5205,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1lyz4sm8vgu4c9f9hxcv6enzpx0kxct827s4x7t2vc8n6djfw9geq9l5z4w",
-    "name": "Robonomix Series",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
-    "id": "terra10tc799vxuwwdmy2hxchf6cl4n2qhed3wdhpv6kj7xfzhnsucsd5q8su39g",
-    "name": "Rockettes",
-    "symbol": "Rock",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1ulsw8hclj4quxzq8yut0uq3cq5wrvgz99fwvx4txdz25afzhjcpq3tgphp",
-    "name": "Rockettes",
-    "symbol": "Rock",
-    "decimals": "0"
-  },
-  {
     "id": "terra1mz858mn7jeglmzj0ay8z5zy6v78fvv7em9tljz",
     "name": "RockOnTerra",
     "symbol": "ROCK",
@@ -10726,12 +5215,6 @@
     "name": "ROI Token",
     "symbol": "ROI",
     "decimals": "8"
-  },
-  {
-    "id": "terra17m4n3s8fj8g56aukpeneu6vyq6zj3u8alenv388ctjekyv6mzcwqt8kxrk",
-    "name": "Royal Token Society ",
-    "symbol": "RYLS",
-    "decimals": "6"
   },
   {
     "id": "terra17h82zsq6q8x5tsgm5ugcx4gytw3axguvzt4pkc",
@@ -10778,12 +5261,6 @@
     "decimals": "3"
   },
   {
-    "id": "terra1987ddrcpwgwrpkxw44l73lgzhuldxmt7ue9nj9e5c5rm3w9pmx6qaqwvrv",
-    "name": "Sandy Chuchat Collection",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra1lchkxy5ednukxepwxejak8xevqlmz89ukjh6hl",
     "name": "Santas Big Sack",
     "symbol": "SBS",
@@ -10805,48 +5282,6 @@
     "id": "terra1pduqn0tpqce36ndwcv6z6xjlnujdddl6pedz9y",
     "name": "Satoshi Nakamoto Token",
     "symbol": "SATOSHI",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1x599eytp94hky39qardrpnc4qjrcplqlc6u6vh7pugk2s6nqqghq97qlc5",
-    "name": "SAYV-ASTR-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra138k8ca3rn28zgek2ljdtwhzaqmtekazvrgl9yp07prtvlws2ygqq8sdgq3",
-    "name": "SAYV-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1l3r2z220fs6hfz8var4ms8w0tlxhw7aqdulslvgz9ur9g3g7mn9qd9mptr",
-    "name": "SAYV-IBC/-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1w3vxxyvrq909w8nqrxypaeazqtt3ldyy3ucre3jwz23nyznnd3eql5hymn",
-    "name": "SAYV-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1zqthrqndchxp5ye443zdulhhh2938uak78q4ztthfrnkfltpgrpsu3c5xd",
-    "name": "SAYV-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1q5y5kyacmmq3p32khe8y7qrumawyfqq0tnxjw4afl8mmedqra96q0jt425",
-    "name": "SAYV-XSAY-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1w8ru4dhgsf8sx6f74vp60nf0k07a2aw4vj9qz350cttukthhdhnse760et",
-    "name": "SAYVE Token (Wormhole)",
-    "symbol": "SAYVE",
     "decimals": "6"
   },
   {
@@ -10979,24 +5414,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1ytu6fskvcdsuzj48l42nwah72y0g8pughgamlt5k8786aslq6vrqnxq56k",
-    "name": "Sirmagiste NFT",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra19899s4dtmr7ug7wgqdwtlu04u9863lnuur64u0ev30x6p4rjylpqu7dz9s",
-    "name": "Skeleton Punks",
-    "symbol": "SP",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1x7rf4nquswmmrjtzlxg6dk3d70ef69prth2q7vk3v9vdprepdh0sjxrvl7",
-    "name": "Skeleton Punks",
-    "symbol": "SP",
-    "decimals": "0"
-  },
-  {
     "id": "terra1jz9plajrq6knks3vgv9px4ezwshzaxsr2xz7jn",
     "name": "SMART TERRA",
     "symbol": "SMRT",
@@ -11027,12 +5444,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra16thequeddc2jc2pcc8xpsyng5lexqwx45ch6yvngs0e3qxtmc7yqv0t6h0",
-    "name": "soil-test",
-    "symbol": "SOIL",
-    "decimals": "0"
-  },
-  {
     "id": "terra1rl0cpwgtwl4utnaynugevdje37fnmsea7rv4uu",
     "name": "SolanaSail Governance Token V2",
     "symbol": "whgSAIL",
@@ -11043,18 +5454,6 @@
     "id": "terra1ejmg85y0vgsxv5r3cd4024j732pqnwudl0v2d2",
     "name": "SolChicks",
     "symbol": "CHICKS",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14jq0tvadkw3sd9yh8wqs5gdygek7cjn5kkp8htychwz4g7ygcassqcr2h2",
-    "name": "Solid",
-    "symbol": "SOLID",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ksrvpykmhyj9ka3qv4hsd5hecu22cxwzdk8wqvufhcrmnjl8nhaq2443jl",
-    "name": "solUST (Wormhole)",
-    "symbol": "solUST",
     "decimals": "6"
   },
   {
@@ -11070,29 +5469,11 @@
     "decimals": "6"
   },
   {
-    "id": "terra1v765xt7pdpzcr8v9ffpqw0nk2e4776yqtnhgsnuvguhhenrkv9yqfumtem",
-    "name": "SominGaze",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
     "id": "terra1689ys6p6gfu0q6xrjqkzfn80sdyhurjqn0jfdl",
     "name": "Sooah Studio Token",
     "symbol": "SST",
     "decimals": "6",
     "icon": "https://sooahphoto.co.kr/icon/logo.png"
-  },
-  {
-    "id": "terra1rhjm54rh2d58wwrj5gep0xa4vf2uakvqe4e3se7vr7gakwhljrysxhne6n",
-    "name": "Source",
-    "symbol": "SRC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1asuk3yas2rtlfdukfj80lguaghy6ad47fq6n7d45q5my826en7kqgn2jng",
-    "name": "Space Birds ",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
   },
   {
     "id": "terra1l0y8yg0s86x299nqw0p6fhh7ngex3r4phtjeuq",
@@ -11122,94 +5503,18 @@
     "decimals": "3"
   },
   {
-    "id": "terra16f3l8cq99qenutzzuctp2lnghnz72yduxc7yc9cfwkec4n4rsclslyqnsy",
-    "name": "Space Pizza",
-    "symbol": "SPZ",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1vn0qwkp9l53q73ajsrnexdw97ekzscexh2q5rduk2kajqrvzwtkqj4nc08",
-    "name": "Space Toadz",
-    "symbol": "TOAD",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1w2hzqaxdrdqn6wvk3ha5qwy2hxz7xevth6m505mv7y6xjjyu4qmqvrs6zu",
-    "name": "Space Traveler",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1nuxaxnpmu2dm9zt69egmzdyck03r8r8luyp0qg96yada9lpru9kq0zwss6",
-    "name": "Spaceloot",
-    "symbol": "SL",
-    "decimals": "0"
-  },
-  {
     "id": "terra12wlcu0kgdfrfutjydvvcmhlx8jrfsqhwqarc3d",
     "name": "SPAR Finance",
     "symbol": "SPAR",
     "decimals": "6"
   },
   {
-    "id": "terra1gxqzjk4pkyzpnxnrz7h486vntvv4lmaukcs24v9gcsmcm4tyre7qytcm5e",
-    "name": "Spectrum Astroport ampLUNA-LUNA LP cToken",
-    "symbol": "clpAmpLuna",
-    "decimals": "6"
-  },
-  {
-    "id": "terra144mkz6p3mmnuqaenu73pg4jwayr3m28xzhaxedlfwfnyke45w6yqvf9ed6",
-    "name": "Spectrum Astroport ASTRO-axlUSDC LP cToken",
-    "symbol": "clpAstroUsdc",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ufpsjrvj5fkvdedx2ttslnrc2wxvrftf4zcsvu778cufvlh4m9dsmgcf6f",
-    "name": "Spectrum Astroport axlUSDC-axlUSDT LP cToken",
-    "symbol": "clpUsdcUsdt",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1erm54gtdtfqv2s4c7ple3kmret7eecuj02nk5w8h08jjnenjffzsynsp0u",
-    "name": "Spectrum Astroport axlUSDC-LUNA LP cToken",
-    "symbol": "clpUsdcLuna",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1w6l7kjc6wu7an37wnnehcfc3tpksw9tde9u67743ew0caly0hdasv0ws79",
-    "name": "Spectrum Astroport bLUNA-LUNA LP cToken",
-    "symbol": "clpbLuna",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qczgczguzmxpsqfwlcaqm5hpy3jrkgrkkkcdxhd4uf28t8l8j6qsgtd863",
-    "name": "Spectrum Astroport LunaX-LUNA LP cToken",
-    "symbol": "clpLunaX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1j9ggd8wf73ggsfet99wnjvn06f3l9w9lsf50uac43h6vclysfc9sp0nyfh",
-    "name": "Spectrum Astroport RED-LUNA LP cToken",
-    "symbol": "clpRedLuna",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1v9luz2r9u8mzd4w8ew5dm4cczk8kcxun4jry464j48jsl2fus2qss73ld4",
-    "name": "Spectrum Astroport SAYVE-LUNA LP cToken",
-    "symbol": "clpSayveLuna",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1udwqynsmrme00ksrakkyerrfjdkw9p05557yrrw6ca6x94uuj2zs0vpqt2",
-    "name": "Spectrum Astroport TPT-LUNA LP cToken",
-    "symbol": "clpTptLuna",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ha4yvzqnq4mpu205wcd430m6m7wjklpquwn87dq89g9zersuvryses7rua",
-    "name": "Spectrum Astroport VKR-axlUSDC LP cToken",
-    "symbol": "clpVkrUsdc",
-    "decimals": "6"
+    "id": "terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc",
+    "name": "SPDR S&P 500",
+    "symbol": "mSPY",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/SPY.png"
   },
   {
     "id": "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr",
@@ -11217,7 +5522,9 @@
     "symbol": "SPEC",
     "decimals": "6",
     "circ_supply_api": "https://api.spec.finance/api/stat?format=txt&type=circulation",
-    "icon": "https://terra.spec.finance/assets/SPEC.png"
+    "icon": "https://terra.spec.finance/assets/SPEC.png",
+    "coingecko": "https://www.coingecko.com/en/coins/spectrum-token",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/spectrum-token/"
   },
   {
     "id": "terra1k9ltsdc6e4ay4g8f8nt8qd7my9yyd27m7eh82d",
@@ -11232,10 +5539,12 @@
     "decimals": "6"
   },
   {
-    "id": "terra1jsd4c0nkchn6mdqamcduuc3kqrtfjjmta9f9vkjj0pqu2q3vpykqr5sdx0",
-    "name": "Spike's World",
-    "symbol": "SPIKE",
-    "decimals": "8"
+    "id": "terra1u43zu5amjlsgty5j64445fr9yglhm53m576ugh",
+    "name": "Square, Inc.",
+    "symbol": "mSQ",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1u43zu5amjlsgty5j64445fr9yglhm53m576ugh/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/SQ.png"
   },
   {
     "id": "terra16gnk7mpqr84f4mnmqjklpdxxe602dn0fjslwhy",
@@ -11316,63 +5625,9 @@
     "decimals": "6"
   },
   {
-    "id": "terra1nu0c3s69umqz862ltp6wytuztm0rrn6w5079g999u0hvwy62tf3q02qhmr",
-    "name": "StableDao",
-    "symbol": "SDO",
-    "decimals": "6"
-  },
-  {
     "id": "terra143dkyw98s3ksxu97zln8z5s220ytatygd5rqdx",
     "name": "Stader Labs",
     "symbol": "LABS",
-    "decimals": "6"
-  },
-  {
-    "id": "terra129gzxm65ckt7p9tp3rnq8q0zvaz6m48e5l7qpxtmy2s3fnhcjd0sag3tm3",
-    "name": "Stader LunaX Token",
-    "symbol": "LunaX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1s2lr8u69xammmg3s8hemegcz57y07ae0wa7c7d2adupp6du3neyqfukkaz",
-    "name": "Stader LunaX Token",
-    "symbol": "LunaX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1pu5gewue3s70u0pgzsza9asfjhkgt5trkzd7xyd2gyrrdqmumensyn8qy4",
-    "name": "Stader LunaX Token (Wormhole)",
-    "symbol": "LunaX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1j8uqz4d48x5t5sf5tgfv7wtt2uvl7jsrr2ayftxpfy5shkjv793s5qqpsa",
-    "name": "Stader LunaX Token (Wormhole) (Wormhole)",
-    "symbol": "LunaX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ek4upyl20z7ah4xk3mpfgczkxrn9nrqme9njtszht50vwkqyt6cqvchxet",
-    "name": "Stader Token",
-    "symbol": "SDToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1f8p6yc7he3393y8rrpqp3syev5dnqd56kzepx6f36yt7zydghnequtkztf",
-    "name": "Stader Token",
-    "symbol": "SDToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1twakgfn5ch4qefp4xzu3met26ae2rhcd9t8tj7hujry4n50xtw0qhzpjw3",
-    "name": "Stader Token",
-    "symbol": "SDToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1zfx0wkel6sffhu8f9mrcfxs830cauvkqd6x2aqy6szlxlrx658lsasenss",
-    "name": "Stader Token",
-    "symbol": "SDToken",
     "decimals": "6"
   },
   {
@@ -11410,28 +5665,12 @@
     "decimals": "6"
   },
   {
-    "id": "terra1eygp4ps44jnch66r5sm60ky5l3mc9vl2s7qd5g9m9at0mggzwzssy4j5yg",
-    "name": "Starbucks Corporation (Wormhole)",
+    "id": "terra1246zy658dfgtausf0c4a6ly8sc2e285q4kxqga",
+    "name": "Starbucks Corporation",
     "symbol": "mSBUX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra10c8y69yylnlwrhu32ralf08ekladhfknfqrjsy9yqc9ml8mlxpqq6esfh0",
-    "name": "Starbucks Corporation (Wormhole) (Wormhole)",
-    "symbol": "mSBUX",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1z2wr8jmxmpe8x3j25rl8360pfl4w9p3ry3dpss90yuek4je4wgxqefg56f",
-    "name": "STARDUST UST",
-    "symbol": "DUST",
-    "decimals": "2"
-  },
-  {
-    "id": "terra1mtsce8d3hyds76366lrdf3aplakxlzjnal2hwmxmg88fpu9ashpqzjx6j0",
-    "name": "StardustEvents",
-    "symbol": "STDEVNTS",
-    "decimals": "0"
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1246zy658dfgtausf0c4a6ly8sc2e285q4kxqga/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/SBUX.png"
   },
   {
     "id": "terra13xujxcrc9dqft4p9a8ls0w3j0xnzm6y2uvve8n",
@@ -11439,60 +5678,14 @@
     "symbol": "STT",
     "decimals": "6",
     "circ_supply_api": "https://api.starterra.io/cmc?q=circulating",
-    "icon": "https://starterra.io/assets/100x100_starterra.png"
-  },
-  {
-    "id": "terra1qqw2vlmlr0gempsdytwujq67yusscwpxmry5jevdf05wfwcw5jkszp0r5f",
-    "name": "StarTerra Token (Wormhole)",
-    "symbol": "STT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1emm9kdgdznjy37gyw6883m62fg8d3kke26c8n34n6yz2v9fwvm9sq3sqkp",
-    "name": "STEA-SOL-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra175232yuat84jr5yx74mtz243egyyp904l9n69fvdzzkplhru5juqlv8ah6",
-    "name": "Steady test",
-    "symbol": "STDYTEST",
-    "decimals": "6"
-  },
-  {
-    "id": "terra12y8dapy6zvwkxhnxgxf2jnmrr9qqhdc8dh6ez0cj4eywms695zrskyltgd",
-    "name": "SteadyLads",
-    "symbol": "SteadyLads",
-    "decimals": "6"
-  },
-  {
-    "id": "terra188dgygh5qzkc06afamst7sjfrcw2xt4rkr6m3j69f88cnkw4jfqqy9ymrg",
-    "name": "Steak Token",
-    "symbol": "STEAK",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ud6n3r3tczvmw9jg05jy0rw70z6362hrm6q0gzf0zjgg3xc0wv7qfw3vle",
-    "name": "Steak Token",
-    "symbol": "STEAK",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14z3laya7z6883np60l3wu6075s75xakm3kpuqr4w5ezeknuxj9fqmemmtg",
-    "name": "Steak Token (Wormhole)",
-    "symbol": "STEAK",
-    "decimals": "6"
+    "icon": "https://starterra.io/assets/100x100_starterra.png",
+    "coingecko": "https://www.coingecko.com/en/coins/starterra",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/starterra/"
   },
   {
     "id": "terra146fhkmq8d7ae3e6jemufy4h5eq9zerftm8wzmt",
     "name": "Stest",
     "symbol": "Stest",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qpa5u2mwycsku0deum3a0jk8jsselv80xyqnpa5zw0agcumgw0jsuvm48w",
-    "name": "STT (Wormhole)",
-    "symbol": "STT",
     "decimals": "6"
   },
   {
@@ -11558,12 +5751,6 @@
     "icon": "https://app.astroport.fi/tokens/kUST.svg"
   },
   {
-    "id": "terra1vrh8y6aa3v99ttpsfxdawluf8n77m3c6prxmq0dtlmtqdeah364qjzpds5",
-    "name": "T",
-    "symbol": "V",
-    "decimals": "0"
-  },
-  {
     "id": "terra10vvl9llw4p7ca2zhmcdljk5el9fkpp9hg6qy53",
     "name": "t.me/BabyTerran",
     "symbol": "BBT",
@@ -11594,18 +5781,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1gwz4m0q6vq6nyunt88vlsf5u3ve0fv3qc40q0mdky58s4fjy4fcsqpkman",
-    "name": "Talis Token",
-    "symbol": "TALIS",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1szsttj49zfj2wthsld7a7wd44qnzfwgz05czyyc6yu4c5arrfsashv5rsc",
-    "name": "Talis Token",
-    "symbol": "TALIS",
-    "decimals": "6"
-  },
-  {
     "id": "terra18vl2cypy8pdys2qdqlg7pzmcmpqmur8lmrnk2c",
     "name": "TEGX",
     "symbol": "TEGX",
@@ -11622,24 +5797,6 @@
     "name": "TERRA",
     "symbol": "TERRA",
     "decimals": "6"
-  },
-  {
-    "id": "terra1ugyv3qhdvrpkrd983dd8p70cg6zjparxd3xxqqrennzvxfyf2r9svv83a8",
-    "name": "Terra (Wormhole)",
-    "symbol": "LUNA",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1ddg6eprts4z9ypx92fjtjk2vrnwjn68gqu2lv334dqxq2f42xn2s9he0j2",
-    "name": "Terra 2.0 (Wormhole)",
-    "symbol": "LUNA",
-    "decimals": "8"
-  },
-  {
-    "id": "terra10znl5emz4l6qmtr9gq35u0l7rchg8vh2x7wknlgsuzg4azsj6v7q2h0dzl",
-    "name": "Terra Aliens",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
   },
   {
     "id": "terra10l407saphqe2tc35ejhzg7xyulqkeqccvvc6uw",
@@ -11852,22 +6009,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra1lfrgu8r4nyplqql7507khmf79efpns7hz9qyruxwy3rcs32w4s3ql00frh",
-    "name": "Terra Launch Pad",
-    "symbol": "TLP",
-    "decimals": "6"
-  },
-  {
     "id": "terra16q2hhuva6u0zakfav0pmrdw2fhjsanvqq9y56t",
     "name": "Terra Launchpad",
     "symbol": "TPAD",
     "decimals": "6"
-  },
-  {
-    "id": "terra10xr7pndwwmq6ua7nmg0ldfxsf29az9fk59w5dtwmgt2vwgdnwj3shc64d4",
-    "name": "Terra Lotto",
-    "symbol": "TLO",
-    "decimals": "0"
   },
   {
     "id": "terra122anargqcp9anz2cmuwc3u5m4nww6fpvyc39tz",
@@ -11887,18 +6032,6 @@
     "symbol": "TMeta",
     "decimals": "6",
     "icon": "https://i.imgur.com/4H10ALI.jpeg"
-  },
-  {
-    "id": "terra1lxjw8retq4waja95e8jrxpqtalt95nj4xm6w2cyljae3vnh45tjs72cl82",
-    "name": "Terra Meta Royals",
-    "symbol": "TMR",
-    "decimals": "0"
-  },
-  {
-    "id": "terra14lzmdzaqw53sgm0lef8agnzck6n68yhmutasdu80w5j49v7kn4eq4c0mj8",
-    "name": "Terra Meta Royals: Golden Tickets",
-    "symbol": "GOLDEN",
-    "decimals": "0"
   },
   {
     "id": "terra1qv98rklgrdv89gvf47rrzx2lzehd43uwz2rus4",
@@ -11983,30 +6116,6 @@
   {
     "id": "terra1xy2gf523j92khfn8nx0uurkmkguul2u95cwv8v",
     "name": "Terra Name Service",
-    "symbol": "TNS",
-    "decimals": "6"
-  },
-  {
-    "id": "terra17uwa8ppl9dxqkjvmr7eyusua4af9juxnanpax4h0p2v30spgddqsm7lced",
-    "name": "Terra Name Service (Wormhole)",
-    "symbol": "TNS",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qa9mae32y64mn2srmypnr2qjw7x94dqry6wwyej6wxu4ffe9xqtqmakj9e",
-    "name": "Terra Name Service (Wormhole)",
-    "symbol": "TNS",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1fj4sp69zfyna7xk3yv3pyw787ajs3lr6naarralcfsnyu8fwwcqsxhk2dc",
-    "name": "Terra Name Service (Wormhole) (W (Wormhole)",
-    "symbol": "TNS",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1g9h4c3e7tepymhvxec384j2k0yndrufftu27h9q3k4kusdht34yqr8g2kg",
-    "name": "Terra Name Service (Wormhole) (W (Wormhole)",
     "symbol": "TNS",
     "decimals": "6"
   },
@@ -12171,18 +6280,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1z4lds4txngn5dt74trf4knd9xpxwmwmrhf90ft7es38pc6h0hp6swcdj9c",
-    "name": "terra-luna (Wormhole)",
-    "symbol": "terra-luna",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1sskn97j4jvchgcpsd4a4ev7smueamsesls2qfalja5gxqlvnn0gsdwp292",
-    "name": "Terra2Casinos.com",
-    "symbol": "COIN",
-    "decimals": "6"
-  },
-  {
     "id": "terra1xxze8dty562la0d6g9q3srlddh0qemk08kpgfr",
     "name": "TerraAlpha",
     "symbol": "ALPHA",
@@ -12195,36 +6292,6 @@
     "decimals": "3"
   },
   {
-    "id": "terra15lvw2kczml269rl296y85qnnjxw0zvcns3aucsr87kkfldh6gmks3r6tfa",
-    "name": "TerraBots",
-    "symbol": "BOTS",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1zcafgvq74ef8zu5mc62njfprsf3cr33xvan7r4nja269t280djrqkyrjsx",
-    "name": "TerraBots",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra146ypndztcmmrmyxef7e20cul82gh43vjnw4uacwdvg5sp9kva7sqc9mjav",
-    "name": "TerraDoge",
-    "symbol": "TDOGE",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1jlzw6xal0n2c580g3wxs09tjhlzdht9y8dgszq3tupf8fhl7xjus30q76r",
-    "name": "TerraDoge",
-    "symbol": "TDOGE",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qrwaatac4xvf4qnnagvsc93gcnv2x2t7mm575v3drzh2wcap9has6lcuky",
-    "name": "TerraDoge",
-    "symbol": "TDOGE",
-    "decimals": "0"
-  },
-  {
     "id": "terra1a95wwge5ut59aet6wx9m5ukq0alnxj0waf4sgl",
     "name": "TERRADOGE",
     "symbol": "DOGE",
@@ -12234,12 +6301,6 @@
     "id": "terra1cxvsl5qdvctc537a8q9ynv0seu4r5ceacptwx0",
     "name": "TerraEarth",
     "symbol": "EARTH",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1d47r74v2kxezfy3hxchqv5r5d26uyvk2e0k7gx3k9awxwwwsl44s4cesrt",
-    "name": "TerraFloki (Wormhole)",
-    "symbol": "TFLOKI",
     "decimals": "6"
   },
   {
@@ -12328,13 +6389,8 @@
     "symbol": "TLAND",
     "decimals": "6",
     "circ_supply_api": "https://terraland.io/api/tland/statistics/circulating-supply",
-    "icon": "https://terralandio-site.s3.eu-central-1.amazonaws.com/TerraLand-logo-v1c-4x.png"
-  },
-  {
-    "id": "terra1a2nng5e58drpr2canclarhc9n0g3v6wmrnwvlmmxnwxlxvfhklvqd4kqvp",
-    "name": "TERRALION BITS",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
+    "icon": "https://terralandio-site.s3.eu-central-1.amazonaws.com/TerraLand-logo-v1c-4x.png",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-land/"
   },
   {
     "id": "terra19y395vzlylv3s3nasr7cu4yey7s22ghqd35ps8",
@@ -12349,34 +6405,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra1ghuqnsgn576srmtp5rfk5fd7u60d8urce0usyu6xc3jkesy6hrcqkvrtmh",
-    "name": "TERRAMOON",
-    "symbol": "MOON",
-    "decimals": "6"
-  },
-  {
     "id": "terra1tgfw423t34rwaezm4u4vwy5d80tfgzuyx2s6x0",
     "name": "TerraMoonDoge",
     "symbol": "TMoonDoge",
     "decimals": "6"
-  },
-  {
-    "id": "terra19xcvyg8ezn8f8t2fpatzfsg9kknnm3c3jhz74n2pawfv5g6kqlvspvvkvp",
-    "name": "Terranauts",
-    "symbol": "TRNT",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1lndtteve63vp4xv0wnkzk69ngx8ul2jt2k26a2eqpjkym87cjpksjc5zhj",
-    "name": "Terranauts",
-    "symbol": "TRNT",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1x6yunc975rzyu7gx0f80cjwskky8q9ggw8l9em69hjnhf5yjm2vsl26fvt",
-    "name": "Terranauts Sectors",
-    "symbol": "SCTRS",
-    "decimals": "0"
   },
   {
     "id": "terra15plvf4hfgsrev5athn7wmnqgt6f0lddmduzp90",
@@ -12389,54 +6421,6 @@
     "name": "TerraNFT",
     "symbol": "TNFT",
     "decimals": "3"
-  },
-  {
-    "id": "terra1hngslv4p3gk8p9x7y9pc9t9e079mzxfg73mh5zgralq79hq3r9jsdj8utr",
-    "name": "TerraNova",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1ay5guxt0st9eetxakcs58n350dhkttnnxu7d4zt9je5540hfsf9stpa3sz",
-    "name": "Terranova 3D",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1ytctz49dtpn85fagwut7e2eaw2586j74dn49t3cyadwlpwufl72q70qv75",
-    "name": "Terrans",
-    "symbol": "TRRNS",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1e66djga9ku8rcpd6v7ncpt5f0n7fwaw44m05cqrvqq7hv6kg2rjsjvwk4v",
-    "name": "TERRANS",
-    "symbol": "TRN",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1c5umwtky59ypk2ad2jr3c95jwz2rp9r8h2fyselzxsq84yjj95asly9aq2",
-    "name": "Terrans: Limited Edition",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1v04p5nzya7727th4eesmyj34sjwtvt78ht7q7uc8xsmxses75x4qhm0kyj",
-    "name": "Terrapins on Terra",
-    "symbol": "PINS",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1ncyaafj4kt5m50tj3pftga2auuq62zzguwlntk5mtl2mdusagpkst9gmgl",
-    "name": "Terrapins on Terra Eggs",
-    "symbol": "EGGS",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1khf570xnp6g7lnf70ufwax69e9ll446avyhffqh22y4kssr02yds3522gj",
-    "name": "TerraPrints [MIR]",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
   },
   {
     "id": "terra1rfqm5zwkep3jk845nf565yyua66uj654y2vzx3",
@@ -12457,96 +6441,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra12hq58scmmx04vzjlw9sywal7zv6pm6wjjy2m7zwxc990pplc5rpq3ck6k7",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra13yp5jufdd2n5gez84fy26tujq540alr29cm4tpntcsaqg7h660cqwe8dx9",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra154lszr3g2cmstw7me6pmv57jjug3ddqy2lac87eyptv83z9ul25svefc2y",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra179w0ny7mv7qn5h5q4rz6k6jhvspeau5fmkuqpvmtn6qx6l36pu5qe06wr0",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1adyqxpz0vseur93xct7k4sgfjfqf9drhrxt58k2z2p7vvsh4wt5qpmc8dg",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1fn29pxsueea3zt3xw909gpgjmzcwfxw7q55jgcsfh7v5rh4y3a6s2s69k8",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1gjmpaqvm5ns4pap0enqdtsm78m0rc9n3wxsecq8rsjxdv6chwvfqmpnwyn",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1l8z9t0hny99z9ncumpn4uqvd7k6sk6l90m68pu9mgvddmyr4vrwqdqcrp7",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1s80jffm4a5awzed0dfjvkjz79rcs25wfttezgefmpzju6rmgt5eq43x5l8",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1wmqka38647dus86jxsscc8j87ltykwsysl76gs8gq2kqxzkwa2aszfz6em",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1x3ee5rwurm703j2dx0qgwanntszty4egpcylwz6de5jarlr080jsv4hc0r",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1yph6hsldjpc7up5q87jjqyzxnpfllpewzc89r0yk30t065ajv8nq5rz5mx",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ecaxgghq46wg0rr66ema6dp8thf5dn5n8e40p2uaqljx04sf8gjqnyqzf9",
-    "name": "terraswap liquidity token (Wormhole)",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1tu96pg7j0affaqezmlspkeeqnvrkrtcmqhag0up8cm6z4k7wx5csg4ar5s",
-    "name": "terrausd (Wormhole)",
-    "symbol": "terrausd",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1gsd4wtmpkcdlmkr4kpm4c2fe9syx8qyv5r3qykx708kv4850vqssgtvx44",
-    "name": "TerraUSD (Wormhole)",
-    "symbol": "UST",
-    "decimals": "6"
-  },
-  {
     "id": "uusd",
     "name": "TerraUSD Classic",
     "symbol": "USTC",
@@ -12559,12 +6453,6 @@
     "name": "TerraWeed",
     "symbol": "TerraWeed",
     "decimals": "6"
-  },
-  {
-    "id": "terra1g76gzatrn8jnhv7lhmx7aqm6afja4750rpmvypjp3vcw03amva5swskrs0",
-    "name": "TerraWhales",
-    "symbol": "WHALES",
-    "decimals": "0"
   },
   {
     "id": "terra14yyepy06yw57f4x564xrfwxvv460vq0su5ype8",
@@ -12606,10 +6494,12 @@
     "decimals": "6"
   },
   {
-    "id": "terra1sffdl730nq509rv5k0dm62sc0taa3yk7va2v3ngqhhl34gsmfuhsca3jff",
-    "name": "Tesla (Wormhole)",
+    "id": "terra14y5affaarufk3uscy2vr6pe6w6zqf2wpjzn5sh",
+    "name": "Tesla, Inc.",
     "symbol": "mTSLA",
-    "decimals": "6"
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra14y5affaarufk3uscy2vr6pe6w6zqf2wpjzn5sh/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/TSLA.png"
   },
   {
     "id": "terra14rq6etqgza9qqpgz9yjfmsclgnzhk9jsafdtyc",
@@ -12654,12 +6544,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1dm53vefj2g2trw5t8glyjzxthtfg7qhq57l5ky7l26flcnswprzq4x7fsy",
-    "name": "Test",
-    "symbol": "TTT",
-    "decimals": "0"
-  },
-  {
     "id": "terra1ghkclqug2jhanmjsx46x0vymcglchcesg98057",
     "name": "Test",
     "symbol": "Test",
@@ -12669,12 +6553,6 @@
     "id": "terra1gqmd09k8g3lggxxdzu9z94vqcxtr5zylvs95ke",
     "name": "Test",
     "symbol": "Test",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ry68wdl4hgkt0ddg52m0gnj3d8l35nlers08p3lajl7gsn8tmj0qdt2k89",
-    "name": "Test",
-    "symbol": "TEST",
     "decimals": "6"
   },
   {
@@ -12694,24 +6572,6 @@
     "name": "TEST",
     "symbol": "TEST",
     "decimals": "3"
-  },
-  {
-    "id": "terra16vajmyc2zc8nhy7c7z9lxym5rp7qw4lkptuccp4tfqqywkqppdsqc7zkat",
-    "name": "Test 2",
-    "symbol": "TTTT",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1dakfhvgv5rwxngh7wecennfpn7jfyd74nq6cuyfzx8f400nz244sfuzwch",
-    "name": "Test Col",
-    "symbol": "TESTIE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1mma39sqn43aen4jh2sdmka84mv94uk7v7xw3ype2fdvlay6emrlqweyf5u",
-    "name": "Test Cw20 TOKEN",
-    "symbol": "TCW",
-    "decimals": "6"
   },
   {
     "id": "terra1d3pmqshpe6n5cs7d6mnffdun4tg0k05zfy99zh",
@@ -12906,40 +6766,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra1lcvpawl4q8dxwmj4m9fcg7hln95q0g4y8fs2hdvwl2cxnva9vllqh2cpjj",
-    "name": "Test Migration",
-    "symbol": "test",
-    "decimals": "6"
-  },
-  {
-    "id": "terra128v4wvntlyskezlvjqyec89femjva5ksyxtpswxmt5680amlyy3sy3f84g",
-    "name": "test new UI",
-    "symbol": "TNU",
-    "decimals": "0"
-  },
-  {
-    "id": "terra19ng225hv9jp4ty8gt7d3g0er4chga8z96tya5ksmsz68rllp268qry2jyt",
-    "name": "Test nft",
-    "symbol": "BH",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1ycw04kktq9l0ywqr85suuvg9t80h3nr94juxxkuxhh4sha7r8fuscyxyqa",
-    "name": "Test nft",
-    "symbol": "BH",
-    "decimals": "0"
-  },
-  {
     "id": "terra1j8nxezl70lfekdzaeanzyzn75htf4sz9vmwhu7",
     "name": "TEST SVG",
     "symbol": "SVG",
     "decimals": "6"
-  },
-  {
-    "id": "terra168csa8g2prpcthh0qx4wmdfndwq49ef347tf0asy9qasf3zadq0s0flscj",
-    "name": "Test Terra2 NFT",
-    "symbol": "TMT",
-    "decimals": "0"
   },
   {
     "id": "terra1fd2f52tmq59mc093nrawdaey5mzgjnwyu7hwqz",
@@ -12963,7 +6793,7 @@
     "id": "terra12nxvzzqv0yeh80z6eya0gcufyn36ntrkcalnjl",
     "name": "Test Token",
     "symbol": "TTN",
-    "decimals": "0"
+    "decimals": "6"
   },
   {
     "id": "terra12yvwzt5ayh396hgmyd0rwnamgg4g3mxrdgg7c6",
@@ -13014,12 +6844,6 @@
     "decimals": "3"
   },
   {
-    "id": "terra1kz9rs4gurgrsv7qsm4ekmqvwysphnpf043wqj2u4r8n9j9xv3egsmj9ft4",
-    "name": "test1",
-    "symbol": "test",
-    "decimals": "6"
-  },
-  {
     "id": "terra1xp4uhylkhwgam5tc97m0xfaxarajgf6wtcqwp9",
     "name": "testabc",
     "symbol": "testabc",
@@ -13029,12 +6853,6 @@
     "id": "terra1cxusd4uhgpgk2sp99rexrcknpn08anak3v9tz7",
     "name": "testC",
     "symbol": "testC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16wr7gqnzm0e9z4kz92gwaq9wqx2xuusfd02xrrjsks9y4zlyk66q4tt7md",
-    "name": "testdaotoken",
-    "symbol": "test",
     "decimals": "6"
   },
   {
@@ -13110,12 +6928,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra1ery8l6jquynn9a4cz2pff6khg8c68f7urt33l5n9dng2cwzz4c4qj3spm2",
-    "name": "Tether",
-    "symbol": "USDT",
-    "decimals": "6"
-  },
-  {
     "id": "terra1eqvq3thjhye7anv6f6mhxpjhyvww8zjvqcdgjx",
     "name": "Tether USD (Portal from Avalanche)",
     "symbol": "USDTav",
@@ -13130,23 +6942,11 @@
     "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/USDTso_wh.png"
   },
   {
-    "id": "terra12ezq5402h5n3skhdshjp4f49zzg0saxum8fvvhjhauzas2ezyyrqpznqny",
-    "name": "Tether USD (Wormhole)",
-    "symbol": "USDT",
-    "decimals": "8"
-  },
-  {
     "id": "terra1ce06wkrdm4vl6t0hvc0g86rsy27pu8yadg3dva",
     "name": "Tether USD (Wormhole)",
     "symbol": "weUSDT",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Dn4noZ5jgGfkntzcQSUZ8czkreiZ1ForXYoV2H8Dm7S1/logo.png"
-  },
-  {
-    "id": "terra1p2wm9d7lp4pf32pmwzm5ll59q9sqj48p0u66cnfavuzj78gusdeskdgms2",
-    "name": "Tether USD (Wormhole)",
-    "symbol": "USDT",
-    "decimals": "6"
   },
   {
     "id": "terra1a8k3jyv3wf6k3zngza5h6srrxcckdf7zv90p6u",
@@ -13197,76 +6997,10 @@
     "icon": "https://terrafloki.io/ticket6_logo.svg"
   },
   {
-    "id": "terra14n3adwz0pstwqtfgxr62uvdvfqkyctyec8jahf6pl7hwqer80aksk0hwl5",
-    "name": "TFM",
-    "symbol": "TFM",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qg5ega6dykkxc307y25pecuufrjkxkaggkkxh7nad0vhyhtuhw3slg2he2",
-    "name": "The 420 NFT",
-    "symbol": "420",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqgj2ctk",
-    "name": "The 69 NFT",
-    "symbol": "69",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1dcj2st2qhljnl0llxp64n0dex6xn7fusu0ku83ewxasqunzkwgqsz6wkzz",
-    "name": "The Crypto Drugs",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra19xk3rsesaupv72se69y8v6y6m04fl8yj6vnmtv",
     "name": "The Edward Coin",
     "symbol": "EDWARD",
     "decimals": "6"
-  },
-  {
-    "id": "terra1sp32et72dz2yh4ny48txy637gz7drvkmpel29j8lunfzy7xh47vq6e2lka",
-    "name": "The Factory Lives",
-    "symbol": "TFL",
-    "decimals": "0"
-  },
-  {
-    "id": "terra130cpevp2eyqskcsh6xs3nrqkrkeczzfg95xykyp06zt52cdkyeaq4ahe6y",
-    "name": "The Fallen Guardians",
-    "symbol": "FG",
-    "decimals": "0"
-  },
-  {
-    "id": "terra13cja66m0429yp6s6knrn565weskxgmlgm9pwws8r8lvuc6twd25qxvy6fn",
-    "name": "The Gorilla Legue",
-    "symbol": "TGL",
-    "decimals": "0"
-  },
-  {
-    "id": "terra19kpvm4ru3979lkkan2atjas9pdpr4s0w3tnlm02eew5yk8tmh6wqs3rh7h",
-    "name": "The Lab",
-    "symbol": "LAB",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1j0qdr5m3t87p05k93qsfrzcvtu6k2ht6wr3ntnksrqjup9l67j9smm73ut",
-    "name": "The Lab",
-    "symbol": "LAB",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1zm7fylkhyvhrvpnpdec8ak8wlugafrguxg0z8dw6ru7pkg3hvzjqh60gh7",
-    "name": "The Lab",
-    "symbol": "LAB",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1vang7yw0aywnlged2v4jh8xndguqhyr9gv38mqe3rsdjm077qznsu50qkz",
-    "name": "The very essence of Cantonese",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
   },
   {
     "id": "terra149755r3y0rve30e209awkhn5cxgkn5c8ju9pm5",
@@ -13275,18 +7009,6 @@
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra149755r3y0rve30e209awkhn5cxgkn5c8ju9pm5/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
     "icon": "https://whitelist.mirror.finance/icon/DIS.png"
-  },
-  {
-    "id": "terra1w2958rqnrz4qh39m4sfh3y2xl8jf5js4rz8r7dug7nv2gw2damgsplw3z8",
-    "name": "The Walt Disney Company (Wormhole)",
-    "symbol": "mDIS",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1x0u4zwpa0lmmez0adc7zt4amaz04wu6jryhefcav6cdzpqx8ht0svzdkf8",
-    "name": "The Walt Disney Company (Wormhole)",
-    "symbol": "mDIS",
-    "decimals": "6"
   },
   {
     "id": "terra1gtjtyyhj2cu0ekzju4rj86vsvg7d2uu576rrl7",
@@ -13334,33 +7056,9 @@
     "decimals": "6"
   },
   {
-    "id": "terra16xt3d7m8qhhvj9w8dpcf5qhq8wx0jdnhk4n3x5f9spauzxs9at7sgndjdl",
-    "name": "TimeTerra",
-    "symbol": "TMT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra177phs7fn4hq0apnv3usttn0r05pty573548glh5jqkr00hks0ewqf2ekjc",
-    "name": "TimeTerra",
-    "symbol": "TMX",
-    "decimals": "6"
-  },
-  {
     "id": "terra15q3lzrnfstr3rqgh55cqmp95z4xr3we5tfyqm9",
     "name": "TinyDick Kwon",
     "symbol": "tdKWON",
-    "decimals": "6"
-  },
-  {
-    "id": "terra17jfvm266af58rxtapch6gmrgv7zz8t45p46ftulsdk4m2nf85e2qusujaf",
-    "name": "TKNA-ULUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1mqp9jdghpmprs9sc6ujh0juw6h7k7sp2evs0weh6q2u37ys3lf2srxjclc",
-    "name": "TKNB-ULUN-LP",
-    "symbol": "uLP",
     "decimals": "6"
   },
   {
@@ -13382,12 +7080,6 @@
     "decimals": "3"
   },
   {
-    "id": "terra1z9nj8auy33nh8fjp2f40up5qz5qrmwt7tfk3r9a0e27dd40vhues8zrcfa",
-    "name": "TNT (Wormhole)",
-    "symbol": "TNT",
-    "decimals": "6"
-  },
-  {
     "id": "terra12fctlld90cakzkuhd2c3h246zxrhwqd6kp546g",
     "name": "Tobin",
     "symbol": "TOBIN",
@@ -13403,18 +7095,6 @@
     "id": "terra1h8hmr0em0avkz4kzuwgakyxrdvxqwg5d3cg4sd",
     "name": "Token test dont buy",
     "symbol": "LLL",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1nchx6x3xtmme9sq6gxtj0tuux9l3mh05ce0hmmm7ge35vl8zsdeshkn7z5",
-    "name": "TokenA",
-    "symbol": "TKNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16er279t0mgumskzqp2eq5wju9ge68v6y7ylq4qju35rj5as6gwaqpf70xu",
-    "name": "TokenB",
-    "symbol": "TKNB",
     "decimals": "6"
   },
   {
@@ -13466,39 +7146,9 @@
     "decimals": "1"
   },
   {
-    "id": "terra1ntgzf3mp5223jmv4452qx7lvgfga9q0x89zsm5y8kpktwjdsxyws6x8e67",
-    "name": "Toxic Labs Governance",
-    "symbol": "TLT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra150qtrrrta74ewt9glydumq2fz4463hrcqm087vex2ynv97xz95gsha38dl",
-    "name": "TPT-BLUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16h880ss964j75erdsctgy7eyp62e2ladtaqw3x0qapzae8wrgyjqmgnwqm",
-    "name": "TPT-ORNE-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
     "id": "terra1u4gx4v0nqgzm2kcajk3xf0d35gutwcvdyyjrnc",
     "name": "TRhea",
     "symbol": "TRh",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1lu6wy88xv5huk35yq55e2an9k5h2me4nad20cetqsr73ez6vs84quysx2y",
-    "name": "Tricky Dick",
-    "symbol": "NIXON",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1c47hfvyk8pug2qj5wppzfndehptwm9vq2xrus66junwkxhjuucdqcfcmep",
-    "name": "TT DAO Token",
-    "symbol": "TTD",
     "decimals": "6"
   },
   {
@@ -13515,18 +7165,6 @@
     "icon": "https://tuna.money/content/images/2022/06/icon-2.png"
   },
   {
-    "id": "terra1ludp8erwgrd7ytelkycfprhvcnz0y54vjmgp6dausuty0lqmw8nspk6vyv",
-    "name": "Tuna Money (Wormhole)",
-    "symbol": "TUNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qx284aak0wl7vrvlsc6cwcsn6xwajragkh6cjqj87m9p34hx5l2s22p3cp",
-    "name": "Tuna Token",
-    "symbol": "TUNA",
-    "decimals": "6"
-  },
-  {
     "id": "terra1v2s7gkylfrnwsdcx8s83k5475nj3jykzs9gsqm",
     "name": "TWhiteShiba (TerraShiba.com)",
     "symbol": "TWShiba",
@@ -13539,21 +7177,17 @@
     "decimals": "6"
   },
   {
+    "id": "terra1cc3enj9qgchlrj34cnzhwuclc4vl2z3jl7tkqg",
+    "name": "Twitter, Inc.",
+    "symbol": "mTWTR",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1cc3enj9qgchlrj34cnzhwuclc4vl2z3jl7tkqg/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/TWTR.png"
+  },
+  {
     "id": "terra158y6aypem94yj34ycvgdm3py23afhnu2dj24ak",
     "name": "TXXC Token",
     "symbol": "TXXC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1vz7sw3gd5yf4ak755jt9kvshp7jnjc9l3rv6gaf8fehud2xnnltsqtsq2u",
-    "name": "U\\\"\\ (Wormhole) (Wormhole)",
-    "symbol": "U\\\"\\",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1yjmqq3urg2cvkrdhax3qgawjgjpss492amcsruwylht6hdxxwylqad54qv",
-    "name": "U||| (Wormhole) (Wormhole)",
-    "symbol": "U|||",
     "decimals": "6"
   },
   {
@@ -13563,77 +7197,11 @@
     "decimals": "6"
   },
   {
-    "id": "terra1qhlxwadl2k4jj7lx7wzezyt9ys534j3n03dcrvkeqpuzu7gaxwmqj845c3",
-    "name": "UGBT (Wormhole) (Wormhole)",
-    "symbol": "UGBT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1v76yk6j4qsrs3p2w6uu83fq6a2zjz9p966e8jmf8mt89ju0a9tqq6sm5hy",
-    "name": "UKRT (Wormhole) (Wormhole)",
-    "symbol": "UKRT",
-    "decimals": "6"
-  },
-  {
     "id": "terra1fyjsxx73jrufw8ufgtuswa773dvdkny92k70wa",
     "name": "Ultimatalioniscoin",
     "symbol": "ULC",
     "decimals": "18",
     "icon": "https://img1.wsimg.com/blobby/go/f561f953-0bdd-48bf-a39b-982ecbd1698b/downloads/Ultimatalioniscoin225x225.png?ver=1649021019249"
-  },
-  {
-    "id": "terra1gl7a3jvk5ajnxs2rrdyjqz5ea99wf56qjuxct7cjwzf5cs675wlse2qf6v",
-    "name": "ULUN-BTC-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra138fc79ldpkzgswzuuts49xr82y02x078hajjhlnav8982e7z7t7sg3rrf8",
-    "name": "ULUN-DINH-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1f6lmzz9caag00uqssw4dlczrvlaeva4afn2yl3cxfd0ncawpelnqwmtj2d",
-    "name": "ULUN-FRGY-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1w33n04crhh843ly5nh0km58w8zhz5ygstm9taqw6wgwkv57zfaas4w78a8",
-    "name": "ULUN-YLUN-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra17vaenrsjh76yt8dcnlwzn0856k9fzk6h252j32ghr3k898pjyrdq9h55h9",
-    "name": "uluna (Wormhole)",
-    "symbol": "uluna",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1cm09997cnkfylgjz4wg0mk6wj2vd77a5qed67wvhxra0h8smzkds38uzq4",
-    "name": "uluna (Wormhole)",
-    "symbol": "LUNA",
-    "decimals": "8"
-  },
-  {
-    "id": "terra19glrs2vtgxaxww39cq5acxapgv2v8hyw562zmsk7ucn4yznmyv3sljewv9",
-    "name": "uluna-ASTRO-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1rlmjwapg7y3p39aucq2rq5rffyns7z94twm8acl59na4d9aehu9sl2dfkc",
-    "name": "uluna-ibc/B350...C9E4-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1lt586fhwyuccktk58v8k96ugzp9szurhqvmlnjxhyn6yapa6v2jsmc468d",
-    "name": "uluna-LunaX-LP",
-    "symbol": "uLP",
-    "decimals": "6"
   },
   {
     "id": "terra1v7vp6ywlymprx9mk7ngm4uf0xgrz2ektg5wd6z",
@@ -13655,22 +7223,18 @@
     "decimals": "6"
   },
   {
+    "id": "terra1lvmx8fsagy70tv0fhmfzdw9h6s3sy4prz38ugf",
+    "name": "United States Oil Fund, LP",
+    "symbol": "mUSO",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1lvmx8fsagy70tv0fhmfzdw9h6s3sy4prz38ugf/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/USO.png"
+  },
+  {
     "id": "terra1av9tfs7k5gfuzm04e7p0d4ezrc53vq9mn3m08z",
     "name": "UNIX",
     "symbol": "UNIX",
     "decimals": "3"
-  },
-  {
-    "id": "terra1dsxs0u8thjngph6k60k5cepfkv90jtt776hsx7eyvl9x5gnepjjsfjnwyn",
-    "name": "Unstables: Unstable Kwon",
-    "symbol": "UNSTB:3",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1p5ll4frszlw63d7apaf3ghyd2k28dz2phnu4t359ey04xwcra5vq7kuemk",
-    "name": "Unstables: Unstable Kwon",
-    "symbol": "UNSTB:3",
-    "decimals": "0"
   },
   {
     "id": "terra1d9ec4gm0c03p74d3qd95qvny2ptf0ge5twqpdk",
@@ -13679,41 +7243,11 @@
     "decimals": "6"
   },
   {
-    "id": "terra1q4r4zzde2tg52306qevhnaf3qw76a68hnyzw404uuvvzx09n3ckqe2ylrm",
-    "name": "USD ",
-    "symbol": "USD",
-    "decimals": "6"
-  },
-  {
     "id": "terra1yljlrxvkar0c6ujpvf8g57m5rpcwl7r032zyvu",
     "name": "USD Coin (Portal from BSC)",
     "symbol": "USDCbs",
     "decimals": "8",
     "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/USDCbs_wh.png"
-  },
-  {
-    "id": "terra1ezxp0nhct6mqsctckujttfkcsknux2aktv7knn6fjtprl3np74js7tzeqt",
-    "name": "USD Coin (PoS) (Wormhole)",
-    "symbol": "USDC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra10eqslzgvzl5grau5zuhs0hv6v0c8pj8va6lclrgxgzs9mhvfc2zq5hsdmx",
-    "name": "USD Coin (Wormhole)",
-    "symbol": "USDC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra17em5mehxz6wj4ya65ns0kf28zgf0xlz8qp4n0ykd2favszalr63sydrwyl",
-    "name": "USD Coin (Wormhole)",
-    "symbol": "USDC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1cmsh9ju4hk58hhdtlv5k7cqu8dmu0eucpaw5n9ynpwzuw4jluptsvyz8eh",
-    "name": "USD Coin (Wormhole)",
-    "symbol": "USDC",
-    "decimals": "6"
   },
   {
     "id": "terra1e6mq63y64zcxz8xyu5van4tgkhemj3r86yvgu4",
@@ -13730,105 +7264,15 @@
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/A9mUU4qviSctJVPJdBJWkb28deg915LYJKrzQ19ji3FM/logo.png"
   },
   {
-    "id": "terra1uylw76ux3h502muaml8l32j3e7d9v2ne0npwsgt0s46d5l3hpz4swsv2fc",
-    "name": "USD Coin (Wormhole)",
-    "symbol": "USDC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1vzd98s9kqdkatahxs7rsd8m474lf2f8ct39zdgd6shj4nh5e6kuskaz2gy",
-    "name": "USD Coin (Wormhole)",
-    "symbol": "USDC",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1tzaw5m79em9juj0lf4dxr6phxxht79jt770mn77ltvx5e6ww4vpss6hvnu",
-    "name": "USD stable ",
-    "symbol": "USDc",
-    "decimals": "6"
-  },
-  {
-    "id": "terra15x3mm9gl5z89w9d96fgpsqds0pa2eqdsnyp47rat0vey826fjj8svgqthd",
-    "name": "USD Token(Wormhole) (Wormhole)",
-    "symbol": "USD",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1uc3r74qg44csdrl8hrm5muzlue9gf7umgkyv569pgazh7tudpr4qdtgqh6",
-    "name": "USDC",
-    "symbol": "USDC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1pgtc0jsag7ax6cyyd55ntcva3kfnh6t805jtwcnrdm7szkx35pdqvycak5",
-    "name": "USDT (Wormhole)",
-    "symbol": "USDT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1rcmvfsn77pd6m04ctqj3wcu66pvrw9p265cdl72w4zarfup2rv7qjxhkzl",
-    "name": "USDT on terra2",
-    "symbol": "USDT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1jznfc58qvl8f0dldhm4pl505srpz98mwedlullt5rhv6petxwdpqn97n6v",
-    "name": "ust",
-    "symbol": "ust",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1zwv6feuzhy6a9wekh96cd57lsarmqlwxdypdsplw6zhfncqw6ftqynf7kp",
-    "name": "UST",
-    "symbol": "UST",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1rwg5kt6kcyxtz69acjgpeut7dgr4y3r7tvntdxqt03dvpqktrfxq4jrvpq",
-    "name": "UST (Wormhole)",
-    "symbol": "UST",
-    "decimals": "6"
-  },
-  {
     "id": "terra1z49dpvu5g4st7t4j5lsaxaq7v9u6f390m28ap9",
     "name": "UST Puppy",
     "symbol": "UPU",
     "decimals": "6"
   },
   {
-    "id": "terra10tclyxjfcx7u0wd0d0he4muqvhd6nn6d7lr2ktmga275tq0axamqs6gxnj",
-    "name": "UUSK (Wormhole) (Wormhole)",
-    "symbol": "UUSK",
-    "decimals": "6"
-  },
-  {
-    "id": "terra15zmzk6qc9w9cwvjwec2x5jyyredntalv8zuz46c7xhd07k5jvh4qtcpsch",
-    "name": "UUST (Wormhole)",
-    "symbol": "UUST",
-    "decimals": "6"
-  },
-  {
     "id": "terra1l2stn9sszzg6qwfqd6ckfa5n58hs4x5wwjaehh",
     "name": "UUZ Token",
     "symbol": "UUZ",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1vapchnf63wx972v07jkjl0kfunft0ztyjuf5kqxgj2xx3mxfuw8s3gprxs",
-    "name": "V Collection",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1xepgy0lp0lkt9dq89pfe3sqwnfyln29r2zj5qqkp75l2egthmmkqkn36vv",
-    "name": "Valkyrian Pass",
-    "symbol": "vVP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16qlqgly543fpnp5eg6v8elfz3762us49xqt89y86htkrs6t0pams7jy3y6",
-    "name": "Valkyrie Token (Wormhole)",
-    "symbol": "VKR",
     "decimals": "6"
   },
   {
@@ -13888,51 +7332,15 @@
     "icon": "https://raw.githubusercontent.com/vitelabs/crypto-info/master/tokens/vitc/tti_22d0b205bed4d268a05dfc3c.png"
   },
   {
-    "id": "terra1n993kulwk0hj0pe06nhp0n9ll97qynwh2swzcjek6y5qngz0qqhq3c2qsv",
-    "name": "VKR-BUSD-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1xx87xd4wl496gm48e9s4wygehx69z6cwju22zu32dl672ufh2rlsznsu05",
-    "name": "VKR-VVP-LP",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
     "id": "terra1ezkr298e3lef6hh5pzmvrtw0qd0kc6u7dgl5rc",
     "name": "Void Finance",
     "symbol": "VOID",
     "decimals": "6"
   },
   {
-    "id": "terra1c6pzq0s8lr4vwmah8vauhn6mje4uz5ta62wvcpgtp259pxx5qevsgsu3jr",
-    "name": "VoxeLPunk Cards Print #1",
-    "symbol": "VXLPNK",
-    "decimals": "0"
-  },
-  {
-    "id": "terra1cfwepxxkhfnypztquswu2e5vu5x2wg0exzfln8gl48c9hfaj6u6qkht5su",
-    "name": "VoxeLPunks Card Game",
-    "symbol": "TALIS_GNRC",
-    "decimals": "0"
-  },
-  {
     "id": "terra18ejpjp9eyx9t8j07jd7kzah9p0rvkzdfeeva6n",
     "name": "VPRIS",
     "symbol": "VPRIS",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1uq59f5lhzg6ut605ntevvf2a8kg9t2xk2873lgx6pweagkw76r4sdzj6ap",
-    "name": "W-boneLuna",
-    "symbol": "wbLUNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra173z5ggu6k6slyumrrf59rd3ywmpu6hdfftwpqlkc7fp549yk9fmqzqyepj",
-    "name": "W-Eris Amplified LUNA",
-    "symbol": "wampLUNA",
     "decimals": "6"
   },
   {
@@ -13960,24 +7368,6 @@
     "decimals": "3"
   },
   {
-    "id": "terra1x0vlryaz27jr4ncxc7ufd735fvs8uwrprp2kmz7l3pxf2jhkgpysml0yz9",
-    "name": "Warp token",
-    "symbol": "WARP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1y86ynggjnfp9xfjhcxhj3gexkgqzd3f0vcsf5nzh7jl5hu90tjgq3vws3p",
-    "name": "Warp token",
-    "symbol": "WARP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1z85035h0fptflnn004dvaw8c2q754qrnulsd5qwhzen4rtzr9juq5ef6ny",
-    "name": "Warp token",
-    "symbol": "WARP",
-    "decimals": "6"
-  },
-  {
     "id": "terra1c6jwuklh3262naafvnlw8llvns9856uvc50z95",
     "name": "We are Hive",
     "symbol": "HIVE",
@@ -13993,12 +7383,6 @@
     "id": "terra16pektynpxqrs66gk6cgqpwr7rjsudyfzustm6s",
     "name": "WELCOMETOHELL",
     "symbol": "HELL",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1v8pm45c8mecaasuj73wemvl9z7394lh8n92xla5vetwaqtcqsshq8jum8n",
-    "name": "WETH-UETH-LP",
-    "symbol": "uLP",
     "decimals": "6"
   },
   {
@@ -14019,24 +7403,6 @@
     "name": "White Whale Protocol",
     "symbol": "WWP",
     "decimals": "6"
-  },
-  {
-    "id": "terra1z2vjfumarm9ea75ahlwxzxw5ya3x5hh7zjg372j05v9lvxgygqsquzl2w2",
-    "name": "WHT (Wormhole)",
-    "symbol": "WHT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra19ney3d0rgy2qw2sj4s4xjruvex0e098rnpdlmg4q4yj0km9aqn2s5smwgq",
-    "name": "Wicca",
-    "symbol": "WIC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1sxqeul6tr7902ru8x9tum55a7xgfv6l6z770cnpwya78rngfu8xszad92j",
-    "name": "Wicca Badge",
-    "symbol": "WB",
-    "decimals": "0"
   },
   {
     "id": "terra1laczhlpxlgmrwr9un9ds74qxd2fj4754nf82dn",
@@ -14081,14 +7447,18 @@
     "name": "Wormhole:CREDI",
     "symbol": "whCREDI",
     "decimals": "8",
-    "icon": "https://i.ibb.co/M7JKGWM/e1-Qb-Z4q-Q-400x400.jpg"
+    "icon": "https://i.ibb.co/M7JKGWM/e1-Qb-Z4q-Q-400x400.jpg",
+    "coingecko": "https://www.coingecko.com/en/coins/credefi",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/credefi/"
   },
   {
     "id": "terra1efjugpjc50d8sha7lr8s48cr7wmsthz94eevcl",
     "name": "Wormhole:DAO Maker",
     "symbol": "whDAO",
     "decimals": "8",
-    "icon": "https://etherscan.io/token/images/daomaker_128.png"
+    "icon": "https://etherscan.io/token/images/daomaker_128.png",
+    "coingecko": "https://www.coingecko.com/en/coins/dao-maker",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/dao-maker/"
   },
   {
     "id": "terra1gtjr689cyaau20k8ezdxy8eup34tntun5xr9l2",
@@ -14118,30 +7488,6 @@
     "icon": "https://static.lido.fi/stSOL/stSOL.png"
   },
   {
-    "id": "terra1psyhchq2u0lp66xu7rlrvdz4kwtjlf9rhwgad0d6mf7llx8ajrzsmk8hyj",
-    "name": "Wormhole:Luna (Wormhole)",
-    "symbol": "whLUNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16ncvcsl3kysux35vxq06uwtfv5mfghwrshz69sazzd8t5ees5jgslz9eqc",
-    "name": "Wormhole:LUNA (Wormhole)",
-    "symbol": "whLUNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qdtez5zysmsj4l96g9e2t8h4mu43a5jesjjg28zgx8rwy9q9vaws9xpnj5",
-    "name": "Wormhole:LUNA (Wormhole)",
-    "symbol": "whLUNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1q57xmgzpcwnaznpft9qpaf9gxgsjt97ueskywxhpk764jdckqktqhpykmh",
-    "name": "Wormhole:LUNA (Wormhole) (Wormho (Wormhole)",
-    "symbol": "whLUNA",
-    "decimals": "6"
-  },
-  {
     "id": "terra15a9dr3a2a2lj5fclrw35xxg9yuxg0d908wpf2y",
     "name": "Wormhole:Magic Internet Money",
     "symbol": "whMIM",
@@ -14159,12 +7505,6 @@
     "name": "Wormhole:Sarcophagus",
     "symbol": "whSARCO",
     "decimals": "8"
-  },
-  {
-    "id": "terra13eqda0j9a70z8kdhx3j9es9mtwn7aswvuyenednc7xxrlwgj0ghsc7we0d",
-    "name": "Wormhole:TerraUSD (Wormhole)",
-    "symbol": "whUST",
-    "decimals": "6"
   },
   {
     "id": "terra1p5k0vl2g22zv0r07fxm627pf8u5frazevqgkw5",
@@ -14220,41 +7560,11 @@
     "decimals": "6"
   },
   {
-    "id": "terra19hq58hctw2m2mj6262n97x8gevas75pzmtkucf7gvgu4a0mcswnswj6tjz",
-    "name": "Wrapped Bitcoin (Sollet) (Wormhole)",
-    "symbol": "BTC",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1yn9grhzsq2rqe3a4tccxhva8pxqgd66arhhanju8vfx0p86y2nuscpyn3r",
-    "name": "Wrapped BNB",
-    "symbol": "WBNB",
-    "decimals": "18"
-  },
-  {
-    "id": "terra14kg73j92u8af2uwdp76cd7wnr54ray55k0kmcd0qqg7cd2me8ugqzv387z",
-    "name": "Wrapped BNB (Wormhole)",
-    "symbol": "WBNB",
-    "decimals": "8"
-  },
-  {
     "id": "terra1cetg5wruw2wsdjp7j46rj44xdel00z006e9yg8",
     "name": "Wrapped BNB (Wormhole)",
     "symbol": "wbWBNB",
     "decimals": "8",
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9gP2kCy3wA1ctvYWQk75guqXuHfrEomqydHLtcTCqiLa/logo.png"
-  },
-  {
-    "id": "terra1xc7ynquupyfcn43sye5pfmnlzjcw2ck9keh0l2w2a4rhjnkp64uq4pr388",
-    "name": "Wrapped BNB (Wormhole)",
-    "symbol": "WBNB",
-    "decimals": "8"
-  },
-  {
-    "id": "terra172d2q6knsjaz2rkkeevnfekcxvnyuggak8l5ltld64gf8pc5fnqqhngdud",
-    "name": "Wrapped BNB (Wormhole) (Wormhole)",
-    "symbol": "WBNB",
-    "decimals": "8"
   },
   {
     "id": "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55",
@@ -14264,71 +7574,11 @@
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh/logo.png"
   },
   {
-    "id": "terra178rlf3yqng4r4pgvwngh52gl4cwm9ms7gwv3fmmqdywmzt66mamqznassf",
-    "name": "Wrapped Ether (Wormhole) (Wormhole)",
-    "symbol": "WETH",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1f509skqv3aumpwkrgjhnjpyew4mhhxrm6h3ce6zs45r7zme9e8eqwjeqwa",
-    "name": "Wrapped Ethereum",
-    "symbol": "WETH",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ufj34v4agxlazv6gv36fsdm5e8y4kclqgp0qt0l8ureql9pcwssspma238",
-    "name": "Wrapped LUNA",
-    "symbol": "WLUNA",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1he6juwnty79eys2lszamkznek9yf4qu302dqf8qfws0sn03vyk0qfd4cz2",
-    "name": "Wrapped LUNA 2.0 (Wormhole)",
-    "symbol": "LUNA",
-    "decimals": "8"
-  },
-  {
-    "id": "terra12rglpa9u5jcatztvjsr4wfcx9pvgpa4vtz4c6z3n3sx2ynggggdscnt94y",
-    "name": "Wrapped Luna 2.0 Token (Wormhole)",
-    "symbol": "LUNA2",
-    "decimals": "8"
-  },
-  {
-    "id": "terra14axlvgd5mawznhukwf0dq93xhtfjfzq5cpn7pyah7lk5wf4g87tqx5whjg",
-    "name": "Wrapped LUNA Token (Wormhole)",
-    "symbol": "LUNA",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1fxlqv06d7efj8qa3g9r6fz5kel4a9n9d3xtd5ws6zsmm4d2wyp2q426p2g",
-    "name": "Wrapped LUNA Token (Wormhole)",
-    "symbol": "LUNA",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1sfhku0xmw62t8aau3r5rudjxmfxecr8j0ekvpfes6wed2q97yjdqrdnv6n",
-    "name": "Wrapped LUNA Token (Wormhole)",
-    "symbol": "LUNA",
-    "decimals": "8"
-  },
-  {
-    "id": "terra12g9t09vv7gdj0qpz043shtqgug5u80l5mrxm57kwncmxts96vhtqvfw8ep",
-    "name": "Wrapped LUNA Token (Wormhole) (Wormhole)",
-    "symbol": "wLUNA",
-    "decimals": "8"
-  },
-  {
     "id": "terra1dtqlfecglk47yplfrtwjzyagkgcqqngd5lgjp8",
     "name": "Wrapped Matic (Wormhole)",
     "symbol": "WMATIC",
     "decimals": "8",
     "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/MATICpo_wh.png"
-  },
-  {
-    "id": "terra1dnatg47sl457qz6p20mdcm4p3x5djsfysnyk955agkdst2nhpdqs70lmzw",
-    "name": "Wrapped ROSE (Wormhole)",
-    "symbol": "wROSE",
-    "decimals": "8"
   },
   {
     "id": "terra190tqwgqx7s8qrknz6kckct7v607cu068gfujpk",
@@ -14338,39 +7588,15 @@
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png"
   },
   {
-    "id": "terra17udtzsrzsrtg2uhr73zf6xmd3whda2wfg3qt2wtfru4x8dgv2gkqc9axuy",
-    "name": "Wrapped UST (Wormhole) (Wormhole)",
-    "symbol": "wUST",
-    "decimals": "8"
-  },
-  {
-    "id": "terra1j4jen7gtnaec6fqc0kf0c3ku2yahywz0djjhw07596nz5hj9fzrqyhza66",
-    "name": "Wrapped UST Token (PoS) (Wormhole)",
-    "symbol": "UST",
-    "decimals": "8"
-  },
-  {
     "id": "terra1jl0egxpdfw0eqkzsgedzzet9zgwmhet2rd3s6u",
     "name": "WrappedOrion",
     "symbol": "wORION",
     "decimals": "6"
   },
   {
-    "id": "terra1pm6s5x770t27xajnj2qqkn6mku8s4k44ujs0m53h9epqqcarulnqwva8nt",
-    "name": "WW Vault uluna LP token",
-    "symbol": "uLP-uluna",
-    "decimals": "6"
-  },
-  {
     "id": "terra1vm507q46f2sm8jltjcvp3dtncttquwld0tfkdl",
     "name": "XADW Token",
     "symbol": "XADWS",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1wnceq4l76f50xgeatwrs8xvl9v7dzmuaxclrwd0jhzhj0z3lwlys8cgtja",
-    "name": "XAST-CLUN-LP",
-    "symbol": "uLP",
     "decimals": "6"
   },
   {
@@ -14403,18 +7629,6 @@
     "id": "terra162k5t3hl204lrwe8xvalh4pv4gdrjvdrjlgxst",
     "name": "XRUNE, The People's Launchpad",
     "symbol": "XRUNE",
-    "decimals": "6"
-  },
-  {
-    "id": "terra122u87x6k75sa3p4ynsfvk7fs520v2gw4jrwfnupfuw57vcdqsdps6zjed5",
-    "name": "xSAYVE",
-    "symbol": "xSAYVE",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1z2y3vv5mn69ep3k5wu90cmwuh2t6e9vp565j59x35d4fq2rh06esqf37ek",
-    "name": "xSAYVE",
-    "symbol": "xSAYVE",
     "decimals": "6"
   },
   {
@@ -14480,138 +7694,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra10l76clm9psp4whuhzheqhcrng53lzgu9za8hxntpu89ahepr6zqsuq6p4e",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1328565ayxaxcqjmw000v3va943jafszxjcqe0nfz5gf4huavym4qmj39qw",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14q94v3fycwq6vmfyvd7200gx79483lhtp03wlhdwr6clu27jkxdqclzpuw",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra19kf5647manlwql4kez5mwdlwfr4k9vsglcefyp0xxwce7aaztlrq55mu0y",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra19wdfeem79sxej2j7rxqk744axlpfn6egfu6wg9w0j83a0twvuj5sr2ev8n",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1celav7mac6ues3737mfrpgrurqkvmx5xx2yvq3jw5e4fcjpktq3syumv48",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1crat0mf78vtdvf752nk349pr9kjxutuewnakxrp0n5f40z4lmzxsgarjtx",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1elwcevx5x8nstnn460dhxqnahfzfvnjp3ssmuxqrj0j839z20k6skmwdz0",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1fanpvu7kefjl8mdlvjvnnxvq4wawtxxherkpycfrrzm23wjs4pasktjcdd",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1frmvm9fn4y67vgwx35qavs9ch69ly66y90qyp087cpftsp6zdrgquemc2v",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1gs5fpkpgdlwtvs9wqthm6ayu5shynkphp8sqe5zhr8n6gr2rctqsczzv9r",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1h6d2s0qpdx6zd9t2utkhdqsyk2nmln3tg3mxnwcplu2uvzmwmfrq4fd3rc",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1h8y42ee6p7yk2qks09dafd32up2evz3vx8tjf52fshv5s7dz9q6ssy06x3",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1hng4rdkphpr3cn5gghwj7ly8tjl29hcs2ellt9w7yymd62ljql3sh8qr2a",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1hywcdx2qyjjpvfggcsvswn20uy8vxc8dy6vhuqq9szhlr3fm0efq56hvkx",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1js0uheej983dch0w804s53433ta8whngwkatv5kjyk8angw6u3eqlhy32z",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1jwdkhxx8jwce2rex2aw98nj65twe4pnnr9frrqva8y6cavs8fats84w2dm",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1k32vua65agvr4am52f3gkrgjrx0svyacdw6kc4k74j6040tfs5ssfvhaey",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ntlycx2ar0xfcekxw7pkhahcun3dz4vdcxqyxqffk9javdccvsaqgfxaek",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qs6xr9uk3u2kpfqlkaera5evjrvnf7w4jxracpkncyawlv2r2r0sys0j2u",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1v0x26p9ncyclu2ln5n6kh3wr5552se677k7q7f3d4sug87vxc48s04ggta",
-    "name": "yield",
-    "symbol": "yToken",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1lmkpcg09dan6ll6vkh84zd088fxl98nhm3a62a4gj74qvnwaennqpjsr89",
-    "name": "YourGirls",
-    "symbol": "KNOWHERE",
-    "decimals": "0"
-  },
-  {
     "id": "terra13gdkkedrnd48kel0fc8sr08usdfpdce9ku6qku",
     "name": "yout_token_name",
     "symbol": "SYMBOL",
@@ -14651,18 +7733,6 @@
     "id": "terra1gazefv0j5m0hhalp0qea5smypej2r0matncl88",
     "name": "ZERG",
     "symbol": "ZUG",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1zjqd9jey003003jl30jkvccqn99jt4hhyw7xjl60cvkydwvajvascetjyj",
-    "name": "МT (Wormhole)",
-    "symbol": "МT",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1msjxnah55lv7f279pnnpklkm6sfauk2sj0y4yhr38axyk3d8j6dqylf8zm",
-    "name": "저스티스 킹스맨 다오",
-    "symbol": "JKD",
     "decimals": "6"
   }
 ]

--- a/terraclassic/asset.json
+++ b/terraclassic/asset.json
@@ -1,0 +1,7906 @@
+[
+  {
+    "id": "terra17raumdxxxlm8smtx2pcxmqpz7qq9am4zfxzl8d",
+    "entity": "Astroport",
+    "name": "Astroport",
+    "symbol": "ASTRO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dameg63csxum2hspscam9h6d33chnqa4wsn3sp",
+    "entity": "Astroport",
+    "name": "Astroport Finance",
+    "symbol": "ASTRO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vg6wky3jm7qnr4w4qtw6hflhlhc0v79z9jvnxu",
+    "entity": "Astroport",
+    "name": "Astroport Finance",
+    "symbol": "ASTRO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nsuqsk6kh58ulczatwev87ttq2z6r3pusulg9r24mfj2fvtzd4uq3exn26",
+    "entity": "Astroport",
+    "name": "Astroport Token",
+    "symbol": "ASTRO",
+    "decimals": "6",
+    "icon": "https://astroport.fi/astro_logo.png"
+  },
+  {
+    "id": "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
+    "entity": "Astroport",
+    "name": "Astroport Token",
+    "symbol": "ASTRO",
+    "decimals": "6",
+    "circ_supply_api": "https://api.astroport.fi/public/astro-token/circulating_supply",
+    "icon": "https://astroport.fi/astro_logo.png",
+    "website": "https://astroport.fi/",
+    "telegram": "https://t.me/astroport_fi",
+    "twitter": "https://twitter.com/astroport_fi"
+  },
+  {
+    "id": "terra1uxqd9gmtxz45yq53t2m9vrs74twwfrjmrqmdjd",
+    "entity": "Astroport",
+    "name": "Astroport.fi",
+    "symbol": "ASTRO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7",
+    "entity": "Astroport",
+    "name": "Staked Astroport",
+    "symbol": "xASTRO",
+    "decimals": "6",
+    "icon": "https://app.astroport.fi/tokens/xAstro.png"
+  },
+  {
+    "id": "terra1x62mjnme4y0rdnag3r8rfgjuutsqlkkyuh4ndgex0wl3wue25uksau39q8",
+    "entity": "Astroport",
+    "name": "Staked Astroport Token",
+    "symbol": "xASTRO",
+    "decimals": "6",
+    "icon": "https://app.astroport.fi/tokens/xAstro.png"
+  },
+  {
+    "id": "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+    "entity": "boneLuna",
+    "name": "Bonded Luna",
+    "symbol": "bLUNA",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.anchorprotocol.com/logo/bLUNA.png",
+    "website": "https://anchorprotocol.com/",
+    "telegram": "https://t.me/anchor_official",
+    "twitter": "https://twitter.com/anchor_protocol"
+  },
+  {
+    "id": "ibc/18ABA66B791918D51D33415DA173632735D830E2E77E63C91C11D3008CFD5262",
+    "entity": "Cosmos",
+    "name": "Cosmos",
+    "symbol": "ATOM",
+    "decimals": "6",
+    "icon": "https://assets.terra.money/icon/svg/ibc/ATOM.svg"
+  },
+  {
+    "id": "ibc/64B3EFE08A6A3EF5D2A7F1D3AF033DDC951DA51F92E06CC31D3F9AF8E8368860",
+    "entity": "Cosmos",
+    "name": "Cosmos",
+    "symbol": "ATOM",
+    "decimals": "6",
+    "icon": "https://assets.terra.money/icon/svg/ibc/ATOM.svg"
+  },
+  {
+    "id": "terra1vsl7etwe53vglc2xq2rdt7mujarcjy9j694hdk",
+    "entity": "Juno",
+    "name": "JUNO",
+    "symbol": "JUNO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1r7e9a5su34ne07e6v0r7n2xp4h6tjkxc8j2lz2",
+    "entity": "Kujira",
+    "name": "Kuji",
+    "symbol": "KUJI",
+    "decimals": "6"
+  },
+  {
+    "id": "ibc/B22B4DD21586965DAEF42A7600BA371EA77C02E90FC8A7F2330BF9F9DE129B07",
+    "entity": "Kujira",
+    "name": "Kujira",
+    "symbol": "KUJI",
+    "decimals": "6",
+    "icon": "https://assets.terra.money/icon/svg/ibc/KUJI.svg"
+  },
+  {
+    "id": "terra10vwyclaux26l47hj2dgnjw2pcsrt4y0ukfgp9u",
+    "entity": "Kujira",
+    "name": "Kujira",
+    "symbol": "KUJI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn",
+    "entity": "Kujira",
+    "name": "Kujira",
+    "symbol": "KUJI",
+    "decimals": "6",
+    "circ_supply_api": "https://api.kujira.app/api/kuji/supply",
+    "icon": "https://assets.kujira.app/kuji.svg",
+    "website": "https://kujira.app",
+    "telegram": "https://t.me/team_kujira",
+    "twitter": "https://twitter.com/TeamKujira"
+  },
+  {
+    "id": "terra1r8ak49p50g76zamn25h3u7lkmn9n4maq2k2le2",
+    "entity": "Kujira",
+    "name": "KUJIRA",
+    "symbol": "KUJI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13zemc0wmem8lt0un0lya3qtg4cpf9jcdsgtvf3",
+    "entity": "Kujira",
+    "name": "Kujira Token",
+    "symbol": "KUJI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1teh62le6cndl2ch9yw5vkjk30h2fd4mhkrt5wc",
+    "entity": "Kujira",
+    "name": "KujiraFinance",
+    "symbol": "KUJI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
+    "entity": "Lira Financial",
+    "name": "Lira",
+    "symbol": "LIRA",
+    "decimals": "6",
+    "icon": "https://lira.financial/images/icons/lira.svg"
+  },
+  {
+    "id": "terra1hnezwjqlhzawcrfysczcxs6xqxu2jawn729kkf",
+    "entity": "Orne",
+    "name": "Orne",
+    "symbol": "ORNE",
+    "decimals": "6",
+    "circ_supply_api": "https://orne.io/api/",
+    "icon": "https://orne.io/img/token_icon.png",
+    "website": "https://orne.io",
+    "telegram": "https://t.me/orne_io",
+    "twitter": "https://twitter.com/orne_i_o",
+    "coingecko": "https://www.coingecko.com/en/coins/orne"
+  },
+  {
+    "id": "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B",
+    "entity": "Osmosis",
+    "name": "Osmosis",
+    "symbol": "OSMO",
+    "decimals": "6",
+    "icon": "https://assets.terra.money/icon/svg/ibc/OSMO.svg"
+  },
+  {
+    "id": "terra1ye68rx8etwj7xylwc4nd4vp58zz236mlhk0cpx",
+    "entity": "Redacted Money",
+    "name": "Squid Red Token",
+    "symbol": "RED",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tknq3prjtkzttvx2u48hn4r7xfwh7gz9cxzgqf",
+    "entity": "Redacted Money",
+    "name": "Squid VIP Red Token",
+    "symbol": "RED",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s9jnada32ld74gmng8ng5l3zfy9vk8kfds5828",
+    "entity": "Redacted Money",
+    "name": "Terra Squid Red",
+    "symbol": "RED",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14v9wrjs55qsn9lkvylsqela3w2ytwxzkycqzcr",
+    "entity": "Sayve Protocol",
+    "name": "SAYVE Token",
+    "symbol": "SAYVE",
+    "decimals": "6",
+    "circ_supply_api": "https://lcd.terra.dev/wasm/contracts/terra1c0ml4nvpapkuex28yuh40n38cq3zyugszsw59e/store?query_msg=%7B%22check_balance%22%3A%7B%22addr%22%3A+%22terra14v9wrjs55qsn9lkvylsqela3w2ytwxzkycqzcr%22%7D%7D",
+    "icon": "https://i.ibb.co/5xC39ym/sayve.png",
+    "website": "https://www.sayve.money/",
+    "telegram": "https://t.me/SayveProtocolChat",
+    "twitter": "https://www.twitter.com/sayve_protocol"
+  },
+  {
+    "id": "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09",
+    "entity": "Secret Network",
+    "name": "Secret",
+    "symbol": "SCRT",
+    "decimals": "6",
+    "icon": "https://assets.terra.money/icon/60/SCRT.png"
+  },
+  {
+    "id": "terra14xsm2wzvu7xaf567r693vgfkhmvfs08l68h4tjj5wjgyn5ky8e2qvzyanh",
+    "entity": "Stader Labs",
+    "name": "LunaX Token",
+    "symbol": "LunaX",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/stader-labs/assets/main/terra/LunaX_1.png"
+  },
+  {
+    "id": "terra1l23rtnsp0fcfgs2zlww4gcd8dlznkm580p5yrsangcen9jjjhuqstd2sle",
+    "entity": "Stader Labs",
+    "name": "SD Token",
+    "symbol": "SD",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/stader-labs/assets/main/terra/SD_Token.png"
+  },
+  {
+    "id": "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
+    "entity": "Stader Labs",
+    "name": "Stader LunaX Token",
+    "symbol": "LunaX",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://raw.githubusercontent.com/stader-labs/assets/main/terra/LunaX_1.png",
+    "website": "https://staderlabs.com/",
+    "telegram": "https://t.me/staderlabs",
+    "twitter": "https://twitter.com/staderlabs",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/stader/",
+    "coingecko": "https://www.coingecko.com/en/coins/stader"
+  },
+  {
+    "id": "terra1ustvnmngueq0p4jd7gfnutgvdc6ujpsjhsjd02",
+    "entity": "Stader Labs",
+    "name": "Stader SD",
+    "symbol": "SD",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/stader-labs/assets/main/terra/whSD.png"
+  },
+  {
+    "id": "terra1rl4zyexjphwgx6v3ytyljkkc4mrje2pyznaclv",
+    "entity": "Steak",
+    "name": "Steak Token",
+    "symbol": "STEAK",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1rl4zyexjphwgx6v3ytyljkkc4mrje2pyznaclv/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://larry.engineer/assets/steak.svg",
+    "twitter": "https://twitter.com/st4k3h0us3"
+  },
+  {
+    "id": "terra13j2k5rfkg0qhk58vz63cze0uze4hwswlrfnm0fa4rnyggjyfrcnqcrs5z2",
+    "entity": "Terra Poker",
+    "name": "Terra Poker Token",
+    "symbol": "TPT",
+    "decimals": "6",
+    "icon": "https://terra.poker/ico/ms-icon-310x310.png"
+  },
+  {
+    "id": "terra1kx4y3y4pn32jssqr90cj0rw89ds98dc0t5eqfp",
+    "entity": "TerraFloki",
+    "name": "TerraFloki",
+    "symbol": "TFLOKI",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1u2k0nkenw0p25ljsr4ksh7rxm65y466vkdewwj",
+    "entity": "TerraFloki",
+    "name": "TerraFloki",
+    "symbol": "TFLOKI",
+    "decimals": "6",
+    "circ_supply_api": "https://api.terrafloki.io/supply/circulating",
+    "icon": "https://terrafloki.io/terrafloki_logo.png",
+    "website": "https://terrafloki.io/",
+    "telegram": "https://t.me/terrafloki",
+    "twitter": "https://twitter.com/TerraFloki",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terrafloki/"
+  },
+  {
+    "id": "terra1vl3khh0w2fydtd72ly03vjmlll4nr0ldcl9u4z",
+    "entity": "TerraFloki",
+    "name": "TerraFloki",
+    "symbol": "TFLOKI",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1cx8rey3xpd7e7t6pkywvq6n9y98yq3wlfashpm",
+    "entity": "Valkyrie Protocol",
+    "name": "Valkyrie Token",
+    "symbol": "VKR",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dy9kmlm4anr92e42mrkjwzyvfqwz66un00rwr5",
+    "entity": "Valkyrie Protocol",
+    "name": "Valkyrie Token",
+    "symbol": "VKR",
+    "decimals": "6",
+    "circ_supply_api": "https://api.valkyrieprotocol.com/circulating-supply",
+    "icon": "https://app.valkyrieprotocol.com/icon_vkr.png",
+    "website": "https://valkyrieprotocol.com",
+    "telegram": "https://t.me/valkyrie_protocol",
+    "twitter": "https://twitter.com/valkyrie_money"
+  },
+  {
+    "id": "terra1l9pdkujwe6rteefdhprv5lns49cptcglffhpf3",
+    "entity": "Valkyrie Protocol",
+    "name": "Valkyrie Token",
+    "symbol": "VKR",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tnp8vgurcuhtau0r0qjtsx3swmr0hhn6l8r402",
+    "entity": "Valkyrie Protocol",
+    "name": "Valkyrie Token",
+    "symbol": "VKR",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hj8de24c3yqvcsv9r8chr03fzwsak3hgd8gv3m",
+    "entity": "Wormhole",
+    "name": "Wrapped AVAX (Wormhole)",
+    "symbol": "WAVAX",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/AVAX_wh.png"
+  },
+  {
+    "id": "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
+    "entity": "Wormhole",
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs/logo.png"
+  },
+  {
+    "id": "terra1s56hsyhyvq4xxxvnz8qr0pnktm2dadsm4gkl45",
+    "name": "[REDACTED] Governance",
+    "symbol": "RDCTD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dwyd6vds479kv54f7kucevny97lge20c3s9w2k",
+    "name": "<Big Green Dildo>",
+    "symbol": "BGD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hxcsd8ttymrqzp5uh5f5885j0ms0tnzux9jzsc",
+    "name": "🍖 Dog Food",
+    "symbol": "DGFD",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1fkwfm2w8kffl3ged3zulknz849rnfdxnwjgdnk",
+    "name": "🎁🎁🎁🎁🎁",
+    "symbol": "PRESENT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1n4g9jamjrxhe5yssczrlq55syhxvwqkx7jpkjl",
+    "name": "🎄New Year NFT🎄",
+    "symbol": "NYNFT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1qn4v9nnc2a0mdnkzl73rh60264gvhu6pxusz0r",
+    "name": "🎅 Santa",
+    "symbol": "SNTA",
+    "decimals": "3"
+  },
+  {
+    "id": "terra19953ttzk3mxghgwpdt85gua3gzzcj9a6wjwek6",
+    "name": "🐶DogeKwon v2 Terra ",
+    "symbol": "DKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tj9zrn3myxvkct20ehzje5whu5j75c94s8r666",
+    "name": "🤖 RoboNFT 🤖",
+    "symbol": "RNFT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1c0awzlg4ujlt0c2prwtukqeapg2m4qty5fdgs2",
+    "name": "1 COIN is 1 NFT",
+    "symbol": "DEGEN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m9w3pdjst86dmfdamq5tuu4ny99e89eaavdz06",
+    "name": "1$ Kwon",
+    "symbol": "KWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12qeh8p79q6jrnlmw09hvtytv9e99yl2077cmgz",
+    "name": "100BIL",
+    "symbol": "HUNDBIL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xjxegty6mmdr5jwqwde9rqhz758sy8c73vxzea",
+    "name": "10BIL",
+    "symbol": "TENBIL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cjf3m2zsx4lu6c0edhfcvp0v4hps6gfr79hyc4",
+    "name": "1BIL",
+    "symbol": "ONEBIL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1aft2zjfhmetslqvy0jg6d0ywhf9r5zf5zqratc",
+    "name": "2 Girls 1 Dkwon 🌗💵 ",
+    "symbol": "GIDK",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1hn8mghxm4qm2g654m3h4rmqccgs2wcdsvsex82",
+    "name": "2 Girls 1 DoKwon 🌗💵 ",
+    "symbol": "PEPE",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1866wzpwzmrnmh0s267twyhr8c4tc47tqj5aths",
+    "name": "247Payments",
+    "symbol": "PAY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1t7apedqrzywmrl89feackcalpknfzu5mr8t3xg",
+    "name": "25K",
+    "symbol": "TFK",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qt0j6rzqrc0rxpxxlyrvljmjkxrss2frsef5n0",
+    "name": "300 Terrans",
+    "symbol": "TERRANS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra159tnr8a3uutvwxhgkea4f2hucm4v24evv2se2t",
+    "name": "60CentProtocol.App",
+    "symbol": "SixtyCent",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zey5xuv48yfjf9y0v6zkyfdtv2du5kau2kdrna",
+    "name": "6DEC",
+    "symbol": "DEC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wlhgvtult73t5vpeng4sw9qmsq5jlujfm98gg2",
+    "name": "AAA",
+    "symbol": "AAA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dyptd3795l57lencr2eltut973kum8wgu36f7p",
+    "name": "aaaavar",
+    "symbol": "AAAv",
+    "decimals": "3"
+  },
+  {
+    "id": "terra18ej5nsuu867fkx4tuy2aglpvqjrkcrjjslap3z",
+    "name": "Advanced Micro Devices, Inc.",
+    "symbol": "mAMD",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra18ej5nsuu867fkx4tuy2aglpvqjrkcrjjslap3z/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/AMD.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra12qxyx2l90c37kylw4jqe8t40ppnrnu8wqmx940",
+    "name": "AguilarBoys",
+    "symbol": "AGB",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1g4x2pzmkc9z3mseewxf758rllg08z3797xly0n",
+    "name": "Airbnb Inc.",
+    "symbol": "mABNB",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1g4x2pzmkc9z3mseewxf758rllg08z3797xly0n/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/ABNB.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1xc5ll57yu269x8ysxvdpjmvxmac3js7pst5ddr",
+    "name": "Alameda Research DAO",
+    "symbol": "ARD",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1w7zgkcyt7y4zpct9dw8mw362ywvdlydnum2awa",
+    "name": "Alibaba Group Holding Limited",
+    "symbol": "mBABA",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1w7zgkcyt7y4zpct9dw8mw362ywvdlydnum2awa/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/BABA.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra14xulq5g99rfmrm6qkgzmrrspvknupajdqyd92k",
+    "name": "Alibaba Group Holdings Ltd ADR",
+    "symbol": "mBABA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ukk89gn25p7xseqc4s4d45yarjlwychrwx7umv",
+    "name": "ALL TIME High",
+    "symbol": "ATH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1a7ye2splpfzyenu0yrdu8t83uzgusx2malkc7u",
+    "name": "Allbridge",
+    "symbol": "ABR",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/allbridge-io/media/main/token.svg"
+  },
+  {
+    "id": "terra1366wmr8t8rrkh6mag8fagqxntmf2qe4kyte784",
+    "name": "Alpha Pack Token",
+    "symbol": "aLOT",
+    "decimals": "0",
+    "icon": "https://ipfs.playlot.io/icon/profile-logo.png"
+  },
+  {
+    "id": "terra1h8arz2k547uvmpxctuwush3jzc8fun4s96qgwt",
+    "name": "Alphabet Inc.",
+    "symbol": "mGOOGL",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1h8arz2k547uvmpxctuwush3jzc8fun4s96qgwt/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/GOOGL.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra17azgr4x2gz20uquy7vdacfdgjjkgd0h9lm377v",
+    "name": "Alpine Protocol",
+    "symbol": "ALP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv",
+    "name": "Altered",
+    "symbol": "ALTE",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://gblobscdn.gitbook.com/spaces%2F-Mf4Y6TIGwMtHEN3AaXV%2Favatar-1626907729941.png?alt=media",
+    "website": "https://alteredprotocol.com/",
+    "telegram": "https://t.me/Altered_ALTE",
+    "twitter": "https://twitter.com/Altered_ALTE"
+  },
+  {
+    "id": "terra1q93ws00plywc5prwv7mf2gdf7alhuqgk5w68lq",
+    "name": "Alto Protocol",
+    "symbol": "ALTO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra174c2cy42fl7hags7cap8j4xtsmcc0ql2s8q5du",
+    "name": "ALTO, The People's Launchpad",
+    "symbol": "ALTO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tthplnk67e7tvga2dh49jk6l6cn4furuuffu9x",
+    "name": "Amazon.com",
+    "symbol": "mAMZN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra165nd2qmrtszehcfrntlplzern7zl4ahtlhd5t2",
+    "name": "Amazon.com, Inc.",
+    "symbol": "mAMZN",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra165nd2qmrtszehcfrntlplzern7zl4ahtlhd5t2/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/AMZN.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy",
+    "name": "AMC Entertainment Holdings Inc.",
+    "symbol": "mAMC",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/AMC.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1fx6ffswrmgyuf5nsxruce5gertr8vgsm7krrp7",
+    "name": "Anchor aUST Token",
+    "symbol": "aUST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1w724lm9qt5q8rz9n0kqlfglkulz7z98yjvxzn8",
+    "name": "Anchor aUST Token",
+    "symbol": "aUST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+    "name": "Anchor Terra USD",
+    "symbol": "aUST",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.anchorprotocol.com/logo/aUST.png"
+  },
+  {
+    "id": "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
+    "name": "Anchor Token",
+    "symbol": "ANC",
+    "decimals": "6",
+    "circ_supply_api": "https://api.anchorprotocol.com/api/v1/anc",
+    "icon": "https://whitelist.anchorprotocol.com/logo/ANC.png",
+    "website": "https://anchorprotocol.com/",
+    "telegram": "https://t.me/anchor_official",
+    "twitter": "https://twitter.com/anchor_protocol",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/anchor-protocol/",
+    "coingecko": "https://www.coingecko.com/en/coins/anchor-protocol"
+  },
+  {
+    "id": "terra1587zn7hagaylrp22x5edz25zpqfn6szfmvtym4",
+    "name": "Anchor Token",
+    "symbol": "ANC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1aqfqmal9vllc75dhqplx3zdfsyfpmx9c0q9rud",
+    "name": "Anchor Token",
+    "symbol": "ANC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ky3uafsw2kkddrhm039klksqkuwtdsfsmpc748",
+    "name": "Anchor Token",
+    "symbol": "ANC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pujanvsuhqsqf8vc7r3ky9ghr8sgeg4e3ngjun",
+    "name": "Angel Protocol",
+    "symbol": "HALO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq",
+    "name": "Angel Protocol",
+    "symbol": "HALO",
+    "decimals": "6",
+    "icon": "https://i.ibb.co/q9krLwC/halo-token.png",
+    "website": "https://www.angelprotocol.io/",
+    "telegram": "https://t.me/angelprotocoI",
+    "twitter": "https://twitter.com/angelprotocol"
+  },
+  {
+    "id": "terra15xf5wqprgzl59ckfyjtgavh7rqtxcju7gn57rc",
+    "name": "Ape NFT",
+    "symbol": "ANFT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1zn26hzdegq2c9qa0etqcthk2kjcr6cqeaud7q9",
+    "name": "Apollo DAO",
+    "symbol": "APOLLO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra100yeqvww74h4yaejj6h733thgcafdaukjtw397",
+    "name": "Apollo DAO Token",
+    "symbol": "APOLLO",
+    "decimals": "6",
+    "circ_supply_api": "https://price-api-mainnet.apollo.farm/v1/apollo/supply",
+    "icon": "https://i.ibb.co/VC517zj/apollo.png",
+    "website": "https://apollo.farm/",
+    "telegram": "https://t.me/apollodao",
+    "twitter": "https://twitter.com/ApolloDAO"
+  },
+  {
+    "id": "terra10jgqgc3vt34w79t4puharnzjxxv7s3fq8tmnkp",
+    "name": "Apollo DAO Token",
+    "symbol": "APOLLO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vwvpvamj60rtnzxzr00thgtv5hplhu55jx67d6",
+    "name": "Apple",
+    "symbol": "mAAPL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zqyfp259xhhct6q2alp88pke90qrxgr5u2zc7s",
+    "name": "APPLE",
+    "symbol": "mAPPL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vxtwu4ehgzz77mnfwrntyrmgl64qjs75mpwqaz",
+    "name": "Apple Inc.",
+    "symbol": "mAAPL",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1vxtwu4ehgzz77mnfwrntyrmgl64qjs75mpwqaz/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/AAPL.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1vyusa796w86yh99l67dpd5g3hfva759vyuhn5z",
+    "name": "APS Token",
+    "symbol": "APS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qqfx5jph0rsmkur2zgzyqnfucra45rtjae5vh6",
+    "name": "ARK Innovation ETF",
+    "symbol": "mARKK",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1qqfx5jph0rsmkur2zgzyqnfucra45rtjae5vh6/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/ARKK.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1yjlqptvn3al5402jp600l7n3l5yl8man8d4kex",
+    "name": "Art Token",
+    "symbol": "ART",
+    "decimals": "6"
+  },
+  {
+    "id": "terra129796y06jrejsk9hjmvhkhat92mxt76k6qpyfw",
+    "name": "Asan King Token",
+    "symbol": "AKT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kdfsdm3c4reun9j3m4mk3nmyw4a4ns7mj24q3j",
+    "name": "AstroPug Token",
+    "symbol": "PUG",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/astropug/astropug-world/master/logo.png"
+  },
+  {
+    "id": "terra1cl7whtrqmz5ldr553q69qahck8xvk80fm33qjx",
+    "name": "Atlo",
+    "symbol": "ATLO",
+    "decimals": "6",
+    "circ_supply_api": "https://atlo.app/api/atlo-circulating-supply",
+    "icon": "https://assets.atlo.app/images/atlo-logo.svg",
+    "website": "https://atlo.app",
+    "telegram": "https://t.me/Atlo_protocol",
+    "twitter": "https://twitter.com/atlo_protocol"
+  },
+  {
+    "id": "terra1y6mgy2ha0fwhtkd06jdca7hpep7z8hz9n2jz8t",
+    "name": "Atlo",
+    "symbol": "ATLO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zce4mxwwdyk04txa2f3aqepzsq8jy7ca50gn8w",
+    "name": "Atlo Protocol",
+    "symbol": "ATLO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nc6flp57m5hsr6y5y8aexzszy43ksr0drdr8rp",
+    "name": "Audius (Portal)",
+    "symbol": "AUDIO",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/AUDIO_wh.png"
+  },
+  {
+    "id": "terra14tc6kg4my06ckzugrukq0r903sup3a6agdmx4y",
+    "name": "Aurory.io",
+    "symbol": "AURO",
+    "decimals": "6"
+  },
+  {
+    "id": "uaud",
+    "name": "AUT",
+    "symbol": "AUT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/aut",
+    "icon": "https://assets.terra.money/icon/60/AUT.png"
+  },
+  {
+    "id": "terra13x03uqz06gkam3dq4dgx0tj89dpw3vs2nlftjq",
+    "name": "AWDw Token",
+    "symbol": "AWDw",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14q0a4tfmdkwrvzakv7nq9jg2d36w8uj9jkhgee",
+    "name": "AWESOME Money",
+    "symbol": "AWE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dd2qt59v86gwgzl2e6u3xexefvrkjmgd8mu638",
+    "name": "BABY TERRA",
+    "symbol": "BABY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1l385362dg276797k7lzsfktskfssg22n7hn4at",
+    "name": "BABY YODA Token",
+    "symbol": "BYODA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13sg4qarsjual8ew8sr4nwtkv6ut4dd3378820r",
+    "name": "BabyTerraFloki",
+    "symbol": "BabyTFLOKI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1apxgj5agkkfdm2tprwvykug0qtahxvfmugnhx2",
+    "name": "Basic Attention Token (Portal)",
+    "symbol": "BAT",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/BAT_wh.png"
+  },
+  {
+    "id": "terra1vsyyg4rs483uzd7jzw5fqqlm2q5n2yd37yylfc",
+    "name": "BAZ",
+    "symbol": "BAZ",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/BAZustc/BAZ-CORE/main/BAZ.png"
+  },
+  {
+    "id": "terra1g36mr60pqf8x4hr3ulpsptrg84w088m0eunsw0",
+    "name": "BBB",
+    "symbol": "BBB",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qryq5wreecx2wd3cdtzz94syr4z0a92l60asds",
+    "name": "bBRO token",
+    "symbol": "bBRO",
+    "decimals": "6",
+    "icon": "https://brokkr.finance/static/bBRO/bBro-Token-64.svg"
+  },
+  {
+    "id": "terra1ult8nl3u83p7vdjdehtjfn9ylkm6u606nmdry3",
+    "name": "BDED Token",
+    "symbol": "BDED",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
+    "name": "BENQI Staked AVAX (Wormhole)",
+    "symbol": "wasAVAX",
+    "decimals": "8",
+    "icon": "https://benqi.fi/images/assets/savax.svg"
+  },
+  {
+    "id": "terra1p2enl6vfmhdfj7ud32p3fkgns22sg62ls9mh2e",
+    "name": "BetTerra Money",
+    "symbol": "BET",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hauj2lpsnye4jsxxww8kpze4mzyq76e5cjr2wp",
+    "name": "BFDE Token",
+    "symbol": "BFDE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ld37cm20t8z3r0zvk7hx2qcfr2cdayteed8089",
+    "name": "big cock dick",
+    "symbol": "bct",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y5ffh484f3jcy62zuslx3qlv0n6c4zsffjapm8",
+    "name": "big cock token",
+    "symbol": "bct",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1znvnhtdxxsy9vkvmqv85nscujeqmmtjlp2a3wj",
+    "name": "BigDick Kwon",
+    "symbol": "BDKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zpke3t4nprnh4044a4n97hwv384v9vff688cyj",
+    "name": "BigTimeStudio",
+    "symbol": "BTS",
+    "decimals": "3"
+  },
+  {
+    "id": "terra124zh80answg0srxqynl8syswgsjx0heh9txxw9",
+    "name": "binemon.io",
+    "symbol": "BNM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw",
+    "name": "Bitcoin",
+    "symbol": "mBTC",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/BTC.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1vpehfldr2u2m2gw38zaryp4tfw7fe2kw2lryjf",
+    "name": "Bitcoin",
+    "symbol": "BTC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra193c42lfwmlkasvcw22l9qqzc5q2dx208tkd7wl",
+    "name": "Bitlocus Token",
+    "symbol": "BTL",
+    "decimals": "6",
+    "icon": "https://bitlocus.com/assets/btl-token.png",
+    "website": "https://btl.bitlocus.com/",
+    "telegram": "https://t.me/bitlocus_official",
+    "twitter": "https://twitter.com/bitlocus",
+    "coingecko": "https://www.coingecko.com/en/coins/bitlocus"
+  },
+  {
+    "id": "terra1ss460ny4hl5zew0tlvywnw38rsy2ql3n420lv2",
+    "name": "Bitrise Token",
+    "symbol": "BRISE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16gx5th8mk5v62xpvgf675xj2vuaf3dg4v75ml5",
+    "name": "BLACK COCK TOKEN",
+    "symbol": "BDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y8q4jk5xwag3sschctduxa43eesupjkk6kr452",
+    "name": "Black Whale Protocol",
+    "symbol": "BWP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1r7qpupdxkkh58vw9u8y9n9wjp6d9lr08u39j0z",
+    "name": "BLUE TREE",
+    "symbol": "TREE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1x95tutcwe4tjxcdvtgrjg5jxkf24sm74xz3leq",
+    "name": "BLUESKY",
+    "symbol": "SKY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gjuhc34ccr6ajq7dm5266xyedu96sgkv4qnley",
+    "name": "BODE",
+    "symbol": "BODE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1atcayac92cwn9x6fcpxnjzycvmkkhwsk53tg29",
+    "name": "Bogdanoff DAO",
+    "symbol": "BOG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a",
+    "name": "Bonded ATOM",
+    "symbol": "bATOM",
+    "decimals": "6",
+    "icon": "https://files.pstake.finance/logos/bAssets/bATOM.svg"
+  },
+  {
+    "id": "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
+    "name": "Bonded ETH",
+    "symbol": "bETH",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.anchorprotocol.com/logo/bETH.png",
+    "website": "https://anchorprotocol.com/",
+    "telegram": "https://t.me/anchor_official",
+    "twitter": "https://twitter.com/anchor_protocol"
+  },
+  {
+    "id": "terra17wgmccdu57lx09yzhnnev39srqj7msg9ky2j76",
+    "name": "Bonded Luna",
+    "symbol": "BLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1c00vskhyzdv0z63z2tyetzx2qma67n2z3vzyn0",
+    "name": "Bonded SOL",
+    "symbol": "bSOL",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/ChorusOne/token-list/main/assets/mainnet/EbMg3VYAE9Krhndw7FuogpHNcEPkXVhtXr7mGisdeaur/logo.svg"
+  },
+  {
+    "id": "terra15afvt8ch38n8qj4n6wvykwkl2fqvfla826qdqe",
+    "name": "Bonded UST",
+    "symbol": "BUST",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1s0y8aldsy3t6wtg5tpwe8xzq3lyet5e9grwmlz",
+    "name": "Boobs",
+    "symbol": "BOOBS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zfqe2kf0kh8mvyy3ksa29qqnkhc64ncffufg7g",
+    "name": "BOOBS",
+    "symbol": "BOOBS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xktc8znx48tuypg3p47fcgfxrhc07hex0qgpex",
+    "name": "BORED",
+    "symbol": "APE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1a07n2cp4wd49ezxdgm9xgtfrnpmxfcdp4yrdnv",
+    "name": "BORG Token",
+    "symbol": "BORG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1d6vy3aueuucu3sf5qkrccnq7v58uwegh9m9x74",
+    "name": "BOUNTY",
+    "symbol": "BUG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zp4xkexmng539vylktxkf45hxjg68ufx673x8p",
+    "name": "BRDG Luna - FTM",
+    "symbol": "BRLF",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1ltcad0e9cgf2jgtzqwg82n9k54fre68wdddfll",
+    "name": "Bridge",
+    "symbol": "BRDG",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1mt2ytlrxhvd5c4d4fshxxs3zcus3fkdmuv4mk2",
+    "name": "Bro",
+    "symbol": "BRO",
+    "decimals": "6",
+    "icon": "https://brokkr.finance/static/BRO/Bro-Token-64.svg"
+  },
+  {
+    "id": "terra16gqgpuy7z64chzz3su2xugjgrhuj3h89wx2z59",
+    "name": "BST",
+    "symbol": "BST",
+    "decimals": "6",
+    "icon": "https://c2x.world/c2x-station/icon/BST.png"
+  },
+  {
+    "id": "terra1fy7lnlls8ufzfeefc98tkn66x07scud2s3d23p",
+    "name": "BST Fancard Token",
+    "symbol": "BSTfancard",
+    "decimals": "0",
+    "icon": "https://c2x.world/c2x-station/icon/BSTfancard.png"
+  },
+  {
+    "id": "terra13zs7w76g0u4qgagcen6vq92wxuvgfucr3dy4tm",
+    "name": "Burn game token",
+    "symbol": "BURN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f9h22l730vxxj5jmrakuwh3neuhdynwy42ezvv",
+    "name": "BURNED TERRA",
+    "symbol": "FIRE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dw6yapjv8k8anef2kg43hewg3g73wle22ncaje",
+    "name": "C2X",
+    "symbol": "CTX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8",
+    "name": "C2X Token",
+    "symbol": "C2X",
+    "decimals": "6",
+    "icon": "https://c2x.world/c2x-station/icon/C2X.png"
+  },
+  {
+    "id": "terra16ea8pnh3hu69kzqqps5gqw0zdd94hgul9tfnzw",
+    "name": "Cake Terra",
+    "symbol": "CAKE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra142yp486a6jjelr87c0kx6vxv22nw6dsvkcnhma",
+    "name": "canitwork",
+    "symbol": "CANITWORK",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ayxfyasd2ursa5gt5zgzgfywsw999dz4yykjn7",
+    "name": "CanThisActuallyWork",
+    "symbol": "LPTEST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1my8t2mhxxv5rzjtzc8cppj8y76hy3apvcntttw",
+    "name": "CanThisActuallyWork",
+    "symbol": "WORKIT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13fs83g5atgjwuh7c5ydzh6n7gecel6xyhhy2t5",
+    "name": "CAPITRADE TOKEN",
+    "symbol": "CDE",
+    "decimals": "9",
+    "icon": "https://raw.githubusercontent.com/Lotaxgizmo/images/57f862e3c2a68708775dae5f962885f2ed309b2d/ICON%20COLOURED%404x%201.png"
+  },
+  {
+    "id": "terra1aegvmfgdl4dclgpwtajll6382tcc7r0saa2eek",
+    "name": "Captain America Protocol",
+    "symbol": "CAP",
+    "decimals": "6"
+  },
+  {
+    "id": "ucad",
+    "name": "CAT",
+    "symbol": "CAT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/cat",
+    "icon": "https://assets.terra.money/icon/60/CAT.png"
+  },
+  {
+    "id": "terra1laqzmwrpyrd5tumpx5hs638tzhle4nc42k9jak",
+    "name": "CatDog",
+    "symbol": "CATDOG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16pj0sful7hl87j8h5qwnv6j4vv76mxj6a6026v",
+    "name": "CATSA",
+    "symbol": "CATSA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cvsfc32dkdvmla6urrscrtfceztecj0u5tvlvz",
+    "name": "CBM Token",
+    "symbol": "CBM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hppnw4jppmrzzga4yvd8s87y3dwkhe27xwwl5d",
+    "name": "Ceres Governance Token",
+    "symbol": "CERES",
+    "decimals": "6",
+    "icon": "https://cloudflare-ipfs.com/ipfs/QmVeSBHDtJYFd6yKSdFghRRsj4jXHdm81rmCUEdLHDK928?filename=ceres.svg"
+  },
+  {
+    "id": "terra1su6g4t4vwx7y0uh3ksancyaurj4l6w9pfs40qt",
+    "name": "ChainLink Token",
+    "symbol": "LINK",
+    "decimals": "18",
+    "icon": "https://ipfs.io/ipfs/QmbfnNALyHC3siaZR3j2mQ44MDVFr2dtR5ciqu3anbD4eP?filename=chainlink.png"
+  },
+  {
+    "id": "terra12dfv3f0e6m22z6cnhfn3nxk2en3z3zeqy6ctym",
+    "name": "ChainLink Token (Wormhole)",
+    "symbol": "weLINK",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2wpTofQ8SkACrkZWrZDjXPitYa8AwWgX8AfxdeBRRVLX/logo.png"
+  },
+  {
+    "id": "terra1spe82hmc9j2y2vjl6urue78zhrn9r9xyydkyx4",
+    "name": "Chelsea",
+    "symbol": "CFC",
+    "decimals": "3"
+  },
+  {
+    "id": "uchf",
+    "name": "CHT",
+    "symbol": "CHT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/cht",
+    "icon": "https://assets.terra.money/icon/60/CHT.png"
+  },
+  {
+    "id": "ucht",
+    "name": "CHT",
+    "symbol": "CHT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/cht",
+    "icon": "https://assets.terra.money/icon/60/CHT.png"
+  },
+  {
+    "id": "terra1f85kt39ar3tkscq6w8ylxv2t9qh4ktzayw35ta",
+    "name": "CLAW",
+    "symbol": "CLAW",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13eekqp0zgj55arjuacpxqxzgqy2uydf5wzzqns9ddgpepj377afqflunf3",
+    "name": "cLUNA",
+    "symbol": "cLUNA",
+    "decimals": "6",
+    "icon": "https://prismprotocol.app/cLuna.svg"
+  },
+  {
+    "id": "ucny",
+    "name": "CNT",
+    "symbol": "CNT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/cnt",
+    "icon": "https://assets.terra.money/icon/60/CNT.png"
+  },
+  {
+    "id": "terra1yuvwz0wzd49mjlvh24g23jst89dllua0nc3knt",
+    "name": "Coca Cola",
+    "symbol": "COKE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qsnj5gvq8rgs7yws8x5u02gwd5wvtu4tks0hjm",
+    "name": "Coca-Cola",
+    "symbol": "mKO",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1qsnj5gvq8rgs7yws8x5u02gwd5wvtu4tks0hjm/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/KO.png"
+  },
+  {
+    "id": "terra1vlrerpu78hdezzz8zzx34adpced73lmd0ujyqa",
+    "name": "Coca-Cola",
+    "symbol": "mKO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7",
+    "name": "Coin Swap",
+    "symbol": "SWAP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18wayjpyq28gd970qzgjfmsjj7dmgdk039duhph",
+    "name": "Coinbase Global, Inc.",
+    "symbol": "mCOIN",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra18wayjpyq28gd970qzgjfmsjj7dmgdk039duhph/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/COIN.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1n8awtfqa0wphx90pd2zc9v8vccc65f0gvv6rq5",
+    "name": "CoinHall",
+    "symbol": "CHALL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qlan324u6rsdevvc6ye3m02ump7dtp3z67uhqy",
+    "name": "CoinHall",
+    "symbol": "CHALL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1r3u50sue9akjnndgvxm7fe0fy5jdtnyxwuetw8",
+    "name": "Coinhall Fundraiser",
+    "symbol": "CHF",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rwskqpnk03hrh8z8rrprzdluxhzc5udycdn5g4",
+    "name": "CoinHall Offical",
+    "symbol": "CHO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13k5m9dmcdm8y52j95tuppuz23lvjug6hrh7vjx",
+    "name": "Coinhall Token",
+    "symbol": "COIN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q9ec5g6q0s3ncl9v068jkk5s2eae8ng3lxqtlf",
+    "name": "Coinhall🚀",
+    "symbol": "THEBEST",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1tvs43r9ry6s6g6j5mnmruw97s3fjhqxpc540hu",
+    "name": "Connect Labs",
+    "symbol": "CONNECT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1u02lqdhuhdfwph8wsl9yx9r0jupfdsd22q60tc",
+    "name": "Copper",
+    "symbol": "Copper",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1fd0gy7f5dcgmvdl95mt3z9fh8se48gf0wxs68k",
+    "name": "COSMOS TERRA",
+    "symbol": "COSMOS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pjnfhsvg7g52hfkdegr4apz7ax9x9xn0n2eayj",
+    "name": "Crazy Yield",
+    "symbol": "tYIELD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tewnpkjdtqq37udf5c5wjfrtkpegthfmls8lp7",
+    "name": "Crypto Dev",
+    "symbol": "CYD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qsjs0a02jmyfhvaeul4zax22sayx5e8dl8527g",
+    "name": "Crypto Punks",
+    "symbol": "PUNKS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rctv4sdztvscdxw890us4ewcuvh77t8wydxkxr",
+    "name": "CryptoBonds",
+    "symbol": "BRLF",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1hqr3l4je2yvn3l790ly0y6r0vgfs7yukwwj0ak",
+    "name": "CSDW Token",
+    "symbol": "CSDW",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kz7qszu7p4dg9lts7m9m7lpuarsnan47jh3fam",
+    "name": "CST Fancard Token",
+    "symbol": "CSTfancard",
+    "decimals": "0",
+    "icon": "https://c2x.world/c2x-station/icon/CSTfancard.png"
+  },
+  {
+    "id": "terra1jkkt5638cd5pur0u5jnr2juw0v6hz5d6z8xu8m",
+    "name": "CST Token",
+    "symbol": "CST",
+    "decimals": "6",
+    "icon": "https://c2x.world/c2x-station/icon/CST.png"
+  },
+  {
+    "id": "terra1ykq4e3ca2e5qgeetk8k8m3w6tk9tclr0xj2st7",
+    "name": "CUM",
+    "symbol": "CUM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z09gnzufuflz6ckd9k0u456l9dnpgsynu0yyhe",
+    "name": "curio",
+    "symbol": "SITY",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1z09gnzufuflz6ckd9k0u456l9dnpgsynu0yyhe/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://www.curio.art/img/logo.svg"
+  },
+  {
+    "id": "terra172xf4zehmdla56h2x8ergqmejg70f4zczzt74w",
+    "name": "CUTE",
+    "symbol": "CUTE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jju99w456sm6w2snkmatm00gve7cvvzda0j6pn",
+    "name": "CUTE HAPPY",
+    "symbol": "CAT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra144w7e54fwkpz2aavq33p6d2upyc0u006udf32g",
+    "name": "Cutegom",
+    "symbol": "GOM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mely4fttd94g5kgjmz05dmclgdahq45xnv5n22",
+    "name": "CVRG Token",
+    "symbol": "CVRG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dxt75lk0m5g0wpucg0mz905akta99fjhuhafqa",
+    "name": "Daddy Kwon",
+    "symbol": "DADDY",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1zmclyfepfmqvfqflu8r3lv6f75trmg05z7xq95",
+    "name": "DAI (Portal)",
+    "symbol": "DAI",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/DAI_wh.png"
+  },
+  {
+    "id": "terra1vru3mk2ne3jqpwg24wm5mg2356cg5ead0tae2s",
+    "name": "Dan Token",
+    "symbol": "DAN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1d8uw3zddfrexn06f80nz6hx2cd3f32a7p45agf",
+    "name": "DAO Shiba Inu",
+    "symbol": "DSI",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1nzvqd5mr0jn58cvam9j06k9kry4myu0vp7a9ug",
+    "name": "Darth Vader Token",
+    "symbol": "DVT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1l0zqxdgs5h6tfdsvhm34mvwrevyt5cuxj6ewzz",
+    "name": "deal lei lo mei",
+    "symbol": "DLLM",
+    "decimals": "18"
+  },
+  {
+    "id": "terra1vpws4hmpmpsqwnz3gljn8zj42rv7rkpc5atgt4",
+    "name": "DeFiato",
+    "symbol": "DFIAT",
+    "decimals": "8",
+    "icon": "https://defiato-public.s3.ap-southeast-1.amazonaws.com/defiato-logo-small.jpeg"
+  },
+  {
+    "id": "terra1smeev4u44zhv94cn4pyy9dtsshup53n9xefayx",
+    "name": "DefiChainTerra",
+    "symbol": "DCT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1zfcfvsw9m3gzk5l42cek0ukn5g4dmd8gl4lyra",
+    "name": "Delphi Digital NFT Token",
+    "symbol": "DELPHI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zucgllq5ddqkfgsyjr7qnrfhymu0y4rgqsfyet",
+    "name": "Delta Protocol",
+    "symbol": "DELTA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jusuf8pcuw56pmj0len5tcsdu9dm4xpqwqk48p",
+    "name": "Derby Stars",
+    "symbol": "DRBY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z4pfv9rrm53tg72cwkcv6ddvd4x6wcce43nua2",
+    "name": "DFFG Token",
+    "symbol": "DFFG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18zqpuua4d8u9q9d6zsn8fqtjj5k8hk845prz9v",
+    "name": "Diamond Club",
+    "symbol": "DVC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17jnhankdfl8vyzj6vejt7ag8uz0cjc9crkl2h7",
+    "name": "Digipharm",
+    "symbol": "DPH",
+    "decimals": "6",
+    "icon": "https://digipharm.io/wp-content/uploads/2021/02/digipharm_etherscan_logo.png",
+    "website": "https://digipharm.io/",
+    "telegram": "https://t.me/digipharm",
+    "twitter": "https://twitter.com/DigipharmTeam",
+    "coingecko": "https://www.coingecko.com/en/coins/digipharm"
+  },
+  {
+    "id": "udkk",
+    "name": "DKT",
+    "symbol": "DKT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/dkt",
+    "icon": "https://assets.terra.money/icon/60/DKT.png"
+  },
+  {
+    "id": "terra1akwn8y34upderjyw07hgepunte8mza00vafzfd",
+    "name": "Do Kwon",
+    "symbol": "KWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1l95pyqf2ahqy7c53pejt8v7nnlg060fghs2499",
+    "name": "Dogballoon",
+    "symbol": "DOGB",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ng9dsq2m5mw993s0uljj06scrj5g07sq36lq8t",
+    "name": "Dogballoon",
+    "symbol": "DOGB",
+    "decimals": "6",
+    "icon": "https://i.ibb.co/4fDrx1n/dogballoon.jpg",
+    "telegram": "https://t.me/realdogballoon",
+    "twitter": "https://twitter.com/DogBalloon_"
+  },
+  {
+    "id": "terra14kat7dptmcydvhn0l5ur3g3evs65n33925n7w7",
+    "name": "DogCat",
+    "symbol": "DOGCAT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18cs7aktav46v3pwxr8r2hfkl9pdfmrthcn58qf",
+    "name": "Doge Bonk",
+    "symbol": "DOBO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra182vnsj0rv9dnrc7xnccz0wajp69hu73706h2p4",
+    "name": "Doge Land",
+    "symbol": "DOGEL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1paulfn369vuz6s6ty65y56wj8gnamzpdzwk9x3",
+    "name": "Doge Zilla",
+    "symbol": "zDOGE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yss9zexptelas8y4mqans2qscmw69cy2g0tycu",
+    "name": "Doge Zilla",
+    "symbol": "DOGEZ",
+    "decimals": "6"
+  },
+  {
+    "id": "terra166ep78d3434pyufs6txfkwnm7t3ep303f3phpm",
+    "name": "DogeBalloon",
+    "symbol": "DOGEB",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hja2d2790m6hynju77t56nhmmyl0w09s5acqhc",
+    "name": "Dogecoin",
+    "symbol": "DOGE",
+    "decimals": "3"
+  },
+  {
+    "id": "terra14f7u8z4eqpxcrp4xr6knhgfp5n4h68nwy3yzg5",
+    "name": "DogeKwon Terra",
+    "symbol": "DKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16xtp5rmhx4agcas4cyg3srp6m6gauqagh02v9z",
+    "name": "DogeKwon Terra",
+    "symbol": "DKWON",
+    "decimals": "6",
+    "icon": "https://dogekwon.com/wp-content/uploads/2021/10/cropped-logo_new.png",
+    "website": "https://dogekwon.com/",
+    "telegram": "https://t.me/dogekwon_official",
+    "twitter": "https://twitter.com/dogekwon"
+  },
+  {
+    "id": "terra17zhwz3s95dwcw373eklrscvn4jr6f7sd7qpk7y",
+    "name": "DogeKwon Terra",
+    "symbol": "DKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ppuu0devppvm6d75sclj4vwh5ghwyx7grurlvx",
+    "name": "DogeKwon Terra",
+    "symbol": "DKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19j57fzwjahvf52wxffgrajd0jjm9m8akfsl0qw",
+    "name": "DogeKwon Terra -- Version 2",
+    "symbol": "nDKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra192dse96aslp5cduzvjqly4j7jaka6dlv2xx7f8",
+    "name": "DogeKwonV2",
+    "symbol": "DKWONvII",
+    "decimals": "6"
+  },
+  {
+    "id": "terra107pw6g56gfch98r3xw9gr3glcxvmmm8326rdg7",
+    "name": "Dogelon Luna t.me/dogelonluna",
+    "symbol": "ELON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hnsqjjzerf2leaufj7dt9j54nyjvhyppj7khaq",
+    "name": "Doken",
+    "symbol": "tDoken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13u7ddpvnxlephv6ltswy7c7hnq77agz5078l3y",
+    "name": "Donate",
+    "symbol": "Donate",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1nywvm8avu8medrj84x9dxdc4gfdqd2zg8gv049",
+    "name": "Donate Me Please",
+    "symbol": "DMPL",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1c2mghp27ysrmmw0na4cvvsmn5s4n27hq4hhfqd",
+    "name": "Donghwan and Kate",
+    "symbol": "DAK",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1g0rda5pawz0duymd37puescqsx2hgqu9hgrp8h",
+    "name": "DOnkey KWON",
+    "symbol": "DONK",
+    "decimals": "6"
+  },
+  {
+    "id": "terra172qlk30wwyux37m45w5c7mkypn7ks0t0s3d0ms",
+    "name": "DonkeyKwongs",
+    "symbol": "DONKEY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12gsrt6nmp56x0q9t9h47frgr8praqyaqdvpaan",
+    "name": "DONT BUY",
+    "symbol": "KEK",
+    "decimals": "1"
+  },
+  {
+    "id": "terra1uv3298xevlfdcjthfv4me7tn7gjxd3drv6ejvt",
+    "name": "Doom NFT",
+    "symbol": "DOOM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14mvkydkwm2pzz62cgrkpeusphm4trrqrzd88ju",
+    "name": "dosh",
+    "symbol": "DOSH",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra14mvkydkwm2pzz62cgrkpeusphm4trrqrzd88ju/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://dogeshib.xyz/static/media/shiba-doge.0f2ade2f.png",
+    "website": "https://dogeshib.xyz",
+    "telegram": "https://t.me/TerraDogeShib",
+    "twitter": "https://twitter.com/TerraDOSH"
+  },
+  {
+    "id": "terra1ewesd6y7dswxd8qdfff7vxl8g2p0dfwpanf5fv",
+    "name": "dosh",
+    "symbol": "DOSH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lnav098k7vd006lz7d73mychha503pmw35la7l",
+    "name": "dosh",
+    "symbol": "DOSH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y77avpcwxc49ezmex8nsupklgc0qt7le44z4qd",
+    "name": "dosh",
+    "symbol": "DOSH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v8xzfedstujqexgz6vd902hppykuu2e7ar3pu8",
+    "name": "DOT",
+    "symbol": "DOTT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1ry60wuc8a7a4ujt3tmrp3upxzf6a4awj88eys3",
+    "name": "DoWillBuy",
+    "symbol": "DWB",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wz8w0susqsraw2smttuymzkgr3p8tgkntqhcre",
+    "name": "Dragon",
+    "symbol": "DRGN",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1572yxtl5yxa9mjyzg44gj6knemudreekplelxh",
+    "name": "DRAGONAGEKEEP.COM",
+    "symbol": "DRAGON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1veke25wgg7xk34c3gxsweuxsdqajemr307e8df",
+    "name": "Dragonic Fest",
+    "symbol": "GAR",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lrdzs5tgllwqgawtq2emuzn7snpxq87fzzl44y",
+    "name": "DragonSB",
+    "symbol": "SB",
+    "decimals": "6",
+    "icon": "https://s2.coinmarketcap.com/static/img/coins/64x64/14451.png",
+    "website": "https://dragonsb.finance/",
+    "telegram": "https://t.me/dragonsb_offical",
+    "twitter": "https://twitter.com/DragonSBFinance",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/dragonsb/",
+    "coingecko": "https://www.coingecko.com/en/coins/dragonsb"
+  },
+  {
+    "id": "terra1nh6theuhf4pv67pcyqnz58czljr382mxrp2rdh",
+    "name": "DragonSB Token",
+    "symbol": "DragonSB",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1elkjjsg4vm5u4tnesqcj3dzgvhanzld48lkqv2",
+    "name": "DREAM PROTOCOL",
+    "symbol": "DREAM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10thstrfuexp5nf9rnazzs433p7zeu9yxr322r9",
+    "name": "dsh",
+    "symbol": "DSHA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra128vws7v3ruqpysj0wwy95nl8a7an7nnyctmvle",
+    "name": "dsh",
+    "symbol": "DSH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12j5fqlxaurnvxr27dfsg2lku57rnmgqs6nm6ja",
+    "name": "dsh",
+    "symbol": "DSH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1478yfcsa6ycykstdfh2mclwdy3d6zpemkyfu4j",
+    "name": "dsh",
+    "symbol": "ESH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18ykszsm06k0suqjvz0q040lm36u7pn9eeq4uc4",
+    "name": "dsh",
+    "symbol": "DSHA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra194a6jn3cyydhrfpdnz5r5zkj6wx3t3cr673z4r",
+    "name": "dsh",
+    "symbol": "DSHA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1aas795lj3dt6qrsp8n38fr39ypt43p6czgz3ra",
+    "name": "dsh",
+    "symbol": "DSH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1czqey2sj9h2w625ez5kefp6j7d5s08e7lj2yhd",
+    "name": "dsh",
+    "symbol": "GSH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e6lfxnuyqg3wxvczuz0zkmvr40ldvqx26eqk5g",
+    "name": "dsh",
+    "symbol": "FSH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1esezx70a44cqc4pjq0qt3k7k93ksuvepfksscy",
+    "name": "dsh",
+    "symbol": "DSHA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1g2dz304juraseqdqq6ufnktqgeqen67sct3p7d",
+    "name": "dsh",
+    "symbol": "DSH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hd4hgml43g4k50nlyhuntsaw8p7rvnrht0f9e0",
+    "name": "dsh",
+    "symbol": "DSH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1n3l6xg66m9t342qcvgdqk6md5cqvtatgg8tw39",
+    "name": "dsh",
+    "symbol": "DSH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nxwnngqr0ks3j842jlr6pnrmd79kztjqyycer2",
+    "name": "dsh",
+    "symbol": "DSH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jvg4ls8jz098g77t04u4hw2gg2c64w8t5g8jdz",
+    "name": "Dtest",
+    "symbol": "Dtest",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gukawnd63qd9ptuqe0ejm0vvweql45084lx4pq",
+    "name": "DUNE TERRA",
+    "symbol": "DUNE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pzjd5axw303jt40l4pmakfa88d0jpjf8rpmj8n",
+    "name": "DWONS BIG DONG",
+    "symbol": "DBD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10aey3n8rwxup6l2x68fa7fwdurxnu9hwxf0k7f",
+    "name": "DXSale Network",
+    "symbol": "SALE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1aa9kg8crxjq86ts54d4un6ku5skec9e98t6tau",
+    "name": "EarnShiba - Earn 10% Shiba Inu by holding",
+    "symbol": "EarnShiba",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1x5mhyxzmy8da89rh7dnt3v289qz988hclyl6kk",
+    "name": "EEE Token",
+    "symbol": "EEE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s8gu8mx2qcxpx9y90fxvdetpwq9mpyrapphw2u",
+    "name": "ELON BUYS TWITTER",
+    "symbol": "EBT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18we4g8y6u55x7atttzu5xgx46zzss0tpmktf9s",
+    "name": "ELON KWON",
+    "symbol": "EKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cvdaetw5ljrtkxax8z0pgpdyhhhln3saxl8xsg",
+    "name": "Elon Tweets on Terra",
+    "symbol": "tELONTWEETS",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1lxpjyl6k60rsyp0x7fa40s8jsl5l0d27ycmwfh",
+    "name": "ElonShiP",
+    "symbol": "ESP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1re7as700g3gels30zak6ctnjtsjhhc6vjr93ms",
+    "name": "ElonsTerraDoge",
+    "symbol": "ETDOGE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13l9e6lelggxjzm7dxhgkfgqwutwr67y5qvc7mr",
+    "name": "ElonTest",
+    "symbol": "ELONT",
+    "decimals": "8"
+  },
+  {
+    "id": "terra19pz3ehx9f2thr9t9jk5y89aalxmhzuq9j8ak99",
+    "name": "Enter The Matrix",
+    "symbol": "MATRIX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm",
+    "name": "Eris Amplified LUNC",
+    "symbol": "ampLUNC",
+    "decimals": "6",
+    "icon": "https://www.erisprotocol.com/assets/ampLunc100.png"
+  },
+  {
+    "id": "terra1h0jk42weh0urhgdtjql93rrvgdccspnp7vyf49",
+    "name": "ESS Token",
+    "symbol": "ESS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
+    "name": "Ether",
+    "symbol": "mETH",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/ETH.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "ueur",
+    "name": "EUT",
+    "symbol": "EUT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/eut",
+    "icon": "https://assets.terra.money/icon/60/EUT.png"
+  },
+  {
+    "id": "terra1aaqzva7adgwtzfkt9nmrmuvkg9s6lmsgtkg3jd",
+    "name": "EXP",
+    "symbol": "EXPEDITION",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mqsjugsugfprn3cvgxsrr8akkvdxv2pzc74us7",
+    "name": "Facebook Inc.",
+    "symbol": "mFB",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1mqsjugsugfprn3cvgxsrr8akkvdxv2pzc74us7/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/FB.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra17nekftv2yp8n4lsex85008sphchs4t3rnfcqzf",
+    "name": "FFER Token",
+    "symbol": "FFER",
+    "decimals": "6"
+  },
+  {
+    "id": "terra105hjuy8z0j0w4m0frlaynrnu8smk8qrsk36mas",
+    "name": "FINISH",
+    "symbol": "FINAAAZ",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12k6ua9et2dnpmmq2rgz0wn0ugzr9jtyps5l8vt",
+    "name": "FINISH",
+    "symbol": "FINA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra145nmjpjhergp4uw02hp079phtnedslmxv4v3n5",
+    "name": "FINISH",
+    "symbol": "FINA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra187zprsu04wnfs64pznf69mkls6vefhtmtwt8w6",
+    "name": "FINISH",
+    "symbol": "FIN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19ztfg6l5k22cw8xg2h0uncpg3kwpv84ft9h6t0",
+    "name": "FINISH",
+    "symbol": "FINA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1edualxuj7afpm27uxvv38zr4e0zf4r4z6twfyf",
+    "name": "FINISH",
+    "symbol": "FIN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1efu7hut9pywcgwj74klay9mlzswp542s6fa0zq",
+    "name": "FINISH",
+    "symbol": "FINA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gs2pykgl27l04e6lprgqs6uwlr7rm2vjcnya8g",
+    "name": "FINISH",
+    "symbol": "FIN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hpz206wxjhta4x83ukmk4v9rvk9dky2h0texf3",
+    "name": "FINISH",
+    "symbol": "FINA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lrqv79tw447kk4ham08suw7vak3a7pf9de2qx0",
+    "name": "FINISH",
+    "symbol": "FIN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mqug8fps3zqsywzrukz5m6shcnj4j4rqna3kzf",
+    "name": "FINISH",
+    "symbol": "FINA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1p0yttugxt3h2zvs9cghysmss3um6dp0mzt9vwd",
+    "name": "FINISH",
+    "symbol": "FIN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pkfzenexjj6ne68xv2g9t8387s7d6z39c60ghr",
+    "name": "FINISH",
+    "symbol": "FINA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pmmdfnmhrjnywsgkd6xplgp8nx03fxm6ygma09",
+    "name": "FINISH",
+    "symbol": "FINA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qup6c3w83xjrfdtzujqkh5j8pcar96up8f0pdy",
+    "name": "FINISH",
+    "symbol": "FINA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rkn2d2yc0946a0gx0w0hwf3l2j32ve39egsjkd",
+    "name": "FINISH",
+    "symbol": "FINA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s44vplvv5fphrrv4g68gx46xwrmvnqm9e0hazl",
+    "name": "FINISH",
+    "symbol": "FIN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1u2tj2wy6gc8gw9g507a66796ej2csewp9asznk",
+    "name": "FINISH",
+    "symbol": "FINA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1udknntc8sjm4ntxezhlqe6p9atct00r296aw95",
+    "name": "FINISH",
+    "symbol": "FINA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1w5pzereyvecexd9hsmlsakgnpjnlw56fgrha4s",
+    "name": "FINISH",
+    "symbol": "FINA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ygrhf4zv86jp7hnyl358uj42llm75gt7w8e9s4",
+    "name": "FINISH",
+    "symbol": "FINA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yj7vlx4uj39u8x4ptvvpxhpfnmphypmlhfhq42",
+    "name": "FINISH",
+    "symbol": "FIN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rumme3vcguv9ly60p53j6wg5qanacfa9nl5uyw",
+    "name": "Fintech Coin",
+    "symbol": "tAFIN",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1extnklxgx3sylp25zplvxsfarmvh3r4k6grskj",
+    "name": "Floki10000",
+    "symbol": "Flok",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14g3uqp52dwk9qts40mr2skynkqdxsqwlv0862z",
+    "name": "FlokiVerse",
+    "symbol": "FlokiV",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1r2p90ur2zy8javfhnf7ejdvzac60ax3wcvkvxz",
+    "name": "FlokiVerse",
+    "symbol": "FlokiV",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ldrmvk4n0le7tdaxj7r8gk5kny95r6mxw3ask7",
+    "name": "FLOKIZAP.FINANCE",
+    "symbol": "FLOKIZ",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15wwvprh6gddrc7yvshghc2g944ufsq79ay94da",
+    "name": "Flux",
+    "symbol": "TFX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra157n30a667ethsknneaavga2txtze58eajyfv45",
+    "name": "FOC Token",
+    "symbol": "FOC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10c4zqj4f7ze4keuwvm6hk2wrdj9p8h07sp4fg5",
+    "name": "ForFun",
+    "symbol": "FFUN",
+    "decimals": "3"
+  },
+  {
+    "id": "terra17ckx25kqhwzf3fudprs78kqgp3lhpr2w74yf7t",
+    "name": "FOX Token",
+    "symbol": "FOX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m2ar36pnymh6h4n0p7l2w4uxswc70e9auyvxh6",
+    "name": "FROM EARTH TO THE MOON",
+    "symbol": "FETM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1j9zvn74s7v2kylvv2xcg4p0s69pvejrw5qzv7j",
+    "name": "FUCK DKWONvII",
+    "symbol": "FDKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lgx3e9f6fhqda47zdyntfs07rdm5arp745mec7",
+    "name": "FUD TOKEN - DONT BUY",
+    "symbol": "FUD",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1cdc6nlsx0l6jmt3nnx7gxjggf902wge3n2z76k",
+    "name": "FURY",
+    "symbol": "FURY",
+    "decimals": "6",
+    "icon": "https://crytpo11.s3.eu-central-1.amazonaws.com/FANFURY_logo.png"
+  },
+  {
+    "id": "terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls",
+    "name": "Galaxy Digital Holdings Ltd",
+    "symbol": "mGLXY",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/GLXY.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1hytrupk3argcrsl5x7dv55gyda0tn7f2qqlwkl",
+    "name": "Game G",
+    "symbol": "GGGG",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1wlwkuyv9g7d320dm5cqg6wsygplmt8tjjglc6w",
+    "name": "GameChanger",
+    "symbol": "GAME",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1m6j6j9gw728n82k78s0j9kq8l5p6ne0xcc820p",
+    "name": "GameStop Corp",
+    "symbol": "mGME",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1m6j6j9gw728n82k78s0j9kq8l5p6ne0xcc820p/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/GME.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "ugbp",
+    "name": "GBT",
+    "symbol": "GBT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/gbt",
+    "icon": "https://assets.terra.money/icon/60/GBT.png"
+  },
+  {
+    "id": "terra1k5hx3egz7jnzqs7n2ze0d93mce80y4cndd5saj",
+    "name": "GGG",
+    "symbol": "GGG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra133j6tpq7gcrjjgvgj4r3fjwda0hegmmrazmwt0",
+    "name": "GigaChadToken",
+    "symbol": "GCT",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1cp02hkhu2nq7zznz04shwfvh9hdsp3y5334n6t",
+    "name": "Giza",
+    "symbol": "Giza",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1g5unnjllx9900hjsx6x3zhhv504ssqktdc82l5",
+    "name": "GLL",
+    "symbol": "GLL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y3d5qexmyac0fg53pfglh2pjk0664ymfvcq9mc",
+    "name": "Global Transaction Payment Solu",
+    "symbol": "whGTPS",
+    "decimals": "8",
+    "icon": "https://img1.wsimg.com/blobby/go/f561f953-0bdd-48bf-a39b-982ecbd1698b/downloads/32x32coinlogo.png?ver=1640952410118"
+  },
+  {
+    "id": "terra15zvyhmv6gwddht7kt4q6w5nasn4tcpgzcdfmgr",
+    "name": "Global Transaction Payment Solut",
+    "symbol": "GTPS",
+    "decimals": "18",
+    "icon": "https://img1.wsimg.com/blobby/go/f561f953-0bdd-48bf-a39b-982ecbd1698b/downloads/225x225GTPS.png?ver=1649021019248"
+  },
+  {
+    "id": "terra13zx49nk8wjavedjzu8xkk95r3t0ta43c9ptul7",
+    "name": "Glow Token",
+    "symbol": "GLOW",
+    "decimals": "6",
+    "circ_supply_api": "https://glowyield.com/api/supply",
+    "icon": "https://glowyield.com/assets/img/icons/glow.png",
+    "website": "https://glowyield.com/",
+    "twitter": "https://twitter.com/glowyield"
+  },
+  {
+    "id": "terra1ruz2e26humerfnd9uhurc9766a4at8x8e3m2e4",
+    "name": "Glow Token",
+    "symbol": "GLOW",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ktrxxylv7796wsd8rm7u0dftqhrjfs75r72wnn",
+    "name": "GLZA",
+    "symbol": "GLZA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1247nlrmskhfu9qpg66zt5w6f8cw250878enl9g",
+    "name": "GMGN",
+    "symbol": "GMGN",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1jzvh42e8auxk63dg5vdp4lh0fct8vw8pn2s34d",
+    "name": "Go to SUN",
+    "symbol": "SUM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q59h4hyxvfpu2hp3v39r8rpl4wykqe7axrc9rr",
+    "name": "Goat Token",
+    "symbol": "GOAT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hw6q5ecr0gp09v668szzx3qz86w08jru9rqyq7",
+    "name": "GOD",
+    "symbol": "JESUS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lkszqh6duver9s9h0qfr2dcktj605km3hzfzjd",
+    "name": "GOD",
+    "symbol": "GOD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12jhul3zlafuvl4fd54pvaax4ls872z8p06p8qv",
+    "name": "GODS",
+    "symbol": "GODS",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1gwr8mq2ljqzwmufgm55yu58339k55wja9529sg",
+    "name": "GODSq",
+    "symbol": "GODSq",
+    "decimals": "3"
+  },
+  {
+    "id": "terra137drsu8gce5thf6jr5mxlfghw36rpljt3zj73v",
+    "name": "Goldman Sachs Group Inc.",
+    "symbol": "mGS",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra137drsu8gce5thf6jr5mxlfghw36rpljt3zj73v/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/GS.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1d633fx8wlpgqnns9j4xw66cq6ypdy4u8r0rr7j",
+    "name": "GOOD COFFEE",
+    "symbol": "COFFEE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1sf5tt6p6wnlhm0jqlflan8lw7pmv3f82sffsja",
+    "name": "Good Mood",
+    "symbol": "MOOD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hqgzrrtsft73pjnlf7w946u3m70a99cxjjm879",
+    "name": "Google",
+    "symbol": "mGOOGL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xs3pv5rd2xu36w9vg05shkgxcrxkvz40fhnfsv",
+    "name": "GRAY",
+    "symbol": "GRY",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1gmpn6gy7tdm39tc97te2f5prjdpgml760pke8k",
+    "name": "GRAY Token",
+    "symbol": "GRYT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19m0xqgdaltwkesdt6m383jkqh3m9xyxwtp0f6f",
+    "name": "Green Dragon",
+    "symbol": "GRDR",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1tc7tcg8u54p3t2r5yfufgf4z340ggwpvlc2rwt",
+    "name": "GRY token",
+    "symbol": "GRT",
+    "decimals": "1"
+  },
+  {
+    "id": "terra15pkdjxv2ewjzn9x665y26pfz2h6ymak4d4e8se",
+    "name": "Gtps.Finance",
+    "symbol": "GFI",
+    "decimals": "18",
+    "icon": "https://img1.wsimg.com/blobby/go/f561f953-0bdd-48bf-a39b-982ecbd1698b/downloads/GtpsFinance225x225.png?ver=1649021019248"
+  },
+  {
+    "id": "terra1z55rhw0ut70jxdmpvge98mvj0rkwcz74q77z0u",
+    "name": "Guides Token",
+    "symbol": "GUIDES",
+    "decimals": "6",
+    "icon": "https://cdn.fs.guides.co/HBAKzovT2ulOa54snzDg"
+  },
+  {
+    "id": "terra18tc5vrxzvxwlcchq83d4nxy635cu87v8g0030y",
+    "name": "GUILDONG",
+    "symbol": "HONG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lnucwh7feutx0y8dgh3lu759a6netxx4wjzm4w",
+    "name": "GUILDONG",
+    "symbol": "HONGA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v8wg6yr69cu842w053f8qk909f4swp4cn2waqp",
+    "name": "GUILDONG",
+    "symbol": "HONGB",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ra0ljqpyt59k7z4xrx93ef5jvpy67f56lhudf9",
+    "name": "Halborn Security Protocol",
+    "symbol": "Halborn",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y8w753jk2x2j6f7a9ea30xc2qk5esharn89sk2",
+    "name": "Hands of Terra",
+    "symbol": "HOT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zppj8uz7w6xz3ktg6nj2r4ntzzypgpcy07t5qa",
+    "name": "HAPPYJOY",
+    "symbol": "JOY",
+    "decimals": "4"
+  },
+  {
+    "id": "terra1037zmxv6f73e5mlq6hsyadlev0fj4q462llw3d",
+    "name": "Hehe",
+    "symbol": "HEHE",
+    "decimals": "3"
+  },
+  {
+    "id": "terra17yjdhu7pk865t0jeswtpecukg0uw8xelzvfmdq",
+    "name": "hello",
+    "symbol": "HELLO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10ypru3yma98ukk3anr5cjv02yq839pcvqc476k",
+    "name": "Help Ukraine",
+    "symbol": "HELP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10en35kwlud79z2nljssvhp85ep5kx9k0ezzz8s",
+    "name": "Hey Jude",
+    "symbol": "HEY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kafnpwanfluj6ne5t8ayg8ykarx060a50l72sw",
+    "name": "HiJoy",
+    "symbol": "HiJoy",
+    "decimals": "6"
+  },
+  {
+    "id": "uhkd",
+    "name": "HKT",
+    "symbol": "HKT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/hkt",
+    "icon": "https://assets.terra.money/icon/60/HKT.png"
+  },
+  {
+    "id": "terra1779kwh0aux9mesns3l7laxtu7njjpzqd7k7m3r",
+    "name": "HOBC Token",
+    "symbol": "HOBC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kggysvv0q3tq2r58f5nt03hqa8pqj87c2m8k09",
+    "name": "HOBDE Token",
+    "symbol": "HOBDE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wfau60yqgdtrqay0cdtcp5rre3l50khacyyhhz",
+    "name": "HOHO",
+    "symbol": "HOHO",
+    "decimals": "3"
+  },
+  {
+    "id": "terra16hwgds2089kktskluq8dh5ntw7eu5e4q4z6ud4",
+    "name": "howtest",
+    "symbol": "howtest",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nccuq0ujp4hc84kjmfwjc3002z2q7xzmdu6crm",
+    "name": "ICPTerra",
+    "symbol": "ICPT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1n2rujfc5lscglry30zaptfgncfc0gq4n8my0gv",
+    "name": "ID TOKEN ONE",
+    "symbol": "ITO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zjhsuvuy5z7ucvx56facefmlrrgluhun27chlf",
+    "name": "ILT",
+    "symbol": "ILT",
+    "decimals": "6",
+    "icon": "https://c2x.world/c2x-station/icon/ILT.png"
+  },
+  {
+    "id": "terra14s8p2wnvh5vpxn4fgu562m2sm9780pk5gvkf9a",
+    "name": "ILT Fancard Token",
+    "symbol": "ILTfancard",
+    "decimals": "0",
+    "icon": "https://c2x.world/c2x-station/icon/ILTfancard.png"
+  },
+  {
+    "id": "terra1elt5czsf7sntku3qafxf7xrjxdx309kkkmc8up",
+    "name": "Infinity Network",
+    "symbol": "INK",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1gdze0yyar2y6vs3un79my828cery0jea8mzn07",
+    "name": "Infinity Vault Network",
+    "symbol": "IVN",
+    "decimals": "3"
+  },
+  {
+    "id": "terra153qrdszuq65avs9flpeve43e46ypvt4clj6p4p",
+    "name": "INGI_t",
+    "symbol": "INGT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vnkmt0cwd5k870ny0e2crt2yrkmj0cfd3sylvc",
+    "name": "INGI_TEST",
+    "symbol": "ING",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ghtspakevqnazc3jtceag7uc3tnjujs94edlkf",
+    "name": "Inha Seo Token",
+    "symbol": "INHA",
+    "decimals": "6"
+  },
+  {
+    "id": "uinr",
+    "name": "INT",
+    "symbol": "INT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/int",
+    "icon": "https://assets.terra.money/icon/60/INT.png"
+  },
+  {
+    "id": "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf",
+    "name": "INTERCHAIN DAO COIN",
+    "symbol": "IDC",
+    "decimals": "6",
+    "icon": "https://gateway.pinata.cloud/ipfs/Qmd3ussNvHvHhLSqZcZfkT7p6irQ6a2fNSW8jsRPi6uiro"
+  },
+  {
+    "id": "terra1csk6tc7pdmpr782w527hwhez6gfv632tyf72cp",
+    "name": "Invesco QQQ Trust",
+    "symbol": "mQQQ",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1csk6tc7pdmpr782w527hwhez6gfv632tyf72cp/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/QQQ.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1enj2np0785hw3vt2gn2yga9y75306g6e9lq799",
+    "name": "Invesco QQQ Trust",
+    "symbol": "mQQQ",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10h7ry7apm55h4ez502dqdv9gr53juu85nkd4aq",
+    "name": "iShares Gold Trust",
+    "symbol": "mIAU",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra10h7ry7apm55h4ez502dqdv9gr53juu85nkd4aq/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/IAU.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra12lvpnlphqh3q0cxp8y47e5km8k2ad5ydw5asu4",
+    "name": "iShares Gold Trust",
+    "symbol": "mIAU",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15hp9pr8y4qsvqvxf3m4xeptlk7l8h60634gqec",
+    "name": "iShares Gold Trust (Delisted)",
+    "symbol": "mIAU",
+    "decimals": "6",
+    "icon": "https://whitelist.mirror.finance/icon/IAU.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1kscs6uhrqwy6rx5kuw5lwpuqvm3t6j2d6uf2lp",
+    "name": "iShares Silver Trust",
+    "symbol": "mSLV",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1kscs6uhrqwy6rx5kuw5lwpuqvm3t6j2d6uf2lp/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/SLV.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1td527f09l7lgf55fqtr0zvtx5ek0yl0fdrx574",
+    "name": "iShares Silver Trust",
+    "symbol": "mSLV",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zva2uegkvwr03p98mdaam4dtrkfxxvu330zwaq",
+    "name": "James Ryu Token",
+    "symbol": "JRT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10xp0alk5jh0sksynx7vt9jkelgdxdfzs4979tk",
+    "name": "JEFE TOKEN",
+    "symbol": "JEFE",
+    "decimals": "8",
+    "icon": "https://s2.coinmarketcap.com/static/img/coins/64x64/16800.png"
+  },
+  {
+    "id": "terra19k974ngjsml8dtmk56cdhuy6pplr94rxqdt95p",
+    "name": "jenny_coin_1900",
+    "symbol": "asymbol",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1cxaky6tfw4j0xqx8ezxw60cukmkewpx70kr9du",
+    "name": "jennycoin2",
+    "symbol": "jennycoin",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ewvul5j47zpsr6dtyt0fup6q3tquqq3cvxpjhp",
+    "name": "jennycoin3",
+    "symbol": "jennnycoin",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1g7fa8wpfp56tzdd5mgz5r5jsvqw7hm5e3tdlnq",
+    "name": "Jloxchain Future",
+    "symbol": "Jlox",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1fyxs23jdlj5qgfp4hv2qqv4d3csmvqxsva573m",
+    "name": "jndscjv",
+    "symbol": "jndscjv",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1ptdxmj3xmmljzx02nr4auwfuelmj0cnkh8egs2",
+    "name": "Johnson & Johnson",
+    "symbol": "mJNJ",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1ptdxmj3xmmljzx02nr4auwfuelmj0cnkh8egs2/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/JNJ.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1t5y4xm7xdc7csud2j2aezxs6e4uuj3lqpqk7jy",
+    "name": "Joseph @ GT",
+    "symbol": "JGT",
+    "decimals": "3"
+  },
+  {
+    "id": "ujpy",
+    "name": "JPT",
+    "symbol": "JPT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/jpt",
+    "icon": "https://assets.terra.money/icon/60/JPT.png"
+  },
+  {
+    "id": "terra1sa0klf6nt77z3afqlx7nq30xrvr7hsfz5jsqmd",
+    "name": "Jupiter Swap",
+    "symbol": "JPTS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mkw8x32086w0emr0wkprrns9j0c82nnxusn7dw",
+    "name": "JureToken",
+    "symbol": "JURE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dkhqqfc4gkrcs35xjndvea7fl3mur0uptzmaxr",
+    "name": "justatest",
+    "symbol": "justatest",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1l6nqyv78m3kj8v4wa7r5fr3vhp0qzrauwkx5av",
+    "name": "Juta Club Token",
+    "symbol": "JUTA",
+    "decimals": "2",
+    "icon": "https://raw.githubusercontent.com/terraswap/terraswap-web-app/main/public/images/CW20/JUTA.png",
+    "website": "https://juta.club/",
+    "twitter": "https://twitter.com/JutaClub"
+  },
+  {
+    "id": "terra1kujvztl5p8a45k56u42fq39jxldxcvuejtpfq5",
+    "name": "KAB Token",
+    "symbol": "KAB",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1atagmw0ssv6wlgmrjjdaa22p7h4wmsy33eljgw",
+    "name": "Kaizen Finance",
+    "symbol": "KAIZEN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tmar57largkrtts55q8szey2q78zc9em43ej5n",
+    "name": "Kaizen Finance",
+    "symbol": "KAIZEN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1a8an0aqzjghcukqrdgnkt3ygzhmaaqza03mc3h",
+    "name": "Kernel Token",
+    "symbol": "KVT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17efcrd3glln324tqke56w5wgnfkfn5emz4um8j",
+    "name": "Kiba Inu",
+    "symbol": "KIBA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1a59ns8fnk04sj982ymkvx9ygscmf4jjtm4sltg",
+    "name": "KIMCHI COIN",
+    "symbol": "KIMCHI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yeyr6taynkwdl85ppaggr3zr8txhf66cny2ang",
+    "name": "Kinetic Token",
+    "symbol": "KNTC",
+    "decimals": "6",
+    "icon": "https://app.astroport.fi/tokens/kinetic.svg",
+    "website": "https://kinetic.money/",
+    "telegram": "https://t.me/kinetic_money",
+    "twitter": "https://twitter.com/kinetic_money"
+  },
+  {
+    "id": "terra18glhvftntrqg00hv96qkpx3r37g34qh8qytnps",
+    "name": "Kinetic.Money",
+    "symbol": "KINETIC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19mcqz609t5vcudfatwexuhta0mrs49fu9dqj2s",
+    "name": "Kingsman DAO",
+    "symbol": "KINGS",
+    "decimals": "6",
+    "circ_supply_api": "https://polar-inlet-12758.herokuapp.com/",
+    "icon": "https://kingsmandao.com/wp-content/uploads/2021/10/kingsman-logo-transparent_1@0.5x.png",
+    "website": "https://kingsmandao.com/",
+    "telegram": "https://t.me/kingsmandao",
+    "twitter": "https://twitter.com/kingsmandao"
+  },
+  {
+    "id": "terra1c5fr3wdf2trj3dkxcckhmzzxlnnpepqn8cu8f8",
+    "name": "Kishu Inu Need 🌗💵 ",
+    "symbol": "KINU",
+    "decimals": "3"
+  },
+  {
+    "id": "terra170r0wm50x5eh47zkvlrjkxhajp4g7wrmgsz523",
+    "name": "Kishu Inu Need to swap from PEPE ufxd 🌗💵 ",
+    "symbol": "KINU",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1545laqy9s6jcej2pgts32rhqy6dzq62umk8g9q",
+    "name": "Koko token",
+    "symbol": "KOKI",
+    "decimals": "6"
+  },
+  {
+    "id": "ukrw",
+    "name": "KRT",
+    "symbol": "KRT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/krt",
+    "icon": "https://assets.terra.money/icon/60/KRT.png"
+  },
+  {
+    "id": "terra1l670q2m9j3npltmsqe428mwu0msw336m8jtq00",
+    "name": "KRX",
+    "symbol": "KRX",
+    "decimals": "6",
+    "icon": "https://c2x.world/c2x-station/icon/KRX.png"
+  },
+  {
+    "id": "terra1f5m40hs40sa9nuku776swjljsa2t39h58uhlw3",
+    "name": "KRX Fancard Token",
+    "symbol": "KRXfancard",
+    "decimals": "0",
+    "icon": "https://c2x.world/c2x-station/icon/KRXfancard.png"
+  },
+  {
+    "id": "terra1qrq5r95txaregxpa2c7mhf549u5jkm28rzmvt5",
+    "name": "KURT",
+    "symbol": "KURT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1kqsgl8p84szmmv0npvsv0u5qlq5fng3zk8c4w0",
+    "name": "Kwon Bots",
+    "symbol": "Kbots",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1v6p9v6dqaql0600hmdl78h592ax5rxmheefgd2",
+    "name": "KwonSays OnlyUp",
+    "symbol": "OnlyUp",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ffute26m0e5uq3wmzys3452dge62m99u0xz30u",
+    "name": "KwonVault",
+    "symbol": "KwonVault",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14zeffuryjlzw566k7cfrnzf9dy94qeat2xvcda",
+    "name": "L Test",
+    "symbol": "TLU",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1thhm2u93m2stytzynhsxh5h3jrtg540x4punqy",
+    "name": "LCT Fancard Token",
+    "symbol": "LCTfancard",
+    "decimals": "0",
+    "icon": "https://c2x.world/c2x-station/icon/LCTfancard.png"
+  },
+  {
+    "id": "terra1srp2u95kxps35nvan88gn96nfqhukqya2d0ffc",
+    "name": "LCT Token",
+    "symbol": "LCT",
+    "decimals": "6",
+    "icon": "https://c2x.world/c2x-station/icon/LCT.png"
+  },
+  {
+    "id": "terra1hwcnalcf35p48lvj3wt7tztkzh5szmpnxwyvdc",
+    "name": "Learning Test Token",
+    "symbol": "LTT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qq4lemqmahjfhl68kpzx0kheuuvfyeu4ncnkaq",
+    "name": "Learning Test Token",
+    "symbol": "LTT",
+    "decimals": "1"
+  },
+  {
+    "id": "terra1qw6sp3rjar2x7mfa0x4uj90ssemwap8p50f8kh",
+    "name": "Learning Test Token",
+    "symbol": "LTT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xzk97nrq0ma7dzgy6aj5tm04sg92q720lq2yum",
+    "name": "Lebanese Token",
+    "symbol": "LBT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wdc6xjyng08qwssthzvd5u8a4z58r8jxxn3j5t",
+    "name": "Levi Token",
+    "symbol": "LVT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1u5szg038ur9kzuular3cae8hq6q5rk5u27tuvz",
+    "name": "Lido Bonded ETH (Wormhole)",
+    "symbol": "whbETH",
+    "decimals": "8",
+    "icon": "https://static.lido.fi/bETH_Wormhole/bETH_Wormhole.svg"
+  },
+  {
+    "id": "terra1c3xd5s2j3ejx2d94tvcjfkrdeu6rmz48ghzznj",
+    "name": "Lido bonded SOL (Portal)",
+    "symbol": "wsbSOL",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/ChorusOne/token-list/main/assets/mainnet/EbMg3VYAE9Krhndw7FuogpHNcEPkXVhtXr7mGisdeaur/logo.svg"
+  },
+  {
+    "id": "terra1jxypgnfa07j6w92wazzyskhreq2ey2a5crgt6z",
+    "name": "Lido DAO Token (Wormhole)",
+    "symbol": "whLDO",
+    "decimals": "8",
+    "icon": "https://static.lido.fi/LDO/LDO.png"
+  },
+  {
+    "id": "terra1w7ywr6waxtjuvn5svk5wqydqpjj0q9ps7qct4d",
+    "name": "Lido Staked Ether (Portal)",
+    "symbol": "stETH",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/stETH_wh.png"
+  },
+  {
+    "id": "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
+    "name": "Lido Staked Luna",
+    "symbol": "stLUNA",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://static.lido.fi/stLUNA/stLUNA.png"
+  },
+  {
+    "id": "terra1pmcr4gjjsu62t2d9e33q6d75sydrhnpt37nayz",
+    "name": "Lime IMe",
+    "symbol": "Lime",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1m9fuqymdz03umd88guyc79083hd7vppzu74vck",
+    "name": "Little Terra",
+    "symbol": "LTT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1p0w9hh9aea5mg26mjnx7tl695ldwxfksvw4yn4",
+    "name": "LLA Token",
+    "symbol": "LLA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vchw83qt25j89zqwdpmdzj722sqxthnckqzxxp",
+    "name": "Local Terra Token",
+    "symbol": "LOCAL",
+    "decimals": "6",
+    "icon": "https://localterra.money/local-logo-dark.png",
+    "website": "https://localmoney.io/",
+    "twitter": "https://twitter.com/TeamLocalMoney"
+  },
+  {
+    "id": "terra14s3g6jmytjjg2jcxmmaj6k837vcr6h98muxc07",
+    "name": "Locker Test",
+    "symbol": "LOCK",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
+    "name": "Loop Finance",
+    "symbol": "LOOP",
+    "decimals": "6",
+    "circ_supply_api": "https://loop-api.loop.markets/v1/contracts/circulating-supply",
+    "icon": "https://loop.markets/token/logo2.png",
+    "website": "https://dex.loop.markets/",
+    "telegram": "https://t.me/loopfinance",
+    "twitter": "https://twitter.com/loop_finance"
+  },
+  {
+    "id": "terra1ew3yvrg0ejpgvswyw70gcqqp3g2j45d24se5xq",
+    "name": "LOOP Token",
+    "symbol": "LOOP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jx4lmmke2srcvpjeereetc9hgegp4g5j0p9r2q",
+    "name": "LOOPR Token",
+    "symbol": "LOOPR",
+    "decimals": "6",
+    "icon": "https://loop.markets/token/logo3.png",
+    "website": "https://dex.loop.markets/",
+    "telegram": "https://t.me/loopfinance",
+    "twitter": "https://twitter.com/loop_finance"
+  },
+  {
+    "id": "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr",
+    "name": "LoTerra",
+    "symbol": "LOTA",
+    "decimals": "6",
+    "icon": "https://loterra.io/LOTA.png",
+    "website": "https://loterra.io/",
+    "telegram": "https://t.me/LoTerra",
+    "twitter": "https://twitter.com/LoTerra_LOTA"
+  },
+  {
+    "id": "terra182740uw8nh6tk3yjfcf7gu5phg3kqryhtuxp0p",
+    "name": "LOVEKKU",
+    "symbol": "KKU",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13zl9thu8cgpkvpsx8r652hvgw4p2v42sahz6t8",
+    "name": "Luart NFT",
+    "symbol": "LNFT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12flsr4mk5sxmu8yk7m8zc5f44tfx00yjvzj7v4",
+    "name": "Luart Token",
+    "symbol": "LUART",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vjgnhlv9h0nlta2v7s5hts75h2mc065c6ap3j5",
+    "name": "Luart Token",
+    "symbol": "LUART",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12qgpr0fw773gc8lrkys3knnw6nkgdlc8ggaty9",
+    "name": "LUART token",
+    "symbol": "LUART",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17e6sxcxxxp6j2xf6rzhcwnafk6sggrrl5wdvw3",
+    "name": "LUART token",
+    "symbol": "LUART",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1unewn6sa7hg3z0pvhrc9u9rmph7z975h4nrfvq",
+    "name": "LUART token",
+    "symbol": "LUART",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ckvmptla24qm80yrwkxluhptee4y8h3gemwkw7",
+    "name": "LUART Token",
+    "symbol": "LUART",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cu7zc3q8089cuu4z5ed5nl4c9w59qqhs2mmfyy",
+    "name": "LUART Token",
+    "symbol": "LUART",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jwjweh50vrd2gg55y8cr50e32jwwc0vuhvdymh",
+    "name": "LUART Token",
+    "symbol": "LUART",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lesh2dshyf8a7wfm9fkxfrxjxc6yuyqnvspuvw",
+    "name": "LUART Token",
+    "symbol": "LUART",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vwz7t30q76s7xx6qgtxdqnu6vpr3ak3vw62ygk",
+    "name": "LUART Token",
+    "symbol": "LUART",
+    "decimals": "6",
+    "circ_supply_api": "https://api.luart.io/luart-token/circulating-supply",
+    "icon": "https://staking.luart.io/token-white.svg",
+    "website": "https://luart.io/",
+    "telegram": "https://t.me/luart_io",
+    "twitter": "https://twitter.com/luart_io"
+  },
+  {
+    "id": "terra1z454qecteghkd8m3shgd48cdc7j7vtnsgxh4z7",
+    "name": "LUART Token",
+    "symbol": "LUART",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1my0tlq45u0vlpyt2n4qchxkzhzwnxrd2playfq",
+    "name": "LUART TOKEN",
+    "symbol": "LUART",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1n6eltvex47mta0me66ygqw0fgvjx2ul7qm9fjp",
+    "name": "Luart.io token",
+    "symbol": "LUA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rwph273axfefh8gh57scw3jfm7kn4s7t5hlu03",
+    "name": "Luart.io token",
+    "symbol": "LUA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f3nc4md37vcy9l89qte2p5tej42pr8rzch8mfe",
+    "name": "LUNA",
+    "symbol": "tLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12a39fn0k0duteqefme6zgr5efg0g5ya7eglvyu",
+    "name": "LUNA 100 Dollars December 2021",
+    "symbol": "LUNAMOON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ptmrg9j7tcjphzejzlygehaxwtzrr6ywsu72qq",
+    "name": "LUNA 2.0",
+    "symbol": "tLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tm2jhnfh6hmnpvzsyfteqhcn6h5uw2qafr48yh",
+    "name": "Luna Bullish",
+    "symbol": "BULL",
+    "decimals": "6"
+  },
+  {
+    "id": "uluna",
+    "name": "Luna Classic",
+    "symbol": "LUNC",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/luna",
+    "icon": "https://assets.terra.money/icon/svg/LUNC.svg",
+    "website": "https://www.terra.money/",
+    "telegram": "https://t.me/TerraLunaChat",
+    "twitter": "https://twitter.com/terra_money",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-luna/",
+    "coingecko": "https://www.coingecko.com/en/coins/terra-luna"
+  },
+  {
+    "id": "terra1ex5age9gqd5em86wg8hu0ak5wrqez9yufvlrat",
+    "name": "Luna Classic Token",
+    "symbol": "LCL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1r5c53q49wu2vqerecdvua2zpvy9k8vlw7cnx25",
+    "name": "Luna Game Guild",
+    "symbol": "LGGD",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1zpz6dfn24cnykwausjt7qwfdqf87kny0trn94k",
+    "name": "Luna to the Moon",
+    "symbol": "MOON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16z32tp6cqx2f7lpr8t4scv8hj9zlljagprxfh7",
+    "name": "luna-pad.com",
+    "symbol": "LUNAPAD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1j4kt7mns290trwlwyxrun5n7nlfkxxcak57ck2",
+    "name": "LunaApe",
+    "symbol": "APE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zf00lfqwe6ackx0lcl5ys6lzmdhmvmn6sz2rh8",
+    "name": "LunaApe2",
+    "symbol": "APE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e3s670y5lns7vlq3gxdcn9rv8mdpydhd89jdwz",
+    "name": "LunaKwon Terra",
+    "symbol": "LKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1g0pm8xm5c2dq4qtv8j9a80hg4mhe5ndy8qad07",
+    "name": "Lunart",
+    "symbol": "ARTS",
+    "decimals": "6",
+    "icon": "https://i.ibb.co/K9Q53VQ/lunart.png",
+    "website": "https://www.lunart.io/",
+    "telegram": "https://t.me/LunArtProtocol",
+    "twitter": "https://twitter.com/LunArt_NFT"
+  },
+  {
+    "id": "terra1fj06x3hq2xum56htlrdeame70knzl765cq4txr",
+    "name": "LunaticDoge",
+    "symbol": "LDoge",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1h4wq9krj88hcl0m2e2kxfn3gznga30g5rrm4qa",
+    "name": "LunatiCoin",
+    "symbol": "LNTC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rck0zefy4juahqjjk5q0wz2ykp7028hjwvzcaj",
+    "name": "Lunatics (Wormhole)",
+    "symbol": "LunaT",
+    "decimals": "8"
+  },
+  {
+    "id": "terra15k5r9r8dl8r7xlr29pry8a9w7sghehcnv5mgp6",
+    "name": "Lunaverse",
+    "symbol": "LUV",
+    "decimals": "6",
+    "circ_supply_api": "https://source.lunaverse.io/circulation",
+    "icon": "https://lunaverse.io/assets/images/logo.png",
+    "website": "https://lunaverse.io/",
+    "telegram": "https://t.me/lunaverse_chat",
+    "twitter": "https://twitter.com/Lunaverse_io",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/lunaverse/",
+    "coingecko": "https://www.coingecko.com/en/coins/lunaverse"
+  },
+  {
+    "id": "terra1kd4rfff04cvw7vae0szgawj0xye90fkchljv7y",
+    "name": "Lunaverse",
+    "symbol": "LUV",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16x6mn6ulxzg4pgg7gpachkkgrkuac59vl7xgyl",
+    "name": "Lunaverse LUV Token",
+    "symbol": "LUV",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kqf8ua7al5tdnkz95ue4zkuv4gcu52pt63ya54",
+    "name": "Lunc optimizer token",
+    "symbol": "OPZC",
+    "decimals": "6",
+    "icon": "https://assets.terra.money/icon/opz/OPZ.png"
+  },
+  {
+    "id": "terra1rdqy74e080e96qhk5gntnr882awm4pfc7t6dn4",
+    "name": "Lunc optimizer token",
+    "symbol": "OPZC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m3tdguf59xq3pa2twk5fjte5g6szj5y9x5npy7",
+    "name": "LUNI",
+    "symbol": "LUNI",
+    "decimals": "6",
+    "icon": "https://d2s3n99uw51hng.cloudfront.net/static/100_100_LUNI_logo.png",
+    "website": "https://www.luniofficial.com/",
+    "telegram": "https://t.me/LUNIonTerra",
+    "twitter": "https://twitter.com/LUNIonTerra",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/luni",
+    "coingecko": "https://www.coingecko.com/en/coins/luni"
+  },
+  {
+    "id": "terra1ykl7ee0dakfev97ektynnup8hscyuhc9kly9k4",
+    "name": "Luntivo Finance Token",
+    "symbol": "LTVN",
+    "decimals": "3",
+    "icon": "https://luntivo.finance/images/coin.png"
+  },
+  {
+    "id": "terra1u02kfjra4q9272p0ckq8yjtfc5qq6584amvrnm",
+    "name": "MACP",
+    "symbol": "MACP",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1qxfhvu3w83azgs4ghk3v5z2nvmzg8td5gqfd69",
+    "name": "MAGA Coin",
+    "symbol": "MAGA",
+    "decimals": "6",
+    "icon": "https://i.gyazo.com/6384718f275295789378e3794e9b23d1.png",
+    "telegram": "https://t.me/joinchat/G4zK5BmHQWBiZTc5",
+    "twitter": "https://twitter.com/Terra_MAGA"
+  },
+  {
+    "id": "terra1ehcjwxwf96c278n2ks84zes3ece5fqy78fa749",
+    "name": "MAGNETX",
+    "symbol": "MAX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra160y9666sr9ctqfzk4mu7useh6g6swet8vnl7uz",
+    "name": "MAIN",
+    "symbol": "PYTHON",
+    "decimals": "8"
+  },
+  {
+    "id": "terra18m6fr3fk9xh0u9vrvyeu25w0k40dptfrhw53rh",
+    "name": "Manta",
+    "symbol": "MNTT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1qvlpf2v0zmru3gtex40sqq02wxp39x3cjh359y",
+    "name": "Marinade staked SOL (Portal)",
+    "symbol": "mSOL",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/mSOL_wh.png"
+  },
+  {
+    "id": "terra1a7zxk56c72elupp7p44hn4k94fsvavnhylhr6h",
+    "name": "Mars",
+    "symbol": "MARS",
+    "decimals": "6",
+    "icon": "https://marsprotocol.io/mars_logo_colored.svg"
+  },
+  {
+    "id": "terra1z3ejshh0vwkdr35wt9eyxetsqm6mnraya8myxs",
+    "name": "Mars Protocol",
+    "symbol": "MARS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y4yx8w0p9v247w5uv5hfqv2fccda7rmt65mwcd",
+    "name": "MARS PROTOCOL",
+    "symbol": "MARS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n",
+    "name": "Mars Token",
+    "symbol": "MARS",
+    "decimals": "6",
+    "circ_supply_api": "https://api.marsprotocol.io/graphql",
+    "icon": "https://marsprotocol.io/MARSTokenMini.svg",
+    "website": "https://marsprotocol.io/",
+    "telegram": "https://t.me/martiannews",
+    "twitter": "https://twitter.com/mars_protocol",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/mars-protocol/",
+    "coingecko": "https://www.coingecko.com/en/coins/mars-protocol"
+  },
+  {
+    "id": "terra1qs7h830ud0a4hj72yr8f7jmlppyx7z524f7gw6",
+    "name": "Mars Token",
+    "symbol": "MARS",
+    "decimals": "6",
+    "icon": "https://marsprotocol.io/mars_logo_colored.svg"
+  },
+  {
+    "id": "terra1cuku0vggplpgfxegdrenp302km26symjk4xxaf",
+    "name": "Mars UST Liquidity Token",
+    "symbol": "maUST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10t0rgfryqz5ds93z5tqed740nqh4ele9lm9fhq",
+    "name": "MartinLutherKoin",
+    "symbol": "MLK",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1qgvd7llck3nfav7n9k2qh35zcsmjwap073x5et",
+    "name": "MartinLutherKoin",
+    "symbol": "MLK",
+    "decimals": "3"
+  },
+  {
+    "id": "terra18f86dw6n40r6hqzjw0qsfe09nxesqs7vx2jkcx",
+    "name": "MASK",
+    "symbol": "MASK",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1dfasranqm4uyaz72r960umxy0w8t6zewqlnkuq",
+    "name": "Matic Token (Wormhole)",
+    "symbol": "weMATIC",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/C7NNPWuZCNjZBfW5p6JvGsR8pUdsRpEdP1ZAhnoDwj7h/logo.png"
+  },
+  {
+    "id": "terra15823sstx9pl2fqacnpaxsj9jsku2rjrk4aj34z",
+    "name": "𝐌azaterra",
+    "symbol": "maza",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1x5t6zkvhc6dg2jjug34tfreme3hcufpuy77da2",
+    "name": "MCP",
+    "symbol": "MCP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13km0x6rn7fj23ruqdqdqut7p7p7570xyjz35qe",
+    "name": "MDR-Token",
+    "symbol": "MDR",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1vyenreh8z62r35rydtupkqnmjsalee4tl90vn6",
+    "name": "Meta",
+    "symbol": "MTVS",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1t0csdwp5u9592522n35ededwt2e46sur5u4mkg",
+    "name": "META",
+    "symbol": "MVRS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1w45ywafn2srq3q6svsam067uh8l2smlu7ljzv4",
+    "name": "Meta Kwon",
+    "symbol": "mKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1p8yhtrp8ttcrrl90kqez0602yl2sx2gvrw4h23",
+    "name": "Meta Trans",
+    "symbol": "MTT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1sdm7qux8u0qtfxa6ukuh3zgppazdxlhmmjks23",
+    "name": "MetaFrogs",
+    "symbol": "MEFR",
+    "decimals": "3"
+  },
+  {
+    "id": "terra17qfuwapug8scgw5satxs4n95u3taw6fe8hdgty",
+    "name": "MetaSex",
+    "symbol": "MTSEX",
+    "decimals": "3"
+  },
+  {
+    "id": "terra12hesat74nzz6av5hw2c5qxxqkhafxsgjhgnd6y",
+    "name": "METAVERSE",
+    "symbol": "META",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cqxahw3zls3x5k9sngtyjt5qm8nzmzsleyx8hh",
+    "name": "MetaverseTerra",
+    "symbol": "MEVT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1vtr50tw0pgqpes34zqu60n554p9x4950wk8f63",
+    "name": "Miaw Token",
+    "symbol": "MIAW",
+    "decimals": "6",
+    "circ_supply_api": "https://miaw-graph.com/graphql",
+    "icon": "https://www.miaw-trader.com/logo.png",
+    "website": "https://www.miaw-trader.com",
+    "telegram": "https://t.me/miawtrader",
+    "twitter": "https://twitter.com/miawtrader"
+  },
+  {
+    "id": "terra1pshxc56zwgm6j78mhjgn2rgkj5d32aa887l7j6",
+    "name": "Micro Kwon",
+    "symbol": "mcKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mgyht7c5usg40gqt57zmcd93cdwt49eehysm9p",
+    "name": "MicroPets",
+    "symbol": "PETS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1227ppwxxj3jxz8cfgq00jgnxqcny7ryenvkwj6",
+    "name": "Microsoft Corporation",
+    "symbol": "mMSFT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1227ppwxxj3jxz8cfgq00jgnxqcny7ryenvkwj6/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/MSFT.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1yrch507vhsmd9rue6q3v8pz4pe445jl09nrvz6",
+    "name": "Microsoft Corporation",
+    "symbol": "mMSFT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1t4hgtl3uqukaas9lzswl9hr7d55mn3tq3tt3rd",
+    "name": "Mini Kwon",
+    "symbol": "mKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra160hntqlsd7wzyydhzw653lw8puftnwaj327xyd",
+    "name": "Mini Luna",
+    "symbol": "mLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12mvfnsk4r2chx7n032aztme7zcypyla5pllhzm",
+    "name": "Mini Terra",
+    "symbol": "MNT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q0q09duq6jsth9m0gfj7fpxlxwlj5fcxgchuza",
+    "name": "MiniDoge",
+    "symbol": "MINI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ez8x6k2rru42w3z8lnfkzjs778rllmq6xhgf7a",
+    "name": "MiniFloki",
+    "symbol": "mFloki",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nvwf9aegjeg8tddgya7pe63k594k5lzsnm8a9l",
+    "name": "MintDAO",
+    "symbol": "MINT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zd6let0zg0xjn2sestagxv4ax24a4ml6j40qdr",
+    "name": "MintDAO",
+    "symbol": "MINT",
+    "decimals": "6",
+    "circ_supply_api": "https://europe-west1-mintdao-app.cloudfunctions.net/circulatingSupply",
+    "icon": "https://mintdao.io/assets/token.svg",
+    "website": "https://mintdao.io",
+    "telegram": "https://t.me/mintdaoio",
+    "twitter": "https://twitter.com/mintdao_io"
+  },
+  {
+    "id": "terra137qvfdvlkj9vfhrctz4rlkk7lmgql7xalqlwpw",
+    "name": "Mirror",
+    "symbol": "MIR",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
+    "name": "Mirror",
+    "symbol": "MIR",
+    "decimals": "6",
+    "circ_supply_api": "https://graph.mirror.finance/graphql",
+    "icon": "https://whitelist.mirror.finance/icon/MIR.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/mirror-protocol/",
+    "coingecko": "https://www.coingecko.com/en/coins/mirror-protocol"
+  },
+  {
+    "id": "terra1h4hvry62zk4zh0udecqmatfg02phnyu6hq74xd",
+    "name": "Mirror",
+    "symbol": "MIR",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e47v67sld3p2pre5skqh05ddld22rwhu30fnwm",
+    "name": "Mirror BNB",
+    "symbol": "mBNB",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17t0uuy2cg7apfsqj4xqn6w5scxkd2ajgns9xvz",
+    "name": "Mirror NFT",
+    "symbol": "MNFT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13awdw2dt45l958q274ukg0hvvmctghllv343lp",
+    "name": "mmsh",
+    "symbol": "MMSH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18u4zkkm5ddge6decp83dk9zmkx7lvhv2xkynrr",
+    "name": "MMXX Token",
+    "symbol": "MMXX",
+    "decimals": "6"
+  },
+  {
+    "id": "umnt",
+    "name": "MNT",
+    "symbol": "MNT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/mnt",
+    "icon": "https://assets.terra.money/icon/60/MNT.png"
+  },
+  {
+    "id": "terra19cxwwhtkpp4qvf4tvjmhh8lnh8lle7uw7ndqjw",
+    "name": "mocart",
+    "symbol": "mcrt",
+    "decimals": "3"
+  },
+  {
+    "id": "terra16p7wv0m0upx763r5aux6qatzyve44ezdyqpq5m",
+    "name": "MOON",
+    "symbol": "MOON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pkp0pkxp9mtlan7cg0qatu65hmkgyq2342g27g",
+    "name": "Moon Dust",
+    "symbol": "DUST",
+    "decimals": "6",
+    "icon": "https://gateway.pinata.cloud/ipfs/QmQ4gGYkPE6MFGbCpamgdeG1aTeagjhAHcX1eszYzCjzvy"
+  },
+  {
+    "id": "terra1qm5jjajyv5pmap9687sgckc0j9hurlks3xzpx2",
+    "name": "MOON MISSION",
+    "symbol": "MMM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zdpymdwpyg5gj5ye4uvr0mqmxw8c88k5vqegfr",
+    "name": "Moon Token",
+    "symbol": "WEN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1c5p65p6q6ekfav0k72h5ez23mpntve5am07mpr",
+    "name": "MoonBull",
+    "symbol": "MoonBull",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1j874eyvev9pm7uxm0h9l82raswe3qwcug8wxuf",
+    "name": "My Awesome Token",
+    "symbol": "MAT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16ygrvq7q2zxw7jj3f96racur50w0g7r0mj6e2y",
+    "name": "MYS Token",
+    "symbol": "MYS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra185fgz0v2wm79ujn58tm3qeucnvlnfuffa4wpjp",
+    "name": "Nakamoto",
+    "symbol": "NKMT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1zpp3fdnpkrhpehjxvzz3wwwujmk0zxw5h4y0rr",
+    "name": "Native Denom DNS",
+    "symbol": "DNS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hgseash9ctvscp09trutsh8utt34z46lj2n96k",
+    "name": "Nebula Token",
+    "symbol": "NEB",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mpq5zkkm39nmjrjg9raknpfrfmcfwv0nh0whvn",
+    "name": "Nebula Token",
+    "symbol": "NEB",
+    "decimals": "6",
+    "circ_supply_api": "https://supply.neb.money",
+    "icon": "https://assets.neb.money/icons/NEB.png",
+    "website": "https://app.neb.money",
+    "telegram": "https://t.me/nebula_protocol",
+    "twitter": "https://twitter.com/nebula_protocol"
+  },
+  {
+    "id": "terra1cczv3ck2r909w64n9rdqs3gh5gsmwumh4utz49",
+    "name": "Netflix",
+    "symbol": "mNFLX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jsxngqasf2zynj5kyh0tgq9mj3zksa5gk35j4k",
+    "name": "Netflix, Inc.",
+    "symbol": "mNFLX",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1jsxngqasf2zynj5kyh0tgq9mj3zksa5gk35j4k/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/NFLX.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1nagqpmyw55yjphea4rhntlfv87ugmeaj8ym756",
+    "name": "nETH autocompounder share representation",
+    "symbol": "cnETH",
+    "decimals": "6",
+    "icon": "https://terra.nexusprotocol.app/cnETH.svg"
+  },
+  {
+    "id": "terra1f659ez3nysf06765jjjqnl7m65urrqaxx2t40h",
+    "name": "New Year's Eve NFT",
+    "symbol": "NYE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1amz5c45l34n7w8m5a3z7rd7u0k037x4nnsemwj",
+    "name": "Neworld Labs Develpper Token",
+    "symbol": "NWLD",
+    "decimals": "9",
+    "icon": "https://raw.githubusercontent.com/neworld-labs/token-list/master/assets/TestNet/neworld-labs.png"
+  },
+  {
+    "id": "terra1ezz5xply2v3xdyv32gy5tcd7zq4k235q4xtzwe",
+    "name": "Neworld Token",
+    "symbol": "NWT",
+    "decimals": "9",
+    "icon": "https://raw.githubusercontent.com/neworld-labs/token-list/master/assets/MainNet/NWT.png"
+  },
+  {
+    "id": "terra1jtdc6zpf95tvh9peuaxwp3v0yqszcnwl8j5ade",
+    "name": "Nexus bATOM token share representation",
+    "symbol": "nATOM",
+    "decimals": "6",
+    "icon": "https://terra.nexusprotocol.app/nATOM.svg"
+  },
+  {
+    "id": "terra13k62n0285wj8ug0ngcgpf7dgnkzqeu279tz636",
+    "name": "Nexus bAVAX token share representation",
+    "symbol": "nAVAX",
+    "decimals": "6",
+    "icon": "https://terra.nexusprotocol.app/nAVAX.svg"
+  },
+  {
+    "id": "terra178v546c407pdnx5rer3hu8s2c0fc924k74ymnn",
+    "name": "Nexus bETH Token",
+    "symbol": "nETH",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra178v546c407pdnx5rer3hu8s2c0fc924k74ymnn/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://terra.nexusprotocol.app/nEth.svg",
+    "website": "https://nexusprotocol.app/",
+    "telegram": "https://t.me/NexusProtocol",
+    "twitter": "https://twitter.com/NexusProtocol"
+  },
+  {
+    "id": "terra1f887h6wqygswcp4arjjak6mpdhwlrv6nj8y9wt",
+    "name": "Nexus bETH token share representation",
+    "symbol": "nETH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10f2mt82kjnkxqj2gepgwl637u2w4ue2z5nhz5j",
+    "name": "Nexus bLUNA Token",
+    "symbol": "nLUNA",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra10f2mt82kjnkxqj2gepgwl637u2w4ue2z5nhz5j/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://terra.nexusprotocol.app/nLuna.svg",
+    "website": "https://nexusprotocol.app/",
+    "telegram": "https://t.me/NexusProtocol",
+    "twitter": "https://twitter.com/NexusProtocol"
+  },
+  {
+    "id": "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
+    "name": "Nexus Governance Token",
+    "symbol": "Psi",
+    "decimals": "6",
+    "circ_supply_api": "https://api.nexusprotocol.app/getPsiCirculationSupply",
+    "icon": "https://terra.nexusprotocol.app/assets/psi.png",
+    "website": "https://nexusprotocol.app/",
+    "telegram": "https://t.me/NexusProtocol",
+    "twitter": "https://twitter.com/NexusProtocol"
+  },
+  {
+    "id": "terra15z4tj56cdpdk5jxf28nep3ep0myu0frhlh6f3u",
+    "name": "Nexus Token",
+    "symbol": "TNT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19hnegq0ed5w0gds64765uakh5huw7jepvjakh5",
+    "name": "Nexus Token",
+    "symbol": "TNT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ax3mp4cs78xkryavm733s2m4exsv72kd9c4c5g",
+    "name": "Nexus Token",
+    "symbol": "TNT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cwretz2zmeqe2uhq4fuk2mrp4ptuvsct890c6f",
+    "name": "Nexus Token",
+    "symbol": "TNT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ucme9gd7wr7lx0sysnydhdhaqtrg4403nrqm0l",
+    "name": "Nexus Token",
+    "symbol": "TNT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1w94fk75p0qeas276kfvy0m0zhnwgcy49c7vu77",
+    "name": "Nexus Token",
+    "symbol": "TNT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xzn8e3h9k4qk7082z330sn8ptz99lnghyua9xy",
+    "name": "Nexus Token",
+    "symbol": "TNT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17zeqmepm87d9g4dujjsctqjrfhz4xjkup26t03",
+    "name": "NFT Kwon Terra",
+    "symbol": "NKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ft9qff9fgumdca5qluxu3e8fh8xc7d4hfek8s2",
+    "name": "NFT Launchpad",
+    "symbol": "NFT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rp3mdhrwxhdlx923t2q50f0n6z6660z9yqghpv",
+    "name": "NFT LUNAtisc",
+    "symbol": "LUNATISC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1a54dqqqh4qlz70m43n3a0vqeu2dv5tkz6t2zan",
+    "name": "NFT TERRA",
+    "symbol": "NFT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mlhehkx4rgp357jmxhqepy0nr4tjetkje9t686",
+    "name": "NFTerra",
+    "symbol": "NFTERRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17ana8hvzea0q7w367dm0dw48sxwql39qekpt7g",
+    "name": "NIKE, Inc.",
+    "symbol": "mNKE",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra17ana8hvzea0q7w367dm0dw48sxwql39qekpt7g/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/NKE.png"
+  },
+  {
+    "id": "terra1dj2cj02zak0nvwy3uj9r9dhhxhdwxnw6psse6p",
+    "name": "NIO Inc.",
+    "symbol": "mNIO",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1dj2cj02zak0nvwy3uj9r9dhhxhdwxnw6psse6p/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/NIO.png"
+  },
+  {
+    "id": "terra1u553zk43jd4rwzc53qrdrq4jc2p8rextyq09dj",
+    "name": "nLuna autocompounder share representation",
+    "symbol": "cnLuna",
+    "decimals": "6",
+    "icon": "https://terra.nexusprotocol.app/cnLuna.svg"
+  },
+  {
+    "id": "terra1zzfhavsjlhhx42rnjfvwk6u7taplh4qxqmhgfa",
+    "name": "Nome",
+    "symbol": "Simbolo",
+    "decimals": "6"
+  },
+  {
+    "id": "terra155kdqp7le4fw8z8m7wk6c62d6dg5mgdug924nq",
+    "name": "Ños Terra Tes v3t",
+    "symbol": "tNYOSTESTIII",
+    "decimals": "0"
+  },
+  {
+    "id": "terra13j3uuywz8q3tljmqxt6trcgcxy29dd5exrnhtq",
+    "name": "Ños Terra Test",
+    "symbol": "tNYTEST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15pr9sk7qkr46ys4gaxmsyl825m4fgl7fdjwqaj",
+    "name": "Ños Terra Test v2 reloaded",
+    "symbol": "tNYOSTEST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16pem7c3h7renxuxa4jvw8efv4nhrdc3leguzyn",
+    "name": "NotAToken",
+    "symbol": "NAT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra138zs0y4arp48v0vpzqa7r4ehxcy7sk3dpv606e",
+    "name": "NudeCoin",
+    "symbol": "NUDES",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1tdvvjf700gerwvkwncjc7nzythdewstk47ah93",
+    "name": "NudeCoin",
+    "symbol": "NUDES",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1drsjzvzej4h4qlehcfwclxg4w5l3h5tuvd3jd8",
+    "name": "NVIDIA Corporation",
+    "symbol": "mNVDA",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1drsjzvzej4h4qlehcfwclxg4w5l3h5tuvd3jd8/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/NVDA.png"
+  },
+  {
+    "id": "terra1mtm6l7xdmpuelf2q74sq58d2e5gwm72d42algk",
+    "name": "Olymp Terra",
+    "symbol": "OLTR",
+    "decimals": "3"
+  },
+  {
+    "id": "terra19qcznmhmwf88lm75nmrj3prr6cmvtnz02hvu4g",
+    "name": "Olympus DAO",
+    "symbol": "OLD",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1clqsjgv98sa2ewwlmyt3pv4uuzz68u45w9pkyw",
+    "name": "OMICRON",
+    "symbol": "OMICRON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zawrkv57eh7rne45zjta7s876jqc59slrev9xy",
+    "name": "ONLY TERRANS",
+    "symbol": "ONLY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1745fzfxnd8wx5kdrf4uwgj7k0mkqk64pdrh56k",
+    "name": "OracleT",
+    "symbol": "ORCT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra17etsw9uywcmw79st5yp4saar97z22l3np0m3zz",
+    "name": "Orion is Shite",
+    "symbol": "OIS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14l9lspj9lp2rpnhp6qjpruwcqst0yvl9cm6l96",
+    "name": "Orion Money",
+    "symbol": "ORIOM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ufsyu3ddskufc7nel5p4lyrzhv8qdddg3tl550",
+    "name": "Orion Money",
+    "symbol": "orion",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
+    "name": "Orion Money Token",
+    "symbol": "ORION",
+    "decimals": "8",
+    "circ_supply_api": "https://app.orion.money/circulating-supply.txt",
+    "icon": "https://orion.money/assets/ORION-LOGO-2.1-GREEN@256x256.png",
+    "website": "https://orion.money/",
+    "telegram": "https://t.me/Orion_Money",
+    "twitter": "https://twitter.com/orion_money",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/orion-money/",
+    "coingecko": "https://www.coingecko.com/en/coins/orion-money"
+  },
+  {
+    "id": "terra1yhlhrea3rgyx2xdnsswsfakn28qa8z7yp5gmhd",
+    "name": "Orion Money xASTRO Derivative Token",
+    "symbol": "orionASTRO",
+    "decimals": "6",
+    "icon": "https://orion.money/assets/orionASTRO-LOGO@256x256.png"
+  },
+  {
+    "id": "terra1ts6qq7va0msf0se3cwjsppt3vkumkh3t6n4d8a",
+    "name": "Osmosis",
+    "symbol": "OSM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1thrmc4qul2e02y2rskm7583g6guvtrvc8pnlmx",
+    "name": "OTC Terra",
+    "symbol": "OTCT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1vdpk5k7203r73fgl2ppwsg30vmtu5akgk0emse",
+    "name": "owo",
+    "symbol": "OWO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rxl2tv8jhv3rkhnesashgk8dwuvfa9kdzv36rp",
+    "name": "OWOII",
+    "symbol": "OWOII",
+    "decimals": "2"
+  },
+  {
+    "id": "terra1v58klw3jakaeas2dkppqdh4y4dzd52kzda2fgf",
+    "name": "Pace Token",
+    "symbol": "PACE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xvqlpjl2dxyel9qrp6qvtrg04xe3jh9cyxc6av",
+    "name": "PancakeSwap Token (Wormhole)",
+    "symbol": "wbCake",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/J8LKx7pr9Zxh9nMhhT7X3EBmj5RzuhFrHKyJAe2F2i9S/logo.png"
+  },
+  {
+    "id": "terra1qgt75fpc097an2vtqufx52anfcsu33n57wjkac",
+    "name": "PanTerra",
+    "symbol": "PTerra",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1uux6gwd6pzr0gfzrru5kne55cxex9d0700c72r",
+    "name": "Paxos Gold (Wormhole)",
+    "symbol": "whPAXG",
+    "decimals": "8",
+    "icon": "https://github.com/paxosglobal/paxos-gold-contract/blob/master/assets/Pax-Gold-Logo-FINAL-color.png"
+  },
+  {
+    "id": "terra152mtjjndwpwvtszd4cxnhvjm8nzxv6kdwtdugg",
+    "name": "PayMoreDollars",
+    "symbol": "DOLLARSER",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx",
+    "name": "PayPal Holdings Inc",
+    "symbol": "mPYPL",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/PYPL.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1rjf3c4ayvx2d6pej6fanjhe54a2ds8dlh9f69s",
+    "name": "PEPSON TOKEN",
+    "symbol": "PEPON",
+    "decimals": "3",
+    "icon": "https://raw.githubusercontent.com/panpepson/LWLC-crypto/master/terra-pepon/Pepon.png"
+  },
+  {
+    "id": "terra1yg4qw00d3cpdvs9zyhyh32jkfcl8un8nxc3f08",
+    "name": "PHLI",
+    "symbol": "PHLI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra143h4n4h3j36z64t7l8ey7vny6x47ukpz8s2gvs",
+    "name": "Phoenix DAO",
+    "symbol": "PHD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18y93cy77qrxx65vdz959g2ngms55v3s3yythys",
+    "name": "PHZ",
+    "symbol": "PHZ",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nq9epqtswmj7uaymsw59w9n5h5e78k9rwduets",
+    "name": "PlayNity",
+    "symbol": "PLY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q96cf9rkt5aa4eqhun35d0u8pqwwyuqzlzjxps",
+    "name": "PlayNity",
+    "symbol": "PLY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lj0m5346vc6da9r9ljcyx7letcl3727g7wac62",
+    "name": "PLAYNITY",
+    "symbol": "PLY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1t8wkdq7kth8ngxgrpltwam0gv0h88ajh0get5c",
+    "name": "PLAYNITY",
+    "symbol": "PLY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1atpd4n3u6tl9ttqeqdwk303lcj2j7u8tpnx53p",
+    "name": "Playnity Token",
+    "symbol": "PLY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13awdgcx40tz5uygkgm79dytez3x87rpg4uhnvu",
+    "name": "PlayNity token",
+    "symbol": "PLY",
+    "decimals": "6",
+    "circ_supply_api": "https://playnity.io/api/?q=circulating-supply",
+    "icon": "https://i.ibb.co/Snt8gXx/Projekt-bez-tytu-u-3.png",
+    "website": "https://playnity.io/",
+    "telegram": "https://t.me/PLAYNITY",
+    "twitter": "https://twitter.com/play_nity"
+  },
+  {
+    "id": "terra1kdkcxnsldqmj50ll77gmq5x26u69z8m69hdas6",
+    "name": "PLEASE DONT BUY",
+    "symbol": "PDB",
+    "decimals": "2"
+  },
+  {
+    "id": "terra10yycj46tjfnfhkk5d6er49gvcn28jpqk0spthr",
+    "name": "poggers",
+    "symbol": "POG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ep337j8q9xm7t9ypqugr4yhgnvf0jgyjga50tv",
+    "name": "Pokemon",
+    "symbol": "POK",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
+    "name": "Polkadot",
+    "symbol": "mDOT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/DOT.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra130fhr9jz0nylzhdvuwcpp3hne2s5qlft6hfzgv",
+    "name": "PORT Token",
+    "symbol": "PORT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra133r6snp000sw0qhuspkua39fjc4c6pux82cnxh",
+    "name": "Pre TGE SAYVE Token",
+    "symbol": "PSAYVE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
+    "name": "Prism cLUNA Token",
+    "symbol": "cLUNA",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://home.prismprotocol.app/cluna.png",
+    "website": "https://prismprotocol.app/",
+    "telegram": "https://t.me/Prism_Protocol",
+    "twitter": "https://twitter.com/prism_protocol"
+  },
+  {
+    "id": "terra12y2uzvrn3j4y5390kfljtpq6z3wqflyg0wls2z",
+    "name": "Prism Finance",
+    "symbol": "PRISM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1su29mtytdsev3ty2au5xlfrqrjcy696yeqwvcy",
+    "name": "PRISM FINANCE",
+    "symbol": "PRISM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1042wzrwg2uk6jqxjm34ysqquyr9esdgm5qyswz",
+    "name": "Prism Governance Token",
+    "symbol": "xPRISM",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1042wzrwg2uk6jqxjm34ysqquyr9esdgm5qyswz/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://prismprotocol.app/xprism.png",
+    "website": "https://prismprotocol.app/",
+    "telegram": "https://t.me/Prism_Protocol",
+    "twitter": "https://twitter.com/prism_protocol"
+  },
+  {
+    "id": "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
+    "name": "Prism pLUNA Token",
+    "symbol": "pLUNA",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://home.prismprotocol.app/pluna.png",
+    "website": "https://prismprotocol.app/",
+    "telegram": "https://t.me/Prism_Protocol",
+    "twitter": "https://twitter.com/prism_protocol"
+  },
+  {
+    "id": "terra1krg7amkeenvqwkaarp4r4grmrnldd83lmkl26u",
+    "name": "PRISM Protocol",
+    "symbol": "PRISM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wctr29t5gul8qq6qvk6lue2lucymuptvcn9avl",
+    "name": "PRISM Protocol",
+    "symbol": "PRISM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+    "name": "Prism Protocol Token",
+    "symbol": "PRISM",
+    "decimals": "6",
+    "circ_supply_api": "https://api.extraterrestrial.money/v1/api/prices?symbol=PRISM",
+    "icon": "https://prismprotocol.app/prism.png",
+    "website": "https://prismprotocol.app/",
+    "telegram": "https://t.me/Prism_Protocol",
+    "twitter": "https://twitter.com/prism_protocol"
+  },
+  {
+    "id": "terra1jn0w9ttjavzqeqmp79jzx3da6dx3p6jwmm6tk2",
+    "name": "Prism Token",
+    "symbol": "PRISM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17wkadg0tah554r35x6wvff0y5s7ve8npcjfuhz",
+    "name": "Prism yLUNA Token",
+    "symbol": "yLUNA",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra17wkadg0tah554r35x6wvff0y5s7ve8npcjfuhz/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://home.prismprotocol.app/yluna.png",
+    "website": "https://prismprotocol.app/",
+    "telegram": "https://t.me/Prism_Protocol",
+    "twitter": "https://twitter.com/prism_protocol"
+  },
+  {
+    "id": "terra1djd0hmv2hq8s0g9hs53s7gmc2phgg33kqq4uul",
+    "name": "PRISMFINANCE.APP",
+    "symbol": "PRISM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pwu44z0gwlfqecwxuxh6kwn46d8930x226drxw",
+    "name": "PRO TOKEN",
+    "symbol": "OWL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tzkc6jejskv5qnqfa866qrlltx4240n3hwpeay",
+    "name": "PRO TOKEN",
+    "symbol": "PRO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1uhwhrypcnucvcc2ayt92mlky2xtatslrn7tte4",
+    "name": "ProShares VIX",
+    "symbol": "mVIXY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19cmt6vzvhnnnfsmccaaxzy2uaj06zjktu6yzjx",
+    "name": "ProShares VIX Short-Term Futures ETF",
+    "symbol": "mVIXY",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra19cmt6vzvhnnnfsmccaaxzy2uaj06zjktu6yzjx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/VIXY.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45",
+    "name": "ProShares VIX Short-Term Futures ETF (Delisted)",
+    "symbol": "mVIXY",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/VIXY.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra128pe5jpempxu0nws5lw28se9zknhsr78626cpn",
+    "name": "pStake Bonded ATOM (Wormhole)",
+    "symbol": "webATOM",
+    "decimals": "6",
+    "icon": "https://files.pstake.finance/logos/bAssets/bATOM_Wormhole.svg"
+  },
+  {
+    "id": "terra1gl3ywddjkukupa3qv86r8xy434frncmxna630k",
+    "name": "PTS Token",
+    "symbol": "PTS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1k637r8ucfp585tv57gsnqzfdmsw6mnm9zn59zy",
+    "name": "PTT Token",
+    "symbol": "PTT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tesjetjz6q7s2etc0pa93ep6fwhzqqtcvreccl",
+    "name": "PUG",
+    "symbol": "PUG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yanmc0xxg9dl387qkudnysjkymgytj3cdhgeek",
+    "name": "PunksT",
+    "symbol": "PNKT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1tn2upc52zce96qprewh0gk5thvqqtuhaz7r6qd",
+    "name": "PuppyKwon",
+    "symbol": "PUPPY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10ynpvp8trmlkf6n69qx0kp9qjs54d8wsh2pddc",
+    "name": "Putin Token",
+    "symbol": "PUTIN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zsaswh926ey8qa5x4vj93kzzlfnef0pstuca0y",
+    "name": "Pylon bDP Token for Gateway Psi 24m Pool",
+    "symbol": "bPsiDP-24m",
+    "decimals": "6",
+    "icon": "https://assets.pylon.rocks/logo/bPsiDP.png"
+  },
+  {
+    "id": "terra1aydw57mpa6jg5n3xnrau9g7mftd3ch6fh7qzal",
+    "name": "Pylon MINE Token",
+    "symbol": "MINE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy",
+    "name": "Pylon MINE Token",
+    "symbol": "MINE",
+    "decimals": "6",
+    "circ_supply_api": "https://api.pylon.money/api/mine/v1/overview",
+    "icon": "https://assets.pylon.rocks/logo/MINE.png",
+    "website": "https://www.pylon.money/",
+    "telegram": "https://t.me/pylon_protocol",
+    "twitter": "https://twitter.com/pylon_protocol",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/pylon-protocol/",
+    "coingecko": "https://www.coingecko.com/en/coins/pylon-protocol"
+  },
+  {
+    "id": "terra1u9hgxjw5k0aje9xjf0ejfu6uwmamc2k8ylzd7l",
+    "name": "Pylon MINE Token",
+    "symbol": "MINE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra158gqaxafjche7vtew0f4zk9g80224qr07kwfsk",
+    "name": "RandomEarth",
+    "symbol": "rEarth",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ht5sepn28z999jx33sdduuxm9acthad507jg9q",
+    "name": "Raydium (Portal)",
+    "symbol": "RAY",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/RAY_wh.png"
+  },
+  {
+    "id": "terra1kw5eyc86rqlw63wuezj5rcchpgs76h6ux9krfq",
+    "name": "reactor Anchor",
+    "symbol": "reANC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1l9zs09238tw99qvqfe037sgvc0czrv054h83q8",
+    "name": "reactor Astro",
+    "symbol": "reASTRO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17n223dxpkypc5c48la7aqjvverczg82ga3cr93",
+    "name": "Reactor Token",
+    "symbol": "RCT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra17n223dxpkypc5c48la7aqjvverczg82ga3cr93/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://reactor.money/assets/logo.svg",
+    "website": "https://reactor.money/",
+    "telegram": "https://t.me/RCTannouncement",
+    "twitter": "https://twitter.com/reactor_money"
+  },
+  {
+    "id": "terra1tdc7hmydg3es6lmn2asfwfgs8ykq7xa0nz9rkh",
+    "name": "Refinable",
+    "symbol": "Fine",
+    "decimals": "3"
+  },
+  {
+    "id": "terra19cnnyaah7c32hhcdt5m83pvdxa7ts64caarcm8",
+    "name": "REKT",
+    "symbol": "REKT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1krtfgcavw64dc8nhnz89eafpqm5pdz95l9a89f",
+    "name": "ResearchFundToken",
+    "symbol": "RFTOKEN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rz964297kvt86rteajhtp4hsffhcum0ye8eljh",
+    "name": "RESToad Token",
+    "symbol": "TOAD",
+    "decimals": "6",
+    "icon": "https://www.redeyedspacetoads.io/toad_token_logo.svg"
+  },
+  {
+    "id": "terra1j4hwavavmtsafa6zr0npalfz3tk9gf3p4787mp",
+    "name": "Retrograde",
+    "symbol": "RETRO",
+    "decimals": "6",
+    "icon": "https://retrograde.money/retro_logo.png"
+  },
+  {
+    "id": "terra1mvgs32slrxy29qhfmd2vn7y6l8knmtw396uxde",
+    "name": "Rewards Bunny",
+    "symbol": "BUNNY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cdg2m5swqzatvzuvseef9xcxpwqylx2h983hm4",
+    "name": "RIS Token",
+    "symbol": "RIS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18yqdfzfhnguerz9du5mnvxsh5kxlknqhcxzjfr",
+    "name": "Robinhood Markets, Inc.",
+    "symbol": "mHOOD",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra18yqdfzfhnguerz9du5mnvxsh5kxlknqhcxzjfr/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/HOOD.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra19qad83kr29qg89fpl4qh8m02wapmlwzpw5hvc4",
+    "name": "RoboHero",
+    "symbol": "ROBO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f62tqesptvmhtzr8sudru00gsdtdz24srgm7wp",
+    "name": "RoboHero",
+    "symbol": "ROBO",
+    "decimals": "6",
+    "circ_supply_api": "https://robohero-io-api.vercel.app/token/circulatingsupply",
+    "icon": "https://i.ibb.co/nmhRXB9/token.png",
+    "website": "https://robohero.io",
+    "telegram": "https://t.me/robohero",
+    "twitter": "https://twitter.com/RoboHero_io",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/robohero/",
+    "coingecko": "https://www.coingecko.com/en/coins/robohero"
+  },
+  {
+    "id": "terra1gpwkclxwwuzd5wyjw2qn3km0r5ge4t4f4mnf0x",
+    "name": "RoboHero",
+    "symbol": "ROBO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1epz3d7rmltreyt6chgnuv28cy8e0d3yad75xh8",
+    "name": "RoboHero Token",
+    "symbol": "ROBO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1l4uygw365sgdgvasmckkd7lcawyemzn9k83lrh",
+    "name": "RoboHero Token",
+    "symbol": "ROBO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mfek3m9s0sazd40kjraw5qv3963t5n3gwk408u",
+    "name": "RoboHero Token",
+    "symbol": "ROBO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mz858mn7jeglmzj0ay8z5zy6v78fvv7em9tljz",
+    "name": "RockOnTerra",
+    "symbol": "ROCK",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lladdxhn49jz0hrvwgalu4a548txh94mcec595",
+    "name": "ROI Token",
+    "symbol": "ROI",
+    "decimals": "8"
+  },
+  {
+    "id": "terra17h82zsq6q8x5tsgm5ugcx4gytw3axguvzt4pkc",
+    "name": "Saber (Portal)",
+    "symbol": "SBR",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/SBR_wh.png"
+  },
+  {
+    "id": "terra10famrcyze8z9c84x5726aplefwuf4k2zqf3rxr",
+    "name": "Safe Luna",
+    "symbol": "sLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yfjk0jn42krryudpv04mg0c3ghuq4u3qtyztgq",
+    "name": "Safe Terra",
+    "symbol": "sTERRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18gtpe3cu99pp2ej4mmf5hanrfwy6qcvd5x5cmz",
+    "name": "SAFEMOON",
+    "symbol": "SAFEMOON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17qy9f5h35504jxexwprsf6gtj009d3gjcml5pp",
+    "name": "SafeWojak",
+    "symbol": "SafeWojak",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ku5e0dhutxhuxudsmsn5647wwcz6ndr3rsh90k",
+    "name": "SAIL",
+    "symbol": "whSAIL",
+    "decimals": "6",
+    "icon": "https://cloudflare-ipfs.com/ipfs/QmPcQfofQNfiv36EAsGQrgAhiPbqGf17i1Cz648JhXFW9m/logo_solana_sail_v2.png"
+  },
+  {
+    "id": "terra1h067erdar0vs6466jafpjsd7nahzwghtemn6y0",
+    "name": "SAND",
+    "symbol": "SAND",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1lchkxy5ednukxepwxejak8xevqlmz89ukjh6hl",
+    "name": "Santas Big Sack",
+    "symbol": "SBS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q2k77qmnujgk0w89wx55rsnqxecz5wd86y2p2q",
+    "name": "SAP 500",
+    "symbol": "SAP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ypgjelmtp0mv5akzwmnj5xhukhd3fy9gd28wpj",
+    "name": "SAS Token",
+    "symbol": "SAS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pduqn0tpqce36ndwcv6z6xjlnujdddl6pedz9y",
+    "name": "Satoshi Nakamoto Token",
+    "symbol": "SATOSHI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14zj58ljhlyrgshe0n99un3k5ll2s0eucp332nu",
+    "name": "SBOD Token",
+    "symbol": "SBOD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mjhrlgwv8dnvc7mp0cynfxna947hxnm5m4tp6u",
+    "name": "Sciences",
+    "symbol": "SCI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1n0pfp0ygz4sqpcjck8ntvlhw74l3tzhe4k9xd6",
+    "name": "SD Token",
+    "symbol": "SD-",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14ec8v4c5dnwu2pq9plfquaffutu59tq9hld77e",
+    "name": "SDK Token",
+    "symbol": "SDK",
+    "decimals": "6"
+  },
+  {
+    "id": "usdr",
+    "name": "SDT",
+    "symbol": "SDT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/sdt",
+    "icon": "https://assets.terra.money/icon/60/SDT.png"
+  },
+  {
+    "id": "terra1dkam9wd5yvaswv4yq3n2aqd4wm5j8n82qc0c7c",
+    "name": "Serum (Portal from Solana)",
+    "symbol": "SRMso",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/SRMso_wh.png"
+  },
+  {
+    "id": "usek",
+    "name": "SET",
+    "symbol": "SET",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/set",
+    "icon": "https://assets.terra.money/icon/60/SET.png"
+  },
+  {
+    "id": "terra1v60qvtprpwt65w5tfamt4l4wpp3jk5mfeh64rt",
+    "name": "SEXY",
+    "symbol": "SEX",
+    "decimals": "6"
+  },
+  {
+    "id": "usgd",
+    "name": "SGT",
+    "symbol": "SGT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/sgt",
+    "icon": "https://assets.terra.money/icon/60/SGT.png"
+  },
+  {
+    "id": "terra1gxztmp6dlu8xv8kdlty6259gl845mw53gakw9t",
+    "name": "SHEISMINE",
+    "symbol": "HER",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1huku2lecfjhq9d00k5a8dh73gw7dwe6vvuf2dd",
+    "name": "Shiba Inu (Portal)",
+    "symbol": "SHIB",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/SHIB_wh.png"
+  },
+  {
+    "id": "terra18jv5j86hjhc0zx280wu3kjggd9dvfyl9v4t04k",
+    "name": "Shiba Land -- MetaVerse",
+    "symbol": "SHIBAL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra192g6ran4vfvyxhz0q7g4yls29fk6379hza6plw",
+    "name": "Shiba Zilla",
+    "symbol": "SHIBZ",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jkrl0xap6ptp8rd5lecp2j2sx3kws8rzxljsxn",
+    "name": "SHIBOKI.COM",
+    "symbol": "SHIBOKI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gq2yya7grd359c4y0wjfdusgrh805r6ml9jyyl",
+    "name": "SHIBOSHIS",
+    "symbol": "MEME",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14pwhc79alqnxdhtzm0rrxt64uh4s568u8mluhu",
+    "name": "SHIT",
+    "symbol": "SUCK",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lkjq6f2sqlqjk0crs2a7fv6m5pquhl8nuesp3j",
+    "name": "SHIT",
+    "symbol": "SHIT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1uf95uwdtg7rp734pmadujg2ukmuc88fph2925c",
+    "name": "Shitcoin",
+    "symbol": "SHIT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1p9wk5tns7jagwch6cdasgd753nzfj544v75qxr",
+    "name": "SIFCHAIN FINANCE",
+    "symbol": "ROWAN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jz9plajrq6knks3vgv9px4ezwshzaxsr2xz7jn",
+    "name": "SMART TERRA",
+    "symbol": "SMRT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tf6ukhukcqwfasm6e3ae2406c87vc8zhrh5ex7",
+    "name": "SOC Token",
+    "symbol": "SOC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xmd43yrfxm4xy3lnptc7kr4rr93pzh5u0z0wgt",
+    "name": "SOC Token",
+    "symbol": "SOC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pc253zfn4zns6awk7eks779uk3m7dna7y4cmlf",
+    "name": "SODE",
+    "symbol": "SODE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dy469h5zdej955zgn4dlewrqxw2nq2wdegq3y7",
+    "name": "Software",
+    "symbol": "SWE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rl0cpwgtwl4utnaynugevdje37fnmsea7rv4uu",
+    "name": "SolanaSail Governance Token V2",
+    "symbol": "whgSAIL",
+    "decimals": "8",
+    "icon": "https://ipfs.io/ipfs/QmNNt1xoyB7gwjLLzUYMELYGY277ZzZXJw1vhnZW18Wozq?filename=logo_GSAIL.png"
+  },
+  {
+    "id": "terra1ejmg85y0vgsxv5r3cd4024j732pqnwudl0v2d2",
+    "name": "SolChicks",
+    "symbol": "CHICKS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ddjp4wgu52cktzgzvahwkr4dcd95mxaqad2pmu",
+    "name": "somethingcool.xom",
+    "symbol": "scx",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hfyxtste6842zulmjv9n92srv803q6rhn7t8d4",
+    "name": "somethingcool.xom2",
+    "symbol": "someee",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1689ys6p6gfu0q6xrjqkzfn80sdyhurjqn0jfdl",
+    "name": "Sooah Studio Token",
+    "symbol": "SST",
+    "decimals": "6",
+    "icon": "https://sooahphoto.co.kr/icon/logo.png"
+  },
+  {
+    "id": "terra1l0y8yg0s86x299nqw0p6fhh7ngex3r4phtjeuq",
+    "name": "Space Dollars",
+    "symbol": "SDOLLAR",
+    "decimals": "2",
+    "icon": "https://spacedollars.money/wp-content/uploads/2021/10/spacedollars512x512.png",
+    "website": "https://spacedollars.money/",
+    "telegram": "https://t.me/space_dollars",
+    "twitter": "https://twitter.com/space_dollars"
+  },
+  {
+    "id": "terra1z2u9p4x9cnp7c44rnntxzhgqlnepv8elmde43d",
+    "name": "Space Dollars Ticket - Lootopians",
+    "symbol": "SDLTIC",
+    "decimals": "6",
+    "icon": "https://terrafloki.io/SDTIC2-logo.svg",
+    "website": "https://spacedollars.money/",
+    "telegram": "https://t.me/space_dollars",
+    "twitter": "https://twitter.com/space_dollars"
+  },
+  {
+    "id": "terra15uc875u7uu8xyqf833nxwh5x4dm2kmu29u04vl",
+    "name": "Space Dollars Ticket - SpacePets",
+    "symbol": "SDTICI",
+    "decimals": "6",
+    "icon": "https://terrafloki.io/SDOLLAR_ticket.png",
+    "website": "https://spacedollars.money/",
+    "telegram": "https://t.me/space_dollars",
+    "twitter": "https://twitter.com/space_dollars"
+  },
+  {
+    "id": "terra1j3w0tswl56yxduhen4gnela7m4we86w9xkwaee",
+    "name": "Space Haven",
+    "symbol": "SPH",
+    "decimals": "3"
+  },
+  {
+    "id": "terra12wlcu0kgdfrfutjydvvcmhlx8jrfsqhwqarc3d",
+    "name": "SPAR Finance",
+    "symbol": "SPAR",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc",
+    "name": "SPDR S&P 500",
+    "symbol": "mSPY",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/SPY.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr",
+    "name": "Spectrum Token",
+    "symbol": "SPEC",
+    "decimals": "6",
+    "circ_supply_api": "https://api.spec.finance/api/stat?format=txt&type=circulation",
+    "icon": "https://terra.spec.finance/assets/SPEC.png",
+    "website": "https://terra.spec.finance/vaults",
+    "telegram": "https://t.me/spec_finance",
+    "twitter": "https://twitter.com/SpecProtocol",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/spectrum-token/",
+    "coingecko": "https://www.coingecko.com/en/coins/spectrum-token"
+  },
+  {
+    "id": "terra1k9ltsdc6e4ay4g8f8nt8qd7my9yyd27m7eh82d",
+    "name": "SpeicherX_Lovers",
+    "symbol": "SPX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jvsfc3aedh7cyf3wd6vs7r5fmdsf4v6veh525e",
+    "name": "spidertanks.game",
+    "symbol": "SPD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1u43zu5amjlsgty5j64445fr9yglhm53m576ugh",
+    "name": "Square, Inc.",
+    "symbol": "mSQ",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1u43zu5amjlsgty5j64445fr9yglhm53m576ugh/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/SQ.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra16gnk7mpqr84f4mnmqjklpdxxe602dn0fjslwhy",
+    "name": "Squid Game 🌗💵 ",
+    "symbol": "SQSG",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1dssh7fk2gjjgf7yhcrd29repaz2gnxcs9yj9ay",
+    "name": "Squid Green Test Token",
+    "symbol": "GREENTEST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1av86k92kuj9jem24pmrv3j6xkrltr2xluz4665",
+    "name": "Squid Green Token",
+    "symbol": "GREEN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tt9jmf58nvaj8l0lckwfekfl43verjdpywcdwa",
+    "name": "Squid Red Test Token",
+    "symbol": "REDTEST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kntmj30tuu0fyu7vmgcrxuzax8gzt7mdmuppwv",
+    "name": "Squid VIP Green Token",
+    "symbol": "VGREEN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pmc29k34jrv96wde08znhmjq4v2rmzy78y6dhg",
+    "name": "Squid VIP Green Token",
+    "symbol": "GREEN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hj9g4kecf9gncxsa2257w4glhwgrdp7vjsnncv",
+    "name": "Squid VIP Red Token",
+    "symbol": "VRED",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1r6pcn0wdes6lrtxty3xu253c02grcvuxmqg4s9",
+    "name": "SQUIDGAME",
+    "symbol": "SQUID",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tgv52cmga9s6ymah2efz877xlpc4v8phq7mn69",
+    "name": "SquidTerra",
+    "symbol": "SQTR",
+    "decimals": "3"
+  },
+  {
+    "id": "terra13kr45ssru9cqhp2kaaan88wfaa7f2h3jfvuldp",
+    "name": "SS Token",
+    "symbol": "SST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mh7nlhzvvesgc4whcx7dg2nhj3p0dhl9fwrexu",
+    "name": "SSDS Token",
+    "symbol": "SSDS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jp4r38w4j2qkxavjs9ypqv6mv833wdar3tywe2",
+    "name": "SSGE Token",
+    "symbol": "SSGE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17ktj9hq69ae9mj49dwqfzmj05t6eqlkyywukf8",
+    "name": "SSX Token",
+    "symbol": "SSX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra143dkyw98s3ksxu97zln8z5s220ytatygd5rqdx",
+    "name": "Stader Labs",
+    "symbol": "LABS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ln2z938phz0nc2wepxpzfkwp6ezn9yrz9zv9ep",
+    "name": "Stader xSD",
+    "symbol": "xSD",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/stader-labs/assets/main/terra/xSD.png"
+  },
+  {
+    "id": "terra1u3cykdenv7z3hveg6vfc0w23gfhwkdktftka9a",
+    "name": "Staked AVAX",
+    "symbol": "wasAVAX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra188w26t95tf4dz77raftme8p75rggatxjxfeknw",
+    "name": "Staked KUJI",
+    "symbol": "sKUJI",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra188w26t95tf4dz77raftme8p75rggatxjxfeknw/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://assets.kujira.app/skuji.png",
+    "website": "https://kujira.app",
+    "telegram": "https://t.me/team_kujira",
+    "twitter": "https://twitter.com/TeamKujira"
+  },
+  {
+    "id": "terra1rg8f993m9834afwazersesgx7jjxv4p87q9wvc",
+    "name": "Star Atlas (Portal)",
+    "symbol": "ATLAS",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/ATLAS_wh.png"
+  },
+  {
+    "id": "terra1wky9xanuqfjjy4kxt8xa2pcrf7x6lf0zlwenq0",
+    "name": "STAR TERRA",
+    "symbol": "STAR",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1246zy658dfgtausf0c4a6ly8sc2e285q4kxqga",
+    "name": "Starbucks Corporation",
+    "symbol": "mSBUX",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1246zy658dfgtausf0c4a6ly8sc2e285q4kxqga/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/SBUX.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra13xujxcrc9dqft4p9a8ls0w3j0xnzm6y2uvve8n",
+    "name": "StarTerra Token",
+    "symbol": "STT",
+    "decimals": "6",
+    "circ_supply_api": "https://api.starterra.io/cmc?q=circulating",
+    "icon": "https://starterra.io/assets/100x100_starterra.png",
+    "website": "https://starterra.io",
+    "telegram": "https://t.me/starterraofficial",
+    "twitter": "https://twitter.com/StarTerra_io",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/starterra/",
+    "coingecko": "https://www.coingecko.com/en/coins/starterra"
+  },
+  {
+    "id": "terra146fhkmq8d7ae3e6jemufy4h5eq9zerftm8wzmt",
+    "name": "Stest",
+    "symbol": "Stest",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cf9ey4pm9ugeeehat50gadlze9s0mvluxws2c2",
+    "name": "stValentine",
+    "symbol": "VAL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10led4w62hglspyngk0ydxjsdvelvwthftevq0f",
+    "name": "Super Kwon",
+    "symbol": "sKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1k8fakrhcg5h87zux06hlds3eswej8389l8fdlc",
+    "name": "SuperSaiyan",
+    "symbol": "SUPER",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cnsxjj0378qwu3p5vmrja6j9f84gepvt6r62rw",
+    "name": "Sushi🍣",
+    "symbol": "SUSHI",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1l0rnt55mf8q87q2nqfn9un3lxnmxkhqrl939x5",
+    "name": "SushiCoin",
+    "symbol": "SUSHI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1csvuzlf92nyemu6tv25h0l79etpe8hz3h5vn4a",
+    "name": "SushiToken (Wormhole)",
+    "symbol": "weSUSHI",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/ChVzxWRmrTeSgwd3Ui3UumcN8KX7VK3WaD4KGeSKpypj/logo.png"
+  },
+  {
+    "id": "terra1a2f4pxdqd98qclaeafdqxlc3dvnt3wqedx3l77",
+    "name": "SWAP",
+    "symbol": "SWAP",
+    "decimals": "3"
+  },
+  {
+    "id": "terra108fs4ahf6zzy7tqpvczg5yrfjpqw20kxc43pq5",
+    "name": "SWAP finance",
+    "symbol": "SWAP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gcfdqwp2ztyn22mu845n7axlua6nwt38s4nkdl",
+    "name": "SWAP finance",
+    "symbol": "SWAP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1g53pyke8jtmt4lwvk4yl0xaqc4u0qlsl8dz3ex",
+    "name": "Synthetic UST Token",
+    "symbol": "kUST",
+    "decimals": "6",
+    "icon": "https://app.astroport.fi/tokens/kUST.svg",
+    "website": "https://kinetic.money/",
+    "telegram": "https://t.me/kinetic_money",
+    "twitter": "https://twitter.com/kinetic_money"
+  },
+  {
+    "id": "terra10vvl9llw4p7ca2zhmcdljk5el9fkpp9hg6qy53",
+    "name": "t.me/BabyTerran",
+    "symbol": "BBT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18ys4xv4yjy6c7984mv4sz08p3rpl8cdtxxhuhw",
+    "name": "t.me/Safe_Luna",
+    "symbol": "SAFELUNA",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1vsr6l45yyqn58at6nymdx99kph9sw7zql70akr",
+    "name": "t.me/UnstableKwon",
+    "symbol": "UKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lyppcm0cjc5nrge6hmwdkkeqeh4m9cat8nyf3e",
+    "name": "TAC Token",
+    "symbol": "TAC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1j7ft2ze4phmcj4x2mnr7cfcns5x5hqjnnt8myj",
+    "name": "TALIS",
+    "symbol": "TALIS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18vl2cypy8pdys2qdqlg7pzmcmpqmur8lmrnk2c",
+    "name": "TEGX",
+    "symbol": "TEGX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jw43a4x2jdftvk9ylfyuqhy9asam4ymjufme44",
+    "name": "Tellor",
+    "symbol": "TLLR",
+    "decimals": "3"
+  },
+  {
+    "id": "terra12zzantsa5trfm0ssrgsnhvlram502ats35qtc3",
+    "name": "TERRA",
+    "symbol": "TERRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10l407saphqe2tc35ejhzg7xyulqkeqccvvc6uw",
+    "name": "Terra BabyFloki",
+    "symbol": "TBFloki",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pxuknzmg3kup7790vjzssjjuelrq3a3ys4aml6",
+    "name": "Terra BabyLuna",
+    "symbol": "TBLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10jyyy0ylv34lafqv2mldcuxhk4qpdmnckgfls2",
+    "name": "Terra BitBase",
+    "symbol": "TBIT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15kqr498g9r2j5mnddy27qgppcp8a759lcegsz0",
+    "name": "Terra Bots",
+    "symbol": "BOT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1we9tgz73r6q3nqxwre5375l0nxh0s7ry47s6j8",
+    "name": "TERRA BRIDGE",
+    "symbol": "BRIDGE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16mvysduudq3ys8vn08c5ts8yx08g5vahjaylq4",
+    "name": "Terra Bulls",
+    "symbol": "BULLS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1t5kcd9285mqczsyy2ztu96h8h8ecpy5sf6h0qu",
+    "name": "Terra Cardano",
+    "symbol": "tADA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z9yq8l5fn7y5msg37rx2p0up0pgkf52ml4uv0q",
+    "name": "Terra Cash",
+    "symbol": "TCSH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1677xekxjqc4f3jqut8yr6p29e8h5zfay37et58",
+    "name": "Terra CAT",
+    "symbol": "CAT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f77l2dprlhg2h47uvhzp2zhkdrkcy8fse90xkk",
+    "name": "Terra CATE",
+    "symbol": "tCATE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1agkfm4zumwkkudpj0882xaex7fne3rume0775y",
+    "name": "Terra Cate Coin",
+    "symbol": "CATE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hc9zu9jx0vy5gt8yl7evu0wk6xvjl0ylnsg75x",
+    "name": "Terra Cats",
+    "symbol": "Cats",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ufxgdde0fkmmc7mvmkuaxps9raua78r7f0vm3x",
+    "name": "Terra CCC",
+    "symbol": "tCCC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1uc4fwlh2wn59qqk8y7ld0vxc9hvsufaa5gv5z8",
+    "name": "Terra Dao",
+    "symbol": "TDAO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10pvdslu4j8x6rqm2uuvh7dwd3rtaw9qq37g7v7",
+    "name": "Terra Doge",
+    "symbol": "tDOGE",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1f3gyvkfwy6lvst5c63gx7alp6547clceaamyyp",
+    "name": "Terra Doge",
+    "symbol": "tDOGE",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1z3fvf7tae0586jjn5ve580thc3pyj9vwandw4n",
+    "name": "Terra Doge",
+    "symbol": "tDOGE",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1txlylfvu2s9p3tt2fa82xj6qy6pp86avs0t43w",
+    "name": "Terra Doge GF",
+    "symbol": "DOGEGF",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14qs03ha38aya45vac8q9wn8pjy92knwta2exdx",
+    "name": "Terra EEE",
+    "symbol": "tEEE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1p3z96mc9gr66yruc3c0v73u0e574kjpgeledm3",
+    "name": "Terra Farm",
+    "symbol": "TFarm",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18m523525ntva277qramnc6x2hh56a28w0vndjf",
+    "name": "Terra Finance",
+    "symbol": "TEFI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1t9m52s6gey6mcy9upq5ucujl5n6ewwqk80hp8t",
+    "name": "Terra Finance",
+    "symbol": "TEFI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fc38stp3xzjh5q8u0nrlk4n0gagxrnen35rsq8",
+    "name": "Terra FuFu",
+    "symbol": "tFufu",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1534wdj9s0c3c64pmgqk8544usm0jvfysn9zq2k",
+    "name": "Terra Game",
+    "symbol": "TRGM",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1daa3rrcq6nk9vh3ecg08x7rmkx3h6egsfex3ze",
+    "name": "Terra GGG",
+    "symbol": "GGG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tqjzureahwdezhy64uw7x9vpywgxvxcngexecf",
+    "name": "Terra GO",
+    "symbol": "tGO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10ewuq49hkk438jhd7q79hfetqpkkt04tfm7rzc",
+    "name": "Terra HEX",
+    "symbol": "tHEX",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1yx2z4j3wr55k7jns06qhn2hsw6agskvcke6zu6",
+    "name": "Terra Husky",
+    "symbol": "HUS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1353an33z0u5dd0yajwjazfnyt4585q5085c5mg",
+    "name": "Terra Infinity",
+    "symbol": "INFINITY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10rv8jte682eec8s3fyd522hhq577cl75zghx83",
+    "name": "Terra Kasama",
+    "symbol": "tKSM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14ldz32u9l0s9lh07zqqqxgmnzwyww04hmvs923",
+    "name": "Terra Kasama",
+    "symbol": "tKSM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1duggxa56m97yfcat99ew27z3q4rnax4w4u8waw",
+    "name": "Terra Katz",
+    "symbol": "tkatz",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mfwgs4aglpetsyy4y55k9g9hsnp5xtcykknldk",
+    "name": "Terra Kujira",
+    "symbol": "TKUJI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra186qt4d07ghj7dm2x64tyc0muw6rl2876jlhv38",
+    "name": "Terra Land",
+    "symbol": "TLAND",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1exgprpvwmn9we9xfxlqzchfqd533wtnafhg0w4",
+    "name": "Terra Land Token",
+    "symbol": "LAND",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16q2hhuva6u0zakfav0pmrdw2fhjsanvqq9y56t",
+    "name": "Terra Launchpad",
+    "symbol": "TPAD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra122anargqcp9anz2cmuwc3u5m4nww6fpvyc39tz",
+    "name": "Terra Man",
+    "symbol": "MEN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1spuk4t4lxsmgx8wqq0ltqrxagnrzwvk6lmf4t4",
+    "name": "Terra MANTA",
+    "symbol": "tMANTA",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1u72jtyujxu8dmpxedrrtmt5tekn0usf09r2a9h",
+    "name": "Terra META",
+    "symbol": "TMeta",
+    "decimals": "6",
+    "icon": "https://i.imgur.com/4H10ALI.jpeg",
+    "twitter": "https://twitter.com/meta_terra"
+  },
+  {
+    "id": "terra1qv98rklgrdv89gvf47rrzx2lzehd43uwz2rus4",
+    "name": "Terra Mine",
+    "symbol": "tMine",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ml4r2ry9pf9evmahn0nh5nzjzntf63wzmnull3",
+    "name": "Terra miniShiba",
+    "symbol": "miniSHIBA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13jkds0xx2hy2xrqwggzkt4navhremx2cjyl7aw",
+    "name": "TERRA miniWhale 🐳",
+    "symbol": "miniWhale",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hvv3qzmzmmr9qkf2xj928hhy2yxuledwzn2v5u",
+    "name": "Terra Monster",
+    "symbol": "MONSTA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra120v2mhzge3mxat8nsz8ctqgy6f0cnnfjymsgum",
+    "name": "Terra Moon",
+    "symbol": "MOON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19245ct3nfz95j3peem0zxy0e8e0w2uq4n4ssr3",
+    "name": "Terra Moon",
+    "symbol": "MOON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hmxxq0y8h79f3228vs0czc4uz5jdgjt0appp26",
+    "name": "Terra Moon",
+    "symbol": "MOON",
+    "decimals": "6",
+    "icon": "https://moon.gl/logo.png",
+    "website": "https://moon.gl/",
+    "telegram": "https://t.me/TerraMoonOfficial",
+    "twitter": "https://twitter.com/TheTerraMoon"
+  },
+  {
+    "id": "terra1tht79ct6uqe4ngg6wwjpxcu4ep3wdjhlttkthz",
+    "name": "Terra Moon",
+    "symbol": "MOON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1epzqhvam83e7lfqtdmgzatlvlzwu23x8kd4t4v",
+    "name": "Terra Moonshrooms",
+    "symbol": "MOONSHROOMS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1asq6hza8spaeghqt4k7fnj4m7nfaag07ljdqz7",
+    "name": "Terra Musk",
+    "symbol": "tMUSK",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1dwvauhhpsmhwjf2x32uqeukg3zdgm89zy6004g",
+    "name": "Terra Musk",
+    "symbol": "TerraMusk",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12l53n0hg4kh9y8jlafd7lyakj3lrejedpryj7s",
+    "name": "Terra Name Service",
+    "symbol": "TNS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14vz4v8adanzph278xyeggll4tfww7teh0xtw2y",
+    "name": "Terra Name Service",
+    "symbol": "TNS",
+    "decimals": "6",
+    "icon": "https://tns.money/static/images/token-logo.svg",
+    "website": "https://tns.money/",
+    "telegram": "https://t.me/tnsmoney",
+    "twitter": "https://twitter.com/tns_money"
+  },
+  {
+    "id": "terra1xy2gf523j92khfn8nx0uurkmkguul2u95cwv8v",
+    "name": "Terra Name Service",
+    "symbol": "TNS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fcq75y4ezhsws0vudna3cddk20d3k0eg9nznyh",
+    "name": "Terra Net",
+    "symbol": "tNet",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1twcwynuvhs778m8x46n7e6gyvu7srtkjcaufxd",
+    "name": "Terra Pepe🌗💵 Join https://t.me/terrapepe",
+    "symbol": "PEPE",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1kp8vne240370hn722ec5sacsdluyt2j0gc5nph",
+    "name": "Terra Pump It Up",
+    "symbol": "tPUMP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jsxp2vt60nqfsuru6s6ewgfld7vpwgkvv5qqgl",
+    "name": "Terra Raca",
+    "symbol": "tRACA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17n0sj0ed82upz3c38px5hl2zy7mestccskauva",
+    "name": "Terra Reflection - Hold2Earn",
+    "symbol": "HtE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17w68lnnp47k4zkfkpcyzu2xeu6qw576ksfpp4r",
+    "name": "Terra Reflection - Hold2Earn",
+    "symbol": "HtE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1je4ll79zmy03zpl4wdhgmadvznqr08tzrncpqw",
+    "name": "Terra Reflection - Hold2Earn",
+    "symbol": "HtE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nl9dx4pkat90gzw2j99n338n984e4cw7nxq65w",
+    "name": "Terra Reflection - Hold2Earn",
+    "symbol": "H2E",
+    "decimals": "6",
+    "icon": "https://static.wixstatic.com/media/cc2bf7_93413983a23e4cf58679d1155069a2db~mv2.png/v1/fill/w_281,h_281,al_c,q_85,usm_0.66_1.00_0.01/cc2bf7_93413983a23e4cf58679d1155069a2db~mv2.webp",
+    "website": "https://www.hold2earnterra.com",
+    "telegram": "https://t.me/terrah2e",
+    "twitter": "https://twitter.com/Hold2EarnTerra"
+  },
+  {
+    "id": "terra1ulzl6vfexrk39vaje0qryarzlq2ahy80cdl4fz",
+    "name": "Terra Reflection - Hold2Earn",
+    "symbol": "HtE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra140k6k2pmh2lmy4q4wyz5znqmtgwvs3gkgfeevq",
+    "name": "Terra Shiba",
+    "symbol": "tSHIBA",
+    "decimals": "3",
+    "icon": "https://terrashiba.money/terra-shiba.png",
+    "website": "https://terrashiba.money/",
+    "telegram": "https://t.me/terrashiba",
+    "twitter": "https://twitter.com/terrashiba"
+  },
+  {
+    "id": "terra14lmsae6e4d5lu74yt67pkfsdaut4csjtq32a7x",
+    "name": "Terra Shiba",
+    "symbol": "tSHIBA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19ur0s3h72v7t2qmy58z60e0cl0epkal3mle4mu",
+    "name": "Terra Shiba Inu",
+    "symbol": "tSHIB",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1em52fj74ezgeqp5s6mp96y494s2gkjmtqy46sq",
+    "name": "Terra SpaceX",
+    "symbol": "tSPACEX",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1ng3nsd3u3emflmp4rv7ac70ug3g87pt930g6t5",
+    "name": "Terra Squad",
+    "symbol": "SQUAD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15dcd0j3tqtefj96nhqryt59qyr820tyxq3l0dr",
+    "name": "Terra Squid",
+    "symbol": "TSquid",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18lx7nzwlp8sr83y2wymhj37fnrlehm7rj6lhlf",
+    "name": "Terra Squid",
+    "symbol": "TSquid",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gkfv34wapjun9w0qpg8f245greudfguzlhp87f",
+    "name": "Terra Squid Green",
+    "symbol": "GREEN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zf5jn0nsureuqaeqmj4pwkrtcm9m7rmlkdjxra",
+    "name": "Terra SSS",
+    "symbol": "tSSS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e60jlze35lh05dlqrh2yjv3r8z3gktwchykrq0",
+    "name": "Terra Swap",
+    "symbol": "SWAP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra109vclyh90fkj77ruk299pkk460sjm54vs9x6et",
+    "name": "Terra Virtua Kolect",
+    "symbol": "TVK",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
+    "name": "Terra World Token",
+    "symbol": "TWD",
+    "decimals": "6",
+    "circ_supply_api": "https://api.terraworld.me/twd",
+    "icon": "https://app.terraworld.me/static/media/logo.f81b8104.png",
+    "website": "https://terraoffice.world",
+    "telegram": "https://t.me/twdoffices",
+    "twitter": "https://twitter.com/terraworldme"
+  },
+  {
+    "id": "terra1dmkfkt5em3heh003hc9e0sqmplh2cp7vmuxv59",
+    "name": "Terra World Token",
+    "symbol": "TWD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s0fnj6cz44e2j45293320wmwmjp5pmdkuuv878",
+    "name": "Terra World Token",
+    "symbol": "TWD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xhqxa9c3z223lt67lt86r2lsvtmuguddc9g55m",
+    "name": "Terra World Token",
+    "symbol": "TWD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y0spkg2up7ddqd98f9d45wacfwjmdvpq702y72",
+    "name": "Terra World Token",
+    "symbol": "TWD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15fvz44vh89rj4ykamk2tadw0f7wdnccn5qp0ua",
+    "name": "Terra XMAN",
+    "symbol": "XMAN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xxze8dty562la0d6g9q3srlddh0qemk08kpgfr",
+    "name": "TerraAlpha",
+    "symbol": "ALPHA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10t5spcvn5m52fs4j5tnjerm6wzsn9vuqdsheje",
+    "name": "TerraBond",
+    "symbol": "TRBD",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1a95wwge5ut59aet6wx9m5ukq0alnxj0waf4sgl",
+    "name": "TERRADOGE",
+    "symbol": "DOGE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cxvsl5qdvctc537a8q9ynv0seu4r5ceacptwx0",
+    "name": "TerraEarth",
+    "symbol": "EARTH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17qkws34rpkzp5clc86xkyal8235lugj38dhk5v",
+    "name": "Terraformer",
+    "symbol": "TFM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17rwgygp5y7tx83xyclwuxu654vjt2whpwxx688",
+    "name": "TerraFormer",
+    "symbol": "TFM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kx73zld4tmv24r66h7jp8gaz2rrl4asxlzq2g4",
+    "name": "TerraFormer",
+    "symbol": "TFM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m6myw86l5zgw3z58z6rynr8zxaexprfc3m3357",
+    "name": "TERRAforming",
+    "symbol": "TERRAF",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pafrxwl8ur3jzjgw5qhts9vku68xsenctgqvkq",
+    "name": "TerraKub",
+    "symbol": "TKUB",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1sn208s2cmya87707w4r9hf36znv8ml8dcnhr2d",
+    "name": "TerraKub",
+    "symbol": "TKUB",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1sn208s2cmya87707w4r9hf36znv8ml8dcnhr2d/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://terrakub.io/wp-content/uploads/2021/10/TerraKUB_LOGO_200x200_KUBHEAD.png",
+    "website": "https://terrakub.io/",
+    "telegram": "https://t.me/TerraKubCoin",
+    "twitter": "https://twitter.com/TerraKubCoin"
+  },
+  {
+    "id": "terra14pv5z9j9auwf7p4dg3ds0gch8sr8gnnf0psk8c",
+    "name": "TerraKwonDo",
+    "symbol": "TKwonDo",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ckkyhfxnqkumqrvmpl6rnrjzvklephzvsse57z",
+    "name": "TerraLand",
+    "symbol": "LAND",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1whwxszdwu6m4pup0glpfn7qhwmnh6a49mrsv2h",
+    "name": "TerraLand",
+    "symbol": "TLAND",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14dtgwushpvu2c8d8rtc58z9r2t4p67ug8wl4d7",
+    "name": "TerraLand token",
+    "symbol": "TLAND",
+    "decimals": "6"
+  },
+  {
+    "id": "terra152qpnfe76pnkwe8msfjxf4wjq0tcjtuuunv7eg",
+    "name": "TerraLand token",
+    "symbol": "TLAND",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kuf3mxgrcwnlh4zfk5p5c6tcv436j5kza70asm",
+    "name": "TerraLand token",
+    "symbol": "TLAND",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nkf3aaal2j93pqdtytf73x6dqnpxy2u75ezauh",
+    "name": "TerraLand Token",
+    "symbol": "TLAND",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1r5506ckw5tfr3z52jwlek8vg9sn3yflrqrzfsc",
+    "name": "TerraLand Token",
+    "symbol": "TLAND",
+    "decimals": "6",
+    "circ_supply_api": "https://terraland.io/api/tland/statistics/circulating-supply",
+    "icon": "https://terralandio-site.s3.eu-central-1.amazonaws.com/TerraLand-logo-v1c-4x.png",
+    "website": "https://terraland.io/",
+    "telegram": "https://t.me/terra_land",
+    "twitter": "https://twitter.com/Terra_Land",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-land/"
+  },
+  {
+    "id": "terra19y395vzlylv3s3nasr7cu4yey7s22ghqd35ps8",
+    "name": "TerraMeme",
+    "symbol": "TMEME",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17pc8eq0u35yslg7zulkqzc2mvxryfj3hw7nmsr",
+    "name": "TerraMineToken",
+    "symbol": "TMT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tgfw423t34rwaezm4u4vwy5d80tfgzuyx2s6x0",
+    "name": "TerraMoonDoge",
+    "symbol": "TMoonDoge",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15plvf4hfgsrev5athn7wmnqgt6f0lddmduzp90",
+    "name": "terranetwork.ust",
+    "symbol": "TNK",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lxh32h38lf8xdk6lv7k5w0ewy7gu6psy4gfmnm",
+    "name": "TerraNFT",
+    "symbol": "TNFT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1rfqm5zwkep3jk845nf565yyua66uj654y2vzx3",
+    "name": "TerraPunks",
+    "symbol": "TPUNKS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18ky9ln4g6x3n9f9s8a5ttshynv6lgzfppmrmyg",
+    "name": "TerraRX Token",
+    "symbol": "TRX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ghnll5fz4n6c0vt47jdnnyrjgfg4fgnqnchwys",
+    "name": "terraSUN",
+    "symbol": "SUN",
+    "decimals": "6"
+  },
+  {
+    "id": "null",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1079zf52uyn4hnxdrst38fvd9ga582xcjrmenw8",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10jmlz5uwz6w5hks8y9tretjjk4f8ad2me44lve",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10l54yyxus354jl80v57npylas00ktj7vpedml7",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10zkfrqvgqvsh026ljcswe59lwh88yc5v43yc9q",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra122asauhmv083p02rhgyp7jn7kmjjm4ksexjnks",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1237hndgalhuukzuccfvfjj538az8739td5cnaw",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1283mf36gl6zks6yxr50mc5cvzvg26qg50mq74s",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12awas0yfsn4r4ppzp4agqu8rp8gyw8weglpuca",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12dnl585uxzddjw9hw4ca694f054shgpg93cg90",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12ndzg4g6k6q48hasdrrk7rul428npl88ljugtf",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13dvh4d653c6tyu7f30hwcpjnrz8xhx87yduphr",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14dgkwkplgmw9tkdf4rc72ppk6q5p2mu0uhfl09",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14uaqudeylx6tegamqmygh85lfq8qg2jmg7uucc",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15hus6hg88440lypz37a8u90t8twdjmwnp92yfn",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15pclv9fqytszqlmjymshyk9cfytaaqrs4h87sf",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15qmh9jl388v2hr2yn75v8psdj0q9ghfwwxzckg",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra165k229vdtpng40rhdfn3tqtqphwxeyjx5wrwxw",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra166h9t9xrsy0wq8t7hpdjx52eecze4gcussgr44",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16auz7uhnuxrj2dzrynz2elthx5zpps5gs6tyln",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16c2lh2lr0xe92ayf558rgzw47gf8cmqh58v06n",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16ejsp5mhav3kppkj7w438spp0eawknsj0afhvx",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16j09nh806vaql0wujw8ktmvdj7ph8h09ltjs2r",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16ledesd9tn24fte454883p577qvr24hngmfefg",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra178cf7xf4r9d3z03tj3pftewmhx0x2p77s0k6yh",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17dkr9rnmtmu7x4azrpupukvur2crnptyfvsrvr",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17gjf2zehfvnyjtdgua9p9ygquk6gukxe7ucgwh",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17smg3rl9vdpawwpe7ex4ea4xm6q038gp2chge5",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17tlyml4tq2hw922aq2dq4dhnjcu296mlkgrx6n",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17vddhyh8zulk4yx2zapsk9z5y5r5mjaf9w6egv",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18qgqfp2pay886vakll5duudytylazyy9eh89yq",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19t9e42yxukxuuqzyekccm5jpu3gek3nttdsz8f",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19zju3mkymrhfefd9lv7mq0u9ke0xmveemuu33g",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1aeusm5e93ptz2twem0vpfy370c7d7vy2dp0vke",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1azk43zydh3sdxelg3h4csv4a4uef7fmjy0hu20",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1c9wr85y8p8989tr58flz5gjkqp8q2r6murwpm9",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cmrl4txa7cwd7cygpp4yzu7xu8g7c772els2y8",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cvwy6kx24fhpeq4gjuyp2ynwcsxu8gtvk3mde7",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1d2muut0rea9fkff6y304yn6qkr2uacau7ltggc",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1d34edutzwcz6jgecgk26mpyynqh74j3emdsnq5",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1d5j958a4vrfmv20gddyp0gz0f6yx0kpd702qke",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dmuw5wyluxe6hf85x7waepwuqjgs2460fmj8qn",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dsj8lxhuvtz8k8vt9v7zjm85cca4qjhsqgvced",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e7d7325sjpfk02vnzqkwsnlu0xqejydleeh2h8",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e92r33fhkft6p8fyamwu3zp300t5l35cjxf5tf",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ekd58y58vq4gmxlzpc27dwuhw7wmms928ftuep",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f2mpaw7jmm7jzhkgf2x7yg50vr9m4aplu7gkxg",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f7jzky244gwy220xp7cdd0vzhu6l5ncafderaf",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fa6hue6yjt90ytjuxqv6mlsmrm2agc7w6vjhd4",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1falkl6jy4087h4z567y2l59defm9acmwcs70ts",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fc5a5gsxatjey9syq93c2n3xq90n06t60nkj6l",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ftd4p3rfcry6sgrwjs78s0562kmut3p6cpnq77",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fxzmf732l2mj23wq3aryww50xg7gclhelvs2k3",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gecs98vcuktyfkrve9czrpgtg0m3aq586x6gzm",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gk602sa0jwk73xlr8tpkd3fpukhfa8hjety68r",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hl09j27s27407wkct646lqnxg3qskpl2ehuvn9",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hqpfh2g457fuzrm8e0skagwwh79pffr3zzqwek",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hvz34zmk4h6k896t94vd8d5qjdchhnkdndunzx",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jh2dh4g65hptsrwjv53nhsnkwlw8jdrxaxrca0",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jl4vkz3fllvj6fchnj2trrm9argtqxq6335ews",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jl875nm4p2z4jgapz6al2h74ug0fpf59n7pfjg",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jmauv302lfvpdfau5nhzy06q0j2f9te4hy2d07",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jmzlups5p4upfx995j824vyngnahsx5tjpk3m7",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jnn5xpmeythug88hu66pwl3x9fz2s0ms034aw6",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jqqegd35rg2gjde54adpj3t6ecu0khfeaarzy9",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1juspa927c7kdr0jf7wc0lxg6wfjz2cersm9r82",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jvewsf7922dm47wr872crumps7ktxd7srwcgte",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1k5kumxd24cyvhf52r5u4ywlr3ztktj657wnf7a",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1k5z9y8h9jr4ex63cmmlazn3kjc7mncn66xrrk4",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1k67ut87c2up66tury4qc4n96d85t43u20v24sy",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1klc5n2zy79ttxur0mdvhqldyzhkmcehaqm877w",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1klgaa9lyrcgdwudd9mvu0ys2spdsxd8mk55ure",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1knrlem7cg0ywg5hldmghlj8eqh0f8lw2fhc599",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ktckr8v7judrr6wkwv476pwsv8mht0zqzw2t0h",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1l0yxvzzszzfcrfcle55wdf2xxmalc9eg5c28ej",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1l8jgxd9uv430rdt2u58h4h7kdfxsle4w6w2ecq",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m4q5lr2s3j5eylf2jq06d8vw0au3trgdadezfc",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m5gwp6ujj0frnwkgxlkmhwu5we9xaysnwa6f8s",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m8mr9u3su46ezxwf7z7xnvm0jsapl2jd8vgefh",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mljg7dvzknqh3gc62emagf7hwxxg8efemennp8",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mnj6zstfk2ne0htcre9cvjv9ut0zd5t95wyagy",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mtvslkm2tgsmh908dsfksnqu7r7lulh24a6knv",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mv3pgkzs4krcennqj442jscg6jv84cejrs50n2",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mwu3cqzvhygqg7vrsa6kfstgg9d6yzkgs6yy3t",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1my49papxtmataag9arh9wdrqyyuqyjfw7cc44v",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mzpxqr5vwnzl822sjd3yskaekz2lyvfpavush6",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1n8fwsrf3qruwx99eg87dmw7x4pjc8n0a35vlef",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1na4sgkt5ft37s72l9hd6wsa7hdql0j75er0u7l",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ndlx5ndkknvmgj6s5ggmdlhjjsz0w6wrnwn5cf",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nuy34nwnsh53ygpc4xprlj263cztw7vc99leh2",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1p60datmmf25wgssguv65ltds3z6ea3me74nm2e",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1p6fhh4n9keyyhzq6stytvn0qs6etj8md6mwe72",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pjgzke6h5v4nz978z3a92gqajwhn8yyh5kv4zv",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1prswk9yyayfkkq99fpaz5zs7h0lhcpsqa4swj9",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ptsj2ufnvp5nv5lf8gtxek7c44rlztppedepfu",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q7m2qsj3nzlz5ng25z5q5w5qcqldclfe3ljup9",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q7n7hzd9dsmakmzjql2mdg5gfrnx42a9hj8665",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qjlakmnnswdzmssfzurpdg48ygu5cnw4lg9h80",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qxlp0q3z20llu0gz9c7urzw7rmlnchm23yk8xc",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rqkyau9hanxtn63mjrdfhpnkpddztv3qav0tq2",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s0dgcsdy9kgunnf3gnwl40uwy9rxtmc39mhy2m",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1stfeev27wdf7er2uja34gsmrv58yv397dlxmyn",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1t0mgl6lns0ff6wva27zjwqfpqrjdzw550ed652",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1t46rhfcgqpz9xkx33qpzk55yudp7wdaygj7yfw",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1t4xype7nzjxrzttuwuyh9sglwaaeszr8l78u6e",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1t8qmg9p583jcp2f7uuhga73yh7ze0u4ny7kmzy",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tmw02ugjulhezj868pu4s6mhlmshlez7thzane",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ungyyyachxaszce53zstctel0mpzactmtz8hdp",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1utf3tm35qk6fkft7ltcnscwml737vfz7xghwn5",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1uwhf02zuaw7grj6gjs7pxt5vuwm79y87ct5p70",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1veqh8yc55mhw0ttjr5h6g9a6r9nylmrc0nzhr7",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vkjgr2rsagh52jdcur4zgjyj7ag5xrfmyekne2",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wd25umnrgnfydwd7k7m364ykk79r76tclm5v4n",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wdjsxymg424mw4sv6zmw4luqajwxa5e7qfvfxw",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wdmkqdhqmyv9csgwfdh8739fu65qpay7jj5vvh",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wfms03rc04cdc0xvs7rh8z3s498ns2zgqctq7y",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wg3dhzz6m5q3dm738u6sxzxhld60l0chgvpele",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1whdv289y72n38x8sevz5erze8zys493ha2fd0a",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1x3musrr03tl3dy9xhagm6r5nthwwxgx0hezc79",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xqeym28j9xgv0p93pwwt6qcxf9tdvf9ztfxf0w",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xsv563k2wyuqkwza0mrz6ye8exx4a9r0hdvxs6",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xxracarga8mf8yadf8s25hekr4kd92l3wr35vm",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y097nnhjger6l3ds9r96xfdpq7vcdp5yh70n6x",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y6x3mh07l8xdpxap7xw2u5pclrenjaulpcfh36",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y9kxxm97vu4ex3uy0rgdr5h2vt7aze5sqx7jyl",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yg09m7lcj739wvr3ns6d67znhyp4jexvpx2vkg",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ygazp9w7tx64rkx5wmevszu38y5cpg6h3fk86e",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yqnd70kvrdfazu7aplalwqdp3ksnu35fv9cv9m",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z0z6hz96au9lr027uedxay3s09ry36md3wpm0v",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zy5sjsw4aswykccwtvkaq27s2eedspvakut7gw",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "uusd",
+    "name": "TerraUSD Classic",
+    "symbol": "USTC",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/ust",
+    "icon": "https://assets.terra.money/icon/60/UST.png"
+  },
+  {
+    "id": "terra1zvhvg09zeyl3txrc7v3crnqnnwc0d2nvgxvdhd",
+    "name": "TerraWeed",
+    "symbol": "TerraWeed",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14yyepy06yw57f4x564xrfwxvv460vq0su5ype8",
+    "name": "TerraZilla",
+    "symbol": "tZILLA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ckrsweg4dtg47qv55ecayntlax3j8ja956nq2l",
+    "name": "TerraZilla",
+    "symbol": "tZILLA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16wggm67a34msdxasg2vergm2pt289y7930wv7d",
+    "name": "Terrnado Token",
+    "symbol": "TND",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1wuchppam64t2chrfmevv9tv64mur2ls395qa44/store?query_msg=eyJzdGF0ZSI6e319",
+    "icon": "https://terrnado.cash/logo.png",
+    "website": "https://terrnado.cash/"
+  },
+  {
+    "id": "terra1n9k2he20h5vpyn4mgv7pg4pzvw2n3wc4a86v3g",
+    "name": "TerrnadoCash",
+    "symbol": "sTND",
+    "decimals": "6",
+    "icon": "https://terrnado.cash/stnd_logo.svg"
+  },
+  {
+    "id": "terra1z8ta6q6tfvp3sec0f4yftt8ew656d0x8zhgp66",
+    "name": "Terror",
+    "symbol": "TERROR",
+    "decimals": "6"
+  },
+  {
+    "id": "terra176eej9z5upauemz7wg2q6n86472xyy836v6smx",
+    "name": "Tesla",
+    "symbol": "mTSLA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14y5affaarufk3uscy2vr6pe6w6zqf2wpjzn5sh",
+    "name": "Tesla, Inc.",
+    "symbol": "mTSLA",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra14y5affaarufk3uscy2vr6pe6w6zqf2wpjzn5sh/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/TSLA.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra14rq6etqgza9qqpgz9yjfmsclgnzhk9jsafdtyc",
+    "name": "test",
+    "symbol": "test",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1elveensfjwt270xzt8rcpvwmnhawrrqfx5atj4",
+    "name": "test",
+    "symbol": "HAHA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kh0w04u79rhwvchmjsd7q4xxlm72y5wpf6a87v",
+    "name": "test",
+    "symbol": "test",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1sqagv65dlqj3hlg4fxrljlhfg5wulsp4nm58j7",
+    "name": "test",
+    "symbol": "test",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wdz268njqhhpy30qcd6zxmvtu5y0xr06cnkdqq",
+    "name": "test",
+    "symbol": "TST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra149tus2mxyak6ec9tm0fqs6eumeryga2ps9w7ku",
+    "name": "Test",
+    "symbol": "test",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17ggkh9upvkmeyew240lz95zcdytpd2j9m55he5",
+    "name": "Test",
+    "symbol": "Test",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ghkclqug2jhanmjsx46x0vymcglchcesg98057",
+    "name": "Test",
+    "symbol": "Test",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gqmd09k8g3lggxxdzu9z94vqcxtr5zylvs95ke",
+    "name": "Test",
+    "symbol": "Test",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zfvr6uszt8khnf4damxrujfkhgl0mep0khcs7w",
+    "name": "Test",
+    "symbol": "Test",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zrfd9hf3z6kwewxrt3rluzdj5d7ymzxnnptc6k",
+    "name": "Test",
+    "symbol": "Test",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pr2swnalac9ny993tgvtcfyhe4h9cuqm3rdmnf",
+    "name": "TEST",
+    "symbol": "TEST",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1d3pmqshpe6n5cs7d6mnffdun4tg0k05zfy99zh",
+    "name": "Test DB",
+    "symbol": "TestDB",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10qjtgmpsnx7kn53nxmw2mfx626g8y4xaw04pd8",
+    "name": "TEST DONOT BUY",
+    "symbol": "ZMT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14a2t4c4a8us6q24k2hkfm7kdenzxu0yxph35wd",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15as2k330rp40z3yp8ufs2uqnmdurlzgl643fsp",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15tqztw9vjcuc9znkvmxn7rh30ffdnahhnw4vym",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra174tuptw39sd3s5yqq466xc5lygh9z8gp05wf4j",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra183x8jduwtdgcqkwtqxdzjlq2mq0rlnj6hm22j7",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra187lnjdwluvfnzxcef4appgr4v7fwljj5d5wdhf",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1897wmaycufjr9hu894mt0g33ddcgm9vfsfcyyd",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra18neulu99zm7kj040tndhavjskjm7aaxsk240rx",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19u8cgzsmgg27mnevcc22293yl3j82f26l8nvtz",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1amehwqrzcdrwmwdz9apz9mmctckez66ns67k5s",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1ce0z2295uajnvxltll75zuvh5mvecczy3fmlzj",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1cyaj8agnyzqtw2k5095ysxxgjpgqptyam283dj",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1d8h5yckrkgzneng72c8yskgdfd2s9870fuxnfy",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e05lrpp2tl6sfm8p095mgn8hqu9c42f9sn0eh5",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1fdg5u7nttkcw2v4sepgzlwsznfffn8pnml35pu",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1h56g0tp38whpxlgdwcqdtgmrkkdyqerkymyklp",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1hpkk7ar777hx8ne5vgkkg5tvntm8j9m32w6zam",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1juul8ypgcs4wtuqsc7fjv76g0tq77nc44ymxph",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jwnz2uet8f4yjqyntgsfrplp503wutt24n7srk",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1k7pvdmk0z4hxhcncanp4pxl6ev3hqzeekzu437",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kf3ez7z2kzvvv7z7kte4en35gxm8keurgl09nj",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lcs47eqhugywzrf83xhk65skmfqmxgvkqfq64g",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lnrphdxwfre5w7rwazzfnp0k9d4glm63t7gg70",
+    "name": "TEST DONOT BUY",
+    "symbol": "ZMT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m09t5cs473tvl7lsregj024d3dwg65su6ufpfh",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ma4frxgvc974je0xsxrzpa52j34h9swlww2yed",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1mq6sw9dt57hlpe7ffjm2z3pytr98l4a00lnxp6",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1qxfl4e8gjnunk0t3kq7a6ladu2p4cddk95s5jj",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1r98ydsd3jdjpnq8hhcdd5rnptf2l0r7zvaxu48",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1wzxpydn6z4z0us0wpx3n96gcs5p9qqavhw5sqs",
+    "name": "TEST DONOT BUY",
+    "symbol": "DONT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1rxfw0y02hfhnase727dqpn8kn2uu49qwrwul8t",
+    "name": "test dont buy 100",
+    "symbol": "testd",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1j8nxezl70lfekdzaeanzyzn75htf4sz9vmwhu7",
+    "name": "TEST SVG",
+    "symbol": "SVG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fd2f52tmq59mc093nrawdaey5mzgjnwyu7hwqz",
+    "name": "TEST TEST TEST",
+    "symbol": "TEST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ch852sflpmw500y9jzvkpspzw8ej2jf5934g2n",
+    "name": "test token",
+    "symbol": "TTT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1klz458efcl7md99vafn5sdxtluauem0q5nqjtn",
+    "name": "test token",
+    "symbol": "TEST",
+    "decimals": "3"
+  },
+  {
+    "id": "terra12yvwzt5ayh396hgmyd0rwnamgg4g3mxrdgg7c6",
+    "name": "Test Token",
+    "symbol": "TEST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f0us6p9axmzacwq2fn7sm5ke8k302tx7hg7s49",
+    "name": "Test Token",
+    "symbol": "BDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1t5r5ptw6ympy9npq0z7fa37nrk39n8054c6763",
+    "name": "Test Token",
+    "symbol": "BDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v7q43s46ntt4p7cpxcvsxjk6srr7uxvldn6vuk",
+    "name": "Test Token",
+    "symbol": "BDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra138d8ek2zl48pp3el4s25jxnxn8m9nl2n4y0glm",
+    "name": "Test Token ABI",
+    "symbol": "TESTABI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16hhm24fc3wle66m3529n2jctqqsds57wv4c087",
+    "name": "Test Token ABL",
+    "symbol": "TESTABL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra172hwjglf7rsgrnwet52zqnzjhg7vjgcpm7nctn",
+    "name": "test ttoken",
+    "symbol": "tTEST",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1zvncquef39sne2adlvl3xpzcsge0fypakp00zx",
+    "name": "Test UwU",
+    "symbol": "UwU",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1xp4uhylkhwgam5tc97m0xfaxarajgf6wtcqwp9",
+    "name": "testabc",
+    "symbol": "testabc",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cxusd4uhgpgk2sp99rexrcknpn08anak3v9tz7",
+    "name": "testC",
+    "symbol": "testC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18lk5y974rsknqmcqlruj636mvg57yln93ay0h8",
+    "name": "TesterPog",
+    "symbol": "TESTPOG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1sussd2d7r3y5k6up6n6sxap3ee75gegxah96up",
+    "name": "TestFlok",
+    "symbol": "TestFlo",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f8m2ylcpzfeg3675yk7htw90d72jltgk4mkr9t",
+    "name": "TestingKwon",
+    "symbol": "TestK",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wx4h5qzvgp90ez53fgqr2s9t4rqzzjc03cjxr4",
+    "name": "TESTKWON",
+    "symbol": "TESTKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18zg84fg56lthpjd8skj70l4zd3puyul5weqfer",
+    "name": "TestKwonT",
+    "symbol": "TKWONT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra197txx8gsllv9rakjs6zh7pw6hnlgvte8yf8a8t",
+    "name": "TestNOW",
+    "symbol": "TestNOW",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pamyemqvkj8ws0easzq9pkl8usnjt424ddraff",
+    "name": "testonterra",
+    "symbol": "TEST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13yf7ukapmeznh2uamd0342g0hy872my8shc74j",
+    "name": "TESTSAMOGEN",
+    "symbol": "TSMG",
+    "decimals": "3"
+  },
+  {
+    "id": "terra158ut7lycly6ep0v334rpjtcjs8hlvwjzf5tfrk",
+    "name": "testssss",
+    "symbol": "testsss",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10722f40cxl8tkxjk7f88uj0ehkcw6lu2j504f0",
+    "name": "testtesttest",
+    "symbol": "testtesttest",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1js38ca30k0gt9rz53jc8x47yt638l8f86d5lpt",
+    "name": "Testtttt",
+    "symbol": "Testtttt",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mqeqfh4t746pmrx3u9tuqtqcmjlld6w7a6dxvt",
+    "name": "testwhale",
+    "symbol": "TWHALE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1eqvq3thjhye7anv6f6mhxpjhyvww8zjvqcdgjx",
+    "name": "Tether USD (Portal from Avalanche)",
+    "symbol": "USDTav",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/USDTav_wh.png"
+  },
+  {
+    "id": "terra1hd9n65snaluvf7en0p4hqzse9eqecejz2k8rl5",
+    "name": "Tether USD (Portal from Solana)",
+    "symbol": "USDTso",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/USDTso_wh.png"
+  },
+  {
+    "id": "terra1ce06wkrdm4vl6t0hvc0g86rsy27pu8yadg3dva",
+    "name": "Tether USD (Wormhole)",
+    "symbol": "weUSDT",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Dn4noZ5jgGfkntzcQSUZ8czkreiZ1ForXYoV2H8Dm7S1/logo.png"
+  },
+  {
+    "id": "terra1a8k3jyv3wf6k3zngza5h6srrxcckdf7zv90p6u",
+    "name": "TFloki NFT TICKET",
+    "symbol": "TFTIC",
+    "decimals": "6",
+    "icon": "https://terrafloki.io/ticket_logo.png",
+    "website": "https://terrafloki.io/",
+    "telegram": "https://t.me/terrafloki",
+    "twitter": "https://twitter.com/TerraFloki"
+  },
+  {
+    "id": "terra1xt9fgu7965kgvunnjts9zkprd8986kcc444q86",
+    "name": "TFloki NFT TICKET 2",
+    "symbol": "TFTICII",
+    "decimals": "6",
+    "icon": "https://terrafloki.io/ticket2_logo.png",
+    "website": "https://terrafloki.io",
+    "telegram": "https://t.me/terrafloki",
+    "twitter": "https://twitter.com/TerraFloki"
+  },
+  {
+    "id": "terra16t8cdhps9sxk7sje2w77fay8lh4se3p4gqjeya",
+    "name": "TFloki NFT TICKET 3",
+    "symbol": "TFTICIII",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vte2xv7dr8sfnrnwdf9arcyprqgr0hty5ads28",
+    "name": "TFloki NFT TICKET 3",
+    "symbol": "TFTICIII",
+    "decimals": "6",
+    "icon": "https://terrafloki.io/ticket3_logo.png",
+    "website": "https://terrafloki.io",
+    "telegram": "https://t.me/terrafloki",
+    "twitter": "https://twitter.com/TerraFloki"
+  },
+  {
+    "id": "terra1pmf2x6gp8u979q672lkkkruuhe9zarxyu5w7t2",
+    "name": "TFloki NFT TICKET 4",
+    "symbol": "TFTICIV",
+    "decimals": "6",
+    "icon": "https://terrafloki.io/ticket4_logo.svg",
+    "website": "https://terrafloki.io",
+    "telegram": "https://t.me/terrafloki",
+    "twitter": "https://twitter.com/TerraFloki"
+  },
+  {
+    "id": "terra1mzxr59qj8qr5plgd8kmqx9vn937qr5vzjd055w",
+    "name": "TFloki NFT TICKET 5",
+    "symbol": "TFTICV",
+    "decimals": "6",
+    "icon": "https://terrafloki.io/ticket5_logo.svg",
+    "website": "https://terrafloki.io",
+    "telegram": "https://t.me/terrafloki",
+    "twitter": "https://twitter.com/TerraFloki"
+  },
+  {
+    "id": "terra1yzj58vsvryarrasx6rkf9deyn5h60zlm7lzv8r",
+    "name": "TFLOKI NFT TICKET D6",
+    "symbol": "TFTICVI",
+    "decimals": "6",
+    "icon": "https://terrafloki.io/ticket6_logo.svg",
+    "website": "https://terrafloki.io/",
+    "telegram": "https://t.me/terrafloki",
+    "twitter": "https://twitter.com/TerraFloki"
+  },
+  {
+    "id": "terra19xk3rsesaupv72se69y8v6y6m04fl8yj6vnmtv",
+    "name": "The Edward Coin",
+    "symbol": "EDWARD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra149755r3y0rve30e209awkhn5cxgkn5c8ju9pm5",
+    "name": "The Walt Disney Company",
+    "symbol": "mDIS",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra149755r3y0rve30e209awkhn5cxgkn5c8ju9pm5/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/DIS.png"
+  },
+  {
+    "id": "terra1gtjtyyhj2cu0ekzju4rj86vsvg7d2uu576rrl7",
+    "name": "Thelawenforcer",
+    "symbol": "TLE",
+    "decimals": "18"
+  },
+  {
+    "id": "terra1vn8rmcu3yywfndh2ze43v5h2wg28rycdekdr6u",
+    "name": "Thetan Arena",
+    "symbol": "THG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yy0w2w8rkrfn5ul967rhpjrj4a0hpjy6m7end7",
+    "name": "THEterraProtocol",
+    "symbol": "THE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m86rdykfvtwucrd0y0gzlel7wpcdryctak5wyl",
+    "name": "Thorstarter",
+    "symbol": "XRUNE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1td743l5k5cmfy7tqq202g7vkmdvq35q48u2jfm",
+    "name": "Thorstarter Token",
+    "symbol": "XRUNE",
+    "decimals": "6",
+    "icon": "https://thorstarter.org/static/img/src/favicon.png"
+  },
+  {
+    "id": "uthb",
+    "name": "THT",
+    "symbol": "THT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/tht",
+    "icon": "https://assets.terra.money/icon/60/THT.png"
+  },
+  {
+    "id": "terra19tvczk4us839rsvet9ncwg8est73nmzecdewkm",
+    "name": "TIME",
+    "symbol": "TIME",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15q3lzrnfstr3rqgh55cqmp95z4xr3we5tfyqm9",
+    "name": "TinyDick Kwon",
+    "symbol": "tdKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1j0te9qwyxggd9xq7vhscnnek7yg7cv5gpgurer",
+    "name": "TLP",
+    "symbol": "TLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1g77epr507pp572hnhaprjuz9fp6yn3e4mgyxar",
+    "name": "TNS Token",
+    "symbol": "TNS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1aszsg6mzlzkydqtm46u42mf8zxur9m4ydh9vrr",
+    "name": "TNT",
+    "symbol": "TNT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra12fctlld90cakzkuhd2c3h246zxrhwqd6kp546g",
+    "name": "Tobin",
+    "symbol": "TOBIN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18lxu0868tj9pek9xn3wlgnlv0hs3s9t6473saz",
+    "name": "TofuSwap",
+    "symbol": "TOFU",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1h8hmr0em0avkz4kzuwgakyxrdvxqwg5d3cg4sd",
+    "name": "Token test dont buy",
+    "symbol": "LLL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra145627szryw7lxr58cvclx9aj468qupld4vnf88",
+    "name": "TOKENTOKEN",
+    "symbol": "TOKO",
+    "decimals": "3"
+  },
+  {
+    "id": "terra14eqahu3wavvesuyplmstsrnfu7uglxxy3m96dl",
+    "name": "TOKENTOKEN",
+    "symbol": "TOKO",
+    "decimals": "3"
+  },
+  {
+    "id": "terra174muj5m4c83mvtr49dm4gvf5h2zp24nzphwvmc",
+    "name": "TOKENTOKEN",
+    "symbol": "TOKO",
+    "decimals": "3"
+  },
+  {
+    "id": "terra17zucl25842g99vytr9yzw0eqmql3wwpql357cx",
+    "name": "TOKENTOKEN",
+    "symbol": "TOKO",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1p8y9f7dpmyzy85ldv3k8xccuw0u87lsn9fl86l",
+    "name": "TOKENTOKEN",
+    "symbol": "TOKO",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1z0ewtcsaskfmsp6ue59skulunehzv27ndw5yl0",
+    "name": "TOKENTOKEN",
+    "symbol": "TOKO",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1lm2lwzrpmyyt2qfhkmj7rwvh7yrh0npzpl6k7v",
+    "name": "Top Terra",
+    "symbol": "TOP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ydznesu47hety3am8athucgp6hl4dcxsxqpka3",
+    "name": "Tori Paitan",
+    "symbol": "CHO",
+    "decimals": "1"
+  },
+  {
+    "id": "terra1u4gx4v0nqgzm2kcajk3xf0d35gutwcvdyyjrnc",
+    "name": "TRhea",
+    "symbol": "TRh",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pfynaj6mslxnlekjx7f6rxgfastl46c4hg3kg7",
+    "name": "ttsh",
+    "symbol": "TTSH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra102cjx95xvww7cl9l6usxltk75ww3mpxtyw4lpm",
+    "name": "Tuna Money",
+    "symbol": "TUNA",
+    "decimals": "6",
+    "icon": "https://tuna.money/content/images/2022/06/icon-2.png"
+  },
+  {
+    "id": "terra1v2s7gkylfrnwsdcx8s83k5475nj3jykzs9gsqm",
+    "name": "TWhiteShiba (TerraShiba.com)",
+    "symbol": "TWShiba",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gun7mcfjq965gm2jqmq2upxkeqd2lay4qrzfej",
+    "name": "Twitter",
+    "symbol": "mTWTR",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cc3enj9qgchlrj34cnzhwuclc4vl2z3jl7tkqg",
+    "name": "Twitter, Inc.",
+    "symbol": "mTWTR",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1cc3enj9qgchlrj34cnzhwuclc4vl2z3jl7tkqg/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/TWTR.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra158y6aypem94yj34ycvgdm3py23afhnu2dj24ak",
+    "name": "TXXC Token",
+    "symbol": "TXXC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yv2fdec6ej4g8pv9sru5ezcz75a2zrczllxn86",
+    "name": "UFO finance",
+    "symbol": "UFO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fyjsxx73jrufw8ufgtuswa773dvdkny92k70wa",
+    "name": "Ultimatalioniscoin",
+    "symbol": "ULC",
+    "decimals": "18",
+    "icon": "https://img1.wsimg.com/blobby/go/f561f953-0bdd-48bf-a39b-982ecbd1698b/downloads/Ultimatalioniscoin225x225.png?ver=1649021019249"
+  },
+  {
+    "id": "terra1v7vp6ywlymprx9mk7ngm4uf0xgrz2ektg5wd6z",
+    "name": "Undead Shiba",
+    "symbol": "USHIBA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wyxkuy5jq545fn7xfn3enpvs5zg9f9dghf6gxf",
+    "name": "Uniswap (Wormhole)",
+    "symbol": "weUNI",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/8FU95xFJhUUkyyCLU13HSzDLs7oC4QZdXQHL6SCeab36/logo.png"
+  },
+  {
+    "id": "terra1ay3729yle6u6wxj3wcm8racn50a2yq5r8vxvkx",
+    "name": "United States Oil Fund, LP",
+    "symbol": "mUSO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lvmx8fsagy70tv0fhmfzdw9h6s3sy4prz38ugf",
+    "name": "United States Oil Fund, LP",
+    "symbol": "mUSO",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1lvmx8fsagy70tv0fhmfzdw9h6s3sy4prz38ugf/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/USO.png",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
+  },
+  {
+    "id": "terra1av9tfs7k5gfuzm04e7p0d4ezrc53vq9mn3m08z",
+    "name": "UNIX",
+    "symbol": "UNIX",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1d9ec4gm0c03p74d3qd95qvny2ptf0ge5twqpdk",
+    "name": "Uranus Protocol Token",
+    "symbol": "ANS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yljlrxvkar0c6ujpvf8g57m5rpcwl7r032zyvu",
+    "name": "USD Coin (Portal from BSC)",
+    "symbol": "USDCbs",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/USDCbs_wh.png"
+  },
+  {
+    "id": "terra1e6mq63y64zcxz8xyu5van4tgkhemj3r86yvgu4",
+    "name": "USD Coin (Wormhole)",
+    "symbol": "USDC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/USDCso_wh.png"
+  },
+  {
+    "id": "terra1pepwcav40nvj3kh60qqgrk8k07ydmc00xyat06",
+    "name": "USD Coin (Wormhole)",
+    "symbol": "weUSDC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/A9mUU4qviSctJVPJdBJWkb28deg915LYJKrzQ19ji3FM/logo.png"
+  },
+  {
+    "id": "terra1z49dpvu5g4st7t4j5lsaxaq7v9u6f390m28ap9",
+    "name": "UST Puppy",
+    "symbol": "UPU",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1l2stn9sszzg6qwfqd6ckfa5n58hs4x5wwjaehh",
+    "name": "UUZ Token",
+    "symbol": "UUZ",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg",
+    "name": "Vault UST",
+    "symbol": "vUST",
+    "decimals": "6",
+    "icon": "https://www.whitewhale.money/vustlogo.png"
+  },
+  {
+    "id": "terra17pv5zcuddm96m0nuanw25u4p8nkc9460hz0sy4",
+    "name": "vegas token",
+    "symbol": "VAGAS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19fd35n93667mg020fj5lupws9rhkw59cw459wm",
+    "name": "VENUS SWAP",
+    "symbol": "VENUS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1j7p2fxrzryfpzrrsfe585klnkqutg94kca9vtj",
+    "name": "VikingDoge Staking",
+    "symbol": "VKDogeST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18n2k7nwwkgn20epntr4usy8nrs4l9ecu6wzqv6",
+    "name": "VikingDoge Terra",
+    "symbol": "VKDoge",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y273xzgr58qsdkc89xa6qu5y9padxtm265am00",
+    "name": "VikingDoge Terra",
+    "symbol": "Test",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mt957lrc2z93f5utk509zma6pgtceaq6tqedc6",
+    "name": "VikingDoge Terra - FIXED",
+    "symbol": "VKDogeFIXED",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ttm7w640scqrarn0qxqz26798d84u94sg7gshw",
+    "name": "VikingDoge Terra - RELAUNCH",
+    "symbol": "VKDogeNEW",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14vw4sfqwe7jw8ppcc7u44vq7hy9qa2nlstnxmu",
+    "name": "Vitamin Coin",
+    "symbol": "VITC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/vitelabs/crypto-info/master/tokens/vitc/tti_22d0b205bed4d268a05dfc3c.png"
+  },
+  {
+    "id": "terra1ezkr298e3lef6hh5pzmvrtw0qd0kc6u7dgl5rc",
+    "name": "Void Finance",
+    "symbol": "VOID",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18ejpjp9eyx9t8j07jd7kzah9p0rvkzdfeeva6n",
+    "name": "VPRIS",
+    "symbol": "VPRIS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dszjh6392kc6avpztu4vdx8xl0qte4ntmue07r",
+    "name": "WAGMI BOND",
+    "symbol": "WAGMI",
+    "decimals": "3"
+  },
+  {
+    "id": "terra10hr9gx9m9tq44xcxk2c5mzzlk7p22zd7x6esr7",
+    "name": "WAGMI TERRA",
+    "symbol": "WAGMI",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1wwpxtgrrfn0jxq8f0hlrzngx8m28r8kd5umaq8",
+    "name": "Wanaka Farm",
+    "symbol": "WANA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1uwsnmc4fpalrv3xgvf0aedx8tfn22xcyrx4467",
+    "name": "Warhammer",
+    "symbol": "WHMT",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1c6jwuklh3262naafvnlw8llvns9856uvc50z95",
+    "name": "We are Hive",
+    "symbol": "HIVE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10aa5cyfu879fm88glc099sjg8unejcp46cv6hd",
+    "name": "Welcome to the Family",
+    "symbol": "WTTF",
+    "decimals": "2"
+  },
+  {
+    "id": "terra16pektynpxqrs66gk6cgqpwr7rjsudyfzustm6s",
+    "name": "WELCOMETOHELL",
+    "symbol": "HELL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13k03g6n38f4m90pchn5h3nmk55xrnzt5ksvsml",
+    "name": "Whale Club",
+    "symbol": "WHC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz",
+    "name": "Whale Token",
+    "symbol": "WHALE",
+    "decimals": "6",
+    "icon": "https://whitewhale.money/logo-small.svg",
+    "website": "https://whitewhale.money/",
+    "telegram": "https://t.me/WhiteWhaleTerra",
+    "twitter": "https://twitter.com/WhiteWhaleTerra"
+  },
+  {
+    "id": "terra19v4cg3w698qprsjwzw52cns6245vkxug74q9lc",
+    "name": "White Whale Protocol",
+    "symbol": "WWP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1laczhlpxlgmrwr9un9ds74qxd2fj4754nf82dn",
+    "name": "Willisch Coin",
+    "symbol": "WCOIN",
+    "decimals": "6",
+    "icon": "https://drive.google.com/file/d/1wuKLSoWwaTLj9NqabA0cdlY4yhVKOm8v/view?usp=sharing"
+  },
+  {
+    "id": "terra1999psgmwex5f7fs0u9nnxrnu82c0c6s7qczhxy",
+    "name": "Woffff Token",
+    "symbol": "WOFFFF",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10gpgrr85u4g42uu6c3hkkxkggg2nw5kt95yc7x",
+    "name": "WOLF",
+    "symbol": "WOLF",
+    "decimals": "6"
+  },
+  {
+    "id": "terra143gyjf53a8ksn6r4nulaa69ld0dp6yety5gkmx",
+    "name": "Wormhole:Axelar Wrapped LUNA",
+    "symbol": "whLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1afgfjpny09lvxl06llcy7hfu0m2epfddzn0f75",
+    "name": "Wormhole:BTCB Token",
+    "symbol": "whBTCB",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1skjr69exm6v8zellgjpaa2emhwutrk5a6dz7dd",
+    "name": "Wormhole:BUSD Token",
+    "symbol": "whBUSD",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/BUSDbs_wh.png"
+  },
+  {
+    "id": "terra18xyl0ees6ueyhkhn0mjdtrm82e393ult2dazl3",
+    "name": "Wormhole:CREDI",
+    "symbol": "whCREDI",
+    "decimals": "8",
+    "icon": "https://i.ibb.co/M7JKGWM/e1-Qb-Z4q-Q-400x400.jpg",
+    "website": "https://credefi.finance/",
+    "telegram": "https://t.me/credefi",
+    "twitter": "https://twitter.com/credefi_finance",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/credefi/",
+    "coingecko": "https://www.coingecko.com/en/coins/credefi"
+  },
+  {
+    "id": "terra1efjugpjc50d8sha7lr8s48cr7wmsthz94eevcl",
+    "name": "Wormhole:DAO Maker",
+    "symbol": "whDAO",
+    "decimals": "8",
+    "icon": "https://etherscan.io/token/images/daomaker_128.png",
+    "website": "https://daomaker.com/",
+    "telegram": "https://t.me/daomaker",
+    "twitter": "https://twitter.com/thedaomaker",
+    "coinmarketcap": "https://coinmarketcap.com/currencies/dao-maker/",
+    "coingecko": "https://www.coingecko.com/en/coins/dao-maker"
+  },
+  {
+    "id": "terra1gtjr689cyaau20k8ezdxy8eup34tntun5xr9l2",
+    "name": "Wormhole:Dogecoin",
+    "symbol": "whDOGE",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1948uvsah8aw40dhsa9mhl3htq8lraj0smlh77g",
+    "name": "Wormhole:DragonSB",
+    "symbol": "whSB",
+    "decimals": "6",
+    "icon": "https://dragonsb.finance/img/image2/SB.png"
+  },
+  {
+    "id": "terra1fpfn2kkr8mv390wx4dtpfk3vkjx9ch3thvykl3",
+    "name": "Wormhole:Governance OHM",
+    "symbol": "whgOHM",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/gOHM_wh.png"
+  },
+  {
+    "id": "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap",
+    "name": "Wormhole:Lido Staked SOL",
+    "symbol": "whstSOL",
+    "decimals": "8",
+    "icon": "https://static.lido.fi/stSOL/stSOL.png"
+  },
+  {
+    "id": "terra15a9dr3a2a2lj5fclrw35xxg9yuxg0d908wpf2y",
+    "name": "Wormhole:Magic Internet Money",
+    "symbol": "whMIM",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/MIMet_wh.png"
+  },
+  {
+    "id": "terra1gdapfuda0dxtjc98raemhszntcxty7chyr0wpd",
+    "name": "Wormhole:Orion Money Token [via ChainPort",
+    "symbol": "whORION",
+    "decimals": "8"
+  },
+  {
+    "id": "terra19th22mng47zxe9ndrtvd470fjkn7n7ymmn28mr",
+    "name": "Wormhole:Sarcophagus",
+    "symbol": "whSARCO",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1p5k0vl2g22zv0r07fxm627pf8u5frazevqgkw5",
+    "name": "Wormhole:TEST1",
+    "symbol": "whTEST1",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1vlqeghv5mt5udh96kt5zxlh2wkh8q4kewkr0dd",
+    "name": "Wormhole:Tether USD",
+    "symbol": "whUSDT",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/USDTbs_wh.png"
+  },
+  {
+    "id": "terra1pvel56a2hs93yd429pzv9zp5aptcjg5ulhkz7w",
+    "name": "Wormhole:USD Coin",
+    "symbol": "whUSDC.e",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/USDCav_wh.png"
+  },
+  {
+    "id": "terra1kkyyh7vganlpkj0gkc2rfmhy858ma4rtwywe3x",
+    "name": "Wormhole:USD Coin (PoS)",
+    "symbol": "whUSDC",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/USDCpo_wh.png"
+  },
+  {
+    "id": "terra16qsk2zwv5fsqd944p28f2dkddr7eq9uzuxeh8h",
+    "name": "Wormhole:WAVES",
+    "symbol": "whWAVES",
+    "decimals": "8"
+  },
+  {
+    "id": "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
+    "name": "Wormhole:Wrapped liquid staked Ether 2.0",
+    "symbol": "whwstETH",
+    "decimals": "8",
+    "icon": "https://static.lido.fi/wstETH/wstETH.png"
+  },
+  {
+    "id": "terra169edevav3pdrtjcx35j6pvzuv54aevewar4nlh",
+    "name": "Wormhole:XDEFI",
+    "symbol": "whXDEFI",
+    "decimals": "8",
+    "icon": "https://github.com/sushiswap/assets/blob/master/blockchains/ethereum/assets/0x72B886d09C117654aB7dA13A14d603001dE0B777/logo.png?raw=true",
+    "website": "https://www.xdefi.io/",
+    "telegram": "https://t.me/xdefi_io",
+    "twitter": "https://twitter.com/xdefi_wallet"
+  },
+  {
+    "id": "terra133q7a0uctlld9kru6put3hk99qvxm9qzmklu9f",
+    "name": "Wouaf Token",
+    "symbol": "WOUAF",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cetg5wruw2wsdjp7j46rj44xdel00z006e9yg8",
+    "name": "Wrapped BNB (Wormhole)",
+    "symbol": "wbWBNB",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9gP2kCy3wA1ctvYWQk75guqXuHfrEomqydHLtcTCqiLa/logo.png"
+  },
+  {
+    "id": "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55",
+    "name": "Wrapped BTC",
+    "symbol": "WBTC",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh/logo.png"
+  },
+  {
+    "id": "terra1dtqlfecglk47yplfrtwjzyagkgcqqngd5lgjp8",
+    "name": "Wrapped Matic (Wormhole)",
+    "symbol": "WMATIC",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/MATICpo_wh.png"
+  },
+  {
+    "id": "terra190tqwgqx7s8qrknz6kckct7v607cu068gfujpk",
+    "name": "Wrapped SOL (Wormhole)",
+    "symbol": "wsSOL",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png"
+  },
+  {
+    "id": "terra1jl0egxpdfw0eqkzsgedzzet9zgwmhet2rd3s6u",
+    "name": "WrappedOrion",
+    "symbol": "wORION",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vm507q46f2sm8jltjcvp3dtncttquwld0tfkdl",
+    "name": "XADW Token",
+    "symbol": "XADWS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m97d9028kdz002wkq23kp329w68yun7p0x6vlh",
+    "name": "XDEFI Wallet",
+    "symbol": "XDEFI",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1a04v570f9cxp49mk06vjsm8axsswndpwwt67k4",
+    "name": "xMars Token",
+    "symbol": "XMARS",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1a04v570f9cxp49mk06vjsm8axsswndpwwt67k4/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://marsprotocol.io/xMARSTokenMini.svg",
+    "website": "https://marsprotocol.io/",
+    "telegram": "https://t.me/martiannews",
+    "twitter": "https://twitter.com/mars_protocol"
+  },
+  {
+    "id": "terra103ws85fnvy3j9vr3ss9va2zr26vepemqx2n88u",
+    "name": "XOND Token",
+    "symbol": "XOND",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tvqeau0ahuk72x49uqjhf0r6y0je8q6s27ad7u",
+    "name": "XPLA (Wormhole)",
+    "symbol": "XPLA",
+    "decimals": "8"
+  },
+  {
+    "id": "terra162k5t3hl204lrwe8xvalh4pv4gdrjvdrjlgxst",
+    "name": "XRUNE, The People's Launchpad",
+    "symbol": "XRUNE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra153u8c40h2mm8nvs0daqxsnwgvpw43muxj3c28h",
+    "name": "XSE Token",
+    "symbol": "XSE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kvjscdgwuvwc6uzm4rqfjl6nlmuhj28tequlnc",
+    "name": "xterra",
+    "symbol": "XTRA",
+    "decimals": "6",
+    "icon": "https://terraworld.me/assets/XTRA.png",
+    "website": "https://app.terraworld.me/Gov",
+    "telegram": "https://t.me/twdoffice",
+    "twitter": "https://twitter.com/terraworldme"
+  },
+  {
+    "id": "terra1tw845kgt0uq0gfmavawacfvaq5t9fa9v57g6m9",
+    "name": "XTerra",
+    "symbol": "XTERRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vfhh44f57a72vaqdk69k2y9pllwlrhkv32n6nr",
+    "name": "XVVD Token",
+    "symbol": "XVVD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fhsljj6qc8f7cnu62e8uxqt82czflztge05dwk",
+    "name": "XXDS Token",
+    "symbol": "XXDS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lj2t6zem4kk3cf400srvhaczpv2lg8kzpy5xr5",
+    "name": "XXX Token",
+    "symbol": "XXX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jm9jv95f0w3e0kk3kxxvtqg50456mf2c92xd7f",
+    "name": "xyz Bonus Token",
+    "symbol": "xyzBONUS",
+    "decimals": "6",
+    "icon": "https://pbs.twimg.com/profile_images/1437844740452589578/jKbfh-rM.jpg",
+    "website": "https://planets.collectxyz.com/",
+    "twitter": "https://twitter.com/collectxyznft"
+  },
+  {
+    "id": "terra15pv3xxp2d5f65qeu2v27vqf9zpqjx0fuztfwcu",
+    "name": "xzx",
+    "symbol": "xzx",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ktugzem827nn5uh2ccjk8y6xr9z4szvdc7x39r",
+    "name": "YAYtest",
+    "symbol": "YAY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ua6saapgern9jpmklkvxxq4l06nal2cwd0003t",
+    "name": "YFIX Finance",
+    "symbol": "FYIX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13gdkkedrnd48kel0fc8sr08usdfpdce9ku6qku",
+    "name": "yout_token_name",
+    "symbol": "SYMBOL",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1c5wn5quxclujf8n38cu0sh2r4hq697lpc9385g",
+    "name": "yout_token_name",
+    "symbol": "SYMBOL",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1ctfsa4qfanzmz4my78m3u4r9k5qr9gpua9f6hj",
+    "name": "yout_token_name",
+    "symbol": "SYMBOL",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1dgwaqnzp9yt4w4g8l2kwxemrhlwqm50j7eehns",
+    "name": "yout_token_name",
+    "symbol": "SYMBOL",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1ltfq7n4x383t8wjmp8ujjzrvyskk6eu4y2p3qh",
+    "name": "yout_token_name",
+    "symbol": "SYMBOL",
+    "decimals": "3"
+  },
+  {
+    "id": "terra1xk0a738cxushekjtvf6f9qtr7uz36yxc3egne4",
+    "name": "YUMIs",
+    "symbol": "CELL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gazefv0j5m0hhalp0qea5smypej2r0matncl88",
+    "name": "ZERG",
+    "symbol": "ZUG",
+    "decimals": "6"
+  }
+]

--- a/terraclassic/asset.json
+++ b/terraclassic/asset.json
@@ -1,5 +1,76 @@
 [
   {
+    "id": "terra1cmf8ytutcwrjrv08zskj9phuh46a3w3nkjax7en4hxezsrdr58lqvzy05q",
+    "entity": "alentejo.money",
+    "name": "alentejo.money",
+    "symbol": "Alem",
+    "decimals": "6",
+    "icon": "https://static.wixstatic.com/media/1e62a0_42c272173eb244a893daa63902538ffe~mv2.png/v1/fill/w_560,h_560,fp_0.50_0.50,enc_auto/1e62a0_42c272173eb244a893daa63902538ffe~mv2.png"
+  },
+  {
+    "id": "terra1ftd8l9xny6dhc2299m9rd59aknutl8fvrc7h9ywammxcus5se9ese03yfd",
+    "entity": "Astroport",
+    "name": "ALEM-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q6hpxkcx5a0g8u0m0n30cl6afafufpl5yl4lza2umk5up9tzerwqszqvr7",
+    "entity": "Astroport",
+    "name": "AMPL-LUNA-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e9ge099thjrfx9y74aznq38esfkm55lpqvdvun078aw0nejdhu0qsn5n9d",
+    "entity": "Astroport",
+    "name": "AMPL-STEA-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16esjk7qqlgh8w7p2a58yxhgkfk4ykv72p7ha056zul58adzjm6msvc674t",
+    "entity": "Astroport",
+    "name": "ASTR-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kusqucsy7x5yhfl4lu064f0kyhdx7mhj67z7uclhhxr8mm3ayatq4zse64",
+    "entity": "Astroport",
+    "name": "ASTR-RED-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17ymsjrzhtz04wt6ftamthph5sfnuem0f0xgr4ajvas9uzjll6p0sdu36ff",
+    "entity": "Astroport",
+    "name": "ASTR-USD-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fw969f420dy50t4glu0nct9whdftsralf2sdywxh5zklzyj7350sp94ycs",
+    "entity": "Astroport",
+    "name": "ASTR-USDC-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1sdajd4wfkxvwzd3em9h9qdpsf0mavuc9ukt8hpcxklp2znd7lrhsgkudn0",
+    "entity": "Astroport",
+    "name": "ASTR-VKR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wkcyh5l9204m6ef5aujdlnh3frswyhpl8xp7evr7rk0qmyqyhrkqg287g8",
+    "entity": "Astroport",
+    "name": "ASTR-XAST-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra17raumdxxxlm8smtx2pcxmqpz7qq9am4zfxzl8d",
     "entity": "Astroport",
     "name": "Astroport",
@@ -45,6 +116,391 @@
     "decimals": "6"
   },
   {
+    "id": "terra19lpvantkz339ze3wssmjxph7wqaj6ahs6qwdyz9cvf7szfczzmxs0u5hzz",
+    "entity": "Astroport",
+    "name": "BGT-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z3nctlwtasqshsagu2l4lj74pdm8hl7jhjyeepergtkny4cyka0se48n37",
+    "entity": "Astroport",
+    "name": "BGT-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mckjrtvxvsxtxvc5jttxmvheyh4wjcrlrnfy28xnln5a87qhxz6s4el0sy",
+    "entity": "Astroport",
+    "name": "BLUN-AMPL-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1h3z2zv6aw94fx5263dy6tgz6699kxmewlx3vrcu4jjrudg6xmtyqk6vt0u",
+    "entity": "Astroport",
+    "name": "BLUN-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tr7355as8t6k9y94wru5humch34yacrv3mwz9n690fugwcc8mrvs296qz8",
+    "entity": "Astroport",
+    "name": "BLUN-XAST-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13f7dedzar82afsedw4kn388zvfg94r8uusefa8nj0zysrayqaszsvcje3e",
+    "entity": "Astroport",
+    "name": "BOND-USD-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tf2lj6lp4y29kw36ue6tjsa97ad4e5fha6te08h26pg6y4v7c23qhu2k4j",
+    "entity": "Astroport",
+    "name": "BTC-UETH-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18cl4602q8gfaxgm5gvh254s5qf9xhrhmlntsdpmduqgxa2qg9dgqkraadh",
+    "entity": "Astroport",
+    "name": "BTC-USD-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1eavy3qvhwcvmvah8hgru8x6sc3cnluxfyqlkctur0e4jkcqvwgxqxmc3hl",
+    "entity": "Astroport",
+    "name": "BTC-USDC-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14hq8h7sjvkjv9dv90mcy3lt74fyevktrg9685rzeshx0y2vpkl9sg38zmv",
+    "entity": "Astroport",
+    "name": "BURN-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yhpasjvjfc84ywwxl07tfy50zqqhh7l8k0280tfqyr8t5uu6gf4s6u0hxh",
+    "entity": "Astroport",
+    "name": "CLUN-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17rlm3qv3c9epnkpc2l3h3n9zjn3ldjugwhxtuuw6mhhm2vskjkws04xzza",
+    "entity": "Astroport",
+    "name": "DUST-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ahr8gc72dht7s3fxhqp95xrnvn25uf3tw5elg3vfgtqm2qqk36yszxlcuq",
+    "entity": "Astroport",
+    "name": "FATM-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xq08x97luxlraz7d79x240ntdaf8k8w0jtqmgtzr46drkz86xxqslh4fwt",
+    "entity": "Astroport",
+    "name": "GEA-GEB-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rw5h8yrwkemd7nqmr2k70az2pel8r875qutu03cwjkczve4fev5q9m024s",
+    "entity": "Astroport",
+    "name": "GEA-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14qulp86csugtkn6mz2czdsf0rudwu8kt89ccrzdfrf5v9tt3jvxqnk94ce",
+    "entity": "Astroport",
+    "name": "GEB-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1r2e983ghd0jsk7r6k36zw4lnqf8y9raghzdnrusgsg97465uuvfq8nuls7",
+    "entity": "Astroport",
+    "name": "GIDO-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15hgjqvr89q5t4qmvyt0qnmmlx34dyyn7e6x9z3fnqn5wtgj6lllqa95dm8",
+    "entity": "Astroport",
+    "name": "IBC/-BUSD-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra135t2lyz8638ad0l7nasth49agcm6cn36zdp9mtxd6gdxx0tzhlmqs3dq0q",
+    "entity": "Astroport",
+    "name": "IBC/-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15me9trrk8nrtmwcgx248n98unlgw4a65vef8942rk336tytynqysqc53pq",
+    "entity": "Astroport",
+    "name": "IBC/-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1khsxwfnzuxqcyza2sraxf2ngkr3dwy9f7rm0uts0xpkeshs96ccsqtu6nv",
+    "entity": "Astroport",
+    "name": "IBC/-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14tu8x3hgzycpqlu6z87fm66uzthu409lk58u7uut5y9ev0swkxeq25axte",
+    "entity": "Astroport",
+    "name": "IBC/-LIRA-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ctkly6fuddqfpsq9fjjsqudx9zsl5crma0z4jl29zky3k8ezfe5s23gd7s",
+    "entity": "Astroport",
+    "name": "IBC/-LIRA-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10rwjgm2nzweq04fqlqykld7azm4t0yhj8gwnyg9k7c4w4laht3aqrmwjyn",
+    "entity": "Astroport",
+    "name": "IBC/-OPZA-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1p2n59z2dnx9rt8m8qnztpyw9jgwt0gypenf3q6q0wpkqjcypkqvsq8u3pf",
+    "entity": "Astroport",
+    "name": "IBC/-TPT-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s5ywajpamm25ny872ek26a56a7y3368h6eu4su2eff5ua8jw8yyqlxmtwr",
+    "entity": "Astroport",
+    "name": "IBC/-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1n9yykacl3ft9fw95sr0eckqsd6p9l62ehdhf5u6k6akmvupqr7as9ygupx",
+    "entity": "Astroport",
+    "name": "IBC/-USD-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yj078tseqc85x9r54u06jhektnqhvcxayxqwycg0y3yt9867pglqcuqym5",
+    "entity": "Astroport",
+    "name": "IBC/-USDC-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v4ytr73tfkms7e5qhuy7qnmfkfgf6fs5ut9av6u78j9tv9ahwrlqazaycp",
+    "entity": "Astroport",
+    "name": "IBC/-USDT-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1r8m2zuy0wmrv5p3uxzctmpltztwd8x4hh0sw05hs7q9y7qq0m3hqws0lty",
+    "entity": "Astroport",
+    "name": "IBC/-UST-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gglgnmzuzfdu0v4v59c2442m9zj7sp7un256m0rvk6hg9jlh0wqsu4tsx3",
+    "entity": "Astroport",
+    "name": "IDC-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1l0dv709pqv2gcs86jr9w3k67jr7tk62vem0h8ntzzkpl443f27vsy47gsm",
+    "entity": "Astroport",
+    "name": "IDC-OPZA-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16arnls40rkd07japhu3g4hf5j9ypqfmtfvl9hp9egmtg2m9eenvsaj72xu",
+    "entity": "Astroport",
+    "name": "IDC-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1t906pc4s8ptgrr8gx8m52hvvse8ytq5za86fmudm2wr4vw2kyqzqyph4ml",
+    "entity": "Astroport",
+    "name": "LOCA-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s3fy4zc643suxfz7wsvhhgvhd0zv8jwrcl8ugdfq6z6nl3nxkg0q3s9nl2",
+    "entity": "Astroport",
+    "name": "LUBI-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kv246hnusfqh3d97ww0u59hgaqf335844hmj4mrsadvnjwaf2n0qtyhrg5",
+    "entity": "Astroport",
+    "name": "LUNA-BLUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16hnd8a8cy0z5u6t56mcv28yencp8dwv4rtjs4kftxmqn5mhnga3q0ceajp",
+    "entity": "Astroport",
+    "name": "LUNA-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lgsccchaws9nnm74aj7uhdj289jd99893ngkv2am9j40cn0sza8sxkzc9r",
+    "entity": "Astroport",
+    "name": "LUNA-UST-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zweae4lq0p3pa493njmjexywk9wmr6cznhp6pz50hmyvelluf8qqq82mpg",
+    "entity": "Astroport",
+    "name": "LUNA-XAST-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qaudeq98hht76r9efvexhkf8k7waqq6cexqztgp5t6v0ptt7ljxq95nqlw",
+    "entity": "Astroport",
+    "name": "MAAP-UST-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qqh6vpync8tylpdfv9mjemml02xutzmufetrp35na09k2cnlnl7qxh0lqy",
+    "entity": "Astroport",
+    "name": "MINE-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1alu4y2ncdyaamv9tgkxwefcazc433n5t9mpmpahnsy2dsng0m3rswmxpfp",
+    "entity": "Astroport",
+    "name": "MMSF-UST-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1n3zc3fey96mnfm094jka7hmezu38sdnswz3mp3my9hjuryd5gxjqxhx4ut",
+    "entity": "Astroport",
+    "name": "MOON-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14v6sh40tydg22c9ws2yhj8qgyhj8wsgand8uhmcvl4wad3209dzs0an099",
+    "entity": "Astroport",
+    "name": "MUSK-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10ht5t5vzpt6lfh8r6lau6mtsha3rqeznhkw5whc65scgrtkqradq0zy9pa",
+    "entity": "Astroport",
+    "name": "ORNE-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zf35dfsvk69c5dgytka82762922l2r4cj3v24un0uycln9hy695qkwlpga",
+    "entity": "Astroport",
+    "name": "PCE-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17786erkmuydha7cwlgvvnler20cktz5egdea7pxs7ely9xu3v7eswdqa8h",
+    "entity": "Astroport",
+    "name": "PLUN-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1aqu49fznmzfgxky72fd3f4rjewexueu9c7yzjs59z2hqxv6ktxpsfffw87",
+    "entity": "Astroport",
+    "name": "PLUN-YLUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qnxq4gjc72nraczff0gefthv0d83gxn3gzpqe70n9wynlvh2afjq86elkt",
+    "entity": "Astroport",
+    "name": "PN-U-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14a40x0uxgz3h76dk6l2u8qukkzsscrn3kdzv7ct85dltyrcqdpgs8uenjs",
+    "entity": "Astroport",
+    "name": "RED-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ua7uk7xvx89dg8tnr8k8smk5vermlaer50zsglmpx8plttaxvvtsem5fgy",
+    "entity": "Astroport",
+    "name": "RED-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1eex8w4vqukz54pzzngt8xzmp4w9wz2mp5hcde7wwqhmepzm0ec9qarwx3v",
+    "entity": "Astroport",
+    "name": "SD-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fltdf8rkxz4ss06vtf2a4qt9tdplt52saefq650vyf47y4mt7q2qk0gtfv",
+    "entity": "Astroport",
+    "name": "SDO-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra109sh4nxudwcqrq0v8gdna46sc3mhs9qh49jrv3m6546asc3kk87s3z28hr",
+    "entity": "Astroport",
+    "name": "SOL-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s7q7vl49xfqheeskh8dxss473kuaxhgd3qtrx5rpg0u57fwt7zeqzm7u9t",
+    "entity": "Astroport",
+    "name": "SOL-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7",
     "entity": "Astroport",
     "name": "Staked Astroport",
@@ -61,6 +517,1339 @@
     "icon": "https://app.astroport.fi/tokens/xAstro.png"
   },
   {
+    "id": "terra1v7uxpztn2xk8v05y3ak8dkjlfrdsnyl9stv63np0kfp6yzh0rz8qph3upx",
+    "entity": "Astroport",
+    "name": "STEA-ASTR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dpvp8xra378kadfmn0c93n9qvf942r04vkznh75c2s4cy3atq72sq3jetx",
+    "entity": "Astroport",
+    "name": "STEA-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra182wam9eklls989k5qqrcv5s64a9cat6ctw4zr3paa6k79dxt4k0q4kd97a",
+    "entity": "Astroport",
+    "name": "STEA-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1w45txv24j32l27kmnj23rrrpz34c0hf2aj2tmqf466g758ndhgzsu5y42s",
+    "entity": "Astroport",
+    "name": "TCW-AUTO-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1339twwfe6rqgj4ge7qe5mdzu238ke2farlnwm7k2allh9un96w9sywjsff",
+    "entity": "Astroport",
+    "name": "TCW-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "null",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1079zf52uyn4hnxdrst38fvd9ga582xcjrmenw8",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10jmlz5uwz6w5hks8y9tretjjk4f8ad2me44lve",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10l54yyxus354jl80v57npylas00ktj7vpedml7",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10zkfrqvgqvsh026ljcswe59lwh88yc5v43yc9q",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra122asauhmv083p02rhgyp7jn7kmjjm4ksexjnks",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1237hndgalhuukzuccfvfjj538az8739td5cnaw",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1283mf36gl6zks6yxr50mc5cvzvg26qg50mq74s",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12awas0yfsn4r4ppzp4agqu8rp8gyw8weglpuca",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12dnl585uxzddjw9hw4ca694f054shgpg93cg90",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12ndzg4g6k6q48hasdrrk7rul428npl88ljugtf",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13dvh4d653c6tyu7f30hwcpjnrz8xhx87yduphr",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14dgkwkplgmw9tkdf4rc72ppk6q5p2mu0uhfl09",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14uaqudeylx6tegamqmygh85lfq8qg2jmg7uucc",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15hus6hg88440lypz37a8u90t8twdjmwnp92yfn",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15pclv9fqytszqlmjymshyk9cfytaaqrs4h87sf",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15qmh9jl388v2hr2yn75v8psdj0q9ghfwwxzckg",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra165k229vdtpng40rhdfn3tqtqphwxeyjx5wrwxw",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra166h9t9xrsy0wq8t7hpdjx52eecze4gcussgr44",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16auz7uhnuxrj2dzrynz2elthx5zpps5gs6tyln",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16c2lh2lr0xe92ayf558rgzw47gf8cmqh58v06n",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16ejsp5mhav3kppkj7w438spp0eawknsj0afhvx",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16j09nh806vaql0wujw8ktmvdj7ph8h09ltjs2r",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16ledesd9tn24fte454883p577qvr24hngmfefg",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra178cf7xf4r9d3z03tj3pftewmhx0x2p77s0k6yh",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17dkr9rnmtmu7x4azrpupukvur2crnptyfvsrvr",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17gjf2zehfvnyjtdgua9p9ygquk6gukxe7ucgwh",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17smg3rl9vdpawwpe7ex4ea4xm6q038gp2chge5",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17tlyml4tq2hw922aq2dq4dhnjcu296mlkgrx6n",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17vddhyh8zulk4yx2zapsk9z5y5r5mjaf9w6egv",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18qgqfp2pay886vakll5duudytylazyy9eh89yq",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19t9e42yxukxuuqzyekccm5jpu3gek3nttdsz8f",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19zju3mkymrhfefd9lv7mq0u9ke0xmveemuu33g",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1aeusm5e93ptz2twem0vpfy370c7d7vy2dp0vke",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1azk43zydh3sdxelg3h4csv4a4uef7fmjy0hu20",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1c9wr85y8p8989tr58flz5gjkqp8q2r6murwpm9",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cmrl4txa7cwd7cygpp4yzu7xu8g7c772els2y8",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cvwy6kx24fhpeq4gjuyp2ynwcsxu8gtvk3mde7",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1d2muut0rea9fkff6y304yn6qkr2uacau7ltggc",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1d34edutzwcz6jgecgk26mpyynqh74j3emdsnq5",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1d5j958a4vrfmv20gddyp0gz0f6yx0kpd702qke",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dmuw5wyluxe6hf85x7waepwuqjgs2460fmj8qn",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dsj8lxhuvtz8k8vt9v7zjm85cca4qjhsqgvced",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e7d7325sjpfk02vnzqkwsnlu0xqejydleeh2h8",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e92r33fhkft6p8fyamwu3zp300t5l35cjxf5tf",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ekd58y58vq4gmxlzpc27dwuhw7wmms928ftuep",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f2mpaw7jmm7jzhkgf2x7yg50vr9m4aplu7gkxg",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f7jzky244gwy220xp7cdd0vzhu6l5ncafderaf",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fa6hue6yjt90ytjuxqv6mlsmrm2agc7w6vjhd4",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1falkl6jy4087h4z567y2l59defm9acmwcs70ts",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fc5a5gsxatjey9syq93c2n3xq90n06t60nkj6l",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ftd4p3rfcry6sgrwjs78s0562kmut3p6cpnq77",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fxzmf732l2mj23wq3aryww50xg7gclhelvs2k3",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gecs98vcuktyfkrve9czrpgtg0m3aq586x6gzm",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gk602sa0jwk73xlr8tpkd3fpukhfa8hjety68r",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hl09j27s27407wkct646lqnxg3qskpl2ehuvn9",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hqpfh2g457fuzrm8e0skagwwh79pffr3zzqwek",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hvz34zmk4h6k896t94vd8d5qjdchhnkdndunzx",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jh2dh4g65hptsrwjv53nhsnkwlw8jdrxaxrca0",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jl4vkz3fllvj6fchnj2trrm9argtqxq6335ews",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jl875nm4p2z4jgapz6al2h74ug0fpf59n7pfjg",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jmauv302lfvpdfau5nhzy06q0j2f9te4hy2d07",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jmzlups5p4upfx995j824vyngnahsx5tjpk3m7",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jnn5xpmeythug88hu66pwl3x9fz2s0ms034aw6",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jqqegd35rg2gjde54adpj3t6ecu0khfeaarzy9",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1juspa927c7kdr0jf7wc0lxg6wfjz2cersm9r82",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jvewsf7922dm47wr872crumps7ktxd7srwcgte",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1k5kumxd24cyvhf52r5u4ywlr3ztktj657wnf7a",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1k5z9y8h9jr4ex63cmmlazn3kjc7mncn66xrrk4",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1k67ut87c2up66tury4qc4n96d85t43u20v24sy",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1klc5n2zy79ttxur0mdvhqldyzhkmcehaqm877w",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1klgaa9lyrcgdwudd9mvu0ys2spdsxd8mk55ure",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1knrlem7cg0ywg5hldmghlj8eqh0f8lw2fhc599",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ktckr8v7judrr6wkwv476pwsv8mht0zqzw2t0h",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1l0yxvzzszzfcrfcle55wdf2xxmalc9eg5c28ej",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1l8jgxd9uv430rdt2u58h4h7kdfxsle4w6w2ecq",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m4q5lr2s3j5eylf2jq06d8vw0au3trgdadezfc",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m5gwp6ujj0frnwkgxlkmhwu5we9xaysnwa6f8s",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m8mr9u3su46ezxwf7z7xnvm0jsapl2jd8vgefh",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mljg7dvzknqh3gc62emagf7hwxxg8efemennp8",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mnj6zstfk2ne0htcre9cvjv9ut0zd5t95wyagy",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mtvslkm2tgsmh908dsfksnqu7r7lulh24a6knv",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mv3pgkzs4krcennqj442jscg6jv84cejrs50n2",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mwu3cqzvhygqg7vrsa6kfstgg9d6yzkgs6yy3t",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1my49papxtmataag9arh9wdrqyyuqyjfw7cc44v",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mzpxqr5vwnzl822sjd3yskaekz2lyvfpavush6",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1n8fwsrf3qruwx99eg87dmw7x4pjc8n0a35vlef",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1na4sgkt5ft37s72l9hd6wsa7hdql0j75er0u7l",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ndlx5ndkknvmgj6s5ggmdlhjjsz0w6wrnwn5cf",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nuy34nwnsh53ygpc4xprlj263cztw7vc99leh2",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1p60datmmf25wgssguv65ltds3z6ea3me74nm2e",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1p6fhh4n9keyyhzq6stytvn0qs6etj8md6mwe72",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pjgzke6h5v4nz978z3a92gqajwhn8yyh5kv4zv",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1prswk9yyayfkkq99fpaz5zs7h0lhcpsqa4swj9",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ptsj2ufnvp5nv5lf8gtxek7c44rlztppedepfu",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q7m2qsj3nzlz5ng25z5q5w5qcqldclfe3ljup9",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q7n7hzd9dsmakmzjql2mdg5gfrnx42a9hj8665",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qjlakmnnswdzmssfzurpdg48ygu5cnw4lg9h80",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qxlp0q3z20llu0gz9c7urzw7rmlnchm23yk8xc",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rqkyau9hanxtn63mjrdfhpnkpddztv3qav0tq2",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s0dgcsdy9kgunnf3gnwl40uwy9rxtmc39mhy2m",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1stfeev27wdf7er2uja34gsmrv58yv397dlxmyn",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1t0mgl6lns0ff6wva27zjwqfpqrjdzw550ed652",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1t46rhfcgqpz9xkx33qpzk55yudp7wdaygj7yfw",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1t4xype7nzjxrzttuwuyh9sglwaaeszr8l78u6e",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1t8qmg9p583jcp2f7uuhga73yh7ze0u4ny7kmzy",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tmw02ugjulhezj868pu4s6mhlmshlez7thzane",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ungyyyachxaszce53zstctel0mpzactmtz8hdp",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1utf3tm35qk6fkft7ltcnscwml737vfz7xghwn5",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1uwhf02zuaw7grj6gjs7pxt5vuwm79y87ct5p70",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1veqh8yc55mhw0ttjr5h6g9a6r9nylmrc0nzhr7",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vkjgr2rsagh52jdcur4zgjyj7ag5xrfmyekne2",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wd25umnrgnfydwd7k7m364ykk79r76tclm5v4n",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wdjsxymg424mw4sv6zmw4luqajwxa5e7qfvfxw",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wdmkqdhqmyv9csgwfdh8739fu65qpay7jj5vvh",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wfms03rc04cdc0xvs7rh8z3s498ns2zgqctq7y",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wg3dhzz6m5q3dm738u6sxzxhld60l0chgvpele",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1whdv289y72n38x8sevz5erze8zys493ha2fd0a",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1x3musrr03tl3dy9xhagm6r5nthwwxgx0hezc79",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xqeym28j9xgv0p93pwwt6qcxf9tdvf9ztfxf0w",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xsv563k2wyuqkwza0mrz6ye8exx4a9r0hdvxs6",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xxracarga8mf8yadf8s25hekr4kd92l3wr35vm",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y097nnhjger6l3ds9r96xfdpq7vcdp5yh70n6x",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y6x3mh07l8xdpxap7xw2u5pclrenjaulpcfh36",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y9kxxm97vu4ex3uy0rgdr5h2vt7aze5sqx7jyl",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yg09m7lcj739wvr3ns6d67znhyp4jexvpx2vkg",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ygazp9w7tx64rkx5wmevszu38y5cpg6h3fk86e",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yqnd70kvrdfazu7aplalwqdp3ksnu35fv9cv9m",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z0z6hz96au9lr027uedxay3s09ry36md3wpm0v",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zy5sjsw4aswykccwtvkaq27s2eedspvakut7gw",
+    "entity": "Astroport",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra153zpj7f0shmfrt95s2jmets2k7fuuclerxh295n7hltf0z7p9xdsdngtdr",
+    "entity": "Astroport",
+    "name": "TFLO-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y0hu67n6jq49a3ml43py4jzkr43a4qn38clvxsmd567rr4kdtj5sn4ehez",
+    "entity": "Astroport",
+    "name": "TKNA-TKNB-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cjz82w795jcsxp09dpps697qwx55aryprvypl3n07my4zwrxfchs34lqcc",
+    "entity": "Astroport",
+    "name": "TPT-OPZA-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ces6k6jp7qzkjpwsl6xg4f7zfwre0u23cglg69hhj3g20fhygtpsu24dsy",
+    "entity": "Astroport",
+    "name": "TPT-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1n6sa5dykwq87w8v08xqr2jnhwv2r7kzznvvqz7dvhkqch8kapwjs6xtl5s",
+    "entity": "Astroport",
+    "name": "TPT-XTPT-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13qn86nhlj09kh6ea3pzvswj48yzyrh49rnhjwh9qv7gvu54qgq2qrmet53",
+    "entity": "Astroport",
+    "name": "TUNA-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1paat6jjgnfvavhfncdxhx4djpzansv9h06vge5grf3daqn8suezql2t7gx",
+    "entity": "Astroport",
+    "name": "TUNA-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18e6uqw3sx6xgg57t7rglstmqgqrm4ks9428am8crg2aeuqkxk37qzhq9xx",
+    "entity": "Astroport",
+    "name": "TUNA-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13406847ntuyct7qgefrks05cfuca7jtf4u9zqnahud2c7vnarkysj2c8gj",
+    "entity": "Astroport",
+    "name": "UETH-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cq22eugxwgp0x34cqfrxmd9jkyy43gas93yqjhmwrm7j0h5ecrqq5j7dgp",
+    "entity": "Astroport",
+    "name": "ULUN-AMPL-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fs0p7gammucw7get7mq7rzdk6rexxgszp003zr3859qyfc02ur2sdha672",
+    "entity": "Astroport",
+    "name": "ULUN-ASTR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15sytd365u3nw8xku492cj9nec6pgn9py6w5qka83fd9d26yr8cgsu5apxc",
+    "entity": "Astroport",
+    "name": "ULUN-BLUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xnjmgzzukpnp92mlhsu9ghmlg29h5hdtrv8n34mhvgmsctug4prq9prw2l",
+    "entity": "Astroport",
+    "name": "ULUN-BLUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1psd6waufk7hnhquh82wgnpt6qhevplnsjkwp6vw3enk2czxkjvmqzmyvkr",
+    "entity": "Astroport",
+    "name": "ULUN-BUSD-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12lq8l9tc3z9h8cy4qt9khmalrzv2nszdu8rl2yfsmjvcn0vffnfqhznup3",
+    "entity": "Astroport",
+    "name": "ULUN-GIDO-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ngp9lsp72hjjate0jlmhz27ra6mjap97ptg0r4nuytf3kuk2md6sz8twrv",
+    "entity": "Astroport",
+    "name": "ULUN-HERO-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ckmsqdhlky9jxcmtyj64crgzjxad9pvsd58k8zsxsnv4vzvwdt7qke04hl",
+    "entity": "Astroport",
+    "name": "ULUN-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yfm49ecnsaxjh83raczdxy6jgq2rykp8kc2pmlw62rxu3dyy4laq9fzmu2",
+    "entity": "Astroport",
+    "name": "ULUN-LIRA-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kggfd6z0ad2k9q8v24f7ftxyqush8fp9xku9nyrjcs2wv0e4kypszfrfd0",
+    "entity": "Astroport",
+    "name": "ULUN-LUNA-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12vc5agylj7g9xudc0lf06n76dfvplmqxcpcsuy9805sljrukhgxq3sfy5y",
+    "entity": "Astroport",
+    "name": "ULUN-USD-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cfs2gjc96wca6ahq0hzjcj56wy37fj76slvtfq22hpfrly7vfzeqa9ruz7",
+    "entity": "Astroport",
+    "name": "ULUN-USDC-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra120c58hp4d6e4c5uksdvcfhqkruxxhm3fljlmywza5x25gdm45tts8f9jkg",
+    "entity": "Astroport",
+    "name": "ULUN-USDT-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pccqe4pufnw05wwl0xe9uc99lngnddpn8az48fe3svpeca0hq0tqrfeznp",
+    "entity": "Astroport",
+    "name": "USD-UETH-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1g79v06mvtn0jm6q274axyyg00l2yv5lgrxhl53ht728sxr8ke4fs8pgazj",
+    "entity": "Astroport",
+    "name": "USD-USDC-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mnysxy8lrsx0vzsgpnln8c6p40rm5z00umhpmks6he6utr0cw56scfpt48",
+    "entity": "Astroport",
+    "name": "USDC-BUSD-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wv46n9zggd8sx30d8gfgzeyu2a7rmdc8makk7cl4qgtlnw342kpq94faz0",
+    "entity": "Astroport",
+    "name": "USDC-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pqd0vm00z7urf8u8wmg4m4kpavr7g5myrcz9he4xzyq9etkafyds0hkkk9",
+    "entity": "Astroport",
+    "name": "USDC-UETH-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v6z888r63vzc094w2cll9z42xjwc7kuf8feccyh9f5ehkqmwqcdst2afjf",
+    "entity": "Astroport",
+    "name": "USDC-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ef5veuvpudt392jvwrzfw79e0glcdjthgq0cyj3xs8uc98p7x3tqg293tl",
+    "entity": "Astroport",
+    "name": "USDC-USDT-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vuh08zt4qcsmmu0g4p8k62mpzkj2v3rff4dg4srzdd2xenlm5qeqlwjht3",
+    "entity": "Astroport",
+    "name": "USDT-BUSD-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1r3v8yfhvkmx6gy2sa93d062sjf60c7atm3xage4pn3rsuum8ktvqesvl8h",
+    "entity": "Astroport",
+    "name": "UST-ASTR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19ugc0gmww0f94pckazqfa4elnvt3rlrd6wp23w0ry88j3dfuya5sm7nyns",
+    "entity": "Astroport",
+    "name": "UST-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ljjau3mzxv2rpje5p67vfa2uc82uvct5l70z5cqegd0pnus3u26svpura9",
+    "entity": "Astroport",
+    "name": "UST-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vd0pgkrg0t0ekz5gefudvw0crlzvcqztc5ngec34memth5ft6mnqtjmd2m",
+    "entity": "Astroport",
+    "name": "UST-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18mcmlf4v23ehukkh7qxgpf5tznzg6893fxmf9ffmdt9phgf365zqvmlug6",
+    "entity": "Astroport",
+    "name": "VKR-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10e606vcy44er2p570a7g2dkugcvua4k0u0y3gvq9r606uemv3wus967av2",
+    "entity": "Astroport",
+    "name": "VKR-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18pr2eu0js9laz3u4k5tcwyuqfup484z8qm66vtkwcfeukmpgyapq70wj44",
+    "entity": "Astroport",
+    "name": "WAVA-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1njqfs4v35leu654394yx0lyccvcau3j9u5v0k4gnx0dcl55rkqrqxwswd6",
+    "entity": "Astroport",
+    "name": "WAVA-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cs9wyhlcdz7w5arfgs7c9u0x7l2ev8atd6vzqd8pl702zpe69ndqpln7ky",
+    "entity": "Astroport",
+    "name": "WETH-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1857ysefuel7ywk2qhj2zqfa5z2vcpesys7h38v5jdtttatadm36sq0j8vz",
+    "entity": "Astroport",
+    "name": "WETH-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jv3ulmux29vtp89hgnmn9847ww7w5a9p433l7lgjrpzuxfagcs0sc77g48",
+    "entity": "Astroport",
+    "name": "XAST-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19ruafuuna67knun0e4falancl0u39jtnar9euv8s3h08le46wyfq7lyn4u",
+    "entity": "Astroport",
+    "name": "XAST-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ysdymqfph9jwlkynm9rm8gskf38pulzc8p2t707wtu00j6n6w8vsyke4zp",
+    "entity": "Astroport",
+    "name": "XTPT-XAST-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12xcl4p6wmksle9a4vax4vr9umju30s4mv495pmnmkjj9587ugkrqg7jz3l",
+    "entity": "Astroport",
+    "name": "YN-U-PN-U-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "ibc/2E9CD07D7A6572A4CDAABBF0FBB89F69A9A362818132221182654819E277220A",
+    "entity": "Axelar",
+    "name": "Axelar AAVE",
+    "symbol": "axlAAVE",
+    "decimals": "18",
+    "icon": "https://assets.terra.money/icon/svg/ibc/axlAAVE.svg"
+  },
+  {
+    "id": "ibc/1FD62537E1FBE67DF7574E0234112B4FE417B20AADC2F574026CB664EA9492C7",
+    "entity": "Axelar",
+    "name": "Axelar ChainLink",
+    "symbol": "axlLINK",
+    "decimals": "18",
+    "icon": "https://assets.terra.money/icon/svg/ibc/axlLINK.svg"
+  },
+  {
+    "id": "ibc/E46EF5449878F6B81219163F211E7329CC0729AA99DA8A589A865F82F754ADE8",
+    "entity": "Axelar",
+    "name": "Axelar DAI",
+    "symbol": "axlDAI",
+    "decimals": "18",
+    "icon": "https://assets.terra.money/icon/svg/ibc/axlDAI.svg"
+  },
+  {
+    "id": "ibc/2E435CEEEBA18CCB2719E0182BC5D142A364D6CCE9957DE6E1AC4D62127D2913",
+    "entity": "Axelar",
+    "name": "Axelar Frax",
+    "symbol": "axlFRAX",
+    "decimals": "18",
+    "icon": "https://assets.terra.money/icon/svg/ibc/axlFRAX.svg"
+  },
+  {
+    "id": "ibc/14E4FD1AB72DE9BF1D6725CBA18373C406CB9A7DA17955299F3F4DC5C6131A4E",
+    "entity": "Axelar",
+    "name": "Axelar Matic",
+    "symbol": "axlMATIC",
+    "decimals": "18",
+    "icon": "https://assets.terra.money/icon/svg/ibc/axlMATIC.svg"
+  },
+  {
+    "id": "ibc/6EFF21F9E65C9101370C38AA53049E4D1FF2B206A7C350B45F0ED3660E57AC75",
+    "entity": "Axelar",
+    "name": "Axelar Uniswap",
+    "symbol": "axlUNI",
+    "decimals": "18",
+    "icon": "https://assets.terra.money/icon/svg/ibc/axlUNI.svg"
+  },
+  {
+    "id": "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4",
+    "entity": "Axelar",
+    "name": "Axelar USD Coin",
+    "symbol": "axlUSDC",
+    "decimals": "6",
+    "icon": "https://assets.terra.money/icon/svg/ibc/axlUSDC.svg"
+  },
+  {
+    "id": "ibc/CBF67A2BCF6CAE343FDF251E510C8E18C361FC02B23430C121116E0811835DEF",
+    "entity": "Axelar",
+    "name": "Axelar USD Tether",
+    "symbol": "axlUSDT",
+    "decimals": "6",
+    "icon": "https://assets.terra.money/icon/svg/ibc/axlUSDT.svg"
+  },
+  {
+    "id": "ibc/05D299885B07905B6886F554B39346EA6761246076A1120B1950049B92B922DD",
+    "entity": "Axelar",
+    "name": "Axelar Wrapped Bitcoin",
+    "symbol": "axlWBTC",
+    "decimals": "8",
+    "icon": "https://assets.terra.money/icon/svg/ibc/axlWBTC.svg"
+  },
+  {
+    "id": "ibc/BC8A77AFBD872FDC32A348D3FB10CC09277C266CFE52081DE341C7EC6752E674",
+    "entity": "Axelar",
+    "name": "Axelar Wrapped Ethereum",
+    "symbol": "axlWETH",
+    "decimals": "18",
+    "icon": "https://assets.terra.money/icon/svg/ibc/axlETH.svg"
+  },
+  {
     "id": "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
     "entity": "boneLuna",
     "name": "Bonded Luna",
@@ -70,7 +1859,23 @@
     "icon": "https://whitelist.anchorprotocol.com/logo/bLUNA.png"
   },
   {
+    "id": "terra17aj4ty4sz4yhgm08na8drc0v03v2jwr3waxcqrwhajj729zhl7zqnpc0ml",
+    "entity": "boneLuna",
+    "name": "boneLuna",
+    "symbol": "bLUNA",
+    "decimals": "6",
+    "icon": "https://i.imgur.com/8CpJdcB.jpeg"
+  },
+  {
     "id": "ibc/18ABA66B791918D51D33415DA173632735D830E2E77E63C91C11D3008CFD5262",
+    "entity": "Cosmos",
+    "name": "Cosmos",
+    "symbol": "ATOM",
+    "decimals": "6",
+    "icon": "https://assets.terra.money/icon/svg/ibc/ATOM.svg"
+  },
+  {
+    "id": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
     "entity": "Cosmos",
     "name": "Cosmos",
     "symbol": "ATOM",
@@ -84,6 +1889,30 @@
     "symbol": "ATOM",
     "decimals": "6",
     "icon": "https://assets.terra.money/icon/svg/ibc/ATOM.svg"
+  },
+  {
+    "id": "ibc/B090DC21658BD57698522880590CA53947B8B09355764131AA94EC75517D46A5",
+    "entity": "Crescent Network",
+    "name": "Crescent Network",
+    "symbol": "CRE",
+    "decimals": "6",
+    "icon": "https://assets.terra.money/icon/svg/ibc/CRE.svg"
+  },
+  {
+    "id": "terra1ttspm8jgeylc6us3mlpwpmlwzr3rkesm70vn6zkfr07pz7e3rzkq73ah2j",
+    "entity": "Gidorah",
+    "name": "Gidorah Token",
+    "symbol": "GIDO",
+    "decimals": "6",
+    "icon": "https://firebasestorage.googleapis.com/v0/b/wicca-c3bbe.appspot.com/o/app%2Fmainnet%2Ftoken%2FMIRhzK1keYKtJsRYg_oL9.jpeg?alt=media&token=5de0205f-d0f6-4a76-b765-e6dd59d7d47a"
+  },
+  {
+    "id": "ibc/4CD525F166D32B0132C095F353F4C6F033B0FF5C49141470D1EFDA1D63303D04",
+    "entity": "Juno",
+    "name": "Juno",
+    "symbol": "JUNO",
+    "decimals": "6",
+    "icon": "https://assets.terra.money/icon/svg/ibc/JUNO.svg"
   },
   {
     "id": "terra1vsl7etwe53vglc2xq2rdt7mujarcjy9j694hdk",
@@ -145,12 +1974,340 @@
     "decimals": "6"
   },
   {
+    "id": "ibc/14ACCAD1750327C74BB35978AD0C3E97B184DAB9F0BF4BD876FBD1F782B57110",
+    "entity": "Kujira",
+    "name": "USK",
+    "symbol": "USK",
+    "decimals": "6",
+    "icon": "https://assets.terra.money/icon/svg/ibc/USK.svg"
+  },
+  {
+    "id": "terra1ee4g63c3sus9hnyyp3p2u3tulzdv5ag68l55q8ej64y4qpwswvus5mtag2",
+    "entity": "Lira Financial",
+    "name": "Lira",
+    "symbol": "LIRA",
+    "decimals": "6",
+    "icon": "https://lira.financial/images/icons/lira.svg"
+  },
+  {
     "id": "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
     "entity": "Lira Financial",
     "name": "Lira",
     "symbol": "LIRA",
     "decimals": "6",
     "icon": "https://lira.financial/images/icons/lira.svg"
+  },
+  {
+    "id": "terra1uv8ltv32tuq4qf6xspytpv058p0pef64s5xdncfywjexv22lfjzs7mul8s",
+    "entity": "Luna Bird",
+    "name": "Luna Bird",
+    "symbol": "LUBI",
+    "decimals": "6",
+    "icon": "https://www.lunabird.network/logo.png"
+  },
+  {
+    "id": "terra18ej5nsuu867fkx4tuy2aglpvqjrkcrjjslap3z",
+    "entity": "Mirror Protocol",
+    "name": "Advanced Micro Devices, Inc.",
+    "symbol": "mAMD",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra18ej5nsuu867fkx4tuy2aglpvqjrkcrjjslap3z/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/AMD.png"
+  },
+  {
+    "id": "terra1g4x2pzmkc9z3mseewxf758rllg08z3797xly0n",
+    "entity": "Mirror Protocol",
+    "name": "Airbnb Inc.",
+    "symbol": "mABNB",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1g4x2pzmkc9z3mseewxf758rllg08z3797xly0n/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/ABNB.png"
+  },
+  {
+    "id": "terra1w7zgkcyt7y4zpct9dw8mw362ywvdlydnum2awa",
+    "entity": "Mirror Protocol",
+    "name": "Alibaba Group Holding Limited",
+    "symbol": "mBABA",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1w7zgkcyt7y4zpct9dw8mw362ywvdlydnum2awa/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/BABA.png"
+  },
+  {
+    "id": "terra1h8arz2k547uvmpxctuwush3jzc8fun4s96qgwt",
+    "entity": "Mirror Protocol",
+    "name": "Alphabet Inc.",
+    "symbol": "mGOOGL",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1h8arz2k547uvmpxctuwush3jzc8fun4s96qgwt/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/GOOGL.png"
+  },
+  {
+    "id": "terra165nd2qmrtszehcfrntlplzern7zl4ahtlhd5t2",
+    "entity": "Mirror Protocol",
+    "name": "Amazon.com, Inc.",
+    "symbol": "mAMZN",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra165nd2qmrtszehcfrntlplzern7zl4ahtlhd5t2/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/AMZN.png"
+  },
+  {
+    "id": "terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy",
+    "entity": "Mirror Protocol",
+    "name": "AMC Entertainment Holdings Inc.",
+    "symbol": "mAMC",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/AMC.png"
+  },
+  {
+    "id": "terra1vxtwu4ehgzz77mnfwrntyrmgl64qjs75mpwqaz",
+    "entity": "Mirror Protocol",
+    "name": "Apple Inc.",
+    "symbol": "mAAPL",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1vxtwu4ehgzz77mnfwrntyrmgl64qjs75mpwqaz/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/AAPL.png"
+  },
+  {
+    "id": "terra1qqfx5jph0rsmkur2zgzyqnfucra45rtjae5vh6",
+    "entity": "Mirror Protocol",
+    "name": "ARK Innovation ETF",
+    "symbol": "mARKK",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1qqfx5jph0rsmkur2zgzyqnfucra45rtjae5vh6/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/ARKK.png"
+  },
+  {
+    "id": "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw",
+    "entity": "Mirror Protocol",
+    "name": "Bitcoin",
+    "symbol": "mBTC",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/BTC.png"
+  },
+  {
+    "id": "terra18wayjpyq28gd970qzgjfmsjj7dmgdk039duhph",
+    "entity": "Mirror Protocol",
+    "name": "Coinbase Global, Inc.",
+    "symbol": "mCOIN",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra18wayjpyq28gd970qzgjfmsjj7dmgdk039duhph/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/COIN.png"
+  },
+  {
+    "id": "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
+    "entity": "Mirror Protocol",
+    "name": "Ether",
+    "symbol": "mETH",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/ETH.png"
+  },
+  {
+    "id": "terra1mqsjugsugfprn3cvgxsrr8akkvdxv2pzc74us7",
+    "entity": "Mirror Protocol",
+    "name": "Facebook Inc.",
+    "symbol": "mFB",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1mqsjugsugfprn3cvgxsrr8akkvdxv2pzc74us7/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/FB.png"
+  },
+  {
+    "id": "terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls",
+    "entity": "Mirror Protocol",
+    "name": "Galaxy Digital Holdings Ltd",
+    "symbol": "mGLXY",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/GLXY.png"
+  },
+  {
+    "id": "terra1m6j6j9gw728n82k78s0j9kq8l5p6ne0xcc820p",
+    "entity": "Mirror Protocol",
+    "name": "GameStop Corp",
+    "symbol": "mGME",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1m6j6j9gw728n82k78s0j9kq8l5p6ne0xcc820p/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/GME.png"
+  },
+  {
+    "id": "terra137drsu8gce5thf6jr5mxlfghw36rpljt3zj73v",
+    "entity": "Mirror Protocol",
+    "name": "Goldman Sachs Group Inc.",
+    "symbol": "mGS",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra137drsu8gce5thf6jr5mxlfghw36rpljt3zj73v/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/GS.png"
+  },
+  {
+    "id": "terra1csk6tc7pdmpr782w527hwhez6gfv632tyf72cp",
+    "entity": "Mirror Protocol",
+    "name": "Invesco QQQ Trust",
+    "symbol": "mQQQ",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1csk6tc7pdmpr782w527hwhez6gfv632tyf72cp/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/QQQ.png"
+  },
+  {
+    "id": "terra10h7ry7apm55h4ez502dqdv9gr53juu85nkd4aq",
+    "entity": "Mirror Protocol",
+    "name": "iShares Gold Trust",
+    "symbol": "mIAU",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra10h7ry7apm55h4ez502dqdv9gr53juu85nkd4aq/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/IAU.png"
+  },
+  {
+    "id": "terra15hp9pr8y4qsvqvxf3m4xeptlk7l8h60634gqec",
+    "entity": "Mirror Protocol",
+    "name": "iShares Gold Trust (Delisted)",
+    "symbol": "mIAU",
+    "decimals": "6",
+    "icon": "https://whitelist.mirror.finance/icon/IAU.png"
+  },
+  {
+    "id": "terra1kscs6uhrqwy6rx5kuw5lwpuqvm3t6j2d6uf2lp",
+    "entity": "Mirror Protocol",
+    "name": "iShares Silver Trust",
+    "symbol": "mSLV",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1kscs6uhrqwy6rx5kuw5lwpuqvm3t6j2d6uf2lp/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/SLV.png"
+  },
+  {
+    "id": "terra1ptdxmj3xmmljzx02nr4auwfuelmj0cnkh8egs2",
+    "entity": "Mirror Protocol",
+    "name": "Johnson & Johnson",
+    "symbol": "mJNJ",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1ptdxmj3xmmljzx02nr4auwfuelmj0cnkh8egs2/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/JNJ.png"
+  },
+  {
+    "id": "terra1227ppwxxj3jxz8cfgq00jgnxqcny7ryenvkwj6",
+    "entity": "Mirror Protocol",
+    "name": "Microsoft Corporation",
+    "symbol": "mMSFT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1227ppwxxj3jxz8cfgq00jgnxqcny7ryenvkwj6/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/MSFT.png"
+  },
+  {
+    "id": "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
+    "entity": "Mirror Protocol",
+    "name": "Mirror",
+    "symbol": "MIR",
+    "decimals": "6",
+    "circ_supply_api": "https://graph.mirror.finance/graphql",
+    "icon": "https://whitelist.mirror.finance/icon/MIR.png"
+  },
+  {
+    "id": "terra1jsxngqasf2zynj5kyh0tgq9mj3zksa5gk35j4k",
+    "entity": "Mirror Protocol",
+    "name": "Netflix, Inc.",
+    "symbol": "mNFLX",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1jsxngqasf2zynj5kyh0tgq9mj3zksa5gk35j4k/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/NFLX.png"
+  },
+  {
+    "id": "terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx",
+    "entity": "Mirror Protocol",
+    "name": "PayPal Holdings Inc",
+    "symbol": "mPYPL",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/PYPL.png"
+  },
+  {
+    "id": "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
+    "entity": "Mirror Protocol",
+    "name": "Polkadot",
+    "symbol": "mDOT",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/DOT.png"
+  },
+  {
+    "id": "terra19cmt6vzvhnnnfsmccaaxzy2uaj06zjktu6yzjx",
+    "entity": "Mirror Protocol",
+    "name": "ProShares VIX Short-Term Futures ETF",
+    "symbol": "mVIXY",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra19cmt6vzvhnnnfsmccaaxzy2uaj06zjktu6yzjx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/VIXY.png"
+  },
+  {
+    "id": "terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45",
+    "entity": "Mirror Protocol",
+    "name": "ProShares VIX Short-Term Futures ETF (Delisted)",
+    "symbol": "mVIXY",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/VIXY.png"
+  },
+  {
+    "id": "terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc",
+    "entity": "Mirror Protocol",
+    "name": "SPDR S&P 500",
+    "symbol": "mSPY",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/SPY.png"
+  },
+  {
+    "id": "terra1u43zu5amjlsgty5j64445fr9yglhm53m576ugh",
+    "entity": "Mirror Protocol",
+    "name": "Square, Inc.",
+    "symbol": "mSQ",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1u43zu5amjlsgty5j64445fr9yglhm53m576ugh/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/SQ.png"
+  },
+  {
+    "id": "terra1246zy658dfgtausf0c4a6ly8sc2e285q4kxqga",
+    "entity": "Mirror Protocol",
+    "name": "Starbucks Corporation",
+    "symbol": "mSBUX",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1246zy658dfgtausf0c4a6ly8sc2e285q4kxqga/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/SBUX.png"
+  },
+  {
+    "id": "terra14y5affaarufk3uscy2vr6pe6w6zqf2wpjzn5sh",
+    "entity": "Mirror Protocol",
+    "name": "Tesla, Inc.",
+    "symbol": "mTSLA",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra14y5affaarufk3uscy2vr6pe6w6zqf2wpjzn5sh/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/TSLA.png"
+  },
+  {
+    "id": "terra1cc3enj9qgchlrj34cnzhwuclc4vl2z3jl7tkqg",
+    "entity": "Mirror Protocol",
+    "name": "Twitter, Inc.",
+    "symbol": "mTWTR",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1cc3enj9qgchlrj34cnzhwuclc4vl2z3jl7tkqg/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/TWTR.png"
+  },
+  {
+    "id": "terra1lvmx8fsagy70tv0fhmfzdw9h6s3sy4prz38ugf",
+    "entity": "Mirror Protocol",
+    "name": "United States Oil Fund, LP",
+    "symbol": "mUSO",
+    "decimals": "6",
+    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1lvmx8fsagy70tv0fhmfzdw9h6s3sy4prz38ugf/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
+    "icon": "https://whitelist.mirror.finance/icon/USO.png"
+  },
+  {
+    "id": "terra19p20mfnvwh9yvyr7aus3a6z6g6uk28fv4jhx9kmnc2m7krg27q2qkfenjw",
+    "entity": "Orne",
+    "name": "Orne",
+    "symbol": "ORNE",
+    "decimals": "6",
+    "icon": "https://orne.io/img/token_icon.png"
   },
   {
     "id": "terra1hnezwjqlhzawcrfysczcxs6xqxu2jawn729kkf",
@@ -168,6 +2325,95 @@
     "symbol": "OSMO",
     "decimals": "6",
     "icon": "https://assets.terra.money/icon/svg/ibc/OSMO.svg"
+  },
+  {
+    "id": "terra167khnalh9aawqx9qynj7kk9y0n8hc30qe6s8cy7y5yu2azrc2edqyjprp9",
+    "entity": "Phoenix",
+    "name": "IBC/-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s3zkg95yrmdl0nlxnynkunq3uqyeuu6mk3ca6vtcag0us9ejtjas0dv7em",
+    "entity": "Phoenix",
+    "name": "IBC/-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14s6uknh7zc97m3zqfejfqkkzm90tx9zez6k4swqa3422xvgpy56s3tyn49",
+    "entity": "Phoenix",
+    "name": "IBC/-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fqh5u2m7qs7vfz0ty8c8n9td74afgltrgg98ezqmxqg2dgqdfqrq2wy9r6",
+    "entity": "Phoenix",
+    "name": "IBC/-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wwmlrhulv55ph6vnv8wlgma5sjca2p8k8ykrmkfyh9qj3kct9m7sez5cv8",
+    "entity": "Phoenix",
+    "name": "IBC/-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12ctxrpmkpqr0gzrndjwr2a8k0gp3stx94x4q5p7g7u30p9mnrezsc2sl3n",
+    "entity": "Phoenix",
+    "name": "LUNA-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dxd7vh4x6cf6n20p2x6syatxdv4jftzzs45n42wn7kutqc0xxj8sj3p0dc",
+    "entity": "Phoenix",
+    "name": "LUNA-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14zymzz73zzmrpfujjxkv6drcqdjdve3jsz5rx00464x9jdld6ays06l0n3",
+    "entity": "Phoenix",
+    "name": "MINE-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1spkm49wd9dqkranhrks4cupecl3rtgeqqljq3qrvrrts2ev2gw6sy5vz3k",
+    "entity": "portugal.protocol",
+    "name": "dinheiro",
+    "symbol": "Dinheiros",
+    "decimals": "0",
+    "icon": "https://static.wixstatic.com/media/1e62a0_04207897171e4f5c8931295172b3e34c~mv2.png"
+  },
+  {
+    "id": "terra1qj5hs3e86qn4vm9dvtgtlkdp550r0rayk9wpay44mfw3gn3tr8nq5jw3dg",
+    "entity": "portugal.protocol",
+    "name": "escudo",
+    "symbol": "Escudos",
+    "decimals": "6",
+    "icon": "https://static.wixstatic.com/media/1e62a0_37bd3a14b88646f987919ec4ea30533c~mv2.png"
+  },
+  {
+    "id": "terra1sdglum2dt4f3fmq7jrt2phf2tegmnudc7qqqqujkpqcm9ujuxxkqakv5u8",
+    "entity": "portugal.protocol",
+    "name": "real",
+    "symbol": "Reis",
+    "decimals": "6",
+    "icon": "https://static.wixstatic.com/media/1e62a0_89af25478e5144089de9292b990493e2~mv2.png"
+  },
+  {
+    "id": "terra1xe8umegahlqphtpvjsuwfzfvyjfvag5h8rffsx6ezm0el4xzsf8s7uzezk",
+    "entity": "Redacted Money",
+    "name": "Red",
+    "symbol": "RED",
+    "decimals": "6",
+    "circ_supply_api": "https://api-v2.redacted.money/circulating_supply",
+    "icon": "https://red.redacted.money/red.svg"
   },
   {
     "id": "terra1ye68rx8etwj7xylwc4nd4vp58zz236mlhk0cpx",
@@ -191,6 +2437,23 @@
     "decimals": "6"
   },
   {
+    "id": "terra1q8kfp0v9rhef0d3u44ds9shwvwcusjheh8nhye3n7gwjd95ze96sehyp6w",
+    "entity": "Santerra",
+    "name": "Santerra SANT",
+    "symbol": "SANT",
+    "decimals": "6",
+    "icon": "https://santerra.app/sant_logo.svg"
+  },
+  {
+    "id": "terra1xp9hrhthzddnl7j5du83gqqr4wmdjm5t0guzg9jp6jwrtpukwfjsjgy4f3",
+    "entity": "Sayve Protocol",
+    "name": "Sayve Token",
+    "symbol": "SAYVE",
+    "decimals": "6",
+    "circ_supply_api": "https://raw.githubusercontent.com/sayveprotocol/web-assets/main/data/circulating-supply",
+    "icon": "https://raw.githubusercontent.com/sayveprotocol/web-assets/main/logos/sayve-logo.png"
+  },
+  {
     "id": "terra14v9wrjs55qsn9lkvylsqela3w2ytwxzkycqzcr",
     "entity": "Sayve Protocol",
     "name": "SAYVE Token",
@@ -198,6 +2461,22 @@
     "decimals": "6",
     "circ_supply_api": "https://lcd.terra.dev/wasm/contracts/terra1c0ml4nvpapkuex28yuh40n38cq3zyugszsw59e/store?query_msg=%7B%22check_balance%22%3A%7B%22addr%22%3A+%22terra14v9wrjs55qsn9lkvylsqela3w2ytwxzkycqzcr%22%7D%7D",
     "icon": "https://i.ibb.co/5xC39ym/sayve.png"
+  },
+  {
+    "id": "terra16zc783wt2w5lvlt9u4as977lt39c3se427akkenrzyax5vtde70qa89ukv",
+    "entity": "Sayve Protocol",
+    "name": "xSAYVE",
+    "symbol": "xSAYVE",
+    "decimals": "6",
+    "icon": "https://raw.githubusercontent.com/sayveprotocol/web-assets/main/logos/xsayve-logo.png"
+  },
+  {
+    "id": "ibc/10BD6ED30BA132AB96F146D71A23B46B2FC19E7D79F52707DC91F2F3A45040AD",
+    "entity": "Secret Network",
+    "name": "Secret",
+    "symbol": "SCRT",
+    "decimals": "6",
+    "icon": "https://assets.terra.money/icon/svg/ibc/SCRT.svg"
   },
   {
     "id": "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09",
@@ -258,6 +2537,22 @@
     "icon": "https://terra.poker/ico/ms-icon-310x310.png"
   },
   {
+    "id": "terra1e9s5m6vrl9ms75q0862llq2vcsz8r43czm36s6xnn3vh8dfmwe0s3c86e8",
+    "entity": "Terra Poker",
+    "name": "xTPT",
+    "symbol": "xTPT",
+    "decimals": "6",
+    "icon": "https://terra.poker/ico/ms-icon-310x310.png"
+  },
+  {
+    "id": "terra1564y9uxzhast8sk5n47teypy4mxy7fg5vne2msuztsft7qk3pj9sxxuxmc",
+    "entity": "TerraFloki",
+    "name": "TerraFloki",
+    "symbol": "TFLOKI",
+    "decimals": "6",
+    "icon": "https://terrafloki.io/tf-logo.png"
+  },
+  {
     "id": "terra1kx4y3y4pn32jssqr90cj0rw89ds98dc0t5eqfp",
     "entity": "TerraFloki",
     "name": "TerraFloki",
@@ -281,6 +2576,377 @@
     "decimals": "3"
   },
   {
+    "id": "terra10nnsamvtc5yux6m9utwc6dtee20h8fe8gp06jfqy0ffqtxrk384s4l0rru",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra136ce352lvvlgs662hplc0rlf8tq8tvjrcaadp2ezzf2wf604gvsswflejp",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra139djw4keg5vu2x2cwucapkxp4efst286rf0n9gh3cv3ptm65c80shy0fwl",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13w89pfxhk5k62xp8ctckkhrjwwvq34czmltwkvsck0kvenyspk7q7cpcss",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14avgfstw3th676cy3mg7kwqd5a09yfwwk02uztqzq4lzu78e738saktxrk",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14m6nt5dwnxsmvt6pv6am8dkmqrf263acgjq6ex00un3t0qdd9pts2fy2cq",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18fe2jdsll40rhfhfj34n0vlkysjsndwd20jecvezdxc3dp4kcr5s7uucd3",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18jq3nawedex6s67f2rwkz3e7a57a5nxq40r9905yvyran5x7dh6sm7krj2",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19dgcuxy7vlu2u4lpv407kcrg7yeaj9an72r0gver20thkejgprksvd06yv",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1a0fyanyqm496fpgneqawhlsug6uqfvqg2epnw39q0jdenw3zs8zqlykdyd",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1a0s7u0zej7jpzuq90yglms75ng5yvq9q20awu44h395hc9k249hsry5d2j",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1a4hcacqpkqgmh94jpe290gekgv6f7euhfcl2fxm22s2r78uck9lqw33t99",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dsy8ly4t2xtzlseflqlphg8cr47sgg3egmk8pktnnq5cd7hu04lqhp80mu",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1eh2aulwsyc9m45ggeznav402xcck4ll0yn0xgtlxyf4zkwch7juqsxvfzr",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ep6pquxwgfljxzvgs7l7d0epp8spx3erysymhd8m6u4x94ztjxhqyhmyrp",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1epvnlk847v85sa82ndvt730ndhkalq22lehkwrv3fwzy00kyydxqyk27m6",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1erku46zd9ac98ts6mzj0fxv3rv37c4al5afff4xejhx5cveqefrqa9js3n",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gdj85sxs0tqhap50pv6jr6vrku4vqfrx5k62x0fu4gxt4l66qjgqqyz386",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gkg8cxha802dy8km0jldyegmtj384f69wp0c3cvtfq43gu8caa7swpe4kc",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gte4eejaw3hrs2d8pt0zhp0yfd34xp24qdgqumjul29jt5hwl5tsx3qmw7",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gxnp98ghg5mqddw3n0ve6uw3ay9hnt0ks9r3dyucjn0y007u64vqw03d6f",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1h7kgccvtdf6z2udech63qlvn5j06pw0vny9uq2wl8eqad63vt95q2pkmrq",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hhjh8hj0zdx2qh70gsuse4efer0dq93rwggkwd6w2jqpafa5gw4qhzn047",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hw5n2l4v5vz8lk4sj69j7pwdaut0kkn90mw09snlkdd3f7ckld0sutg4p7",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1k6pf84kdfxqz6gmcl9w0wwphkvwxccuz3e9fryrgvlxepuw5qrhqp07sd9",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ka40j33h55z3vkr98etwd4l0v8htaup4883pa53ze4ncaa8z9vgqd49ngc",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kzwl8dk45sn3nrfpangz73za32kzcyz4t6lq8jq9ctrwrzv07c4qda7sy8",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ma0g752dl0yujasnfs9yrk6uew7d0a2zrgvg62cfnlfftu2y0egqjpj90v",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mpyp9t48q2dy6s4lkxwjpy8sgg4r823hwam2tap2ra86hmgrrqyqcf6ehy",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nc84knc0n7td5xqplwy0luh97zd8hv5mhvm9cdempc05xk0xvxyqjr6cyg",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nf8q6w0tl3hmnvs3llakr52f9gtlnyfmtt0ynmwweppx4g2y42dqxaqrek",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1np60v3wfrdp232m765ulrmvcwqz5ymkfvflfw59enhftnnn3sceq9gt7f0",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nvd25azm56h9fk7qn9r0usjsn3g2n34w7dypw52gam8ytgvrcrfslrq2ff",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nwju0tcdykx037phw8qh7jzwqal5uk7ekqjkxzpuymkpmc7a4sjs3d3t9a",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pt6wkxlkga4fw2spxawd0ymqfdy63xk7y4tr6cawafmd06dfzgxqr9mwk8",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q3647qp780u7y2zvau5fn748zqxsfm4kr6lcvr5jjev5a77kchxsjy2m4x",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qatnqunnama825l0xf6nmxgts6j27vqfhnzadwecld4mnlumhkkq9q7cn7",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qcax3h3cadtpqua2uev06euuse8wxsjzfrtlmt0nyp2aw0a7hctq0ww6p9",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qzn7zc70c5npg5tyc6pvwrpvfp7p9utkpcwlaugn9avn6r49609suh5g0r",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rwx6w02alc4kaz7xpyg3rlxpjl4g63x5jq292mkxgg65zqpn5llq9etvsk",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rwz4h4xqlmlt6h475ckllxks8t8gulrg9dpgj5tkm8udf5mgcy7sj2rtva",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1sn3ee5c5ujczx9ksky8hn2x0jwqf2sc5hxgn9gch32933mxjjv7qtl53w5",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tewy0s0xydvh3l2wkpf238rp48n5mmd3xjfwp6j3cy603hvpgf2sztgvv8",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ttaekgrc60xc3xcflq069m49lwu79m5t552rjcws48rzhxcr4g6shmdw2v",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ugtkewkzkq26ya8ye6gfwkt9jpj08sw0737ddjj9h803ee4768xqwr56d4",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1uvqk5vj9vn4gjemrp0myz4ku49aaemulgaqw7pfe0nuvfwp3gukq4rz3fj",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vz29w25qu5lzfghz89yy6cq7jaj5snjf5p66qcmp4hza87jcstfqylf5er",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1w2l4w5p66l5t2nmrmsvz7k4cu50s7e8dc6h59gcxsnmp2tgy7q7smfaxql",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xgkjhtn4d5csgwchma73gtx5yzjxuq0eywz25lj56eqgq4d4r37sygw8wn",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xj8h7gkdr4kalgqmvvpmdxd2rkn6u5amlg0j3zek523y4sz2nlfs5gcgyv",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xnudulcse7gp2rg0hpzxtx7cz72mg20pjqhzw87z0j3pk5y9lufqupgj22",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xnxsxarhsj6v5xlrc2es2lw937z6jxat643p5uvqa3dllewl5s4qa7hwkw",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zmlgklwyrzvhgvn5sfrq28fad69wcevjymkea7jgpz8gheuk6qas2w8krk",
+    "entity": "Terraswap",
+    "name": "terraswap liquidity token",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra1cx8rey3xpd7e7t6pkywvq6n9y98yq3wlfashpm",
     "entity": "Valkyrie Protocol",
     "name": "Valkyrie Token",
@@ -294,6 +2960,15 @@
     "symbol": "VKR",
     "decimals": "6",
     "circ_supply_api": "https://api.valkyrieprotocol.com/circulating-supply",
+    "icon": "https://app.valkyrieprotocol.com/icon_vkr.png"
+  },
+  {
+    "id": "terra1gy73st560m2j0esw5c5rjmr899hvtv4rhh4seeajt3clfhr4aupszjss4j",
+    "entity": "Valkyrie Protocol",
+    "name": "Valkyrie Token",
+    "symbol": "VKR",
+    "decimals": "6",
+    "circ_supply_api": "https://terra-api.valkyrieprotocol.com/partner/coinhall/circulating-supply",
     "icon": "https://app.valkyrieprotocol.com/icon_vkr.png"
   },
   {
@@ -319,6 +2994,14 @@
     "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/AVAX_wh.png"
   },
   {
+    "id": "terra1qmnxhecc3vnmhef9q7vap7spx9tgpnw9fqe8ljqfwrlz7rur9y5qu2dlp6",
+    "entity": "Wormhole",
+    "name": "Wrapped AVAX (Wormhole)",
+    "symbol": "WAVAX",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/AVAX_wh.png"
+  },
+  {
     "id": "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
     "entity": "Wormhole",
     "name": "Wrapped Ether",
@@ -327,15 +3010,211 @@
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs/logo.png"
   },
   {
+    "id": "terra15hhqg8gyz04zapynqtk7uvlsp7lzay7etrt9ann0276v94yae63sxygeat",
+    "entity": "Wormhole",
+    "name": "Wrapped Ether (Wormhole)",
+    "symbol": "WETH",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs/logo.png"
+  },
+  {
+    "id": "terra1ctelwayk6t2zu30a8v9kdg3u2gr0slpjdfny5pjp7m3tuquk32ysugyjdg",
+    "entity": "Wormhole",
+    "name": "Wrapped SOL (Wormhole)",
+    "symbol": "SOL",
+    "decimals": "8",
+    "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png"
+  },
+  {
+    "id": "terra1dwtgrdjtgx3d3laypgx8ptch0kk20skh4p6ra3euy38x6n9s7kws4yzlgf",
+    "name": "  T (Wormhole)",
+    "symbol": "  T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xcv6yvatcr9d5prd58d6d939c252l7zwcga9yfrscexekdnnfsmskk7rh5",
+    "name": " \\T (Wormhole)",
+    "symbol": " \\T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19jtesa3t75krekhf62jjedtrk3y7l9phnkspfhyyrfqxz7c4jhusw5vlux",
+    "name": "__proto__ (Wormhole)",
+    "symbol": "__proto__",
+    "decimals": "8"
+  },
+  {
+    "id": "terra14vcfzv7f3ucedpmxsue9glsg6gnkw38js7srjynmmu60zpn3w3ys2ukckv",
+    "name": "__proto__.__proto__ (Wormhole)",
+    "symbol": "__proto__.__proto__",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1zk5vshetgylrptlr8x5swd9kp5jprtuhxp9axc6tc6ds30vsj72ss4yee3",
+    "name": "__proto__.admin = true; (Wormhole)",
+    "symbol": "__proto__.admin = true;",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1wzp5fl2jdca9xlqgl6wmncuuylfz44y29tg7y8fe77ljc73hedlsaquqay",
+    "name": "__T (Wormhole)",
+    "symbol": "__T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19092gh8hswt696qy9d649azg0lsu0drth40uw7udhuxuk8uymcws638z94",
+    "name": "_-T (Wormhole)",
+    "symbol": "_-T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1aaav9c766djrgaadwcnwfxals3gqmq5rtmryff4gga82rwqmy9tsx6nujl",
+    "name": "--T (Wormhole)",
+    "symbol": "--T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16x6ymtdpru5pfmpjdcx3te9dtmz4almzqy5ur4ghth06023udrqqfdea99",
+    "name": ":::::::::::::::::::::::::::::::: (Wormhole)",
+    "symbol": "::::::::::::::::::::::::::::::::",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1lls0emf6ra0gjtc7ym35f7eaaf9f9u5cd92t9u9wjzuw40aru4ds0j34km",
+    "name": ":::::::::::::::::::::::::::::::: (Wormhole)",
+    "symbol": "::::::::::::::::::::::::::::::::",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1vk5efw9sdx09hkzfatpvxzk2jse5t0gj2w8hgnk8m2f0rk5zeazsnuyv3r",
+    "name": ":::::::::::::::::::::::::::::::: (Wormhole)",
+    "symbol": "::::::::::::::::::::::::::::::::",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1wwz4299eputh34ya8jp25kc3m5f7d3kql0ydvh8kj3fku3sayyas7r64wv",
+    "name": ":::::::::::::::::::::::::::::::: (Wormhole)",
+    "symbol": "::::::::::::::::::::::::::::::::",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1cmvf7863w80wykszfy5xj8s4asy8urv3u6sfup6wvzezd0alqhsq2ak99c",
+    "name": "::T (Wormhole)",
+    "symbol": "::T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1g9e7gkztzzp0ke2jw8cwp538470lxs65esdsz2dxt3upnt2klrgsj3j4el",
+    "name": "''T (Wormhole)",
+    "symbol": "''T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra180pk9zdn0xjk6vcsc7tgye7qxf37mc5ja0jj72wvq86mp0qjw6uqrk9mph",
+    "name": "\"\"T (Wormhole)",
+    "symbol": "\"\"T",
+    "decimals": "6"
+  },
+  {
     "id": "terra1s56hsyhyvq4xxxvnz8qr0pnktm2dadsm4gkl45",
     "name": "[REDACTED] Governance",
     "symbol": "RDCTD",
     "decimals": "6"
   },
   {
+    "id": "terra1nw80nxy20lg2xtkragal0785jregaqeqgeyypn7cacfxt3cqdwtsds64u3",
+    "name": "@darky_daria art",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1rnaz3celr57g5z06qz2qlzrjvlga6zk7wtjdwyltx4tc9tc9nnpq2pr3a2",
+    "name": "/\\T (Wormhole)",
+    "symbol": "/\\T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14mfxv7fgx9fkf8pwgq4n8vkt5hr5f7vjflxduspnjkzc57wcpdes9ys48s",
+    "name": "\\'T (Wormhole)",
+    "symbol": "\\'T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z6gxfprq5h7qw82jwjfcx6kt4arh2klz27e8rzup9vzf2nldhr3qvfc2m3",
+    "name": "\\/T (Wormhole)",
+    "symbol": "\\/T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17mh4p9t0cf59tyzeyeqt5wmnkpztdgavl7497w6y9u4hs8w0fktq0verp3",
+    "name": "\\\\T (Wormhole)",
+    "symbol": "\\\\T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fjnfcpcey8x7h3yh45thr86ug32f8dux3llllcpyglxkyg8qpy0qjxl7vz",
+    "name": "\\\\T (Wormhole)",
+    "symbol": "\\\\T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fpz8xnkpn3j5r34zgyz0td6wcqw3xggjr5g0e70hjzf3xq474vzs242dlj",
+    "name": "\\\\T (Wormhole)",
+    "symbol": "\\\\T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1myac7574328jxy0ylgnntzl0vd62yhaqv3g68vdccuz9h7msvh4q7x6far",
+    "name": "\\\\T (Wormhole)",
+    "symbol": "\\\\T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15gn9456wttxvcxv7csgn9njqz3lnlf5jxqtrwjwm6dvwgd58ql9q97wem7",
+    "name": "\\`T (Wormhole)",
+    "symbol": "\\`T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16j8wmvu3cynnp4qqpg6z2ksh4zpngrszcne59svq8mz35jtq84cqdsrdpv",
+    "name": "\\`T (Wormhole)",
+    "symbol": "\\`T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qrgeuwxl8etjwjasvumrjmgat70d8m4la6jkng5tfc0gvgwu2xcs8fvddw",
+    "name": "\\ET (Wormhole)",
+    "symbol": "\\ET",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hd30kzycu4hu04u2rdkyt3pjqadgk4hgvauetm8pul0ps4swdswq37gs7f",
+    "name": "`'T (Wormhole)",
+    "symbol": "`'T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ncn2xqfksmsjqv4xwzk0s8ryfcp4epp3qu74n6dx7rnkyrefjutsx6ek72",
+    "name": "``T (Wormhole)",
+    "symbol": "``T",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17n8dqgaal20u6pux7jpdhus8zxa45u69xhpedkrlcw40gcfkw05q4zqkh0",
+    "name": "<>T (Wormhole)",
+    "symbol": "<>T",
+    "decimals": "6"
+  },
+  {
     "id": "terra1dwyd6vds479kv54f7kucevny97lge20c3s9w2k",
     "name": "<Big Green Dildo>",
     "symbol": "BGD",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1825g0pmvp2c0wq66n2g4lksjc3zf9a3s53dsyzslcc2k5k440p7q0uxmdx",
+    "name": "><T (Wormhole)",
+    "symbol": "><T",
     "decimals": "6"
   },
   {
@@ -387,6 +3266,42 @@
     "decimals": "6"
   },
   {
+    "id": "terra13xc83q58y74qplhwstu9er6axycapdjmnfrw288kndt3gdukxtmq8hedc2",
+    "name": "10% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra172mepny4gzvseeunw3wu0acywk0r9hzyzn5gzqxgssfhnw9p36gsf7uz3e",
+    "name": "10% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12nkef0actgu77mzl2ywt6gratctps8mheq7n3uvagzeffyhusnrq7rc77x",
+    "name": "10% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qdujz3vtn6nsc0lyf2jzukwzvpqa8mwfcl6mgdhkp07hkpwlyr6q3a6qfn",
+    "name": "100% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y0yajkqm3dfa2mcyq5cdffhk9dn6v40d6qm67gde7vaj40cmx9uq0qncja",
+    "name": "100% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lz689avwnzzthqer5nw9xsv5pu7pxe9z5ajml8hea3he33zpsysqll5h87",
+    "name": "100% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra12qeh8p79q6jrnlmw09hvtytv9e99yl2077cmgz",
     "name": "100BIL",
     "symbol": "HUNDBIL",
@@ -417,6 +3332,24 @@
     "decimals": "3"
   },
   {
+    "id": "terra1ahzlzgvcf8879da55es9mly2vrr750na6vksyuu26wxm6g6xw4xqz88lka",
+    "name": "20% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ghpf3cwp0exaq685yrkxfzpjyr69lstm2yakrzm25emng0xvqs0sq5q5r5",
+    "name": "20% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18st042rg72wm60z7vjcufnej64kdr57qpemmkjtmkrv5laxlh3hq558sqy",
+    "name": "20% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra1866wzpwzmrnmh0s267twyhr8c4tc47tqj5aths",
     "name": "247Payments",
     "symbol": "PAY",
@@ -429,9 +3362,81 @@
     "decimals": "6"
   },
   {
+    "id": "terra1hqg5nfwdkm6858tm0sxgplkh87f66ry0jgrc84nd8yj5mtxn7d7quwspmg",
+    "name": "30% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13t6ndytpw7td2yjls6ln64062x8vxywsclzd0gytmd87pecg8ursdw43p8",
+    "name": "30% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1chgx4qzdgsa5rykng5nwhm82gld9au6jkwg4ueayt2dkm8skhfssgwe63r",
+    "name": "30% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra1qt0j6rzqrc0rxpxxlyrvljmjkxrss2frsef5n0",
     "name": "300 Terrans",
     "symbol": "TERRANS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pmdjqw6cuql7e4wakcvte4xh8ltvkky7rzn8gqwpcx9vfst46g3q7c04w4",
+    "name": "40% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yff2t0wdhftjmy67ydjhyv6h4f3kz4sc3sn3ff4tje0axs82lpvs24ykqa",
+    "name": "40% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zu389vgu4pkpqrulfz3yk3jm870fwrd2hs0pes5en4rjwrsqx54sven5em",
+    "name": "40% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vf4z3lys8awmcxcclxsu8d9lwxv0wzhxtzkkfg0ntth4kks7pu2sv45ku8",
+    "name": "50% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1l420mu6pkgffqhsxz9w42lxls80l7yg7f7la5ajdz99g07u94xhqdxlv9l",
+    "name": "50% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1d9k26t24afcq3gha076yg39y4eg0hcayg9xzlskheluq59l5ut4s75qjuf",
+    "name": "50% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f8yude2jpdyfhx3f4p99nnreelx09950hkqcd263mpr9w9jykkmq58xsae",
+    "name": "60% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mt942r7k6c9wlkk32nzt2ewhs5p5y0haxkx5nepwk2astr6e2uxqkta3ps",
+    "name": "60% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z5x2rzk79eljmjnjfpt262hf2alnsph4eq8vr6vgl3dmn3q6k7nqvyqc6a",
+    "name": "60% Spaces LP",
+    "symbol": "SpacesLP",
     "decimals": "6"
   },
   {
@@ -447,10 +3452,100 @@
     "decimals": "6"
   },
   {
+    "id": "terra1p0x4c5r6n9dz4lm0mqssee8s8j4lafpwf46vvqyclputftcnh0rq3mueus",
+    "name": "70% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1axg4x9pgx7xhlslcza9el0xqsyxd8fl69svs83895ycl0v22dv8styklnx",
+    "name": "70% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16uun4j2ajew6pxz095d6nglswed6kjruevus9rn6y63djtrlkkeqx6cx4u",
+    "name": "70% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xmj3ln6hyfyzc4ky4vh9cl5x8tv8f5hx7lwmy0xgar069kqnehcq6fe3xs",
+    "name": "80% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pj8ng6reunzed6f0z26k7hfpd03g73z8jdhsnx8reu8uqsyapydqnjk50m",
+    "name": "80% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14504gwrp7gvhd42l7qny4ld67xaqrnrvk6dm33xp37rls3ert9cs7c43f5",
+    "name": "80% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ftpzlskr027fulju0mj9sz83zysy55whtspqghhxx2kjtu2mgqqsewnjkz",
+    "name": "90% Angel LP",
+    "symbol": "AngelLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wf9gd0yuszsuqqxkm0gu0rzgnkr3yp5awzm8clurv4ljyc34j9vqamar9p",
+    "name": "90% Burn LP",
+    "symbol": "BurnLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14a7sujcak07xe90axfrplc3qd2uykt0snq3huastvu7jffdwpnlsqe5lyz",
+    "name": "90% Spaces LP",
+    "symbol": "SpacesLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s53ze5358jeq0rggeuf8pqvt4y7fpe23w4hepl8g6zlkzklc374qllh09v",
+    "name": "90s PUNKS",
+    "symbol": "9PKS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1e88qgtfw4c5zmgv9zhwsy569jwwsav4gukz64l5ewyxa3xaqckksc0z3hc",
+    "name": "A Space Doodle",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra17nyvdvmm2hjdajldme6x3y3nle6kp9wtn8qfmajw76hkk7g5tpuqgpkum5",
+    "name": "A Spooky Doodle",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1mdsnqpzj558p5qkujywpx6e59cmm68hkctfzm39zlgnlxfl738dqq2g47a",
+    "name": "A-Folkalypse",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1h48d3ccyaf50pzef0zc3v40vnv9zkq6mmslgm3gwl9s5s66cz42qz9enxe",
+    "name": "A-Team Lunaside ",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra1wlhgvtult73t5vpeng4sw9qmsq5jlujfm98gg2",
     "name": "AAA",
     "symbol": "AAA",
     "decimals": "6"
+  },
+  {
+    "id": "terra1zdwggjn7rkrpgz8ukm77yeh7a4gsallhq67f9dxjd9pmklve2gksc23gc2",
+    "name": "AAAA NFT Collection",
+    "symbol": "ADFC",
+    "decimals": "0"
   },
   {
     "id": "terra1dyptd3795l57lencr2eltut973kum8wgu36f7p",
@@ -459,12 +3554,16 @@
     "decimals": "3"
   },
   {
-    "id": "terra18ej5nsuu867fkx4tuy2aglpvqjrkcrjjslap3z",
-    "name": "Advanced Micro Devices, Inc.",
-    "symbol": "mAMD",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra18ej5nsuu867fkx4tuy2aglpvqjrkcrjjslap3z/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/AMD.png"
+    "id": "terra1x4lm86rnw376xtuca3jux27yqwwnc9gu76vt4gggzp54hrxnegtqhz57e4",
+    "name": "ABCMETA Token (Wormhole)",
+    "symbol": "META",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1f7lvy8xrm4xnue6vtzkerzuwhszne5gqekmxx7y3fx7m603jzm8qjh2xsg",
+    "name": "Adventure of Homies",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra12qxyx2l90c37kylw4jqe8t40ppnrnu8wqmx940",
@@ -473,32 +3572,28 @@
     "decimals": "6"
   },
   {
-    "id": "terra1g4x2pzmkc9z3mseewxf758rllg08z3797xly0n",
-    "name": "Airbnb Inc.",
-    "symbol": "mABNB",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1g4x2pzmkc9z3mseewxf758rllg08z3797xly0n/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/ABNB.png"
-  },
-  {
     "id": "terra1xc5ll57yu269x8ysxvdpjmvxmac3js7pst5ddr",
     "name": "Alameda Research DAO",
     "symbol": "ARD",
     "decimals": "3"
   },
   {
-    "id": "terra1w7zgkcyt7y4zpct9dw8mw362ywvdlydnum2awa",
-    "name": "Alibaba Group Holding Limited",
-    "symbol": "mBABA",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1w7zgkcyt7y4zpct9dw8mw362ywvdlydnum2awa/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/BABA.png"
+    "id": "terra1693sgskk3tj24n8atssq5x7aq090awq6wy7hkmpew403vg6svzjq6x04nh",
+    "name": "alentejo.money",
+    "symbol": "alem",
+    "decimals": "6"
   },
   {
     "id": "terra14xulq5g99rfmrm6qkgzmrrspvknupajdqyd92k",
     "name": "Alibaba Group Holdings Ltd ADR",
     "symbol": "mBABA",
     "decimals": "6"
+  },
+  {
+    "id": "terra10330cpst4uvum97nvrqcrt3wachznh0akxgtzfxn20kvn0y7ue7qv2m5s3",
+    "name": "All i END 2.0",
+    "symbol": "AIE2",
+    "decimals": "0"
   },
   {
     "id": "terra1ukk89gn25p7xseqc4s4d45yarjlwychrwx7umv",
@@ -514,6 +3609,18 @@
     "icon": "https://raw.githubusercontent.com/allbridge-io/media/main/token.svg"
   },
   {
+    "id": "terra15rqxf0fdmja0vxay3q7jspmkxd3yh6mcqf5jyppme5ue459csshqnm57cc",
+    "name": "Alpha Ark Test",
+    "symbol": "ALPHA_ARK_TEST",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1zvm0y8x4pxq7dhpvuevv3v3cdkvlcxtv99e67lcrtfayrr9glpns3fjara",
+    "name": "Alpha Ark Test",
+    "symbol": "ALPHA_ARK_TEST",
+    "decimals": "0"
+  },
+  {
     "id": "terra1366wmr8t8rrkh6mag8fagqxntmf2qe4kyte784",
     "name": "Alpha Pack Token",
     "symbol": "aLOT",
@@ -521,12 +3628,10 @@
     "icon": "https://ipfs.playlot.io/icon/profile-logo.png"
   },
   {
-    "id": "terra1h8arz2k547uvmpxctuwush3jzc8fun4s96qgwt",
-    "name": "Alphabet Inc.",
-    "symbol": "mGOOGL",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1h8arz2k547uvmpxctuwush3jzc8fun4s96qgwt/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/GOOGL.png"
+    "id": "terra1rpsh2wzwupdkp9ka5muq43fdnh9vkw8ee4uzznpy46ety0e56h2qk8407d",
+    "name": "Alphabreedies",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
   },
   {
     "id": "terra17azgr4x2gz20uquy7vdacfdgjjkgd0h9lm377v",
@@ -555,26 +3660,106 @@
     "decimals": "6"
   },
   {
+    "id": "terra1g79985x9uyqqynn8ckynk32rj04juqxecjqtmxazz7dq3weywz2swen6s3",
+    "name": "ALUN-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m7rxu2099cdglmlz46ldqhkxtk26lwjgydszrq2v8ffauzmg5saq0n7rcc",
+    "name": "AMAZE",
+    "symbol": "AMG",
+    "decimals": "6"
+  },
+  {
     "id": "terra1tthplnk67e7tvga2dh49jk6l6cn4furuuffu9x",
     "name": "Amazon.com",
     "symbol": "mAMZN",
     "decimals": "6"
   },
   {
-    "id": "terra165nd2qmrtszehcfrntlplzern7zl4ahtlhd5t2",
-    "name": "Amazon.com, Inc.",
-    "symbol": "mAMZN",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra165nd2qmrtszehcfrntlplzern7zl4ahtlhd5t2/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/AMZN.png"
+    "id": "terra1e5vchf97lakl6sulztkn54aapekzfzsa6amdt88exvwmu25s3z0sg6hplq",
+    "name": "amp-ASTR-IBC/-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
   },
   {
-    "id": "terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy",
-    "name": "AMC Entertainment Holdings Inc.",
-    "symbol": "mAMC",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/AMC.png"
+    "id": "terra16akp34qkh3v6537gra4ypqj4z208fmesdpzp9vgx3w3luruplgmse5rvku",
+    "name": "amp-BLUN-ULUN-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cgtn7dnlexpqdzr44srt7t5edxlwjqae970prfmlzywjhttae99sche4v8",
+    "name": "amp-IBC/-IBC/-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xxyr0tduxlggrujcsqmnllu74dmg4697heyjmvvyv6tj3q0hh0qqqq8d6h",
+    "name": "amp-RED-ULUN-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rlfuqcq935j6avrwsurzn6altrq6htet0ggz3hv86kueeewfzunqj2u6lw",
+    "name": "amp-SAYV-ULUN-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m9fvkwjpwd4ddgkxd5ddvc2jst9wtv33u7kj89tq2wr0tjm34j8qyfmpwm",
+    "name": "amp-TPT-ULUN-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ymwcpz20lcaue5kkawj3t2fe7et4xd7xkxtuxzc43at0dvcywrsqcuunk2",
+    "name": "amp-ULUN-AMPL-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1as76h247wvey3aqmw22mlkq8g6vj8zj7qw4wywwn388s2mjt0rtqpp570z",
+    "name": "amp-ULUN-IBC/-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kle8kd6gwx9fwpav6spj8zg25uhftsm87gdss4ssmej4pnee2rtshhyct4",
+    "name": "amp-ULUN-LUNA-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nrzw3c28h5sq9q7pw9umc0882607exz8he5uj9yx2yw22m3mhrmsxw2lql",
+    "name": "amp-VKR-IBC/-LP",
+    "symbol": "ampLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hva5lt2whpgav5hhsxfvegvkk2kjjshprzj7spe3cl24g4705asq4kx299",
+    "name": "AMPL-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ppjw8uh4d7mpp8ymutfdtv4ch0acgll7rrs059y3ghhvrs4jgm2szjp74n",
+    "name": "ampLuna Pool",
+    "symbol": "ptAmpLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qxfq924wkxpx0vwy7eudxlumkn3k96e37eynvxdmhje96ftv0h8qykyyrv",
+    "name": "ampLuna Pool",
+    "symbol": "ptAmpLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wu5cts7zr3sfmwlxfh7an3nthrx9cuz8fx7xfesmdudg2kzcwmhsaw24r8",
+    "name": "ANC",
+    "symbol": "ANC",
+    "decimals": "6"
   },
   {
     "id": "terra1fx6ffswrmgyuf5nsxruce5gertr8vgsm7krrp7",
@@ -589,12 +3774,36 @@
     "decimals": "6"
   },
   {
+    "id": "terra1gwdxyqtu75es0x5l6cd9flqhh87zjtj7qdankayyr0vtt7s9w4ssm7ds8m",
+    "name": "Anchor Terra axlUSD",
+    "symbol": "aaxlUSDT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qgwcdwsk9hg064l5elnxmn84ll03ps0022mndxs87mt25wpj7tfqmt3mdq",
+    "name": "Anchor Terra axlUSD",
+    "symbol": "aaxlUSDT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tyacsyss53dmsss5fj8rv7fzu2nm55p2pyre0ylz9wfjgzp9z3yqsarc8m",
+    "name": "Anchor Terra axlUSD",
+    "symbol": "aaxlUSDT",
+    "decimals": "6"
+  },
+  {
     "id": "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
     "name": "Anchor Terra USD",
     "symbol": "aUST",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
     "icon": "https://whitelist.anchorprotocol.com/logo/aUST.png"
+  },
+  {
+    "id": "terra16j2duml4u8rlmggc26w4nz8ctxpk3h55l25fgz7u6zjg5evs4suqkc3uws",
+    "name": "Anchor Terra USD (Wormhole)",
+    "symbol": "aUST",
+    "decimals": "6"
   },
   {
     "id": "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
@@ -623,6 +3832,42 @@
     "decimals": "6"
   },
   {
+    "id": "terra1gs5k436vrwd38rqeanlnacl25swv8gmljgg0zej2ccvdmzr3lpdqmfxrl2",
+    "name": "Anchor Token (Wormhole)",
+    "symbol": "ANC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15yw86743jryfe890fkuuz8egx22j5te7wat6j76gfm4pgywd0erqaxsr65",
+    "name": "Anchor Token (Wormhole) (Wormhol (Wormhole)",
+    "symbol": "ANC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1g5ghrkqcc5h6cg7ppjljlmx3gcwqzae4a5dwyaajwck2wzyl7p5sgr9tvc",
+    "name": "Anchor Token (Wormhole) (Wormhol (Wormhole)",
+    "symbol": "ANC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zfhdvjkejtpp639emz9jyre3pp90zq35snrlypyv84x3qrza4xzs5cykdt",
+    "name": "Anchor Token (Wormhole) (Wormhol (Wormhole)",
+    "symbol": "ANC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vppkxz6706zmd0qq037sv76qhlr4sw8wxyrhr99upmsfez3a576sj7g6wk",
+    "name": "And Enjoy",
+    "symbol": "ENJOY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19zz9g0lze6s2hjtslhr96h8hn9kl7zktmrx200cqpywrun9z4a0sktfxwr",
+    "name": "Android 51",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra1pujanvsuhqsqf8vc7r3ky9ghr8sgeg4e3ngjun",
     "name": "Angel Protocol",
     "symbol": "HALO",
@@ -634,6 +3879,18 @@
     "symbol": "HALO",
     "decimals": "6",
     "icon": "https://i.ibb.co/q9krLwC/halo-token.png"
+  },
+  {
+    "id": "terra12ew4cuffqj20l8cz35lzngtk6x2f278dk77wm8pfpc28wle5pd6q88yrp0",
+    "name": "Ankr Reward Bearing BNB (Wormhole)",
+    "symbol": "ankrBNB",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1vj8jwvu0896hhq34r37krtqpfknfm3vway8vghygnrnr7kfzmncqurnvvl",
+    "name": "Ankr Reward Earning BNB (Wormhole)",
+    "symbol": "aBNBb",
+    "decimals": "8"
   },
   {
     "id": "terra15xf5wqprgzl59ckfyjtgavh7rqtxcju7gn57rc",
@@ -674,12 +3931,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra1vxtwu4ehgzz77mnfwrntyrmgl64qjs75mpwqaz",
-    "name": "Apple Inc.",
+    "id": "terra1p67lldutk5haqpmnk5thuhmhyff8ntf8axa37mzm87qq58082u0qqp9mmu",
+    "name": "Apple (Wormhole)",
     "symbol": "mAAPL",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1vxtwu4ehgzz77mnfwrntyrmgl64qjs75mpwqaz/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/AAPL.png"
+    "decimals": "6"
   },
   {
     "id": "terra1vyusa796w86yh99l67dpd5g3hfva759vyuhn5z",
@@ -688,12 +3943,22 @@
     "decimals": "6"
   },
   {
-    "id": "terra1qqfx5jph0rsmkur2zgzyqnfucra45rtjae5vh6",
-    "name": "ARK Innovation ETF",
-    "symbol": "mARKK",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1qqfx5jph0rsmkur2zgzyqnfucra45rtjae5vh6/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/ARKK.png"
+    "id": "terra16hx93yrc3s7xlx8facausmtz3sfrgknd6mf70fhmzhjkej97g42qkflfs2",
+    "name": "Aptos Coin (Wormhole)",
+    "symbol": "APT",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1plhefzma59lh6rjk5gfkq45pz2chfq35nm9xgdz4pcuhp3nnwekq8sthua",
+    "name": "APY 365%",
+    "symbol": "BOND",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12xzq4mpgzp357yh5pwpztr3j66aaqph5xucttt24f9qw0hf9lg3q686kru",
+    "name": "ARGO TOKEN",
+    "symbol": "ARGO",
+    "decimals": "6"
   },
   {
     "id": "terra1yjlqptvn3al5402jp600l7n3l5yl8man8d4kex",
@@ -702,10 +3967,118 @@
     "decimals": "6"
   },
   {
+    "id": "terra19yuxlwnndlayj4p4d2ue0cpdw0wlhgvekshefar5vvxgkt8rsnlqst9wdx",
+    "name": "ARTerraLand - Mar de Pulpi",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra10fjq3tt0gzffek4099uwtrdv3acaeh69l86j0xycqr54qxyq98nqpj46lg",
+    "name": "Artistic Alphabots",
+    "symbol": "AABT",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1aukmt9xg0857dtzky3pd6cl83ken8dtgagntykytg7yfz9elrccsatlr4z",
+    "name": "Artistic Alphabots",
+    "symbol": "AABZ",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1c3kcc689kuexyx6ylgy6dj0ha3f8vfyhsruntuhj3xsnkcawfmvs6qsgy7",
+    "name": "Artistic Alphabots",
+    "symbol": "AABT",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1kcr0ymnr02ffn2amk3kd6wwdp5c90x5utqpwe4847c55ws634eqst53k24",
+    "name": "Artistic Alphabots",
+    "symbol": "ARLBOTS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1p7nwjxm2mjjys9vxg4gkvl2jjjf3qqqtvpkysptf5s833nvv96xsxaelq5",
+    "name": "Artistic Alphabots",
+    "symbol": "AABT",
+    "decimals": "0"
+  },
+  {
     "id": "terra129796y06jrejsk9hjmvhkhat92mxt76k6qpyfw",
     "name": "Asan King Token",
     "symbol": "AKT",
     "decimals": "6"
+  },
+  {
+    "id": "terra1s9gdu78jm0yg8e8ceeefcn2j8upmxuf7f6zku4lkwtsngdct6yuqd289yd",
+    "name": "asd",
+    "symbol": "asdsad",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mrg8rzx2mc43grmzveulyqxpw3enh2uvzlv7vv7ue28gv2d7wcgsap9cag",
+    "name": "ASPARAGOID",
+    "symbol": "MOUSE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1tgjah63kfmsk38nmanckpf2j28qntdg6zp6vqx4v6mttaza0l3ls0ld7km",
+    "name": "ASTR-BLUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wrjl547wvaw7vm7e2vqvnvmaeszumfx9whpqdaw8xl5vh65cx24sf6jgap",
+    "name": "ASTR-BRGR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra185r56sntq8cjem0ttcg93l5cwsx58f4vsl74uen0j8j8z2qnlf2sjgaaqt",
+    "name": "ASTR-DRMR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13qaz542ft2ve34jfdy8epp33v6gfd857vc98sjxapf86fh83p99spzqf0u",
+    "name": "ASTR-FRGY-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e8panxssahk726tf0uualyl7z3n8x9w80lxz6nmdqflm806rs3jq6f7wwm",
+    "name": "ASTR-IDC-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1u9amrmxnnhfwecku6ndaxk2034e73cddxau96avzg4r0xvta4wns2ckane",
+    "name": "ASTR-TPT-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1w4j2zjmam5c2cnclq4tr0v09dncw493y73fttf7hh9fgf3jpxx8szecyaw",
+    "name": "ASTR-WAVA-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1w47prn6mgznc0crx57ckg676kt93y8tr6ts6va5el02juf6rdydskf5spy",
+    "name": "Astro Herro",
+    "symbol": "Astro",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1m2s0tezk5y56cryqnvh7d8zt526th20my5hs02f5eaaya020kmvs0el8nk",
+    "name": "Astroport (Wormhole)",
+    "symbol": "ASTRO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pkw7a047dna36hc7kxce90f9v3trszjamr2swzun0cfmc0k2jxdqahzf9c",
+    "name": "Astroport Lockdrop NFT",
+    "symbol": "n/a",
+    "decimals": "0"
   },
   {
     "id": "terra1kdfsdm3c4reun9j3m4mk3nmyw4a4ns7mj24q3j",
@@ -713,6 +4086,24 @@
     "symbol": "PUG",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/astropug/astropug-world/master/logo.png"
+  },
+  {
+    "id": "terra1pm0gpgsqmjk3rgy43m8z5edmjjx80r738mq4enyswgfz9uhppg4s849crt",
+    "name": "Astroverse #01",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ur483uv42hht0dz73ammau4wav7mlxuxgtxvmgqx7swy9lg94qhqxjfhzx",
+    "name": "Astroverse #02",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra16968kw24zy3uayaexe6prht89e9zvntcgjuz6a4tf4ujewwfm4ls4jsfp4",
+    "name": "Astroverse x Vinboy",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1cl7whtrqmz5ldr553q69qahck8xvk80fm33qjx",
@@ -756,6 +4147,18 @@
     "icon": "https://assets.terra.money/icon/60/AUT.png"
   },
   {
+    "id": "terra1jh37p2akmwprfwr2235kjyt3wuz0s2sfenhtytg9cajsxnxfvdasnaurdp",
+    "name": "Auto",
+    "symbol": "AUTO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jqt5mmlpd6x3jtwfdsxwtrknvaczz2xmplukzc8h86xhupg7fe7q7nkzdp",
+    "name": "Auto TOKEN",
+    "symbol": "AUTO",
+    "decimals": "6"
+  },
+  {
     "id": "terra13x03uqz06gkam3dq4dgx0tj89dpw3vs2nlftjq",
     "name": "AWDw Token",
     "symbol": "AWDw",
@@ -765,6 +4168,48 @@
     "id": "terra14q0a4tfmdkwrvzakv7nq9jg2d36w8uj9jkhgee",
     "name": "AWESOME Money",
     "symbol": "AWE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19cx22u6uxzdv4mn7ga8g039wm5yzfe4k7rg4an4f5hwst9vjpxfqt5qfd4",
+    "name": "Axelar Wrapped LUNA (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15wg4cwcar39mxq0yg3zlpgcsm5s75sptrp9f57deycmvu30gh5nsshktux",
+    "name": "Axelar Wrapped USDC (Wormhole)",
+    "symbol": "axlUSDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16dqd7fy7z9rxn0ytue6xjz0flwqyux00vnyqnjlv8j4fya8jeuzq3vs4jk",
+    "name": "Axelar Wrapped USDC (Wormhole)",
+    "symbol": "axlUSDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q9rn56280frulg8h9qmv2r2zjxqhx04fdls322egged43n4308xqsxe3pd",
+    "name": "Axelar Wrapped UST (Wormhole)",
+    "symbol": "UST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qma34k8hxsl65vqf9anrhnr7muvwamhpj7f6u0azwxvvx6uv3exsz2ru8u",
+    "name": "Axelar Wrapped UST (Wormhole)",
+    "symbol": "UST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1j7ckshknp3px4vggcews2ezp9llqkw65v7f383t2lhqvdvdgkngsgp0npu",
+    "name": "AXL INU (Wormhole)",
+    "symbol": "AXL",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1kkrplzf5hfz04l6pey44s0wd6nctdpv0nrsx47a5ts5s2wagsjcsly7cn4",
+    "name": "AXT (Wormhole)",
+    "symbol": "AXT",
     "decimals": "6"
   },
   {
@@ -786,6 +4231,36 @@
     "decimals": "6"
   },
   {
+    "id": "terra1v4u6kjlc0m6lq089tczfpve2vwpw5cqvrdklcc55xyws2qphqctqp3tp4g",
+    "name": "Bag of D*cks",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1km69jdkp00zvsqya0pmyqn8e3thg7csuud2yw0v2a7jy87uh52qqz7rcq5",
+    "name": "BASI-DRC-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1uuz0sfj2gauppp9p8sul50x97nu3jhtfj7y22x93wgte4kgs0jpqad4qmf",
+    "name": "BASI-DRMR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1plcht4ueytcpwk6vh4c366g74p3dzrt7st4phszx4mjmsfh74y2sq04nw2",
+    "name": "BASI-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1uelwtk27dq4luvyj0w0u8jvsejcw2l5fvy8n3kxurl69pleqkp5sl5t2rq",
+    "name": "Basic",
+    "symbol": "Basic",
+    "decimals": "6"
+  },
+  {
     "id": "terra1apxgj5agkkfdm2tprwvykug0qtahxvfmugnhx2",
     "name": "Basic Attention Token (Portal)",
     "symbol": "BAT",
@@ -793,11 +4268,29 @@
     "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/BAT_wh.png"
   },
   {
+    "id": "terra10k0kuaxr2lrgqlp9wqc0xxs3u5lwx434ttg2avc0mtttavykzh2qssgtku",
+    "name": "BAZ",
+    "symbol": "BAZ",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1a7zeajhk6nnj7jzu2rxynwr3yvp58gj2ffxe9k4dneyte0v5kkeqnmzwvq",
+    "name": "BAZ",
+    "symbol": "BAZ",
+    "decimals": "6"
+  },
+  {
     "id": "terra1vsyyg4rs483uzd7jzw5fqqlm2q5n2yd37yylfc",
     "name": "BAZ",
     "symbol": "BAZ",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/BAZustc/BAZ-CORE/main/BAZ.png"
+  },
+  {
+    "id": "terra1xaqh7av93gwvuf2jj0n9sk3fju5pkclh033r8g5phtzawmu5hzusahf5r2",
+    "name": "BAZ",
+    "symbol": "BAZ",
+    "decimals": "6"
   },
   {
     "id": "terra1g36mr60pqf8x4hr3ulpsptrg84w088m0eunsw0",
@@ -824,6 +4317,12 @@
     "symbol": "wasAVAX",
     "decimals": "8",
     "icon": "https://benqi.fi/images/assets/savax.svg"
+  },
+  {
+    "id": "terra1gyg0pys40ex2f6a4dytd3ewpx2xfrsnt3rdc2t4j3s3jc9qx8kqsrd5c0p",
+    "name": "bETH (Wormhole) (Wormhole)",
+    "symbol": "bETH",
+    "decimals": "8"
   },
   {
     "id": "terra1p2enl6vfmhdfj7ud32p3fkgns22sg62ls9mh2e",
@@ -868,18 +4367,28 @@
     "decimals": "6"
   },
   {
-    "id": "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw",
+    "id": "terra18sv25lxt8v2z2zueatehtchjzv6f67qwsqah9anjyjzntf2rkkxqe9hnd7",
     "name": "Bitcoin",
-    "symbol": "mBTC",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/BTC.png"
+    "symbol": "BTC",
+    "decimals": "6"
   },
   {
     "id": "terra1vpehfldr2u2m2gw38zaryp4tfw7fe2kw2lryjf",
     "name": "Bitcoin",
     "symbol": "BTC",
     "decimals": "6"
+  },
+  {
+    "id": "terra1urs3y9w7rsk3ysshtftkqtmx90dwxen59j8e0gj79m0wcpygy24ql7flqh",
+    "name": "Bitcoin (Wormhole)",
+    "symbol": "mBTC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra147kkv9tdq4lcuksu2u2h38ucp2rc9sk783wr5zhuxq3p709funpqrl0hk7",
+    "name": "BitLift",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra193c42lfwmlkasvcw22l9qqzc5q2dx208tkd7wl",
@@ -907,6 +4416,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra1nfgjhx7yh7j0qzw5uz24kr5q2wtneuya9ahs8cet2e0kcetu2seqh46nnu",
+    "name": "Blocks By Artog",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra1r7qpupdxkkh58vw9u8y9n9wjp6d9lr08u39j0z",
     "name": "BLUE TREE",
     "symbol": "TREE",
@@ -916,6 +4431,24 @@
     "id": "terra1x95tutcwe4tjxcdvtgrjg5jxkf24sm74xz3leq",
     "name": "BLUESKY",
     "symbol": "SKY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vpcj4fj0yxy4m928lxf8us7tk8kdqr3ny6q2gtx7g0s935awdreqppm7au",
+    "name": "BLUN-USDC-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra173yxt55wz7aemm7xf2v83ttpnvtwxsaa4q53xp4jdz7m8g97plmsnv2duv",
+    "name": "bLuna",
+    "symbol": "bLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hspy32cecnj72wwpma59eldpmsmfndlrwqxnzx6awfdtarns66qqw5kn85",
+    "name": "bLuna",
+    "symbol": "bLuna",
     "decimals": "6"
   },
   {
@@ -952,6 +4485,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra16tvjldrp7mgudk5sn6m7yhady8dg30lw9x4sa07exv2l65gtce8s5835nt",
+    "name": "Bonded Luna (Wormhole)",
+    "symbol": "BLUNA",
+    "decimals": "6"
+  },
+  {
     "id": "terra1c00vskhyzdv0z63z2tyetzx2qma67n2z3vzyn0",
     "name": "Bonded SOL",
     "symbol": "bSOL",
@@ -963,6 +4502,18 @@
     "name": "Bonded UST",
     "symbol": "BUST",
     "decimals": "3"
+  },
+  {
+    "id": "terra14rpyyhc6vgrachny6ycu4evjyx06j7f46w5gh8ckhay7ueecukss43m2vx",
+    "name": "Bone Luna",
+    "symbol": "bLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kl3kqkmfe8cdu42y6gdl0stwuckegvxdm8td7jndtj025zxelp6skktt0t",
+    "name": "boneLuna",
+    "symbol": "bLuna",
+    "decimals": "6"
   },
   {
     "id": "terra1s0y8aldsy3t6wtg5tpwe8xzq3lyet5e9grwmlz",
@@ -983,10 +4534,40 @@
     "decimals": "6"
   },
   {
+    "id": "terra1dpsvhwqqnyllpg40l9ylttnhj3z4wqmwhsjn2u4s8lwvxs6zln3s89ezn8",
+    "name": "Bored Brat Squad 1st Collections ",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1czc4z2r4xvj90xr537e664et7pq9xs2c4vkdwxlk3hdhzxwc4cqsmmarah",
+    "name": "Bored SkullPIX Club",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra18wzq25g7cfleaca0rypsrz5dnu73agjqk7j3lg2uj4c9vtp29efseldtqj",
+    "name": "Bored Skullz",
+    "symbol": "BS",
+    "decimals": "0"
+  },
+  {
     "id": "terra1a07n2cp4wd49ezxdgm9xgtfrnpmxfcdp4yrdnv",
     "name": "BORG Token",
     "symbol": "BORG",
     "decimals": "6"
+  },
+  {
+    "id": "terra1fenpr826qpr42a6u5qwp9lktvzx84cq8dnmpm05fl3d65t75q84sf2yx78",
+    "name": "Born Sinner",
+    "symbol": "LUNA",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1syksjwl88dhetkzfw9snr8f8sg0spsmlvm9h4jq6y7sd6axjd9yqxu3w5u",
+    "name": "Born Sinner",
+    "symbol": "LUNA",
+    "decimals": "0"
   },
   {
     "id": "terra1d6vy3aueuucu3sf5qkrccnq7v58uwegh9m9x74",
@@ -995,10 +4576,46 @@
     "decimals": "6"
   },
   {
+    "id": "terra15mygj54nztctlmq0g7hfjaetsd2zryjnmctws9v2mjdteppp5znqusylxa",
+    "name": "Brand Governance Token",
+    "symbol": "BGT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kkpf3f049trkyscv0av2pa9ad02dzls7f6m8s24q07ehetggytesru7qqp",
+    "name": "Brand Governance Token",
+    "symbol": "BGT",
+    "decimals": "6"
+  },
+  {
     "id": "terra1zp4xkexmng539vylktxkf45hxjg68ufx673x8p",
     "name": "BRDG Luna - FTM",
     "symbol": "BRLF",
     "decimals": "3"
+  },
+  {
+    "id": "terra15sad8j5wx8u0aptgfvmz7zwsjrl7mfuc207d3gljh9gdaxx0d0kqq8d7kc",
+    "name": "BRGR-BASI-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m06sj94uj26c9lscuyfvns5avk9jckehs7287zkfa9usctfpu5tq8y8fd8",
+    "name": "BRGR-DRC-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ul4xg7ddcppfyl405rqyhxcsgp4kg2zfwk40lc5tx433x4tzlsysga3kre",
+    "name": "BRGR-DRMR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra152ffgyevz7u3nu2a8s0tfur8m7w2uqd5asv9tlzpfnldeft6k2jqraps9l",
+    "name": "BRGR-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
   },
   {
     "id": "terra1ltcad0e9cgf2jgtzqwg82n9k54fre68wdddfll",
@@ -1028,6 +4645,30 @@
     "icon": "https://c2x.world/c2x-station/icon/BSTfancard.png"
   },
   {
+    "id": "terra1a2gdn43yjllg3jvna7xcv2zea0ppjchsww2fedd63l9k2azg6j7qg6v3pj",
+    "name": "BTC",
+    "symbol": "BTC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pjpkzmnsuupnchte5vz8svwyf4vgr74hdtw7h8vqhd3hcts2ttpskkjeax",
+    "name": "BTC boys",
+    "symbol": "BB",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1uy87s853kqhlac6m7fdc7w2zx43ww5y20qv5llnuanj8fp9lek6q8djl75",
+    "name": "Burger",
+    "symbol": "BRGR",
+    "decimals": "12"
+  },
+  {
+    "id": "terra13e7da9f90m32s04kg4knlpsakmn50kqz2zx2rqypkahhp29gxdwqu4vy8q",
+    "name": "BURN",
+    "symbol": "BURN",
+    "decimals": "6"
+  },
+  {
     "id": "terra13zs7w76g0u4qgagcen6vq92wxuvgfucr3dy4tm",
     "name": "Burn game token",
     "symbol": "BURN",
@@ -1037,6 +4678,42 @@
     "id": "terra1f9h22l730vxxj5jmrakuwh3neuhdynwy42ezvv",
     "name": "BURNED TERRA",
     "symbol": "FIRE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z0fvc52jy3630rx36vcya4u3qmnxf9jdjqq40hsumddme8rjpdfsxvhlxk",
+    "name": "Burnt LUNC Using MM Pool",
+    "symbol": "BLUMP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra129zjaxquhh3h5upn0clqzdawnze43a9z34ktt4l6um2hf5w0xqjsta42u5",
+    "name": "BUSD Token (Wormhole)",
+    "symbol": "BUSD",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1aplktggys8uf3mm8rnx5nz2vz66jgu4pszpjg72nn6kst299y58qv46ajc",
+    "name": "BushMills",
+    "symbol": "MILLS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13y658n8mssa6sesrnqcz05mmxfd7ucma6gg04vwkd2862a2ptexssar2h7",
+    "name": "BushMills2",
+    "symbol": "MILLSTWO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xmn82g2e6pch8fwfrxfc90gquek93n6glf38z450mx3hxl8fteasluup20",
+    "name": "BushMills3",
+    "symbol": "MILLSTHREE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ndlsnn3lcc8s2arj9t5x9qqj8vxsqd4r2rt60zzg7cldwr4askpqlza99x",
+    "name": "BWT (Wormhole)",
+    "symbol": "BWT",
     "decimals": "6"
   },
   {
@@ -1051,6 +4728,12 @@
     "symbol": "C2X",
     "decimals": "6",
     "icon": "https://c2x.world/c2x-station/icon/C2X.png"
+  },
+  {
+    "id": "terra1szqw035afuqmdc42tr2sxd6z5ady0ap9k97fhadzt8mdh46ts2ms2lmsqg",
+    "name": "Cactus MetaGloria",
+    "symbol": "GLORIA",
+    "decimals": "0"
   },
   {
     "id": "terra16ea8pnh3hu69kzqqps5gqw0zdd94hgul9tfnzw",
@@ -1077,6 +4760,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra1l3uautulwdvn0v4pl928merxhh40fj46v8vgtpv0yymtk5t3n95s509m0z",
+    "name": "Canvas Worlds",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
     "id": "terra13fs83g5atgjwuh7c5ydzh6n7gecel6xyhhy2t5",
     "name": "CAPITRADE TOKEN",
     "symbol": "CDE",
@@ -1090,12 +4779,30 @@
     "decimals": "6"
   },
   {
+    "id": "terra15cqf7tdtef7umt9tm7lwf72qg4rdxf2wug0pdqznjduam0c9v9rq0rsw6x",
+    "name": "Captain Cookies",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1cyaaw5d03vqp20j0lttlqsnx2ey6e7jgc226fys2q6fnc48mlzwqrdfrdz",
+    "name": "Captive Insurance DAO",
+    "symbol": "CID",
+    "decimals": "6"
+  },
+  {
     "id": "ucad",
     "name": "CAT",
     "symbol": "CAT",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/cat",
     "icon": "https://assets.terra.money/icon/60/CAT.png"
+  },
+  {
+    "id": "terra17n96e2maa553se4u6ntmyzaqan93y6r4q33hwhwr5p386fulk0qqer6jj0",
+    "name": "Catching Fire",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1laqzmwrpyrd5tumpx5hs638tzhle4nc42k9jak",
@@ -1110,10 +4817,52 @@
     "decimals": "6"
   },
   {
+    "id": "terra14zhee4jgeage596qhcwzx7u49yguwud9dn80sesa98r878ly3f6sjleq3m",
+    "name": "Cavern Bonded Luna",
+    "symbol": "aLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra170e8mepwmndwfgs5897almdewrt6phnkksktlf958s90eh055xvsrndvku",
+    "name": "Cavern Bonded Luna",
+    "symbol": "aLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1avs8kkqal38smrr8wwd0rjggz8yltay0hshefnzns8gwh964l6yslkdaae",
+    "name": "Cavern Bonded Luna",
+    "symbol": "aLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cadlgv6qes2ee94qj8d8uyll3ujr4qdl8u3u3rsww2ezyutfjnmsqwr8sw",
+    "name": "Cavern Protocol Documents",
+    "symbol": "CAVDOCS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1cx38qvyv4mj9hrn6p6m4fj7vhj726t5dg3ldpeupkkgel495ngnq5rtplq",
+    "name": "Cavern Protocol Documents",
+    "symbol": "CAVDOCS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1v30xmf35gw2lh4rxc8a26ltt65h6ej99fqxmcaxed78uex8ygctstd7864",
+    "name": "Cavern Protocol Documents",
+    "symbol": "CAVDOCS",
+    "decimals": "0"
+  },
+  {
     "id": "terra1cvsfc32dkdvmla6urrscrtfceztecj0u5tvlvz",
     "name": "CBM Token",
     "symbol": "CBM",
     "decimals": "6"
+  },
+  {
+    "id": "terra1w9j54nkyuc4733tp2fz52md27k3qe95y7dfq0x39rcuk6nsjj5sqpmarhl",
+    "name": "Celo native asset (Wormhole)",
+    "symbol": "CELO",
+    "decimals": "8"
   },
   {
     "id": "terra1hppnw4jppmrzzga4yvd8s87y3dwkhe27xwwl5d",
@@ -1135,6 +4884,24 @@
     "symbol": "weLINK",
     "decimals": "8",
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/2wpTofQ8SkACrkZWrZDjXPitYa8AwWgX8AfxdeBRRVLX/logo.png"
+  },
+  {
+    "id": "terra1thjqc88nra6sv9c702qpxgjs4n4mdje526uyfal5z2zzf03k9qcq83evd5",
+    "name": "ChainLink Token (Wormhole)",
+    "symbol": "LINK",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1m4anzhza4w5jf78f298f45s0wm2hzjpjfnn3v4xrax3yfvfjhxqqe0xqy3",
+    "name": "Charlie's Crew",
+    "symbol": "Crew",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1273k2c654p6jdu36mel90rxs2cdu7lk5tj9n3wfgkun2rll6pm2qypnu6y",
+    "name": "Chatmasala",
+    "symbol": "Chm",
+    "decimals": "0"
   },
   {
     "id": "terra1spe82hmc9j2y2vjl6urue78zhrn9r9xyydkyx4",
@@ -1165,6 +4932,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra1r9sy95elmdvur3et4xgkx6scgfmcaywlnvjsq7eatwnhjqc6hwaq3j660v",
+    "name": "CLUN-LUNA-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra13eekqp0zgj55arjuacpxqxzgqy2uydf5wzzqns9ddgpepj377afqflunf3",
     "name": "cLUNA",
     "symbol": "cLUNA",
@@ -1178,6 +4951,12 @@
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/cnt",
     "icon": "https://assets.terra.money/icon/60/CNT.png"
+  },
+  {
+    "id": "terra1hsqqj2namaepxt9h80snquszljxlsygl7kr32k5wyr424zs3j8zsl76l9d",
+    "name": "COAL",
+    "symbol": "COAL",
+    "decimals": "6"
   },
   {
     "id": "terra1yuvwz0wzd49mjlvh24g23jst89dllua0nc3knt",
@@ -1200,18 +4979,16 @@
     "decimals": "6"
   },
   {
+    "id": "terra1u4caj7h7f89w9jzudr9ryy3aq9kr6skwa9gf2k764wpzqjj0k55s0nsp2e",
+    "name": "Coffee Planets",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7",
     "name": "Coin Swap",
     "symbol": "SWAP",
     "decimals": "6"
-  },
-  {
-    "id": "terra18wayjpyq28gd970qzgjfmsjj7dmgdk039duhph",
-    "name": "Coinbase Global, Inc.",
-    "symbol": "mCOIN",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra18wayjpyq28gd970qzgjfmsjj7dmgdk039duhph/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/COIN.png"
   },
   {
     "id": "terra1n8awtfqa0wphx90pd2zc9v8vccc65f0gvv6rq5",
@@ -1250,10 +5027,34 @@
     "decimals": "3"
   },
   {
+    "id": "terra1dkkpnzmq88fsl4gfah4r6k9445vtpeqsucxpu34x6lp2cnkgu4lsae6d27",
+    "name": "colinB",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra1tvs43r9ry6s6g6j5mnmruw97s3fjhqxpc540hu",
     "name": "Connect Labs",
     "symbol": "CONNECT",
     "decimals": "6"
+  },
+  {
+    "id": "terra10l5yur0teqfllu296sd86y86xxmh49wgy3sahws2yt3t3xh45g8q0zwqdp",
+    "name": "Cool Ape Punk",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1j2qpcu8c3rgwtnq4azh0lpn035phmw9ummds7g3llrjuj5xvksjs6epy6t",
+    "name": "Cool Jerry Gang",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19pwawxl2xzve0k06uehl5pl8fhvcykxuc0yfpzqy2pv39jv03fpqha5uwe",
+    "name": "Cool Teenager ",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1u02lqdhuhdfwph8wsl9yx9r0jupfdsd22q60tc",
@@ -1274,10 +5075,52 @@
     "decimals": "6"
   },
   {
+    "id": "terra1s28fv278avrpazql4ktsstgymj8un6ua8t4yjehcr3kj2qm2ns8splxk40",
+    "name": "CrazyGhostsss",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1vkzknym2gw2xe59vsn8lf20lvdd0zrduew8km49fwjvn7a223kfserjsgy",
+    "name": "CRT (Wormhole)",
+    "symbol": "CRT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hparjahcp0yrthrae7vhu07ynqy2fj09n8p46y3epn8xr3g9jvwsnr27yw",
+    "name": "CRT (Wormhole) (Wormhole) (Wormhole)",
+    "symbol": "CRT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s53wmnfeu5zj394jfc4p5uhgzlkc6wjgva7w8ksv5gc3avg9jhps8xlqle",
+    "name": "CrudeArt: Wildcard",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra14kzm7p634852h2k2qqg2cr3zvaqvn796lejflycg53sfkmgq02fsmlnj6n",
+    "name": "Crypto Compass",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra1tewnpkjdtqq37udf5c5wjfrtkpegthfmls8lp7",
     "name": "Crypto Dev",
     "symbol": "CYD",
     "decimals": "6"
+  },
+  {
+    "id": "terra1ew4g9l5gh9tgls7yd9uz3lyue9m2u0u6z0jtw7s0fgvq8gvl693s07wepu",
+    "name": "Crypto Donkeys",
+    "symbol": "CDK",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1yqacrx2jvrnede4x87w370g4qgsstq3qjnqaqy77ypx3fqeynrjqfaa023",
+    "name": "Crypto King",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1qsjs0a02jmyfhvaeul4zax22sayx5e8dl8527g",
@@ -1290,6 +5133,18 @@
     "name": "CryptoBonds",
     "symbol": "BRLF",
     "decimals": "3"
+  },
+  {
+    "id": "terra1akahwercw3vmmd6ac4hudum9kj3tlvuw28ku064tj3gnk00d5w0qg2j6vs",
+    "name": "CryptoGlobe",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra16aq0p35g346xe3h60yuhkns3rhj6k66wwtz6czwgep7fwvmyjxqqw5gktz",
+    "name": "Cryptoismyjam",
+    "symbol": "JADE",
+    "decimals": "0"
   },
   {
     "id": "terra1hqr3l4je2yvn3l790ly0y6r0vgfs7yukwwj0ak",
@@ -1332,6 +5187,18 @@
     "decimals": "6"
   },
   {
+    "id": "terra1a3kqxlfgqnlmzrx6c22w7g94ucxlhcmnyafr8d8sldjzgplk66gq35fdtk",
+    "name": "Cute Corgi Crew",
+    "symbol": "CCC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1gdxwdrezs9dcrwgyjha9a0dwypumragsxqwm3x6hv7tfea8zzqtshsm5f4",
+    "name": "Cute Fat Chonky White Cats",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra1jju99w456sm6w2snkmatm00gve7cvvzda0j6pn",
     "name": "CUTE HAPPY",
     "symbol": "CAT",
@@ -1344,10 +5211,28 @@
     "decimals": "6"
   },
   {
+    "id": "terra1q4l8zelhlcte9l496spty7wxdmlp74vvxjyqdjjw063x9qqc4udsyd29we",
+    "name": "Cuties of the Terra Universe",
+    "symbol": "WOOF",
+    "decimals": "0"
+  },
+  {
     "id": "terra1mely4fttd94g5kgjmz05dmclgdahq45xnv5n22",
     "name": "CVRG Token",
     "symbol": "CVRG",
     "decimals": "6"
+  },
+  {
+    "id": "terra1g2xx0jjngyahfhh4j2zdp5hwt8l0runfl9td6fx8l8vdx82rc8yqqy9hww",
+    "name": "cw-plus:cw20_base",
+    "symbol": "TEST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1490pnjx2g7tce3ywcrzn3detm6r8w0jm5vzcc6kxvgzvg2eplgwqewl349",
+    "name": "Cyberdeck: First Settlers",
+    "symbol": "CBD",
+    "decimals": "0"
   },
   {
     "id": "terra1dxt75lk0m5g0wpucg0mz905akta99fjhuhafqa",
@@ -1369,10 +5254,28 @@
     "decimals": "6"
   },
   {
+    "id": "terra16vdmyrgc344tsj3p5sz25wtx608nx97wl65w96x98s8x9we84dasnlpxdw",
+    "name": "danku_r | WAGMIstones",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra1d8uw3zddfrexn06f80nz6hx2cd3f32a7p45agf",
     "name": "DAO Shiba Inu",
     "symbol": "DSI",
     "decimals": "3"
+  },
+  {
+    "id": "terra1jva62gxl46aga43p8pfpp2xrujw73g37605334m7cng9mus39qksurqsdn",
+    "name": "Dark Waters - EP",
+    "symbol": "TESDW",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1w6szmq0vwlc8wlqt59fyrucw96xlptwrvejz3amhlp3ejdeuc5dqcuxjyq",
+    "name": "Dark Waters - EP",
+    "symbol": "TESDW",
+    "decimals": "0"
   },
   {
     "id": "terra1nzvqd5mr0jn58cvam9j06k9kry4myu0vp7a9ug",
@@ -1412,6 +5315,48 @@
     "decimals": "6"
   },
   {
+    "id": "terra133ehn057cmupzcnk5l5rmgzqn90wfe6qemj2mj9r4mlh0l5slgfsznda3t",
+    "name": "demo_token",
+    "symbol": "udemo",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1zre8uunucxf7g3gyxnmntj4e723wjad0phmj9xtar5g67kcep73s9qlqsk",
+    "name": "demo_token",
+    "symbol": "udemo",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1hfg2yzqnvaplc04mnhu9cwff7llwxvhq2fjh50449q7kh9u4xuxsdcngfs",
+    "name": "Dengue's Fever",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19j7859076jveetfhdskc6hwjnr7cpt2t78llp8nz9qnaqtgvj8ns0qgp9j",
+    "name": "Depeg Nation",
+    "symbol": "DPEG",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1kad44vp08yqcz9ec366krj89yvsvs6nmauvhqu6sl93jjw5ugw2qd3xdnw",
+    "name": "Depeg Nation - Tales of dUST ",
+    "symbol": "DPEGC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra17gck626vgax9jpe6utm7dhx4vdzawfkt0jhru03l7a3dzu98wedsfad4sz",
+    "name": "Depegged UST",
+    "symbol": "dUST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1n3j3l0w2eclpv3me28yxzjesfa9cqt4m0e2d3xhxjk03pch2uxqsds9fud",
+    "name": "Depegged UST",
+    "symbol": "dUST",
+    "decimals": "6"
+  },
+  {
     "id": "terra1jusuf8pcuw56pmj0len5tcsdu9dm4xpqwqk48p",
     "name": "Derby Stars",
     "symbol": "DRBY",
@@ -1422,6 +5367,18 @@
     "name": "DFFG Token",
     "symbol": "DFFG",
     "decimals": "6"
+  },
+  {
+    "id": "terra1p648gcmx8zmjfqqk095zp6jxr5c4an0mdgl5rlrs8r82rp33yngsxw4qs2",
+    "name": "Día de Muertos",
+    "symbol": "Dia",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1rfr0epuuk5adhlp7qay7fxy6sdf78u492epen2jfs844cfxcqltqze6jmz",
+    "name": "Día de Muertos",
+    "symbol": "Dia",
+    "decimals": "0"
   },
   {
     "id": "terra18zqpuua4d8u9q9d6zsn8fqtjj5k8hk845prz9v",
@@ -1437,12 +5394,42 @@
     "icon": "https://digipharm.io/wp-content/uploads/2021/02/digipharm_etherscan_logo.png"
   },
   {
+    "id": "terra1vnzcsvy7ytan9tnjnzzhg8k7hpg0f30seg26xe6c66t4e8p0d84sqls0w0",
+    "name": "Dinheiros",
+    "symbol": "Dinheiros",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hm53sx43hhdaad8uhvuz8gnh9zq7ukr7au7257adevcwpn267zashyfcjr",
+    "name": "Dino Hodl Crew",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "udkk",
     "name": "DKT",
     "symbol": "DKT",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/dkt",
     "icon": "https://assets.terra.money/icon/60/DKT.png"
+  },
+  {
+    "id": "terra17ytwg38lx24x4nhker06er64sa2tvr9h6ppdc9ewupnswgqxxjpqq0q2fl",
+    "name": "DKT (Wormhole)",
+    "symbol": "DKT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xvxmxw8rsywqzxmlzpw9wu9ddtxts5hwwusayya95fva7up4577slfmp55",
+    "name": "DN",
+    "symbol": "DN",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1sdvvdhaeusr96sq5yunkkn78uvlwr4uuaasctjq85gh5sy6f7w2sqqqzhq",
+    "name": "Do Klown Kwonzi Inu",
+    "symbol": "KLOWNZI",
+    "decimals": "6"
   },
   {
     "id": "terra1akwn8y34upderjyw07hgepunte8mza00vafzfd",
@@ -1468,6 +5455,12 @@
     "name": "DogCat",
     "symbol": "DOGCAT",
     "decimals": "6"
+  },
+  {
+    "id": "terra183tzpzemhgjdsfh6ahsvkc43s6xajd58qgppd2r2rrc0afetzftq624xw8",
+    "name": "Doge",
+    "symbol": "DOGE",
+    "decimals": "0"
   },
   {
     "id": "terra18cs7aktav46v3pwxr8r2hfkl9pdfmrthcn58qf",
@@ -1591,9 +5584,27 @@
     "decimals": "1"
   },
   {
+    "id": "terra1j6l6q3cnwqgpldf2k92mce2cd888wtecz3fun7yffcpghw3wn9qsgl52nv",
+    "name": "Doodle Baby Ape",
+    "symbol": "DBA",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1usnq8smssvxfjcdt2jdl0f6vc0wxssjy8vdx698mlyluy25ejrzslq3t5x",
+    "name": "DoodlesXXX",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra1uv3298xevlfdcjthfv4me7tn7gjxd3drv6ejvt",
     "name": "Doom NFT",
     "symbol": "DOOM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nm3hvfs4g6l48zrnxp75js39dvmdvjt85eh0pzz20mhvf92ler3qrrspek",
+    "name": "DOSCOIN",
+    "symbol": "DOSCOIN",
     "decimals": "6"
   },
   {
@@ -1627,6 +5638,12 @@
     "name": "DOT",
     "symbol": "DOTT",
     "decimals": "3"
+  },
+  {
+    "id": "terra1tqpzf2f5ll3zmm53nwczatp8fzlu2stzrlxwrjgqsx3wxqwxw8uskh9qfp",
+    "name": "DOUN",
+    "symbol": "DOUN",
+    "decimals": "6"
   },
   {
     "id": "terra1ry60wuc8a7a4ujt3tmrp3upxzf6a4awj88eys3",
@@ -1666,9 +5683,45 @@
     "decimals": "6"
   },
   {
+    "id": "terra1zjtpdke8qnqjflgeyyd8wrg2de32z3g2avk2utwlc4vzjw974jfs34nu08",
+    "name": "DRC-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra1elkjjsg4vm5u4tnesqcj3dzgvhanzld48lkqv2",
     "name": "DREAM PROTOCOL",
     "symbol": "DREAM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1c5qexuz3hx9rkac8tfa9ktytfgurg767qd5p08e7l7khkhtktk7sx84vdk",
+    "name": "Dreamer",
+    "symbol": "DRMR",
+    "decimals": "18"
+  },
+  {
+    "id": "terra1gn3fwtw7k40gl465723phk4qgarthw32t962acxz5e5rjzgepwpsjysppv",
+    "name": "DreamersCubed",
+    "symbol": "DRC",
+    "decimals": "18"
+  },
+  {
+    "id": "terra1kytfl8v8e9pq0s5texq2vwcjy9k456ky44x0429yeh3cwj9m64cqdfpa9k",
+    "name": "DRMR-DRC-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cpflqqkse0lljw4cekrh9sqdz0km9p9lzteqd55y5qd0yrdzxg8sytqdpk",
+    "name": "DRMR-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10n8tq3hxa5rkgzwdjylehrl27alhlutyssqlrajr0h80vze46dfsye9y8v",
+    "name": "DRMR-ULUN-LP",
+    "symbol": "uLP",
     "decimals": "6"
   },
   {
@@ -1768,6 +5821,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra13cdqlhz4z7ml27y792xx4rnf93u05y4m49jmfh7jn7cglg7qn7cqggt7dq",
+    "name": "dUST",
+    "symbol": "dUST",
+    "decimals": "6"
+  },
+  {
     "id": "terra1pzjd5axw303jt40l4pmakfa88d0jpjf8rpmj8n",
     "name": "DWONS BIG DONG",
     "symbol": "DBD",
@@ -1786,9 +5845,81 @@
     "decimals": "6"
   },
   {
+    "id": "terra1uegpgqzy3aqwzpkfeyp7e8ljs0m3jm9upq77g4f7kv7jcfrd9lcslayred",
+    "name": "eCash (Wormhole)",
+    "symbol": "XEC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1d9ac0uug25qdu00te7mlsam608aqy7608k9ay406kz3zz60f23csq058vv",
+    "name": "Edge AxlUSDC",
+    "symbol": "eaxlUSDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fjane47sgaaljgm0qe0ysjwtuqjlp493ar4gwt8rez45qaazf9gsfgc6af",
+    "name": "Edge AxlUSDC",
+    "symbol": "eaxlUSDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gpcn0jvm6rv2zxce7dlgmh0k3l8zns72m5l2u47m44ehyxgar2dq6v8p75",
+    "name": "Edge AxlUSDC",
+    "symbol": "eaxlUSDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v6v4rcut5tsyufktp6da4vnn0a7jgm8e83ypdndsgykev5fu8uvqg5x2q7",
+    "name": "Edge AxlUSDC",
+    "symbol": "eaxlUSDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15a409g7juszev4k88pvvvh80654903k7q00qtlddjasqynhjj45qzvk893",
+    "name": "Edge LUNA",
+    "symbol": "eLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18p9qapupd23gv7pf5k0n4ce5staqq39p7msl6vcvntrr3kgm54xqkrhffh",
+    "name": "Edge LUNA",
+    "symbol": "eLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1texwq26vke5vqem2lljwteqvyd9azy7x4mm0nxfgq7kleg8k5ukquvnqft",
+    "name": "Edge LUNA",
+    "symbol": "eLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zd49uw3gd3z2v4tujlxyapsdw62e3g0n29gm2kpn5crl0y5zfg7slhxykm",
+    "name": "Edge LUNA",
+    "symbol": "eLUNA",
+    "decimals": "6"
+  },
+  {
     "id": "terra1x5mhyxzmy8da89rh7dnt3v289qz988hclyl6kk",
     "name": "EEE Token",
     "symbol": "EEE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10mdchp7kmpj8v5maqk902pwnm0ynj39shme66krac6nm2cw9zh4qxvvcx9",
+    "name": "EGA",
+    "symbol": "EGA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e427e4zp7unnpr2677wkegqjdxqx9w7mtdenewjyg755ell0238qz27c6z",
+    "name": "EGA-EGB-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v0g6jel2c5rf00yw5szjw38fn527w5p6szujmw44n2x9azkfumcqpv4j9s",
+    "name": "EGB",
+    "symbol": "EGB",
     "decimals": "6"
   },
   {
@@ -1828,6 +5959,12 @@
     "decimals": "8"
   },
   {
+    "id": "terra1md6qktuqpa0uat6gk7glh8lfxs87t04ym2pmy4uvxg83jwxdcmasrcxt90",
+    "name": "EMIYA",
+    "symbol": "EMD",
+    "decimals": "0"
+  },
+  {
     "id": "terra19pz3ehx9f2thr9t9jk5y89aalxmhzuq9j8ak99",
     "name": "Enter The Matrix",
     "symbol": "MATRIX",
@@ -1841,18 +5978,34 @@
     "icon": "https://www.erisprotocol.com/assets/ampLunc100.png"
   },
   {
+    "id": "terra1w0ajeq6pu757yy0uxkvg4g0ayssdvx4r570d9a93u88ax2uau7wstvhywy",
+    "name": "Eris Amplified LUNC (Wormhole)",
+    "symbol": "ampLUNC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1t4m5lcffscupfuzthf06s30w5ghkzupyfnknsh8f4rwtm69x6fsqrxrhme",
+    "name": "Escudo",
+    "symbol": "ESCUDO",
+    "decimals": "6"
+  },
+  {
     "id": "terra1h0jk42weh0urhgdtjql93rrvgdccspnp7vyf49",
     "name": "ESS Token",
     "symbol": "ESS",
     "decimals": "6"
   },
   {
-    "id": "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
-    "name": "Ether",
-    "symbol": "mETH",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/ETH.png"
+    "id": "terra1ly8vd2q69h3jlyjgnwqq0q4wngulmr2l2gr0lxd93tqle42596rsq5zz5d",
+    "name": "ETH  in USDC",
+    "symbol": "uETH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ggefs7qz3spjmkmjk9k37xycljlf8525ea6sf4d356vufnrn9z0s7hrjy5",
+    "name": "Ethereum (Wormhole)",
+    "symbol": "ETH",
+    "decimals": "8"
   },
   {
     "id": "ueur",
@@ -1863,23 +6016,87 @@
     "icon": "https://assets.terra.money/icon/60/EUT.png"
   },
   {
+    "id": "terra1m24v9uumvuuhqu27xjlcqyzt8v78766vuu9sae5gt83u4xffam9s57vq6k",
+    "name": "EUT (Wormhole)",
+    "symbol": "EUT",
+    "decimals": "6"
+  },
+  {
     "id": "terra1aaqzva7adgwtzfkt9nmrmuvkg9s6lmsgtkg3jd",
     "name": "EXP",
     "symbol": "EXPEDITION",
     "decimals": "6"
   },
   {
-    "id": "terra1mqsjugsugfprn3cvgxsrr8akkvdxv2pzc74us7",
-    "name": "Facebook Inc.",
-    "symbol": "mFB",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1mqsjugsugfprn3cvgxsrr8akkvdxv2pzc74us7/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/FB.png"
+    "id": "terra1uhepfcw3va42nd8uwjymtjykuqs24y2jxgrjcfh69nd3gzwxj2ws5s8xf8",
+    "name": "FAFA",
+    "symbol": "FAFA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19m0l67v6atfmu4cfmu9dw3hvum3rju6gt4jcw2ecpc6qr5lln2gsjs0439",
+    "name": "Fake Punk",
+    "symbol": "FP",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1jyfsmyzgk54gwjqcvvmq5xxaruada40hnfzvfzlt3njt7y72a0zqng56p8",
+    "name": "Fake Punk",
+    "symbol": "FP",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1v8787ruq4sgy2ple8pq5r4v5gsrjytnutxeseuknqjqpjxh555esar9wzs",
+    "name": "Fake Punk",
+    "symbol": "FP",
+    "decimals": "0"
+  },
+  {
+    "id": "terra142rnaaef6m5085p8kexfs0gfzky0evq47zffst7leezgdtsksrrqytxaaz",
+    "name": "Fallen Guardians",
+    "symbol": "WHALE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19eg7fk4aw0muwe57lnawjpu6gvxe0e7naewnkgh8ytx686te2gks59sg28",
+    "name": "Falling Squares",
+    "symbol": "FLS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1vmqa8hls3axrk8vqwqcztuu02t5w5hkrx6mzt7pn7jrhnx5xkxcs7lk6rg",
+    "name": "FAT (Wormhole)",
+    "symbol": "FAT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1dtaqwlmzlk3jku5un6h6rfunttmwsqnfz7evvdf4pwr0wypsl68q6nuam0",
+    "name": "FatManTerra",
+    "symbol": "FATMAN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zf90xr38pdgq0yjq2d56scclpfyu3ep4d720s9r2yw9gmwg7khaq0c30rl",
+    "name": "FatManTerra",
+    "symbol": "FATMAN",
+    "decimals": "6"
   },
   {
     "id": "terra17nekftv2yp8n4lsex85008sphchs4t3rnfcqzf",
     "name": "FFER Token",
     "symbol": "FFER",
+    "decimals": "6"
+  },
+  {
+    "id": "terra129w4tcrmzxk8u37qqtc0hezp66mkef45m3d9atnvlz09dar9a50qv30u04",
+    "name": "FIFI",
+    "symbol": "FIFI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xpwvt75aqj69kxcez0mm4z2fty40gaxc2ed0vzdy0y47qnswpxhq3d4wpg",
+    "name": "FIFI",
+    "symbol": "FIFI",
     "decimals": "6"
   },
   {
@@ -2069,6 +6286,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra10exkttsx4xq2j5k3uel9h4gvxy63yd90u46yt3qzn9vfcuh2utwqydz8rq",
+    "name": "Froggy",
+    "symbol": "FRGY",
+    "decimals": "6"
+  },
+  {
     "id": "terra1m2ar36pnymh6h4n0p7l2w4uxswc70e9auyvxh6",
     "name": "FROM EARTH TO THE MOON",
     "symbol": "FETM",
@@ -2094,12 +6317,22 @@
     "icon": "https://crytpo11.s3.eu-central-1.amazonaws.com/FANFURY_logo.png"
   },
   {
-    "id": "terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls",
-    "name": "Galaxy Digital Holdings Ltd",
-    "symbol": "mGLXY",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/GLXY.png"
+    "id": "terra1p08zvpe4qr53w26fjjs2sjsh7tuhdfmuz5s3eltr7t6htmc6vh5qslqfga",
+    "name": "Galactic Cat Club",
+    "symbol": "GCC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra16ds898j530kn4nnlc7xlj6hcxzqpcxxk4mj8gkcl3vswksu6s3zszs8kp2",
+    "name": "Galactic Punks",
+    "symbol": "GP",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1dpryq9v7aqdzgkjkn9tgxstw7mclj78evh7zegupek4jjwsgt0wq7r26wp",
+    "name": "Galactic Punks",
+    "symbol": "GP",
+    "decimals": "0"
   },
   {
     "id": "terra1hytrupk3argcrsl5x7dv55gyda0tn7f2qqlwkl",
@@ -2114,12 +6347,22 @@
     "decimals": "3"
   },
   {
-    "id": "terra1m6j6j9gw728n82k78s0j9kq8l5p6ne0xcc820p",
-    "name": "GameStop Corp",
-    "symbol": "mGME",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1m6j6j9gw728n82k78s0j9kq8l5p6ne0xcc820p/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/GME.png"
+    "id": "terra1cmz3jsnf0r6z5f5zsxjsgspeyqdn06w4sr9jmtuvm544s400a8dsc8jtrx",
+    "name": "GAMMA aUST (Wormhole)",
+    "symbol": "gaUST",
+    "decimals": "8"
+  },
+  {
+    "id": "terra16eryf4yctfe39ppa48507a40dl2dka4psm33tasg0c3ra2n57jxstf6za6",
+    "name": "GavertC",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1f7zfr8j7etlmcypgm2aw6mky3sqfq4hn8au4kulj5puxkls6wvkqm5gy8y",
+    "name": "GavertC",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
   },
   {
     "id": "ugbp",
@@ -2130,9 +6373,51 @@
     "icon": "https://assets.terra.money/icon/60/GBT.png"
   },
   {
+    "id": "terra105eh7wgzv9k39unzre6yfey9tvzdex737uc6ylk6phpmtfepylpqy6v6nw",
+    "name": "GBT (Wormhole)",
+    "symbol": "GBT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13jlm0anpdd3hc0xctw9vtncmcfnrag8dh686s2juy7m226unwd4q0tmx2v",
+    "name": "GEA",
+    "symbol": "GEA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1m496u7arteks5hg29dea8gd64f9jvtg3rlg8we8rese6v70ggvpqjt4e60",
+    "name": "GEA-GEB-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1asmlnmhg7kua2ceyaedyjh54hs6w9wu28dlqu8a2rqw0d49ya5lqqptjfz",
+    "name": "GEA-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v5j5azhyxl54h78udlt9n9vs24flvw4h0syfnpj6fr4v23tukzssgz9yys",
+    "name": "GEA-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mrdgys0e0hhq0n56zgy3e0htahcnwtdt4dy2ec9wcltcr6qjntmq0yen07",
+    "name": "GEB",
+    "symbol": "GEB",
+    "decimals": "6"
+  },
+  {
     "id": "terra1k5hx3egz7jnzqs7n2ze0d93mce80y4cndd5saj",
     "name": "GGG",
     "symbol": "GGG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra177huv6k3gyqwxcd7n32ts56tvxt68dgll0fn56k56rcvy9zeke9s5gfn3c",
+    "name": "Gidorah",
+    "symbol": "gido",
     "decimals": "6"
   },
   {
@@ -2140,6 +6425,24 @@
     "name": "GigaChadToken",
     "symbol": "GCT",
     "decimals": "8"
+  },
+  {
+    "id": "terra14phr0v3x8spgxwp64lxckzwzdlcfqtel3ynn5zcv6k7ded67pe6qk2my2r",
+    "name": "GIRL FROME KNOWHERE ",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1at27manc5tsujxfulas6rucuh24tsrkrr5spl5k7xryxlfd62ylsjpg6s4",
+    "name": "Girl's on Illustration.",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1y8z5urkg2e0ludtghuvrkspluzy2a5a7dwyv7n2pkw5heuczjavq3nrpqj",
+    "name": "Girls in kimono",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1cp02hkhu2nq7zznz04shwfvh9hdsp3y5334n6t",
@@ -2206,6 +6509,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra1q8e48hqgqr6kkrxyf0x2e4ngy5pxfq832nqr3md54wgpk4gnf9esrh6fw9",
+    "name": "Goblin Punks",
+    "symbol": "GP",
+    "decimals": "0"
+  },
+  {
     "id": "terra1hw6q5ecr0gp09v668szzx3qz86w08jru9rqyq7",
     "name": "GOD",
     "symbol": "JESUS",
@@ -2230,12 +6539,10 @@
     "decimals": "3"
   },
   {
-    "id": "terra137drsu8gce5thf6jr5mxlfghw36rpljt3zj73v",
-    "name": "Goldman Sachs Group Inc.",
-    "symbol": "mGS",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra137drsu8gce5thf6jr5mxlfghw36rpljt3zj73v/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/GS.png"
+    "id": "terra1u8z5eyklvsuutcmrxf7szr6u099e7c7phrm7jhywnplqkdxxgj9s0ked3h",
+    "name": "gold luna",
+    "symbol": "gold luna",
+    "decimals": "0"
   },
   {
     "id": "terra1d633fx8wlpgqnns9j4xw66cq6ypdy4u8r0rr7j",
@@ -2256,6 +6563,42 @@
     "decimals": "6"
   },
   {
+    "id": "terra139xv68tuktzq68u6fuv3snfk8tc34z8y3xgv7jw3kmcztuzmc3uq6dd32m",
+    "name": "Gorilla Haus",
+    "symbol": "GHS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra123sjspx2v6hf2yjms3npz6nkmnx4vcxa9arce5q4n7w7k07wz0uspvsfgf",
+    "name": "Gorilla Haus Alpha",
+    "symbol": "GHA2",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1latd9ny36pdpehr3eukyq26jgm2c89ledpyg7es5e8muz5rul0lshstszh",
+    "name": "Gorilla Haus Alpha",
+    "symbol": "GHA2",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ryy9h3zn6yrs6m2et3drkgszjfzjutfkmajytp98dq7xr8uqwfxs80zfut",
+    "name": "Gorilla Haus v2",
+    "symbol": "GH2",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1wez7n48nvcvw6wr6hctery68zzvfcerqks9phv2nat7ttpkesumqsa5ghv",
+    "name": "GORILLA HAUS v2",
+    "symbol": "GH2",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ekfzeqk8mhvndg0npe9fcuhr06p8c9uv9h8czryheprgma8avmfq2s354e",
+    "name": "Gorilla League Members",
+    "symbol": "GLM",
+    "decimals": "0"
+  },
+  {
     "id": "terra1xs3pv5rd2xu36w9vg05shkgxcrxkvz40fhnfsv",
     "name": "GRAY",
     "symbol": "GRY",
@@ -2268,10 +6611,28 @@
     "decimals": "6"
   },
   {
+    "id": "terra19cqs4lhwtq5uz037w0w7w5kjszyjrj6n0d0js7p5nmhnlzegxpxsvea3nk",
+    "name": "Green Autonomous Society",
+    "symbol": "GAS",
+    "decimals": "9"
+  },
+  {
     "id": "terra19m0xqgdaltwkesdt6m383jkqh3m9xyxwtp0f6f",
     "name": "Green Dragon",
     "symbol": "GRDR",
     "decimals": "3"
+  },
+  {
+    "id": "terra1hqemjht73a5zwuspk36gdrf4e05t30kcmckfh4lpy2fqv5rgyw3sgh5qpe",
+    "name": "Groovy Lunacy",
+    "symbol": "GROOVY",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1swdw97vxj3895nj88d0jhdu0acem6gy2cchcxzlhwfq2pz2p0cksqt50t2",
+    "name": "Groovy Lunacy",
+    "symbol": "GROOVY",
+    "decimals": "0"
   },
   {
     "id": "terra1tc7tcg8u54p3t2r5yfufgf4z340ggwpvlc2rwt",
@@ -2280,11 +6641,29 @@
     "decimals": "1"
   },
   {
+    "id": "terra1kv690w4w7ad2d6st3edmwd9y5zxj5j0ckqtnfywwut555jpw68pq0kz5p6",
+    "name": "GT Capital",
+    "symbol": "GTC",
+    "decimals": "6"
+  },
+  {
     "id": "terra15pkdjxv2ewjzn9x665y26pfz2h6ymak4d4e8se",
     "name": "Gtps.Finance",
     "symbol": "GFI",
     "decimals": "18",
     "icon": "https://img1.wsimg.com/blobby/go/f561f953-0bdd-48bf-a39b-982ecbd1698b/downloads/GtpsFinance225x225.png?ver=1649021019248"
+  },
+  {
+    "id": "terra1mzexcawct0dle4h2pced5efj5zk7gs3dgfulrlxewkaawm2anmes8hfzrf",
+    "name": "Guess who's back",
+    "symbol": "BCK",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1zlls6m9t2eg60t2wmw58aatt6umrh0xw93947kzt2rczkrcejcxsxf6u2d",
+    "name": "Guess Who's Back",
+    "symbol": "GWB",
+    "decimals": "0"
   },
   {
     "id": "terra1z55rhw0ut70jxdmpvge98mvj0rkwcz74q77z0u",
@@ -2348,6 +6727,54 @@
     "decimals": "6"
   },
   {
+    "id": "terra1klxa4rxjgpg9xuaf5mwpgykpv7x9decrvgg3ejresupcne69cgdqzx5yhu",
+    "name": "HERO",
+    "symbol": "HERO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13cdhq2uhsfe3p74jm28j5jf7ap3emj60v6cgmezy2er7hs6zh72sh3rxs4",
+    "name": "Hero Classic",
+    "symbol": "HERO",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1qlpzs5v95dk3f4n8v5nyf5shyq3sye4wecvgjntdxkurrgfrxgpsut38xr",
+    "name": "Hex Gorilla Alpha Terra",
+    "symbol": "HGAT",
+    "decimals": "0"
+  },
+  {
+    "id": "terra18mkl3dmcpa2uc6fr0hcct476jf62k7904puuzv70l99ffwdg5dds229q20",
+    "name": "Hex Gorilla Collab Collection",
+    "symbol": "HCC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1zqjcslj503p4j9svq6hfskzruetn2xtgqsyjmw4qljy2nwhsdmsssahppu",
+    "name": "Hex Gorilla Collab Collection",
+    "symbol": "HCC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1mvf9q3r84rhm3l52xmumluqfj5qvk4n422ycrvgt9z4w8df2f6dsaz4wf2",
+    "name": "Hex Gorilla Faces",
+    "symbol": "HGF",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1sg6wz6h3qngjjreeq96mlcffmu8v40gmgmhrm7l68v7w8zruddws2x54dm",
+    "name": "Hex Gorilla Genesis",
+    "symbol": "HEX",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1sq2ykswasmt352tarwqwn0g32w3rnm2maptryqe5mcdssn27mxgqzwt9kx",
+    "name": "Hex Gorilla Season One",
+    "symbol": "HEXO",
+    "decimals": "0"
+  },
+  {
     "id": "terra10en35kwlud79z2nljssvhp85ep5kx9k0ezzz8s",
     "name": "Hey Jude",
     "symbol": "HEY",
@@ -2380,15 +6807,159 @@
     "decimals": "6"
   },
   {
+    "id": "terra1tf4h7aytval74gk54amuwh45cmztu3fkh2jtkna60wum8mz3pqxqtdyxgu",
+    "name": "HODL ME CLUB",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra1wfau60yqgdtrqay0cdtcp5rre3l50khacyyhhz",
     "name": "HOHO",
     "symbol": "HOHO",
     "decimals": "3"
   },
   {
+    "id": "terra155lgyldnjskt687h9dtk5gfzamzqkt6t9zcjfamwrzj22mn945vqdgvyxp",
+    "name": "Hot Heather Animals Help Crypto",
+    "symbol": "HAC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13f7jnzh7yjfpakahzrup5uxnpdxz5vcng5m96jxskhfs5lwlq8aqcgv4ds",
+    "name": "HOT WEATHER ANIMAL HELP CRYPTO ",
+    "symbol": "HAC",
+    "decimals": "6"
+  },
+  {
     "id": "terra16hwgds2089kktskluq8dh5ntw7eu5e4q4z6ud4",
     "name": "howtest",
     "symbol": "howtest",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lnk3sukea5heg6gjaf7328xez85ta0a60glzrj6zvdsfy65cyaasycn479",
+    "name": "Hudpire Token",
+    "symbol": "hud",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1k94scguypw7ggah8w7t7ly8kxk00wnry3s40a9npdfegtrg76fusmpzlqf",
+    "name": "Hxxk's Airdrops",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1z7ft787p3m94yjch3uhkcydjhmrxz4yccn70uq4e55u2y0jfukkslhdlyt",
+    "name": "Hyper Testing Token",
+    "symbol": "HYTT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lg5wyah066tc679ehp4d9d9cuk82grxk7vd7u73vpq6md8qzm9fq35lx7v",
+    "name": "IBC/-AAXL-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17arxq8nn63u7zghp53kh33alkvuad743d8h77tc6psnq570zuupslmdgur",
+    "name": "IBC/-CLUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yehzc2k78ywgckv2sn2lvaslquffdlf8aypytgt8gcv8ettaxmdqfaslw6",
+    "name": "IBC/-DUST-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18278qyznzktl8sxnepca4yw0cpdmxxjz54zf3xnn8sfh7au3uspq0ka994",
+    "name": "IBC/-FRGY-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1px8kmqg3m6kvmuf39ewua8c9scvl5mypw4pczpt35t7t6rwadxxs53m8a7",
+    "name": "IBC/-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1uv507zlee8j5u4dzaxd6wekyqjuqqjkva94w7p26qxf8u62jjh0q4rlf6k",
+    "name": "IBC/-LUNA-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lmjj99vmu5pxt8rv0taknr4j9v5evv2llk6sulmyexce4vr76gjsvj792v",
+    "name": "IBC/-PN-U-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14n22zd24nath0tf8fwn468nz7753rjuks67ppddrcqwq37x2xsxsddqxqc",
+    "name": "IBC/-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1d8j3v5dg08mnw9yzh242nvdc2mznup400msx8d6hcgpd2ygv4uuqfy4v9p",
+    "name": "IBC/-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1g6466sm9recxrmxhpu2aw79vdh4ahhkswjwq3tpq4mfdawd9nj6s8cxx3n",
+    "name": "IBC/-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zgtka8nyjvnet5v4xhecwl4afpmkv26mp7c22jegsavhp2pmpcrquhluuz",
+    "name": "IBC/-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fxh9c0v6vpvjrlxnywjq6k545yd09vyjdg536eafqk9ngd23l5vq4lfcgu",
+    "name": "IBC/-USD-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12857xqnmsxdcd73qvtl7cr92djguxs03mmpgmgksey0xxzmkzqvs29aadp",
+    "name": "IBC/-USDC-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1j3q7gcxsp20hkrggh2eqa305asmjnsvgzjdc0jjz9rajg0q8shwqpzqhdy",
+    "name": "IBC/-VKR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15spkcas6jj2jrevvff5r0g7ht2s6h3mal7u8fmnjngk7k82rzt9s4gtnmj",
+    "name": "IBC/-YLUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1avfsch3ee82wyrpwlawecyz6zktr9jln0zaxp58xuvmxyl5g305q3rwuj3",
+    "name": "ibc/2739...5EB2-ibc/4CD5...3D04-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17ly9laewec70qu6tl0e3qrwh2vhz9akpf2jd7mxqram63xg2n0rsj36xvr",
+    "name": "ibc/2739...5EB2-ibc/B350...C9E4-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1adp223mw8937arxcfl36acjjyn2dcf7wzp8h09jek5k0gw3vch8sqlq6su",
+    "name": "ibc/2739...5EB2-uluna-LP",
+    "symbol": "uLP",
     "decimals": "6"
   },
   {
@@ -2401,6 +6972,30 @@
     "id": "terra1n2rujfc5lscglry30zaptfgncfc0gq4n8my0gv",
     "name": "ID TOKEN ONE",
     "symbol": "ITO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1l7z4lddtwstgmag6u7pu6jlthqrapk39wrlczm7vp0tjfxh6e84s4d055r",
+    "name": "IDC",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1w7ryjz65q6l48ydht9nnrc687p84jwt8qk5z4afj7z6unf5greas0z4qup",
+    "name": "IDC-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10d4ss2p86v5caxjzsnlsexepjw78f98dqjxvjj66l5dp4qdp2f7s5j7g6y",
+    "name": "IDC-TPT-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14qsj3px3g3nfwhdp36nml33flfqy6hkgurcanae7t6sfl3yu4duq8xlppd",
+    "name": "IDC-WETH-LP",
+    "symbol": "uLP",
     "decimals": "6"
   },
   {
@@ -2448,12 +7043,48 @@
     "decimals": "6"
   },
   {
+    "id": "terra1lt30ry90758wz7mugmagkjr7ehn5t3pk7amlytd3c639sqddwz4qmrgmde",
+    "name": "Initiates of the Flame",
+    "symbol": "FIRE",
+    "decimals": "4"
+  },
+  {
+    "id": "terra1c5urwcswu23k40q640klugf3sz7dlh0m3nxxs07u40xpahtqrwgsrax3gq",
+    "name": "Inspiring Artists",
+    "symbol": "Insp",
+    "decimals": "0"
+  },
+  {
     "id": "uinr",
     "name": "INT",
     "symbol": "INT",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/int",
     "icon": "https://assets.terra.money/icon/60/INT.png"
+  },
+  {
+    "id": "terra1sxnyuh2dxzqrx75e9x62fw0pns7tvcyjkjsdkl0yvzdac7myjgeqep5mel",
+    "name": "INT (Wormhole)",
+    "symbol": "INT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14dadch35htr43e6fu5ra7vxzdq7a8w6jzgx6ksm5awg55aw9wzeqwnpjg7",
+    "name": "Inter galaxy colli by 12yo son",
+    "symbol": "IGLX",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1d4j9lsl453mkvtlg4ctw8y52rdkhafsaefug0hq0z06phczuvvvs7uq0vg",
+    "name": "INTERCHAIN DAO COIN",
+    "symbol": "IDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f7w3h99varl067u5qlsnpuss4etktcelv53at9jcyppsgkp3je4qajud0c",
+    "name": "INTERCHAIN DAO COIN",
+    "symbol": "IDC",
+    "decimals": "6"
   },
   {
     "id": "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf",
@@ -2463,12 +7094,10 @@
     "icon": "https://gateway.pinata.cloud/ipfs/Qmd3ussNvHvHhLSqZcZfkT7p6irQ6a2fNSW8jsRPi6uiro"
   },
   {
-    "id": "terra1csk6tc7pdmpr782w527hwhez6gfv632tyf72cp",
-    "name": "Invesco QQQ Trust",
-    "symbol": "mQQQ",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1csk6tc7pdmpr782w527hwhez6gfv632tyf72cp/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/QQQ.png"
+    "id": "terra10h2zxfgap3ld4evqc6jczhpn6vjcdfhny4gx0k82c0xc658z9dnsepkndm",
+    "name": "InterNFT",
+    "symbol": "n/a",
+    "decimals": "0"
   },
   {
     "id": "terra1enj2np0785hw3vt2gn2yga9y75306g6e9lq799",
@@ -2477,38 +7106,51 @@
     "decimals": "6"
   },
   {
-    "id": "terra10h7ry7apm55h4ez502dqdv9gr53juu85nkd4aq",
-    "name": "iShares Gold Trust",
-    "symbol": "mIAU",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra10h7ry7apm55h4ez502dqdv9gr53juu85nkd4aq/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/IAU.png"
-  },
-  {
     "id": "terra12lvpnlphqh3q0cxp8y47e5km8k2ad5ydw5asu4",
     "name": "iShares Gold Trust",
     "symbol": "mIAU",
     "decimals": "6"
   },
   {
-    "id": "terra15hp9pr8y4qsvqvxf3m4xeptlk7l8h60634gqec",
-    "name": "iShares Gold Trust (Delisted)",
-    "symbol": "mIAU",
-    "decimals": "6",
-    "icon": "https://whitelist.mirror.finance/icon/IAU.png"
-  },
-  {
-    "id": "terra1kscs6uhrqwy6rx5kuw5lwpuqvm3t6j2d6uf2lp",
-    "name": "iShares Silver Trust",
-    "symbol": "mSLV",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1kscs6uhrqwy6rx5kuw5lwpuqvm3t6j2d6uf2lp/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/SLV.png"
-  },
-  {
     "id": "terra1td527f09l7lgf55fqtr0zvtx5ek0yl0fdrx574",
     "name": "iShares Silver Trust",
     "symbol": "mSLV",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1087lrvk5zulanrjhdtcfrf49udx70dxqt7erhn4qssu5k60vz92qcrpv8w",
+    "name": "ITO Token",
+    "symbol": "ITO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14fh69r7jvjmzkna7ucssdusufjmgc5y834ua6k5zgd3d4279f88q54w09g",
+    "name": "ITO Token",
+    "symbol": "ITO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1c5vpgnu4kjzxehmvh8adx08ljcappve3jcqcvxha5klqpxc0pguszglelw",
+    "name": "ITO Token",
+    "symbol": "ITO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f9znhfh3uhzrs3rrmt9m2a4f0f5u7jcxuxr3a63wknlxre4vks8s30ljmf",
+    "name": "ITO Token",
+    "symbol": "ITO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ncstskapt4ccg94glnkkylnlgdknpelwf82s5us4xyxj3pmpc54qd7gtky",
+    "name": "ITO Token",
+    "symbol": "ITO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1u3dcmvrdnutlx5rtvw079fgesucwfav5znpv9d4z584nxmnnn6eqydajhm",
+    "name": "ITO-ULUN-LP",
+    "symbol": "uLP",
     "decimals": "6"
   },
   {
@@ -2523,6 +7165,12 @@
     "symbol": "JEFE",
     "decimals": "8",
     "icon": "https://s2.coinmarketcap.com/static/img/coins/64x64/16800.png"
+  },
+  {
+    "id": "terra1q6gqwja73tlz0jvatvdaassp5czam533vkcvewqyl2kg5tcm96yqdk3hpk",
+    "name": "JEFE TOKEN (Wormhole)",
+    "symbol": "JEFE",
+    "decimals": "8"
   },
   {
     "id": "terra19k974ngjsml8dtmk56cdhuy6pplr94rxqdt95p",
@@ -2555,12 +7203,10 @@
     "decimals": "3"
   },
   {
-    "id": "terra1ptdxmj3xmmljzx02nr4auwfuelmj0cnkh8egs2",
-    "name": "Johnson & Johnson",
-    "symbol": "mJNJ",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1ptdxmj3xmmljzx02nr4auwfuelmj0cnkh8egs2/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/JNJ.png"
+    "id": "terra1afyue93pvg6dq2hmqfhnvawn9q4qpvmfe5aj3e5h0rrcjqcg0l8q3qql79",
+    "name": "Joeken",
+    "symbol": "JOE",
+    "decimals": "0"
   },
   {
     "id": "terra1t5y4xm7xdc7csud2j2aezxs6e4uuj3lqpqk7jy",
@@ -2595,11 +7241,23 @@
     "decimals": "6"
   },
   {
+    "id": "terra1ajcht9tj6ujkpw3vyaadasslz85rp2geppu90yehz2gz6z4depaq0f7fqv",
+    "name": "Justice Kingsman",
+    "symbol": "100",
+    "decimals": "0"
+  },
+  {
     "id": "terra1l6nqyv78m3kj8v4wa7r5fr3vhp0qzrauwkx5av",
     "name": "Juta Club Token",
     "symbol": "JUTA",
     "decimals": "2",
     "icon": "https://raw.githubusercontent.com/terraswap/terraswap-web-app/main/public/images/CW20/JUTA.png"
+  },
+  {
+    "id": "terra1ppjlgcuk70yzexfnnwarcalz9ur0v4yay8h6s3tfc78vyc3q0y8shmaenc",
+    "name": "JUXTAPOSITIONS  ▞",
+    "symbol": "MSC",
+    "decimals": "0"
   },
   {
     "id": "terra1kujvztl5p8a45k56u42fq39jxldxcvuejtpfq5",
@@ -2620,6 +7278,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra1cm5tgyvtrr383xp39z4dhz8xwrcsut3gw0nzqs3z2ugpa5pxmh5qtrfetz",
+    "name": "KateEatsPizza",
+    "symbol": "KATEPIZZA",
+    "decimals": "6"
+  },
+  {
     "id": "terra1a8an0aqzjghcukqrdgnkt3ygzhmaaqza03mc3h",
     "name": "Kernel Token",
     "symbol": "KVT",
@@ -2629,6 +7293,12 @@
     "id": "terra17efcrd3glln324tqke56w5wgnfkfn5emz4um8j",
     "name": "Kiba Inu",
     "symbol": "KIBA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fjlj3twnm3yyt2utd738tsrx7fcerkx3xtpgn3x70yp9tak8ufdq0el8x8",
+    "name": "KIKI",
+    "symbol": "KIKI",
     "decimals": "6"
   },
   {
@@ -2659,6 +7329,12 @@
     "icon": "https://kingsmandao.com/wp-content/uploads/2021/10/kingsman-logo-transparent_1@0.5x.png"
   },
   {
+    "id": "terra1qnfwdkcm92l8ecefz7ypnwlx9xsd63n0mlqtcdavy6trhm8xr2tqlh3mws",
+    "name": "KingsmanDAO Art",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra1c5fr3wdf2trj3dkxcckhmzzxlnnpepqn8cu8f8",
     "name": "Kishu Inu Need 🌗💵 ",
     "symbol": "KINU",
@@ -2669,6 +7345,12 @@
     "name": "Kishu Inu Need to swap from PEPE ufxd 🌗💵 ",
     "symbol": "KINU",
     "decimals": "3"
+  },
+  {
+    "id": "terra1wwehdgkm6aa7vtuzhc3rs39txve0vv00mkhknru4m6ew0fazhfcsuk0zsc",
+    "name": "Knowhere NFT Contest ",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1545laqy9s6jcej2pgts32rhqy6dzq62umk8g9q",
@@ -2685,6 +7367,12 @@
     "icon": "https://assets.terra.money/icon/60/KRT.png"
   },
   {
+    "id": "terra1ndslkk6vfv5dc53chrlsl3k8qzympt4rrynjjttyl72jhuqyqy7s6am3lt",
+    "name": "KRT (Wormhole)",
+    "symbol": "KRT",
+    "decimals": "6"
+  },
+  {
     "id": "terra1l670q2m9j3npltmsqe428mwu0msw336m8jtq00",
     "name": "KRX",
     "symbol": "KRX",
@@ -2697,6 +7385,12 @@
     "symbol": "KRXfancard",
     "decimals": "0",
     "icon": "https://c2x.world/c2x-station/icon/KRXfancard.png"
+  },
+  {
+    "id": "terra10n6dj60zrndyru0udh85elvj7wzy6wtjw3t3gepvnxkexv9deztq8j3z86",
+    "name": "Kuji (Wormhole)",
+    "symbol": "KUJI",
+    "decimals": "6"
   },
   {
     "id": "terra1qrq5r95txaregxpa2c7mhf549u5jkm28rzmvt5",
@@ -2729,6 +7423,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra1s9aew7kfrkn0feqpcau5pxjzyrgx58fyhpq2v7jk3tnld237l6gqr39jlk",
+    "name": "Las Caras en Blanco",
+    "symbol": "LCB",
+    "decimals": "0"
+  },
+  {
     "id": "terra1thhm2u93m2stytzynhsxh5h3jrtg540x4punqy",
     "name": "LCT Fancard Token",
     "symbol": "LCTfancard",
@@ -2741,6 +7441,18 @@
     "symbol": "LCT",
     "decimals": "6",
     "icon": "https://c2x.world/c2x-station/icon/LCT.png"
+  },
+  {
+    "id": "terra1pn7uq2wtv93rlpuemv5ulppf5p37ff8z5m4a2lc6kt0aek2cej9q37vwxv",
+    "name": "LDAO",
+    "symbol": "LDAO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1c5h92xmgl6gjp4pq6ka6p8avsjkr23vatr05pulmzdvtcd38vvqs4epenh",
+    "name": "League Of Gorillas",
+    "symbol": "LOG",
+    "decimals": "0"
   },
   {
     "id": "terra1hwcnalcf35p48lvj3wt7tztkzh5szmpnxwyvdc",
@@ -2815,10 +7527,142 @@
     "decimals": "3"
   },
   {
+    "id": "terra1tquaelpx4tw6xnv9wh8xj8e48auhyyy888s756z699ssfqpq2wasz00fmx",
+    "name": "LIQ-ASTR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1c66atrs8gg2ym7g4rp3clar0vxzssjuwdhu09mk9uun37cv8qt9qtm4uhn",
+    "name": "LIQ-BRGR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qjpzejp4aeugxnxdg8n9j5rh6ls5n3etytkcg9jxc90fmp85agusdwe5uc",
+    "name": "LIQ-DRMR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pzrt6f3g8tdfra54tga49swaac97gskya9e2qfa39d4kpsy8ldrqyux70s",
+    "name": "LIQ-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1usz457mcs432pf6fm84zux4t584es8pfvqcp09jxcqs7qc5gcvcsar3q62",
+    "name": "LIQ-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kvpf2swxmc7kmmh6usnrqr2gd2p0nxnfywvche7vj77807km2f3q3aqvrp",
+    "name": "Liquidity",
+    "symbol": "LIQ",
+    "decimals": "18"
+  },
+  {
+    "id": "terra1cd64uj7mhtgdncx3s62p7f02zvk4w7umtn85hkeemwf244075j4qe2eu9v",
+    "name": "Lira",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ekn2a5h298endnvf7sryt3ec8pwraqpphxte0xpuhgdd3ngn3y8qezatcj",
+    "name": "Lira",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mfmfcet8l7khfwq68jxsqnerv246gv4ztpunjsgdj8ulwe3r0x0s5xa8r0",
+    "name": "Lira",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1n6k0pg6hh5k2qd2u3tw9fr48vcl2q6a7zrt27anqjajnrm63vldq4a23vt",
+    "name": "Lira",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q8hcpc4atfpq8743kk3xq6uux9y20krd383995gye4c7qxy2y6ls79eemw",
+    "name": "Lira",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v9yne0lvwxfv2um36rqwutphgwxznr2suwl5ml9h6xzn2u29vz7q28ez0p",
+    "name": "Lira",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1c45hdhurx9jaz86z9hrt83ddut9nqsz46p2sgey5ewf7vqz0kqvssrhecp",
+    "name": "Lira (Wormhole)",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1njtkekd6dqxgz9vlrs52pf9lfd2mna9vgh2r0mf0wvp5gg6zu3lqf78fqu",
+    "name": "Lira (Wormhole) (Wormhole)",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z2e3mh27wuynd9whzsvm3rfyhcv8g4753ev8qfdd46esrcm4unxq374wy8",
+    "name": "Lira (Wormhole) (Wormhole)",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1prcysrw4ys9kp53m3s3dhx4psus4yj7lyakxr5f68zm7640ss03sccdeqs",
+    "name": "Lira (Wormhole) (Wormhole) (Worm (Wormhole)",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s5uwl6gaxyj9mjtkwze4vwadc5jqtmqrkcxcave9c09frm5uzxpsjzjzy7",
+    "name": "Lira (Wormhole) (Wormhole) (Worm (Wormhole)",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1uqauk8jrgzdp7zy700g6g6mw3txy3u2j9rtp00wven7prkqsc4rsafk4qg",
+    "name": "Lira (Wormhole) (Wormhole) (Worm (Wormhole)",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xdg4gtzsdacv8svusarsmndpsqpnafxhmdfqlhse7rk05ys3326s8f5pc5",
+    "name": "Lira (Wormhole) (Wormhole) (Worm (Wormhole)",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1k8vt0lrm0ah37fpd3t5d0jc969khc200twsg5pqaf8xpg9sy5fnst0p7ka",
+    "name": "Lira (Wormhole) (Wormhole) (Wormhole)",
+    "symbol": "LIRA",
+    "decimals": "6"
+  },
+  {
     "id": "terra1m9fuqymdz03umd88guyc79083hd7vppzu74vck",
     "name": "Little Terra",
     "symbol": "LTT",
     "decimals": "6"
+  },
+  {
+    "id": "terra1rjsmxyv46ashe8hlzsesyawltd6c9ftxkpglf5g688xn08g66v0q0ny2zs",
+    "name": "Little Whale",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1c4tcf7xfaer6rk47s25skqy358jgwhs8jrgxkq3nr7dzmcrtsqxssln0s3",
+    "name": "Livia Testes",
+    "symbol": "liviatestes",
+    "decimals": "3"
   },
   {
     "id": "terra1p0w9hh9aea5mg26mjnx7tl695ldwxfksvw4yn4",
@@ -2827,11 +7671,59 @@
     "decimals": "6"
   },
   {
+    "id": "terra16a6qkmxpqzeyez8gh3w7qhrk7x3xe3arlv9nwfg944y8vzg9smrqntark3",
+    "name": "lns",
+    "symbol": "lns",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1fdea6s9g2w740ml0jmzr3szhwp85c2lg9hjgth70vzst43nz8yzqcyqaxg",
+    "name": "lns",
+    "symbol": "lns",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19gsaaq8wyvgf5l5aaqtr6et83sunsu07dmhklhaghmtw8glwt63s9sdcaj",
+    "name": "Local Alentejo Coin",
+    "symbol": "LACO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f0rhjvayf6ea79jf9ls6zhwm36wjy8wvqtuu2gpq8z5ddnwd3saq9ytkev",
+    "name": "Local Alentejo Coin",
+    "symbol": "LACO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1prnyz7ezw85dt9zeyjcdufldjcf6h4lxxzmvl5ctspyj50w7mt5syn69t8",
+    "name": "Local Alentejo Coin",
+    "symbol": "LACO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1x5332um7nvaudzsgklnujepmdzz28grhn8h0yrl9djpvxva5agvsyaqn8x",
+    "name": "Local Alentejo Coin",
+    "symbol": "LACO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yetl2gafkhtanr6utpmxp0zqtkhkc05k4dgjg0zfyf86p9fzw3ssslv0fj",
+    "name": "Local Alentejo Coin",
+    "symbol": "LACO",
+    "decimals": "6"
+  },
+  {
     "id": "terra1vchw83qt25j89zqwdpmdzj722sqxthnckqzxxp",
     "name": "Local Terra Token",
     "symbol": "LOCAL",
     "decimals": "6",
     "icon": "https://localterra.money/local-logo-dark.png"
+  },
+  {
+    "id": "terra1xzkel96e5e8vfmqw7valzdzzv9hqasfyslclvnmvxdejvpda3xwsskxzus",
+    "name": "Local Terra Token (Wormhole)",
+    "symbol": "LOCAL",
+    "decimals": "6"
   },
   {
     "id": "terra14s3g6jmytjjg2jcxmmaj6k837vcr6h98muxc07",
@@ -2861,11 +7753,29 @@
     "icon": "https://loop.markets/token/logo3.png"
   },
   {
+    "id": "terra1h4me76lqd2450e8jnduewen2vpyfrxlekhtql9aed6kt48thkqqqu00vjq",
+    "name": "Lootopian Items",
+    "symbol": "LOOTITEMS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1c649ctpkwqa9h65g6xmplrncc55d5nzqgz30zhtkcysedkd63zcq02uhs8",
+    "name": "Lootopians",
+    "symbol": "LOOTOPIANS",
+    "decimals": "0"
+  },
+  {
     "id": "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr",
     "name": "LoTerra",
     "symbol": "LOTA",
     "decimals": "6",
     "icon": "https://loterra.io/LOTA.png"
+  },
+  {
+    "id": "terra1jv9h8w29drd2r4fugsvsdnkrsl99wpr2xmn3wn5ukn6acv6g9esqf0uh9x",
+    "name": "LOVE",
+    "symbol": "TERRA",
+    "decimals": "6"
   },
   {
     "id": "terra182740uw8nh6tk3yjfcf7gu5phg3kqryhtuxp0p",
@@ -2972,6 +7882,66 @@
     "decimals": "6"
   },
   {
+    "id": "terra1ed0k9whkuc0upf65znurquqqvhchdawzv3fp9vum496tumwa60rqktjsy0",
+    "name": "Luna (Wormhole)",
+    "symbol": "Luna",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1leavh38n7ycjh5xed5us2s8f576zmpj48ec0nhjs25r0wq5au9lqw3kdqz",
+    "name": "Luna (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fqxs98wj9eeenq95093gkfqzq3emfzxe88hvdr87p46ymyu4agaql5hhv8",
+    "name": "LUNA (Wormhole)",
+    "symbol": "uluna",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1teycrt4svt52jfmhkwywgk5gg9thrvgz87qm3edc8u63kte23djqlv5u0t",
+    "name": "LUNA (Wormhole)",
+    "symbol": "__proto__",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1ukv6djf73m9g459a3pwhq6c8jvuy832gpv8ck4eyyeaj2rptxkvqyxlz43",
+    "name": "LUNA (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "8"
+  },
+  {
+    "id": "terra173scyqe32fh2cec7ctmy5jnxtqpghhlrw69p3z84vk9huzn9s8yqggvjzj",
+    "name": "Luna (Wormhole) (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra18ywl0l4z3u6rjcxg4rwtjhztj89k8nneqfz96jg9tgh9c7tgxjns93v75d",
+    "name": "LUNA (Wormhole) (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f0rcrwut62l0fvnrn2mzg6m6zmq2ls6wgd9w3jjayzssahf74kfskn6ya3",
+    "name": "LUNA (Wormhole) (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1sdr0trqyfjh3469a5j0fvga4u7ged6u4m56jskv0llz9zkm2twyqcgr4ez",
+    "name": "LUNA (Wormhole) (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rq683n66vng4hqp5fuq8jja0z9wdfvem204ckyvwf0r02nvr8xuqgrwglu",
+    "name": "Luna (Wormhole) (Wormhole) (Worm (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "6"
+  },
+  {
     "id": "terra12a39fn0k0duteqefme6zgr5efg0g5ya7eglvyu",
     "name": "LUNA 100 Dollars December 2021",
     "symbol": "LUNAMOON",
@@ -2982,6 +7952,12 @@
     "name": "LUNA 2.0",
     "symbol": "tLUNA",
     "decimals": "6"
+  },
+  {
+    "id": "terra17vysjt8ws64v8w696mavjpqs8mksf8s993qghlust9yey8qcmppqnhgw0e",
+    "name": "Luna Ape Club",
+    "symbol": "LAPEC",
+    "decimals": "0"
   },
   {
     "id": "terra1tm2jhnfh6hmnpvzsyfteqhcn6h5uw2qafr48yh",
@@ -2998,16 +7974,95 @@
     "icon": "https://assets.terra.money/icon/svg/LUNC.svg"
   },
   {
+    "id": "terra16h7keds26d52xj8rn9jfx6lj2x0ja79lt56yxnmlm4xsttf5mu5smq5f78",
+    "name": "Luna Classic (Wormhole)",
+    "symbol": "LUNC",
+    "decimals": "6",
+    "icon": "https://assets.terra.money/icon/svg/LUNC.svg"
+  },
+  {
+    "id": "terra1fvdcu2j85nrlhwhy0rmhttst2caaxtf36ytjcngg47qkt8ndcu8sm6qff6",
+    "name": "Luna Classic (Wormhole)",
+    "symbol": "LUNC",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1y9guyavsd5cjz4hh9jxlsu4th2ce95kjqurc3aprkrgrwg4cj7hqx25p6v",
+    "name": "Luna Classic (Wormhole)",
+    "symbol": "LUNC",
+    "decimals": "8"
+  },
+  {
     "id": "terra1ex5age9gqd5em86wg8hu0ak5wrqez9yufvlrat",
     "name": "Luna Classic Token",
     "symbol": "LCL",
     "decimals": "6"
   },
   {
+    "id": "terra1m20djcturk5yxv8u84s0t6xh5evjx98pmlc3xj8u99qeuwy79hrq5l9dz2",
+    "name": "Luna Crash Survivooors",
+    "symbol": "LCS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra16nfcvfcfd8fnurp6m20xpa2d8c5y3v47g4y0r9jqzr7t6auersxqxd2jf9",
+    "name": "Luna Doodle Bears",
+    "symbol": "LDB",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1rwwtz3aac6w9yxmxa32hzggn0j7swt7e2lrs9838wmygq9wlnl9sdhq3wc",
+    "name": "Luna Doodle Bears",
+    "symbol": "LDB",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1crxcd4m9wvr35j7gjcgwquum6lxtz2f3dssd7f9959xn5jq5lu3q5dyrgh",
+    "name": "Luna Fight Club",
+    "symbol": "LFC",
+    "decimals": "0"
+  },
+  {
     "id": "terra1r5c53q49wu2vqerecdvua2zpvy9k8vlw7cnx25",
     "name": "Luna Game Guild",
     "symbol": "LGGD",
     "decimals": "3"
+  },
+  {
+    "id": "terra1dddhkvrdwjd30xgmamld3zdtvfmjlpeh2u49mluqjx65wgnwarcs882qme",
+    "name": "Luna Kiddy",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1fcqy0khmxkap332srawukpsqc2p9uaujv9us368pkvnpxwzz6r2s8trv6d",
+    "name": "Luna Kiddy Collection X - Hello Moon",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1swldwd2jaj6ewxyckhxu9cdjlhwvsky55rhd02jszfmsgvjcq6hsp04jx5",
+    "name": "Luna Moonz",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1gutsrmwdls9pva4jv8tghe29qt4rfmhnplx8qvy9h9l5f0y9l0xqestddh",
+    "name": "Luna optimizer token",
+    "symbol": "OPZA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ry9f6alqyf9dpj04u9ymq5u4whjndu485agh6gusn89dmqse3ggsnzducj",
+    "name": "Luna optimizer token",
+    "symbol": "OPZA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ldhrtdqhfffrg67q65rgnk9exwrjyv5rpk3p77hrcndg3vu8d9ws2h93nv",
+    "name": "Luna Saver",
+    "symbol": "LUSA",
+    "decimals": "6"
   },
   {
     "id": "terra1zpz6dfn24cnykwausjt7qwfdqf87kny0trn94k",
@@ -3022,6 +8077,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra1ace6qznlfmng9ucmf3s02qa4j4jau702dz0mzjktacqr5yx4hulqysvs3r",
+    "name": "LUNA-Swap.io (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "8"
+  },
+  {
     "id": "terra1j4kt7mns290trwlwyxrun5n7nlfkxxcak57ck2",
     "name": "LunaApe",
     "symbol": "APE",
@@ -3034,10 +8095,64 @@
     "decimals": "6"
   },
   {
+    "id": "terra1vh3djwh20p34y5xla3a8c45n7z2xgvyejy0kp2eke5xgtax7fmrs8a3g77",
+    "name": "LUNABIRD",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1tu3fljc4ksy785l4j7cwj387hvfwxp88avrc6rwxc0clckrjalvq0ctr3j",
+    "name": "LunaGorilla",
+    "symbol": "LG",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1p4z3k297lvxtc8awfewf5g63gjgunakgknh5wj2pnarydltlwz8qx93mmf",
+    "name": "LunaKittys",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra1e3s670y5lns7vlq3gxdcn9rv8mdpydhd89jdwz",
     "name": "LunaKwon Terra",
     "symbol": "LKWON",
     "decimals": "6"
+  },
+  {
+    "id": "terra1525vl2n9zh3w4yx22u96j8jua6mt4rmuy5tuclc9d8yjsekjxnrsnfr7wn",
+    "name": "LunaLapin",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1lxlm3dhchddr0gs9rw0s87c0prhw8xvmzjqh2s920v7pxtzqy9sqwsyqc0",
+    "name": "LUNANA",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1hvjl89vxv6lk5nmwl4tnz70pe7t24plgw7xa4r2yps0l2uytt8xscmhud5",
+    "name": "LunaPunks",
+    "symbol": "LunaPunks",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ntnkf7k3twr4j7j2h6y4k95rz0nfhcx9e3e0ke957vjvpzwynd6qas43zl",
+    "name": "LunaPunks",
+    "symbol": "LunaPunks",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ew0rx3lgecmkeh8qscz92kvw2268flpr0r49k7m44xk3musg4a6spw8yj7",
+    "name": "Lunar Assistant: The Giving",
+    "symbol": "LAV2",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1t5934pztkw2j983azhsgkvkvfp2vgfpgvzrpy58h88krr4uvph6sevnsdm",
+    "name": "Lunar Boots",
+    "symbol": "BOOTS",
+    "decimals": "0"
   },
   {
     "id": "terra1g0pm8xm5c2dq4qtv8j9a80hg4mhe5ndy8qad07",
@@ -3045,6 +8160,24 @@
     "symbol": "ARTS",
     "decimals": "6",
     "icon": "https://i.ibb.co/K9Q53VQ/lunart.png"
+  },
+  {
+    "id": "terra1723fcqetu8dxjqe3as7djqtmzyjwcp7k6rs5mv2jrsytjer032kqvr0vtq",
+    "name": "LUNASKULLS",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra196uh50ak5h6m8zffjpc0uv3vfu56q4lmcwh6hetyzvaldu6yy3gqkmpw23",
+    "name": "Lunatic ConDoms",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1hf3c5ryyk90spej29h8eyxvqkvvl6834x497ruedh9q8ej0v54gq08jmsu",
+    "name": "Lunatic Punks",
+    "symbol": "LP",
+    "decimals": "0"
   },
   {
     "id": "terra1fj06x3hq2xum56htlrdeame70knzl765cq4txr",
@@ -3062,6 +8195,18 @@
     "id": "terra1rck0zefy4juahqjjk5q0wz2ykp7028hjwvzcaj",
     "name": "Lunatics (Wormhole)",
     "symbol": "LunaT",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1ew6ve6nuq8rf33vfnkj7jfsygq4au9gkkkapr2xnp6vhrl30484s99ph5x",
+    "name": "Lunatics Punks",
+    "symbol": "LNP",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19ersf68qqnpc4vu93l3fr4t3e0dwg7v374ynv0k75hk2ggad693q3y9p6z",
+    "name": "LunaV2.io (Luna Token) (Wormhole)",
+    "symbol": "LunaV2.io (Luna Token)",
     "decimals": "8"
   },
   {
@@ -3085,6 +8230,42 @@
     "decimals": "6"
   },
   {
+    "id": "terra13su0l0gx7r52ttqc5srxhg3keu575eyq3admtz39m0c2k0yv499smrty24",
+    "name": "LunaX Pool",
+    "symbol": "ptLunaX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra168x6eryjuwkwdnqkksps0a6e0dr65mjpfclmhswxyurztyqy345qv6y39e",
+    "name": "LunaX Pool",
+    "symbol": "SMBL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10vz23p5agfdmryj62mh8srx9lcctlulnmg28upx2e8x47k6dmc4ssvahhf",
+    "name": "LUNC (Wormhole)",
+    "symbol": "LUNC",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1pujwphjvqww94vvefkhuq7vdlmxqunf5shnlf2zvpdeu8n3suces0r9lta",
+    "name": "LUNC (Wormhole) (Wormhole)",
+    "symbol": "LUNC",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1ulr678u52qwt27dsgxrftthq20a8v8t9s8f3hz5z8s62wsu6rslqyezul4",
+    "name": "LUNC Burn Token",
+    "symbol": "LBUN",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16fk7y0rn7fxdxv44gzv86uq4w3uq4v57y84v5tm6xmklu2v77tes2gwsy0",
+    "name": "LUNC Holocracy Token",
+    "symbol": "HOLO",
+    "decimals": "6"
+  },
+  {
     "id": "terra1kqf8ua7al5tdnkz95ue4zkuv4gcu52pt63ya54",
     "name": "Lunc optimizer token",
     "symbol": "OPZC",
@@ -3098,6 +8279,18 @@
     "decimals": "6"
   },
   {
+    "id": "terra1897y20wkvefn994e5jx0vtmcyu6nkxdsnlg4kfg6uefe0s6ct8hshtakjh",
+    "name": "Lunc Trains",
+    "symbol": "LuncTrains",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1m22wjsm4vyuf5s9mpcczdckhqyqw5jmspxkdftju9v0u9tg8smxq9wdd23",
+    "name": "Lunciferrium - Invaders",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
     "id": "terra1m3tdguf59xq3pa2twk5fjte5g6szj5y9x5npy7",
     "name": "LUNI",
     "symbol": "LUNI",
@@ -3105,11 +8298,23 @@
     "icon": "https://d2s3n99uw51hng.cloudfront.net/static/100_100_LUNI_logo.png"
   },
   {
+    "id": "terra1vfme2h5ffueendzymf0n4hs0g898ncp6ww5n09z8uw5rn8cfwhxq7qnk86",
+    "name": "LUNITA",
+    "symbol": "LUNITA",
+    "decimals": "0"
+  },
+  {
     "id": "terra1ykl7ee0dakfev97ektynnup8hscyuhc9kly9k4",
     "name": "Luntivo Finance Token",
     "symbol": "LTVN",
     "decimals": "3",
     "icon": "https://luntivo.finance/images/coin.png"
+  },
+  {
+    "id": "terra1as057wvx6vjqefawk2cql39k90v62fltn03tuw4262dcqtzppv6qrh897m",
+    "name": "Lylith Iconic Woman",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1u02kfjra4q9272p0ckq8yjtfc5qq6584amvrnm",
@@ -3157,6 +8362,12 @@
     "icon": "https://marsprotocol.io/mars_logo_colored.svg"
   },
   {
+    "id": "terra1pupw8tmlgf7fgz5w9jn4876zkxw03es23jpm8v0207m2g7dpjtqsmdylpv",
+    "name": "MARS (Wormhole)",
+    "symbol": "MARS",
+    "decimals": "6"
+  },
+  {
     "id": "terra1z3ejshh0vwkdr35wt9eyxetsqm6mnraya8myxs",
     "name": "Mars Protocol",
     "symbol": "MARS",
@@ -3167,6 +8378,12 @@
     "name": "MARS PROTOCOL",
     "symbol": "MARS",
     "decimals": "6"
+  },
+  {
+    "id": "terra15gykrtjfdxfy5q52v3jvdaqa0e7sw84nymvxltc4a4jfelvhspgqfwx4w0",
+    "name": "Mars Protocol Token (Wormhole)",
+    "symbol": "MARS",
+    "decimals": "8"
   },
   {
     "id": "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n",
@@ -3222,6 +8439,12 @@
   },
   {
     "id": "terra1x5t6zkvhc6dg2jjug34tfreme3hcufpuy77da2",
+    "name": "MCP",
+    "symbol": "MCP",
+    "decimals": "6"
+  },
+  {
+    "id": "umcp",
     "name": "MCP",
     "symbol": "MCP",
     "decimals": "6"
@@ -3301,17 +8524,21 @@
     "decimals": "6"
   },
   {
-    "id": "terra1227ppwxxj3jxz8cfgq00jgnxqcny7ryenvkwj6",
-    "name": "Microsoft Corporation",
-    "symbol": "mMSFT",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1227ppwxxj3jxz8cfgq00jgnxqcny7ryenvkwj6/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/MSFT.png"
-  },
-  {
     "id": "terra1yrch507vhsmd9rue6q3v8pz4pe445jl09nrvz6",
     "name": "Microsoft Corporation",
     "symbol": "mMSFT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s8u586k3s7xtvasxv4p6ldl0jrxht9w886v8ymkst6crg5hxue3sqn49r9",
+    "name": "Microsoft Corporation (Wormhole)",
+    "symbol": "mMSFT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y5e4plp8evsh2urycmhy35lrqxneqc8ewdqzjpvlu5z9wurpqw7sfj9u5x",
+    "name": "Mine",
+    "symbol": "Mine",
     "decimals": "6"
   },
   {
@@ -3365,16 +8592,14 @@
     "decimals": "6"
   },
   {
-    "id": "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
-    "name": "Mirror",
-    "symbol": "MIR",
-    "decimals": "6",
-    "circ_supply_api": "https://graph.mirror.finance/graphql",
-    "icon": "https://whitelist.mirror.finance/icon/MIR.png"
-  },
-  {
     "id": "terra1h4hvry62zk4zh0udecqmatfg02phnyu6hq74xd",
     "name": "Mirror",
+    "symbol": "MIR",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q2mc9srv908j0jt3mpevdvpqsmy4s8tt0vwgwvae7r6d9cvklfwqgzwk4d",
+    "name": "Mirror (Wormhole)",
     "symbol": "MIR",
     "decimals": "6"
   },
@@ -3411,13 +8636,31 @@
     "icon": "https://assets.terra.money/icon/60/MNT.png"
   },
   {
+    "id": "terra120lhfhg7rwvzwfs5extsj89urmupsdhvghg24g25rvthfma3gxjqnluur5",
+    "name": "MNT (Wormhole)",
+    "symbol": "MNT",
+    "decimals": "6"
+  },
+  {
     "id": "terra19cxwwhtkpp4qvf4tvjmhh8lnh8lle7uw7ndqjw",
     "name": "mocart",
     "symbol": "mcrt",
     "decimals": "3"
   },
   {
+    "id": "terra1saxy7j45avta7z6q8qv3j08p4t0qz0nfsyxwhraejek90eege6asumnl5f",
+    "name": "moon",
+    "symbol": "moon",
+    "decimals": "6"
+  },
+  {
     "id": "terra16p7wv0m0upx763r5aux6qatzyve44ezdyqpq5m",
+    "name": "MOON",
+    "symbol": "MOON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jg848acg7rzt7tnz6zqaxzsc94w2yjhafad80d3uel9937grkmfsv8aycw",
     "name": "MOON",
     "symbol": "MOON",
     "decimals": "6"
@@ -3448,10 +8691,34 @@
     "decimals": "6"
   },
   {
+    "id": "terra1jzl4telukvjx56l72zxuts0xm60gefgu3kla36fvfqlfxn0ckuvsgd6akd",
+    "name": "MuskTerra",
+    "symbol": "Musk",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y92wp8u58396mtaejwhtasz24vrcf0lhsznl7rj0nhw0khp8kchscuqgfs",
+    "name": "MuskTerra",
+    "symbol": "MUSK",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z7xe8pjrr0tdguvsdxh2hj6u0gk3y93dxs2xncz00jsjzt8g6suq95lj5w",
+    "name": "MuskTerra",
+    "symbol": "Musk",
+    "decimals": "6"
+  },
+  {
     "id": "terra1j874eyvev9pm7uxm0h9l82raswe3qwcug8wxuf",
     "name": "My Awesome Token",
     "symbol": "MAT",
     "decimals": "6"
+  },
+  {
+    "id": "terra12rh4v7lwszqwcf73k38yxv05j78vntckczngh4ym8a9dqtzqc08sucptw9",
+    "name": "My Get Rich Token (Wormhole)",
+    "symbol": "MGRT",
+    "decimals": "8"
   },
   {
     "id": "terra16ygrvq7q2zxw7jj3f96racur50w0g7r0mj6e2y",
@@ -3472,6 +8739,90 @@
     "decimals": "6"
   },
   {
+    "id": "terra1gd3ntqq04lvd623xs8ht6dly0s7n4gxnz7lmlw5ga0qnamg9wyrqcggn2h",
+    "name": "Nauticus Luna Principal 042923",
+    "symbol": "pLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1l02355pejytcakcpq6g3n57ydwpqeysuw5nj679hlnrrsz3sc3wssxr69j",
+    "name": "Nauticus Luna Yield 042923",
+    "symbol": "yLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13g39gz8uv4s8h9a7pzmg2pezcmd46jz774lffhe2n9dqckn87mlqqg86nc",
+    "name": "Nauticus Principal: LUNA/LUNAX LP Astro",
+    "symbol": "pLUNA-LUNAX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gqe4qzemuhj8nxn5f3fj9tcscszy90klrapxsjpr2td2a0fnlxmq2klheq",
+    "name": "Nauticus Principal: LUNA/LUNAX LP Astro",
+    "symbol": "pLUNA-LUNAX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hkcahx3u4742adhlx4zx2ya3sxmm7a0xpk5nwkf4ze4j2akg0sns0ydt6l",
+    "name": "Nauticus Principal: LUNA/LUNAX LP Astro",
+    "symbol": "pLUNA-LUNAX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1k57q7f7gh6rm4gyqpqygkxdgsh0d67nxngfuwj6n5d38jpd44psshn5gaq",
+    "name": "Nauticus Principal: LUNA/LUNAX LP Astro",
+    "symbol": "pLUNA-LUNAX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z56spghy7kmvv6j9p7gv2hf569x57mnnex4gcqyx5m8m76d0awvqd6ywfj",
+    "name": "Nauticus Principal: LUNA/LUNAX LP Astro",
+    "symbol": "pLUNA-LUNAX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gk0y0tcxj8pr65tanqvc8zyzv3c8szkwf2kcmzgqj9jm2t9z3f9q4xcnfz",
+    "name": "Nauticus Principal: USDC/USDT LP Astro",
+    "symbol": "pN-USDC-USDT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra157n39w0p0ux2wcec2fwyn30rywfd9tunxjc40qm22z6g5sdlr9uqcv8rza",
+    "name": "Nauticus Yield: LUNA/LUNAX LP Astro",
+    "symbol": "yLUNA-LUNAX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mecwgl3p77l57lv5ksn7zet0p97rjd6c6cdk4vmvrl52m680pk3qgf5y2u",
+    "name": "Nauticus Yield: LUNA/LUNAX LP Astro",
+    "symbol": "yLUNA-LUNAX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1sqxtvf93tpu08evzt6va072cefy45xuvjghutgmcv93pk2aaazgs220eev",
+    "name": "Nauticus Yield: LUNA/LUNAX LP Astro",
+    "symbol": "yLUNA-LUNAX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wjzwg8megt6zsfsr2tduwklh8sx3mpptquqcm7h0krxuzwc5n86sn2xh9a",
+    "name": "Nauticus Yield: LUNA/LUNAX LP Astro",
+    "symbol": "yLUNA-LUNAX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y03yesqka4m799fdtnjp6p5w7n9rup9e5tucdsdqes6pr98t6pes9w6dcv",
+    "name": "Nauticus Yield: LUNA/LUNAX LP Astro",
+    "symbol": "yLUNA-LUNAX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e0uch3fwned9rfhkaeehqv9mnfuwjh9jfhawd4gxw248czljdttsh22jkg",
+    "name": "Nauticus Yield: USDC/USDT LP Astro",
+    "symbol": "yN-USDC-USDT",
+    "decimals": "6"
+  },
+  {
     "id": "terra1hgseash9ctvscp09trutsh8utt34z46lj2n96k",
     "name": "Nebula Token",
     "symbol": "NEB",
@@ -3486,18 +8837,22 @@
     "icon": "https://assets.neb.money/icons/NEB.png"
   },
   {
+    "id": "terra10z9tu85rpzhk7crljs3atqcknyedkyys40a9sj6u7fcqqmky7tmscc6eza",
+    "name": "neo",
+    "symbol": "neo",
+    "decimals": "6"
+  },
+  {
     "id": "terra1cczv3ck2r909w64n9rdqs3gh5gsmwumh4utz49",
     "name": "Netflix",
     "symbol": "mNFLX",
     "decimals": "6"
   },
   {
-    "id": "terra1jsxngqasf2zynj5kyh0tgq9mj3zksa5gk35j4k",
-    "name": "Netflix, Inc.",
+    "id": "terra1hw6ymqhxla8a5wk7xjjfqhxnvewvzqgdv5c5gfhlateg7sfhtymq6ccfuc",
+    "name": "Netflix (Wormhole) (Wormhole)",
     "symbol": "mNFLX",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1jsxngqasf2zynj5kyh0tgq9mj3zksa5gk35j4k/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/NFLX.png"
+    "decimals": "6"
   },
   {
     "id": "terra1nagqpmyw55yjphea4rhntlfv87ugmeaj8ym756",
@@ -3505,6 +8860,18 @@
     "symbol": "cnETH",
     "decimals": "6",
     "icon": "https://terra.nexusprotocol.app/cnETH.svg"
+  },
+  {
+    "id": "terra1w3fjl2nuhpqwwu6mkaarkgnvpugs25t5sd4pj02ktdjn0ayw08ys50lepk",
+    "name": "NETONE",
+    "symbol": "NTO",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10804tj9tsguuhe5k3yt0xm2h6wdtn8zhea4mj9v8s04w6enstf0sgf0mtq",
+    "name": "New Community Luna (Wormhole)",
+    "symbol": "cLuna",
+    "decimals": "8"
   },
   {
     "id": "terra1f659ez3nysf06765jjjqnl7m65urrqaxx2t40h",
@@ -3613,6 +8980,18 @@
     "decimals": "6"
   },
   {
+    "id": "terra1ymkvnzclutwd8plps056479wl26cw4m7ynelg2fxwnswlrct5syse9725q",
+    "name": "NFA",
+    "symbol": "NFA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10cev4e2n2xjen5eqwx2454zusej5yvzfcd8ymzldtaujecwxpxcschl3et",
+    "name": "NFaTman",
+    "symbol": "NFAT",
+    "decimals": "0"
+  },
+  {
     "id": "terra17zeqmepm87d9g4dujjsctqjrfhz4xjkup26t03",
     "name": "NFT Kwon Terra",
     "symbol": "NKWON",
@@ -3643,6 +9022,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra17gg9tteke98elqlfgcy2m4ymx3hzqzs2efdmtvutjml03gxvanpqmzne87",
+    "name": "NICOL DAO COIN",
+    "symbol": "NDC",
+    "decimals": "6"
+  },
+  {
     "id": "terra17ana8hvzea0q7w367dm0dw48sxwql39qekpt7g",
     "name": "NIKE, Inc.",
     "symbol": "mNKE",
@@ -3664,6 +9049,12 @@
     "symbol": "cnLuna",
     "decimals": "6",
     "icon": "https://terra.nexusprotocol.app/cnLuna.svg"
+  },
+  {
+    "id": "terra1tejajvl4y8f9remfdtlpl555zmr7ltqq2rvvs2vrmx3ke98twepsyutyu2",
+    "name": "no-name-yet",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
   },
   {
     "id": "terra1zzfhavsjlhhx42rnjfvwk6u7taplh4qxqmhgfa",
@@ -3708,6 +9099,12 @@
     "decimals": "3"
   },
   {
+    "id": "terra1ey8nrqhufmj0lfcn33x345hf7zhggz03nss03keavs3nxcml0w8spl0w58",
+    "name": "NUSANTARA",
+    "symbol": "NUSA",
+    "decimals": "6"
+  },
+  {
     "id": "terra1drsjzvzej4h4qlehcfwclxg4w5l3h5tuvd3jd8",
     "name": "NVIDIA Corporation",
     "symbol": "mNVDA",
@@ -3736,6 +9133,18 @@
   {
     "id": "terra1zawrkv57eh7rne45zjta7s876jqc59slrev9xy",
     "name": "ONLY TERRANS",
+    "symbol": "ONLY",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14kxhyva49afm4hzurmwgzxf5qftrmtlqap6yyty29rgvzt9f0dkszt5de8",
+    "name": "ONLY-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zd27zxxn976s0ygqa7h2cmgzq0emcuy2h4dk04a6s8jm5a346dfs3zc6u2",
+    "name": "OnlyFeet",
     "symbol": "ONLY",
     "decimals": "6"
   },
@@ -3779,6 +9188,30 @@
     "icon": "https://orion.money/assets/orionASTRO-LOGO@256x256.png"
   },
   {
+    "id": "terra1xvfaprudv2nwh4kcz3rx4hurwfqgxwdencuf5ull6dt8q092ph0q9m7s20",
+    "name": "Orne (Wormhole)",
+    "symbol": "ORNE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s3uyn9nakk9ht6hq455vj89r34y6twc6nejgl63swqyz8ushwtwsg7zh8q",
+    "name": "ORNE-ASTR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zhwjeh96z0ce0l7ze6veynuekmqkhatmawgnmvkfnutg3z4ymsass9cfev",
+    "name": "ORNE-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra13y6q5agfqdvd4mkrzzw9fadp500nk4spnd8rzyrkdls5fsqgurksa74uxz",
+    "name": "ORNE-RED-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra1ts6qq7va0msf0se3cwjsppt3vkumkh3t6n4d8a",
     "name": "Osmosis",
     "symbol": "OSM",
@@ -3803,10 +9236,34 @@
     "decimals": "2"
   },
   {
+    "id": "terra14mvqh98pklf3h9e0ug6tr4h5kpkn4hxqcqkhqvvedszjmef5vzqs9kkn0f",
+    "name": "Ozone Vault 1 01/27",
+    "symbol": "OZ-VaultOne",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16phy60cckrwcl9memglr0m25tp4p50av26n2cnnf2h4kre3gvffsd99kpx",
+    "name": "Ozone Vault 1 01/27",
+    "symbol": "OZ-VaultOne",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1saegtxk5vym89ydrfrfw75smhpfg7202mkje2f4gwx4tvh5m54cqz9xscy",
+    "name": "Ozone Vault 1 04/31",
+    "symbol": "OZ-VaultOne",
+    "decimals": "6"
+  },
+  {
     "id": "terra1v58klw3jakaeas2dkppqdh4y4dzd52kzda2fgf",
     "name": "Pace Token",
     "symbol": "PACE",
     "decimals": "6"
+  },
+  {
+    "id": "terra12562rn6zu6n54gat6nsv83xetexe6kjs50a3mulhmsv8lqwxgaxq5paym4",
+    "name": "Pacha X DCentralize",
+    "symbol": "DCENT",
+    "decimals": "0"
   },
   {
     "id": "terra1xvqlpjl2dxyel9qrp6qvtrg04xe3jh9cyxc6av",
@@ -3835,12 +9292,22 @@
     "decimals": "8"
   },
   {
-    "id": "terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx",
-    "name": "PayPal Holdings Inc",
-    "symbol": "mPYPL",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/PYPL.png"
+    "id": "terra1dzahfzk3vavwy4zqt0x49guswvwe6ef8jm60fpl2cqmq0yl7pp4qyrx3cr",
+    "name": "Pce",
+    "symbol": "Pce",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16zlyx8s596gfrswryazttjtvae2qwc72j27vuvnefcezc2qlazssjmmdn6",
+    "name": "PCE-ASTR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e89c3swfuyykycw0gkqnwdvuwd0lxsg55tqydf3367dwhp73mrqqad6u4f",
+    "name": "PEG",
+    "symbol": "PEG",
+    "decimals": "6"
   },
   {
     "id": "terra1rjf3c4ayvx2d6pej6fanjhe54a2ds8dlh9f69s",
@@ -3866,6 +9333,18 @@
     "name": "PHZ",
     "symbol": "PHZ",
     "decimals": "6"
+  },
+  {
+    "id": "terra1h7g332d4r6chhv63umey9y2g5g5dq3h88s5az6xzpj6mrdefwcgswv558v",
+    "name": "Pinx Ladies",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1kxeefnas9zsgz8dpequcdp85t0mlxshcjd3sar9889z5wwnwad5seexp60",
+    "name": "Pla-net Universe",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1nq9epqtswmj7uaymsw59w9n5h5e78k9rwduets",
@@ -3906,10 +9385,40 @@
     "icon": "https://i.ibb.co/Snt8gXx/Projekt-bez-tytu-u-3.png"
   },
   {
+    "id": "terra18enrpukca3tnun2qstkdnwy27xc326d75fjj682yevzmwe58mqkqcl27n3",
+    "name": "PlayNity token (Wormhole)",
+    "symbol": "PLY",
+    "decimals": "6"
+  },
+  {
     "id": "terra1kdkcxnsldqmj50ll77gmq5x26u69z8m69hdas6",
     "name": "PLEASE DONT BUY",
     "symbol": "PDB",
     "decimals": "2"
+  },
+  {
+    "id": "terra1cysh639syvrhhg7mnsdl4vrhhvmefrzd5udxtd0jftscha2n3cjsnxsmnx",
+    "name": "PLUN-YLUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1e6395r0qgvdg204kuvy96rd2tlf32hme4ksrk86zmpantxku9s5sp59n0t",
+    "name": "PLUN-YLUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1n5392a80qr69ee2waudrtrqrwufk0vjavd42q5ea9nut3hlfscpswx7t80",
+    "name": "PLUN-YLUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16ptks602wpdjqtmd0qg5kpulkm7qf3wr2h6t5hatgrec6cl3l3jsxnkt7r",
+    "name": "PN-U-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
   },
   {
     "id": "terra10yycj46tjfnfhkk5d6er49gvcn28jpqk0spthr",
@@ -3924,12 +9433,16 @@
     "decimals": "6"
   },
   {
-    "id": "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
-    "name": "Polkadot",
-    "symbol": "mDOT",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/DOT.png"
+    "id": "terra1axc098v7zqalr4rgt9dxcw9zh3la4sgcwwlj40easet7yjs00e7q6mn3lf",
+    "name": "Poki Cube",
+    "symbol": "PKC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ymf3js2gud2h2rspqmcd6n7nmsdyk5zvvwyz9wk4vegy3df3r4sqgrepv5",
+    "name": "POOP",
+    "symbol": "POOP",
+    "decimals": "6"
   },
   {
     "id": "terra130fhr9jz0nylzhdvuwcpp3hne2s5qlft6hfzgv",
@@ -3938,9 +9451,873 @@
     "decimals": "6"
   },
   {
+    "id": "terra10fs0sjuudj5suc5w0w6cfcak2w7y6t7wwaaflumh430x203dvn5s25q6yh",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra10fvqy25jyrr8uu5jw70vkshrnh8akzs534t0z9mrhdtw3lhth73qagl5zc",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra10lncq275lsf7jcw75p0mmcnv93zxwgeztyxa8dx0yy87rh3hsnkqa5t7k4",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra10smdczgk3cfay3hwahu9hwqp7ms66usty64n29dxprexd696uhuq4sd44n",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra12gly5yany57srs3m0qhae47h2jvpmdj6m73skwe0qfm0ywrmlk3qhpmpya",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra12jwxnguurh6dzhlwu0qag6fdwty5dh5uk0ldr5ycqrzm6kez080sufcemh",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra12uuqg783xejjds0t4f46ylxfl088pyw42wqtjcnupvgt02lgacyq4ta8ac",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra12wa9vvnffrady2yltzv6u20q37gg59w8qslmt4ufpqyprfe97aws5cyae3",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra137q26tg7gnjvu8lyqlkaffd343qfdzj9d7ynfm428eu7cc60vq2smkhn0w",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra13tzvgrp0zy5q5h50k9xlvdtwhs840pdyt5fyhhp8lskpgj0gsd2q8u5ng4",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra13w3073l43gwxw77tv2np2katn3jrvet87unyfevg8nrj755m3x7ql5xv0g",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra13wppqeqww2y42dlp7u30rwmekwjandzaxjvq3c503ak8fx5nvsyshercr5",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1454mwwpg5g0lqrsnh7gfr74avw8agm2snhawgf70cjectgcn6kssx7jl6e",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra14c7t4686jdtf9mf83hjwm0hqm9hawzzfjt93x77djfa0audx3dyqczda67",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra14dtlxyj2wqteq02293zt538rn39djdsahyt3hayyxm06ds7hn8hqdp54cv",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra14eut6f6mvdk8wpz6hsmuzgdujek5dnhd6dxx4py0gvxejzxwawdsksgtj4",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra14l6hpqyd2vqy0wn63wkep30wxmt62vjzlwzeeyhlkdkgm7grfl4qdf0enc",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra14tcq7cwrjtauqh6zwjd0zdaqg700dm42p5ja2a5fam9smnhn6t7qdek9jy",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1546pd7p449kej7rk2zgphxuymrqf90rlxu9tylyv0uf6dva4srfslhhu47",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra15qleygegrst8wke88m3fqzrsc7c6a45yqnqjlz64xqm94wd9zjaqw0z3an",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra15zsd9j5c3rzw5em6wqvzveek7cqx0ac3s2hzmee8qsdy37vwv7aq8w0fce",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1623wrqxv80s7tcg2ugp63tvygp58j6d4h0tuf8xewxmzv2gmrk5qze554q",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra164caf0wq3xl6fzpn2ek0ermwj3hyznr5dc7d920xsmq99h6auptq0jqujc",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra168nvfltz6z6dt3y8c38zr76p7hx2as32vwgy5hju7atcl7krxacq7yjsm8",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra16n6w0crnx7jskql6hgd2jg0tcafj60kwgp9k7nmpnfyt6j5dju3su923y7",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra17a5n5ln6zflcf23sf34va7ptes3u03vhftza47shqlfd2z04t75q3gkq6n",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra17d9vyjcnpn752dzxvgxn6lm28rn54p5t603q3t97dn5v92lyujlscdvqzj",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra17j6erkccpazwmzklkne96mf4kqwzs93mjxeqx7whxqmt4ha507pqe0a77t",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra17yzdugtznvecr5f7xhf9ralg0gg9l0pah9f6lhhv0xtwkj4aajks47cwtf",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra188ql9msm2g7r4lhm778w2gc5qfss8l4qtv235sz6wyslctmzmn4shg7k8e",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra188qt3hm9d3e50303hk04s4q9grfelfku74df7u5hpgrwgh2hhgeqhvj9t7",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra18cm52mt0c37yz7vutht0fvq37kkr8wgkvkwl6jn4kwx8uaa77d2qpa8ewd",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra18lteke6cy5t8dmc7ndzaj7mkp42acwplsm5f7vq3xmen360s2qxqafmvlf",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1924amcpgxksj7sz296kysxzn8u8lq8l0gvpnyrlx8pp42ryv00gq6k76ag",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19522js50q7gql2fcavcu2emw32lh6v4exypz0h3sm62hl37hmdgqjd69yp",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19664tmugwklf9z72f0nh3jjudzw0vfzjf4gmvttuppl60k9pvarswcmvj6",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra197fuwr564m6efgxdvau5j7j4nn0l8lau5qjcdzpv5cufzjzyjvgshcyd8x",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19evfm7pk6hxth52eq7949dddm64ug9u5xnpggpwg4nlfesahqdhqslrhtz",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19w83ezwxxc4qthcx2skfzre3qtamxzuhd3jj4r7h07c3rx4y9zlqnq9zw6",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1a05hpaqh4h5mkt9nnfpql7m0kjs2972pm0t4t88ezxgenp0xlg8sqfeeru",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1a2sfcfjvqh5hzstzek4flqmj2rcsn9dxgy7dfn3qalmajsuexmssvfdtfc",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1c7th2fkvtvsgy4w083nkzarmjayy4eqdn3qvagpa7sj723fvxprsf7yzgh",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ccrhywcdxwlkhgv74eu8mdmd32vawc3lt9htz4pvy4hv7p4xlewqteunm6",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1crp926elm6g765272tt6ky53k77klq9pvfyacupw3mjzc0d0pk9sxpphpf",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1cv2n08ak4vyywxuzu4sshp9vrwkddmjh6sf9lun9dyf37rtn3llsnd6rej",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1cv9cp72zx7mawt3vgct2x0vhsjp59uf9m007zz8rz9m4zxn6n8lsvvnudp",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1d569vm9mlka059qh8wr99gkt0zdrwrfgnsq3e0ms2nrjzk4pv97scuphsj",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1d8cyqqf958ztmtfm5zdak93j3ymj00xe3l5k47zhgjypykkku67q9epza8",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1dmvcpkkgeuf2n3zy26sfc8l7yhz2tydvhvz9ywa8mwjct6nj9yqqdhcs5h",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1edly287ft06dwp6atdd9528adg4kavfwrqutpyzq0pax499d6whqejghcj",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1et08h5f3kjmles2za0vrhf703pnq2958kjx83z6n2asqgs7zw33s6je5ha",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1etperyw4cne44rfzqz2d76cj9j6hg8gha68ag4uwwffx7qk355dsf7cqsy",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1f29qttj2d62adht0ay89fkxd79rmd538v4f3svdean2ftgr074jqurt6u8",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1f4hv5xl2h5lqwrjvlnsp4zhwtxc364l5w43qryxatv5de23xvmnqje4ck7",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1f754ns6leagk42dkexk6drsxkas2j0zsfsww7yumhuvzs6w9yx2qm3g3kk",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ffcttu9lxc0w2qqhavlchq824zswcnrva4vn4twclj7vpqwdtakqeg6sf2",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1fsdcnggcq05yvt4s6crkkn6yuv92qy6fv7vxwg3h5fm2tvj8rnzq8s6te8",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1fwf47kuhyvtzzm6l9sf7cwvk9lteed7g4fz63x4j26edquurc67q2kyx0u",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1h45p9vdfvv53f2pwne3apd8dw2yf6azqep766hw7rhlcem3t6x0spgmkmx",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1h8xhl9c5x78xnunag5chvlq4frs69t8l2a6tphu7txe23cryw6ps0zd0z2",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1hvmuxay55jngk94s3fcehktnu944ld0nt50phlpm39d77p3pw9wsq3rd95",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1hx08r5dt75txlyk9xcqwyga8zrnfhczcgkn9k6tg2sueadqkrn3sffdegg",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1hz8x8zkuerf3kjqqwv7ftvf6nm7ya6gkm78tquslzjkw6nznpf6qjdess2",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1jetsdecxkel6taay6hw34w7qkgp855mp496ks8hpv7uy9n8n8sussw05st",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1k3wvnmy6fwsqeguvtnta8guvaq2npmhr360mwucq9g9v3gc55nfqg726mt",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1k56kqqmnclet6lvk7mnrm2wpuey429ztlleg789alh3cvpyu6xtsars0cs",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1km4849s0a3vx7alp42ukd3psyxjhs6umwcx76rvcrrthznaftfhstl7p3z",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1kngra82083kv7n39ku4lhwlwwugxavh38fp44xyr99vftjg8502s8hm0k5",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1kt32q3539f0hgurekuda2yq6u2he9py4j3yv3663veqsyvc79uusje9c80",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ktru8mwg7q6ztuvy8906m2w8gj08fwerv38h20mm9gs53tx38uesf4hyzr",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1kymjy4xjsppjv0qd2xxj9cyx626w5ddgcsqkr29qshn7dfdmdghqll9pvr",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1l4cz9ak9rzjpra8tjqpsp2z4k3qguyccr40hej8uypcawp9sawys4yqjl9",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1lhdmrqq8gtfx3sxgvhnkcnkcsuw44mzqjhaa6r6pwjrhpvkguuuskjfz39",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1m2g4y2hs9almn7dayhu7mfk45xnhygpw9cckrywke3f9ucr2t83qq44gae",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1m9cg0gf5axy27pc4dcagejflsnve3c8y5vfuhdljl8kqflecckaqfgzr2c",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1mys8yflclfsg4jlzfwm60alwkjgq2hxq2n78ku5secx2g9hy2l4qc0gpsh",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1newq5r75d2seee7jh34h5g7r7puws66erxkdck62zkj27mn67x4qdejr0h",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1np06dk3p979t9qvu733r4v753zysev4c6jpl62r3n6e8dyea8q3qy3r5na",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1nrvntz7dp6xazrq94h4p6ugv5qqz4txqpk69ysaha4st2f3nwwkqw0j2jd",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1nz6rquzm8lxsp8tu834aq9ttegv80ru2gcls9lktvra5lrput8mst5ayyn",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1p0vnl6gns5wgjjjtqweszjwjuvnptlleztfp79lg4r7agkwgxt8qgey572",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1paqr8p29tazlvt25yhj4c9mnz5g7mj93svnwqeyjewkfz8nruwzsgcdk0z",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1pl9mq3zzk8fxjkjany0p2ewv9u40w6aggpu8m5kgqae3c7ynppgq2tjxjq",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1pulvlgx7cp4l3u4w35kux8sg9zn25n3xzn5cqvcvhkvy5nx0n7vspj3n4w",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1q3p4x32wqy7gyp347wktfxw42we4tdjuped0kuqfvvl07kgygh3s0v8nxn",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1qc2sa5a5rv7rd5jt6rdwy8tgfdh7xsv6dtrldnnkzk5rswk57zeslvxfxp",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1qdsjtafetdr83t97xjgewm6m6ddekjagfvhzsa5fp9mvc82892ds655chn",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1qghmdv9tmm575l6n9mmpp56m5ppyndve5apvj4fnz875yvf7ft0qynlppp",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1qxef85xd7dzqhyll3j0u6686ugvv0x9fke76rpcphyr680ls2c5qnx44ss",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1r4e3jexudvu72n9mxyjuvwedn03r6epjpankmkml44mktx5nvu9satrfd4",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1rajev0zks98jq2rw9jk0vy06nxv8eja564sxrw9fq7c2rvjw66ysrkex4l",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1rgffrrprdyuyjegz262pyz8sy2wd4u5jrza8wf37e7whgcdkq9tqf4n4sq",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1rvtgvc38sfd9zehtgsp3eh8k269naq949u5qdcqm3x35mjg2uctqp7f0yg",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1s9um3sdm0exu9yse43h3wh0zqngd9pg5dqa54pj76ea96uynfcrs5g97nm",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1sc23f03xe60m83jtkghsksapwlppjw65rlzpmvylkn8puhkrpessjlqupn",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1swggew3xu60py79d065zm4aqevt9sujgu06pm2ee64zw8yg7lzzqp4zlfz",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1t45w99d4te55es7lmw9kfmcc2y7549eg9vdfs9veec6zy54ehyzq7ja76l",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1tj89edfq20tdjay4q8aleqkus50lkd3evud82mc4l8lchy0qhh3qhldwvj",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1tm4xanlzde3uye0q5w4zwanpuk6fcr0vupkd7n3n2g7ctur5dres8zp7sv",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1tu3h0sa8s3tveyz8zkyzd9kras2s30qsumanwn5074zwj32qdeuqka5x95",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1tutagjumy6u40v0twxsuh5wsnwfpfwfju4lzw25w24hft3wm83xq72tzpk",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1uuhtyv2lqt95ml6krz824rnkrgt20lu8t5jw8dcl2vsmq49xwqpsn3zmzv",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ux3ku7uv7urkm7gvf2l8557208ewu0sr6gw6688dsm59jk80hgvqzy7fpd",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1uy440n36h8mhhm4kgljzcm0m9crayv9qym5844vm5n00yp63vcms6th2xj",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1vh6u6e7pjlt90lz8v9mtgm58jl4tw8s3mvtns0q2f4e2v26y37ns9ez8xc",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1wdacaf4y9h20k6zq0gfgctxeakkpjlntg8afklnny3dlfrujw4wqryrds3",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1wf5xh4qggdgjd7qkrkyemdflclu8gtjehuqtd0wgdj39pt6dc9wq4xjysr",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1wgp70lydsl4npqcd896d5pfzmdtt6p978ufmcfvwmezeu97leals83mx6u",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1wgq575juumk5fz2vrrrcf3drx7nk0d2t4lj7jrt6g95emsvdz6rs0fteay",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1wr9tck0efj5vkys2m9v6a7a0vayjzyqmv5zruy4hwep48a7r86ws3sq97f",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1wrsdfjyykd3laekus6umln5zy4y0xwgfrzypucn26epaszdaa0msarh9rx",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1x6t9p76dt0qgnz9c84lxg588hvkmkwcug3w6rg8vjmfff3jvj3zq8hyqa9",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1xex8hxw7zq0n02mc627trtrck887yc8jzpeaqhmnn08gjuug8h3qj93nd2",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1xuhyuwjxqk38gsd7cdsa0c7pqeswu3r8ua3epa30j7avdecte80qrqr9c6",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1xwuyf0eth3hvtdfmntgy6t6mj5tggswj4k7ev6dewqf4fa3qwwds3ryhrs",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1y3wr927vujk5037768w43mfm5g8wyp7e5nqyswvmyxkdkr94zpeqtnltvq",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1y6mwa3qy5374ueslr62da4nkt6pqfzv672x0yfm3tsvupye73zfsat37nc",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1z7hxqnd74r6syx3uuxrtvg4a04qzct64pqm2g7ayezrkhq37tl2s2rhu90",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1zqjzzuyrrhqdhrp8y9nt97yle2uvynvphu7wqr9juk0pqjrtzmps7a7hmr",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ztcgnl9fsmk5kw8n3rygvpjkwznmqxh7ec92ydgpeet0kehgsknq733gxc",
+    "name": "Portfolio",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1rwqs9stqn9704hpynza5sgxzs6yqrtn9j25chrrhlheeesw95egszgjvlw",
+    "name": "PPT (Wormhole)",
+    "symbol": "PPT",
+    "decimals": "6"
+  },
+  {
     "id": "terra133r6snp000sw0qhuspkua39fjc4c6pux82cnxh",
     "name": "Pre TGE SAYVE Token",
     "symbol": "PSAYVE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pfnex5dy7wvz2kd26t44t5lzlryg05reskjy5rem8xj6fvdmqwuqvzde7a",
+    "name": "Princess Rockettes",
+    "symbol": "Prin",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1zy2vjzwrc5j3evkkhagstewqxjlsk4vjs04u9q6g2umzw6nkt0sq6y32s0",
+    "name": "Princess Rockettes",
+    "symbol": "Prin",
+    "decimals": "0"
+  },
+  {
+    "id": "terra12jz8a0eaqvwp3w3qc5v7zdr7az25e7xr5z3gxmqcsnns9pkl4a2qjed4f3",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12nlllhjz3s308gazwss9pst0aq63n9uuenw3usup5kffv572jhmq6zmgc3",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15p408hyj9mge2dwsgevvakssjuawdpuqhzeg8cdf7df0a2ndvf7q56zytz",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1aw3pwzqf8l4gnkdelynump5pv8y4frayucpzxdlt2cy5djylfu4s6z9tsg",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1efkg3msnu9nhvwp7t33fqw4309gyn6fzlt2fz7v6jk5ra5qwhewspe7s4h",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f7qn0jk6sg7275hq6dx74fjlcxm323y5yfyq5ewn8scd6uszf6psxgzwfv",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1g3kkzyl57ww3c0pu82n9ayz3pa3hrgvfnlg97t7lhsze5rgslp2sycxwcq",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gjvtunfr4zep4t043grh87cunxzry5wa4c2a4dldcztyat3g7y5qz6a4ds",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hrxrkslv9d4eu4suq33vndrn8flnyhs32qhy7plzugn2zgqmr4kqw4npe3",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hxg704fdvm5wm9re3tuvhjryqv3mte6hpep4eh643chge7cqjmdqk0hh4j",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jr28yjhpm6fqwgd8f972smcxpg0jk9zvxuwc7wskfet9mk28kldsncqpjg",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1knwcergcxqyxlwqr6guyc6luaha5smn3vuljunrf3xr9trqe06msvudm7r",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1kzj8ep2tttwf9a08fmpk40dey9h6f0ygu75ltew5ky44chvn8pmqp2px0q",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lactake5rh3rnael696ha2fu7tm9us8jmgt4skaja9uy8u0djg7svxx366",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1n7xs7hc7j2hxy9a9m7y0y54qgc2vyukv9wg0xpfftjwlmvvhk33sklc6za",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rvdm2esamrsvx6ad3ldzlku8v0h5j9xc0dpguwr4vct9qh6nssjqfp779h",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1unyw7mtg36jhsxyf234ks36xfz6r7g787h4hul5z9aekrrrs7ghq08wvmr",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ux08rv849xtyacwagr29k2m68n4fela54q5pkwveusa2cp9hma7q4lhsjs",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vxpuaymecjk2473mapryd0lnr5jaf9uvercrpfwufdunmvs4n0hq2xnp97",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z7jgpvhhga8t737ed4qk55s7k92gf3fdmwa4vwjnerec3aa96j9s5ql2wc",
+    "name": "principal",
+    "symbol": "pToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zq0gmevf5ty5aggasm72c70klkcj8g63y2yhjayydeqhwmhefcus9675aq",
+    "name": "principal",
+    "symbol": "pToken",
     "decimals": "6"
   },
   {
@@ -4038,22 +10415,6 @@
     "decimals": "6"
   },
   {
-    "id": "terra19cmt6vzvhnnnfsmccaaxzy2uaj06zjktu6yzjx",
-    "name": "ProShares VIX Short-Term Futures ETF",
-    "symbol": "mVIXY",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra19cmt6vzvhnnnfsmccaaxzy2uaj06zjktu6yzjx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/VIXY.png"
-  },
-  {
-    "id": "terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45",
-    "name": "ProShares VIX Short-Term Futures ETF (Delisted)",
-    "symbol": "mVIXY",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/VIXY.png"
-  },
-  {
     "id": "terra128pe5jpempxu0nws5lw28se9zknhsr78626cpn",
     "name": "pStake Bonded ATOM (Wormhole)",
     "symbol": "webATOM",
@@ -4124,10 +10485,46 @@
     "decimals": "6"
   },
   {
+    "id": "terra1ykxe98arwtahe97h9y5nck8gw88kxn2z73gfwlnx5twcd96ct98sqzcsrk",
+    "name": "Pylon MINE Token",
+    "symbol": "MINE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wpmnfxlysju3pq7plc0qljqwyztlh7g0jqdvh3xsy7tt94vg8zjs8tzfcd",
+    "name": "Pylon MINE Token (Wormhole)",
+    "symbol": "MINE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lunpxecglpu5w4pr5xkx9rzyprxktdwwdcd6puxa0zfx6muqsfrqdhjww2",
+    "name": "Rainbow Rockets",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1sf2fftvjt4z75g4rshngdxn5fr6qsccl78fgsz52fefwemxzvmaqptdfnp",
+    "name": "RameNFT",
+    "symbol": "n/a",
+    "decimals": "0"
+  },
+  {
     "id": "terra158gqaxafjche7vtew0f4zk9g80224qr07kwfsk",
     "name": "RandomEarth",
     "symbol": "rEarth",
     "decimals": "6"
+  },
+  {
+    "id": "terra1sn99ks9lgpmj6lqq9za7fu2s00063hy69rqux9cahtzlkvayx2cqzz48dc",
+    "name": "RandomEarth Social",
+    "symbol": "RE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1a8lnalg78u8zdcshjg27qnxma6hr3umxf2cuy253u97p3c4kc7rqxewc5y",
+    "name": "Rare Experience",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1ht5sepn28z999jx33sdduuxm9acthad507jg9q",
@@ -4157,6 +10554,48 @@
     "icon": "https://reactor.money/assets/logo.svg"
   },
   {
+    "id": "terra188vepzwkt623tcuh6p73khm6fuwz0ez89e68jnzzhzpyucal6ens5ccfss",
+    "name": "Real",
+    "symbol": "REAL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hcv8pl2vtakegf2fd2vvc0j3fsl0p0ur46w8jc897kvp8zmz8hzq5yzkez",
+    "name": "Real",
+    "symbol": "REAL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pem93fgdkmt7vvlrnnjseru69qmfqpkmwg8smeacg69fmfgplcvqgq43d4",
+    "name": "Real",
+    "symbol": "REAL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qrgn84zf993s84kyhfsyhhspz4a5alea75pc0tfk07hyy26nvn6qe2hak5",
+    "name": "Real",
+    "symbol": "REAL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gpvpy8qn8xmwmjg2zhs9504y7ptdz9mhk9pdm6pmvjd6egterkrs0as5z9",
+    "name": "Red",
+    "symbol": "RED",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ph3zz8lq842kc0vt634f67qrz8hred0cn9duuufzhlk7a0sh33xsp7wldf",
+    "name": "Red",
+    "symbol": "RED",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hh9rgaxtmfqfkeqkruckwah6qc4ajlxgnweexyjeh4dsptkfnhmqeelzfl",
+    "name": "Redacted | RONINs",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra1tdc7hmydg3es6lmn2asfwfgs8ykq7xa0nz9rkh",
     "name": "Refinable",
     "symbol": "Fine",
@@ -4166,6 +10605,12 @@
     "id": "terra19cnnyaah7c32hhcdt5m83pvdxa7ts64caarcm8",
     "name": "REKT",
     "symbol": "REKT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15wsew96nut3ckfqkynxjhmfkm67hxnzndmtzfragl46prgh9k6vse6lllu",
+    "name": "renLUNA (Wormhole)",
+    "symbol": "renLUNA",
     "decimals": "6"
   },
   {
@@ -4193,6 +10638,12 @@
     "name": "Rewards Bunny",
     "symbol": "BUNNY",
     "decimals": "6"
+  },
+  {
+    "id": "terra14dwdssqhd9wlezr9tnyn2vktlk7f96n0wmdf3p6etj029fst7qxshcrsde",
+    "name": "Riri Cool Club (RCC)",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1cdg2m5swqzatvzuvseef9xcxpwqylx2h983hm4",
@@ -4247,6 +10698,24 @@
     "decimals": "6"
   },
   {
+    "id": "terra1lyz4sm8vgu4c9f9hxcv6enzpx0kxct827s4x7t2vc8n6djfw9geq9l5z4w",
+    "name": "Robonomix Series",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
+    "id": "terra10tc799vxuwwdmy2hxchf6cl4n2qhed3wdhpv6kj7xfzhnsucsd5q8su39g",
+    "name": "Rockettes",
+    "symbol": "Rock",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ulsw8hclj4quxzq8yut0uq3cq5wrvgz99fwvx4txdz25afzhjcpq3tgphp",
+    "name": "Rockettes",
+    "symbol": "Rock",
+    "decimals": "0"
+  },
+  {
     "id": "terra1mz858mn7jeglmzj0ay8z5zy6v78fvv7em9tljz",
     "name": "RockOnTerra",
     "symbol": "ROCK",
@@ -4257,6 +10726,12 @@
     "name": "ROI Token",
     "symbol": "ROI",
     "decimals": "8"
+  },
+  {
+    "id": "terra17m4n3s8fj8g56aukpeneu6vyq6zj3u8alenv388ctjekyv6mzcwqt8kxrk",
+    "name": "Royal Token Society ",
+    "symbol": "RYLS",
+    "decimals": "6"
   },
   {
     "id": "terra17h82zsq6q8x5tsgm5ugcx4gytw3axguvzt4pkc",
@@ -4303,6 +10778,12 @@
     "decimals": "3"
   },
   {
+    "id": "terra1987ddrcpwgwrpkxw44l73lgzhuldxmt7ue9nj9e5c5rm3w9pmx6qaqwvrv",
+    "name": "Sandy Chuchat Collection",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra1lchkxy5ednukxepwxejak8xevqlmz89ukjh6hl",
     "name": "Santas Big Sack",
     "symbol": "SBS",
@@ -4324,6 +10805,48 @@
     "id": "terra1pduqn0tpqce36ndwcv6z6xjlnujdddl6pedz9y",
     "name": "Satoshi Nakamoto Token",
     "symbol": "SATOSHI",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1x599eytp94hky39qardrpnc4qjrcplqlc6u6vh7pugk2s6nqqghq97qlc5",
+    "name": "SAYV-ASTR-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra138k8ca3rn28zgek2ljdtwhzaqmtekazvrgl9yp07prtvlws2ygqq8sdgq3",
+    "name": "SAYV-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1l3r2z220fs6hfz8var4ms8w0tlxhw7aqdulslvgz9ur9g3g7mn9qd9mptr",
+    "name": "SAYV-IBC/-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1w3vxxyvrq909w8nqrxypaeazqtt3ldyy3ucre3jwz23nyznnd3eql5hymn",
+    "name": "SAYV-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zqthrqndchxp5ye443zdulhhh2938uak78q4ztthfrnkfltpgrpsu3c5xd",
+    "name": "SAYV-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q5y5kyacmmq3p32khe8y7qrumawyfqq0tnxjw4afl8mmedqra96q0jt425",
+    "name": "SAYV-XSAY-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1w8ru4dhgsf8sx6f74vp60nf0k07a2aw4vj9qz350cttukthhdhnse760et",
+    "name": "SAYVE Token (Wormhole)",
+    "symbol": "SAYVE",
     "decimals": "6"
   },
   {
@@ -4388,6 +10911,13 @@
     "icon": "https://assets.terra.money/icon/60/SGT.png"
   },
   {
+    "id": "terra1cpluvvuswx6fj0cx98ex6rpds3rjr024vq5eng",
+    "name": "SHARD Token",
+    "symbol": "SHARD",
+    "decimals": "6",
+    "icon": "https://static.wixstatic.com/media/4079cf_14c37331c6a4485591bc6130a37c31a0~mv2.png"
+  },
+  {
     "id": "terra1gxztmp6dlu8xv8kdlty6259gl845mw53gakw9t",
     "name": "SHEISMINE",
     "symbol": "HER",
@@ -4449,6 +10979,24 @@
     "decimals": "6"
   },
   {
+    "id": "terra1ytu6fskvcdsuzj48l42nwah72y0g8pughgamlt5k8786aslq6vrqnxq56k",
+    "name": "Sirmagiste NFT",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19899s4dtmr7ug7wgqdwtlu04u9863lnuur64u0ev30x6p4rjylpqu7dz9s",
+    "name": "Skeleton Punks",
+    "symbol": "SP",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1x7rf4nquswmmrjtzlxg6dk3d70ef69prth2q7vk3v9vdprepdh0sjxrvl7",
+    "name": "Skeleton Punks",
+    "symbol": "SP",
+    "decimals": "0"
+  },
+  {
     "id": "terra1jz9plajrq6knks3vgv9px4ezwshzaxsr2xz7jn",
     "name": "SMART TERRA",
     "symbol": "SMRT",
@@ -4479,6 +11027,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra16thequeddc2jc2pcc8xpsyng5lexqwx45ch6yvngs0e3qxtmc7yqv0t6h0",
+    "name": "soil-test",
+    "symbol": "SOIL",
+    "decimals": "0"
+  },
+  {
     "id": "terra1rl0cpwgtwl4utnaynugevdje37fnmsea7rv4uu",
     "name": "SolanaSail Governance Token V2",
     "symbol": "whgSAIL",
@@ -4489,6 +11043,18 @@
     "id": "terra1ejmg85y0vgsxv5r3cd4024j732pqnwudl0v2d2",
     "name": "SolChicks",
     "symbol": "CHICKS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14jq0tvadkw3sd9yh8wqs5gdygek7cjn5kkp8htychwz4g7ygcassqcr2h2",
+    "name": "Solid",
+    "symbol": "SOLID",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ksrvpykmhyj9ka3qv4hsd5hecu22cxwzdk8wqvufhcrmnjl8nhaq2443jl",
+    "name": "solUST (Wormhole)",
+    "symbol": "solUST",
     "decimals": "6"
   },
   {
@@ -4504,11 +11070,29 @@
     "decimals": "6"
   },
   {
+    "id": "terra1v765xt7pdpzcr8v9ffpqw0nk2e4776yqtnhgsnuvguhhenrkv9yqfumtem",
+    "name": "SominGaze",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
     "id": "terra1689ys6p6gfu0q6xrjqkzfn80sdyhurjqn0jfdl",
     "name": "Sooah Studio Token",
     "symbol": "SST",
     "decimals": "6",
     "icon": "https://sooahphoto.co.kr/icon/logo.png"
+  },
+  {
+    "id": "terra1rhjm54rh2d58wwrj5gep0xa4vf2uakvqe4e3se7vr7gakwhljrysxhne6n",
+    "name": "Source",
+    "symbol": "SRC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1asuk3yas2rtlfdukfj80lguaghy6ad47fq6n7d45q5my826en7kqgn2jng",
+    "name": "Space Birds ",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1l0y8yg0s86x299nqw0p6fhh7ngex3r4phtjeuq",
@@ -4538,18 +11122,94 @@
     "decimals": "3"
   },
   {
+    "id": "terra16f3l8cq99qenutzzuctp2lnghnz72yduxc7yc9cfwkec4n4rsclslyqnsy",
+    "name": "Space Pizza",
+    "symbol": "SPZ",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vn0qwkp9l53q73ajsrnexdw97ekzscexh2q5rduk2kajqrvzwtkqj4nc08",
+    "name": "Space Toadz",
+    "symbol": "TOAD",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1w2hzqaxdrdqn6wvk3ha5qwy2hxz7xevth6m505mv7y6xjjyu4qmqvrs6zu",
+    "name": "Space Traveler",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1nuxaxnpmu2dm9zt69egmzdyck03r8r8luyp0qg96yada9lpru9kq0zwss6",
+    "name": "Spaceloot",
+    "symbol": "SL",
+    "decimals": "0"
+  },
+  {
     "id": "terra12wlcu0kgdfrfutjydvvcmhlx8jrfsqhwqarc3d",
     "name": "SPAR Finance",
     "symbol": "SPAR",
     "decimals": "6"
   },
   {
-    "id": "terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc",
-    "name": "SPDR S&P 500",
-    "symbol": "mSPY",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/SPY.png"
+    "id": "terra1gxqzjk4pkyzpnxnrz7h486vntvv4lmaukcs24v9gcsmcm4tyre7qytcm5e",
+    "name": "Spectrum Astroport ampLUNA-LUNA LP cToken",
+    "symbol": "clpAmpLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra144mkz6p3mmnuqaenu73pg4jwayr3m28xzhaxedlfwfnyke45w6yqvf9ed6",
+    "name": "Spectrum Astroport ASTRO-axlUSDC LP cToken",
+    "symbol": "clpAstroUsdc",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ufpsjrvj5fkvdedx2ttslnrc2wxvrftf4zcsvu778cufvlh4m9dsmgcf6f",
+    "name": "Spectrum Astroport axlUSDC-axlUSDT LP cToken",
+    "symbol": "clpUsdcUsdt",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1erm54gtdtfqv2s4c7ple3kmret7eecuj02nk5w8h08jjnenjffzsynsp0u",
+    "name": "Spectrum Astroport axlUSDC-LUNA LP cToken",
+    "symbol": "clpUsdcLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1w6l7kjc6wu7an37wnnehcfc3tpksw9tde9u67743ew0caly0hdasv0ws79",
+    "name": "Spectrum Astroport bLUNA-LUNA LP cToken",
+    "symbol": "clpbLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qczgczguzmxpsqfwlcaqm5hpy3jrkgrkkkcdxhd4uf28t8l8j6qsgtd863",
+    "name": "Spectrum Astroport LunaX-LUNA LP cToken",
+    "symbol": "clpLunaX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1j9ggd8wf73ggsfet99wnjvn06f3l9w9lsf50uac43h6vclysfc9sp0nyfh",
+    "name": "Spectrum Astroport RED-LUNA LP cToken",
+    "symbol": "clpRedLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v9luz2r9u8mzd4w8ew5dm4cczk8kcxun4jry464j48jsl2fus2qss73ld4",
+    "name": "Spectrum Astroport SAYVE-LUNA LP cToken",
+    "symbol": "clpSayveLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1udwqynsmrme00ksrakkyerrfjdkw9p05557yrrw6ca6x94uuj2zs0vpqt2",
+    "name": "Spectrum Astroport TPT-LUNA LP cToken",
+    "symbol": "clpTptLuna",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ha4yvzqnq4mpu205wcd430m6m7wjklpquwn87dq89g9zersuvryses7rua",
+    "name": "Spectrum Astroport VKR-axlUSDC LP cToken",
+    "symbol": "clpVkrUsdc",
+    "decimals": "6"
   },
   {
     "id": "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr",
@@ -4572,12 +11232,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra1u43zu5amjlsgty5j64445fr9yglhm53m576ugh",
-    "name": "Square, Inc.",
-    "symbol": "mSQ",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1u43zu5amjlsgty5j64445fr9yglhm53m576ugh/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/SQ.png"
+    "id": "terra1jsd4c0nkchn6mdqamcduuc3kqrtfjjmta9f9vkjj0pqu2q3vpykqr5sdx0",
+    "name": "Spike's World",
+    "symbol": "SPIKE",
+    "decimals": "8"
   },
   {
     "id": "terra16gnk7mpqr84f4mnmqjklpdxxe602dn0fjslwhy",
@@ -4658,9 +11316,63 @@
     "decimals": "6"
   },
   {
+    "id": "terra1nu0c3s69umqz862ltp6wytuztm0rrn6w5079g999u0hvwy62tf3q02qhmr",
+    "name": "StableDao",
+    "symbol": "SDO",
+    "decimals": "6"
+  },
+  {
     "id": "terra143dkyw98s3ksxu97zln8z5s220ytatygd5rqdx",
     "name": "Stader Labs",
     "symbol": "LABS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra129gzxm65ckt7p9tp3rnq8q0zvaz6m48e5l7qpxtmy2s3fnhcjd0sag3tm3",
+    "name": "Stader LunaX Token",
+    "symbol": "LunaX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1s2lr8u69xammmg3s8hemegcz57y07ae0wa7c7d2adupp6du3neyqfukkaz",
+    "name": "Stader LunaX Token",
+    "symbol": "LunaX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pu5gewue3s70u0pgzsza9asfjhkgt5trkzd7xyd2gyrrdqmumensyn8qy4",
+    "name": "Stader LunaX Token (Wormhole)",
+    "symbol": "LunaX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1j8uqz4d48x5t5sf5tgfv7wtt2uvl7jsrr2ayftxpfy5shkjv793s5qqpsa",
+    "name": "Stader LunaX Token (Wormhole) (Wormhole)",
+    "symbol": "LunaX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ek4upyl20z7ah4xk3mpfgczkxrn9nrqme9njtszht50vwkqyt6cqvchxet",
+    "name": "Stader Token",
+    "symbol": "SDToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f8p6yc7he3393y8rrpqp3syev5dnqd56kzepx6f36yt7zydghnequtkztf",
+    "name": "Stader Token",
+    "symbol": "SDToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1twakgfn5ch4qefp4xzu3met26ae2rhcd9t8tj7hujry4n50xtw0qhzpjw3",
+    "name": "Stader Token",
+    "symbol": "SDToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zfx0wkel6sffhu8f9mrcfxs830cauvkqd6x2aqy6szlxlrx658lsasenss",
+    "name": "Stader Token",
+    "symbol": "SDToken",
     "decimals": "6"
   },
   {
@@ -4698,12 +11410,28 @@
     "decimals": "6"
   },
   {
-    "id": "terra1246zy658dfgtausf0c4a6ly8sc2e285q4kxqga",
-    "name": "Starbucks Corporation",
+    "id": "terra1eygp4ps44jnch66r5sm60ky5l3mc9vl2s7qd5g9m9at0mggzwzssy4j5yg",
+    "name": "Starbucks Corporation (Wormhole)",
     "symbol": "mSBUX",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1246zy658dfgtausf0c4a6ly8sc2e285q4kxqga/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/SBUX.png"
+    "decimals": "6"
+  },
+  {
+    "id": "terra10c8y69yylnlwrhu32ralf08ekladhfknfqrjsy9yqc9ml8mlxpqq6esfh0",
+    "name": "Starbucks Corporation (Wormhole) (Wormhole)",
+    "symbol": "mSBUX",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z2wr8jmxmpe8x3j25rl8360pfl4w9p3ry3dpss90yuek4je4wgxqefg56f",
+    "name": "STARDUST UST",
+    "symbol": "DUST",
+    "decimals": "2"
+  },
+  {
+    "id": "terra1mtsce8d3hyds76366lrdf3aplakxlzjnal2hwmxmg88fpu9ashpqzjx6j0",
+    "name": "StardustEvents",
+    "symbol": "STDEVNTS",
+    "decimals": "0"
   },
   {
     "id": "terra13xujxcrc9dqft4p9a8ls0w3j0xnzm6y2uvve8n",
@@ -4714,9 +11442,57 @@
     "icon": "https://starterra.io/assets/100x100_starterra.png"
   },
   {
+    "id": "terra1qqw2vlmlr0gempsdytwujq67yusscwpxmry5jevdf05wfwcw5jkszp0r5f",
+    "name": "StarTerra Token (Wormhole)",
+    "symbol": "STT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1emm9kdgdznjy37gyw6883m62fg8d3kke26c8n34n6yz2v9fwvm9sq3sqkp",
+    "name": "STEA-SOL-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra175232yuat84jr5yx74mtz243egyyp904l9n69fvdzzkplhru5juqlv8ah6",
+    "name": "Steady test",
+    "symbol": "STDYTEST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra12y8dapy6zvwkxhnxgxf2jnmrr9qqhdc8dh6ez0cj4eywms695zrskyltgd",
+    "name": "SteadyLads",
+    "symbol": "SteadyLads",
+    "decimals": "6"
+  },
+  {
+    "id": "terra188dgygh5qzkc06afamst7sjfrcw2xt4rkr6m3j69f88cnkw4jfqqy9ymrg",
+    "name": "Steak Token",
+    "symbol": "STEAK",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ud6n3r3tczvmw9jg05jy0rw70z6362hrm6q0gzf0zjgg3xc0wv7qfw3vle",
+    "name": "Steak Token",
+    "symbol": "STEAK",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14z3laya7z6883np60l3wu6075s75xakm3kpuqr4w5ezeknuxj9fqmemmtg",
+    "name": "Steak Token (Wormhole)",
+    "symbol": "STEAK",
+    "decimals": "6"
+  },
+  {
     "id": "terra146fhkmq8d7ae3e6jemufy4h5eq9zerftm8wzmt",
     "name": "Stest",
     "symbol": "Stest",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qpa5u2mwycsku0deum3a0jk8jsselv80xyqnpa5zw0agcumgw0jsuvm48w",
+    "name": "STT (Wormhole)",
+    "symbol": "STT",
     "decimals": "6"
   },
   {
@@ -4782,6 +11558,12 @@
     "icon": "https://app.astroport.fi/tokens/kUST.svg"
   },
   {
+    "id": "terra1vrh8y6aa3v99ttpsfxdawluf8n77m3c6prxmq0dtlmtqdeah364qjzpds5",
+    "name": "T",
+    "symbol": "V",
+    "decimals": "0"
+  },
+  {
     "id": "terra10vvl9llw4p7ca2zhmcdljk5el9fkpp9hg6qy53",
     "name": "t.me/BabyTerran",
     "symbol": "BBT",
@@ -4812,6 +11594,18 @@
     "decimals": "6"
   },
   {
+    "id": "terra1gwz4m0q6vq6nyunt88vlsf5u3ve0fv3qc40q0mdky58s4fjy4fcsqpkman",
+    "name": "Talis Token",
+    "symbol": "TALIS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1szsttj49zfj2wthsld7a7wd44qnzfwgz05czyyc6yu4c5arrfsashv5rsc",
+    "name": "Talis Token",
+    "symbol": "TALIS",
+    "decimals": "6"
+  },
+  {
     "id": "terra18vl2cypy8pdys2qdqlg7pzmcmpqmur8lmrnk2c",
     "name": "TEGX",
     "symbol": "TEGX",
@@ -4828,6 +11622,24 @@
     "name": "TERRA",
     "symbol": "TERRA",
     "decimals": "6"
+  },
+  {
+    "id": "terra1ugyv3qhdvrpkrd983dd8p70cg6zjparxd3xxqqrennzvxfyf2r9svv83a8",
+    "name": "Terra (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1ddg6eprts4z9ypx92fjtjk2vrnwjn68gqu2lv334dqxq2f42xn2s9he0j2",
+    "name": "Terra 2.0 (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "8"
+  },
+  {
+    "id": "terra10znl5emz4l6qmtr9gq35u0l7rchg8vh2x7wknlgsuzg4azsj6v7q2h0dzl",
+    "name": "Terra Aliens",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra10l407saphqe2tc35ejhzg7xyulqkeqccvvc6uw",
@@ -5040,10 +11852,22 @@
     "decimals": "6"
   },
   {
+    "id": "terra1lfrgu8r4nyplqql7507khmf79efpns7hz9qyruxwy3rcs32w4s3ql00frh",
+    "name": "Terra Launch Pad",
+    "symbol": "TLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra16q2hhuva6u0zakfav0pmrdw2fhjsanvqq9y56t",
     "name": "Terra Launchpad",
     "symbol": "TPAD",
     "decimals": "6"
+  },
+  {
+    "id": "terra10xr7pndwwmq6ua7nmg0ldfxsf29az9fk59w5dtwmgt2vwgdnwj3shc64d4",
+    "name": "Terra Lotto",
+    "symbol": "TLO",
+    "decimals": "0"
   },
   {
     "id": "terra122anargqcp9anz2cmuwc3u5m4nww6fpvyc39tz",
@@ -5063,6 +11887,18 @@
     "symbol": "TMeta",
     "decimals": "6",
     "icon": "https://i.imgur.com/4H10ALI.jpeg"
+  },
+  {
+    "id": "terra1lxjw8retq4waja95e8jrxpqtalt95nj4xm6w2cyljae3vnh45tjs72cl82",
+    "name": "Terra Meta Royals",
+    "symbol": "TMR",
+    "decimals": "0"
+  },
+  {
+    "id": "terra14lzmdzaqw53sgm0lef8agnzck6n68yhmutasdu80w5j49v7kn4eq4c0mj8",
+    "name": "Terra Meta Royals: Golden Tickets",
+    "symbol": "GOLDEN",
+    "decimals": "0"
   },
   {
     "id": "terra1qv98rklgrdv89gvf47rrzx2lzehd43uwz2rus4",
@@ -5147,6 +11983,30 @@
   {
     "id": "terra1xy2gf523j92khfn8nx0uurkmkguul2u95cwv8v",
     "name": "Terra Name Service",
+    "symbol": "TNS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17uwa8ppl9dxqkjvmr7eyusua4af9juxnanpax4h0p2v30spgddqsm7lced",
+    "name": "Terra Name Service (Wormhole)",
+    "symbol": "TNS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qa9mae32y64mn2srmypnr2qjw7x94dqry6wwyej6wxu4ffe9xqtqmakj9e",
+    "name": "Terra Name Service (Wormhole)",
+    "symbol": "TNS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fj4sp69zfyna7xk3yv3pyw787ajs3lr6naarralcfsnyu8fwwcqsxhk2dc",
+    "name": "Terra Name Service (Wormhole) (W (Wormhole)",
+    "symbol": "TNS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1g9h4c3e7tepymhvxec384j2k0yndrufftu27h9q3k4kusdht34yqr8g2kg",
+    "name": "Terra Name Service (Wormhole) (W (Wormhole)",
     "symbol": "TNS",
     "decimals": "6"
   },
@@ -5311,6 +12171,18 @@
     "decimals": "6"
   },
   {
+    "id": "terra1z4lds4txngn5dt74trf4knd9xpxwmwmrhf90ft7es38pc6h0hp6swcdj9c",
+    "name": "terra-luna (Wormhole)",
+    "symbol": "terra-luna",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1sskn97j4jvchgcpsd4a4ev7smueamsesls2qfalja5gxqlvnn0gsdwp292",
+    "name": "Terra2Casinos.com",
+    "symbol": "COIN",
+    "decimals": "6"
+  },
+  {
     "id": "terra1xxze8dty562la0d6g9q3srlddh0qemk08kpgfr",
     "name": "TerraAlpha",
     "symbol": "ALPHA",
@@ -5323,6 +12195,36 @@
     "decimals": "3"
   },
   {
+    "id": "terra15lvw2kczml269rl296y85qnnjxw0zvcns3aucsr87kkfldh6gmks3r6tfa",
+    "name": "TerraBots",
+    "symbol": "BOTS",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1zcafgvq74ef8zu5mc62njfprsf3cr33xvan7r4nja269t280djrqkyrjsx",
+    "name": "TerraBots",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra146ypndztcmmrmyxef7e20cul82gh43vjnw4uacwdvg5sp9kva7sqc9mjav",
+    "name": "TerraDoge",
+    "symbol": "TDOGE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jlzw6xal0n2c580g3wxs09tjhlzdht9y8dgszq3tupf8fhl7xjus30q76r",
+    "name": "TerraDoge",
+    "symbol": "TDOGE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qrwaatac4xvf4qnnagvsc93gcnv2x2t7mm575v3drzh2wcap9has6lcuky",
+    "name": "TerraDoge",
+    "symbol": "TDOGE",
+    "decimals": "0"
+  },
+  {
     "id": "terra1a95wwge5ut59aet6wx9m5ukq0alnxj0waf4sgl",
     "name": "TERRADOGE",
     "symbol": "DOGE",
@@ -5332,6 +12234,12 @@
     "id": "terra1cxvsl5qdvctc537a8q9ynv0seu4r5ceacptwx0",
     "name": "TerraEarth",
     "symbol": "EARTH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1d47r74v2kxezfy3hxchqv5r5d26uyvk2e0k7gx3k9awxwwwsl44s4cesrt",
+    "name": "TerraFloki (Wormhole)",
+    "symbol": "TFLOKI",
     "decimals": "6"
   },
   {
@@ -5423,6 +12331,12 @@
     "icon": "https://terralandio-site.s3.eu-central-1.amazonaws.com/TerraLand-logo-v1c-4x.png"
   },
   {
+    "id": "terra1a2nng5e58drpr2canclarhc9n0g3v6wmrnwvlmmxnwxlxvfhklvqd4kqvp",
+    "name": "TERRALION BITS",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra19y395vzlylv3s3nasr7cu4yey7s22ghqd35ps8",
     "name": "TerraMeme",
     "symbol": "TMEME",
@@ -5435,10 +12349,34 @@
     "decimals": "6"
   },
   {
+    "id": "terra1ghuqnsgn576srmtp5rfk5fd7u60d8urce0usyu6xc3jkesy6hrcqkvrtmh",
+    "name": "TERRAMOON",
+    "symbol": "MOON",
+    "decimals": "6"
+  },
+  {
     "id": "terra1tgfw423t34rwaezm4u4vwy5d80tfgzuyx2s6x0",
     "name": "TerraMoonDoge",
     "symbol": "TMoonDoge",
     "decimals": "6"
+  },
+  {
+    "id": "terra19xcvyg8ezn8f8t2fpatzfsg9kknnm3c3jhz74n2pawfv5g6kqlvspvvkvp",
+    "name": "Terranauts",
+    "symbol": "TRNT",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1lndtteve63vp4xv0wnkzk69ngx8ul2jt2k26a2eqpjkym87cjpksjc5zhj",
+    "name": "Terranauts",
+    "symbol": "TRNT",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1x6yunc975rzyu7gx0f80cjwskky8q9ggw8l9em69hjnhf5yjm2vsl26fvt",
+    "name": "Terranauts Sectors",
+    "symbol": "SCTRS",
+    "decimals": "0"
   },
   {
     "id": "terra15plvf4hfgsrev5athn7wmnqgt6f0lddmduzp90",
@@ -5451,6 +12389,54 @@
     "name": "TerraNFT",
     "symbol": "TNFT",
     "decimals": "3"
+  },
+  {
+    "id": "terra1hngslv4p3gk8p9x7y9pc9t9e079mzxfg73mh5zgralq79hq3r9jsdj8utr",
+    "name": "TerraNova",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ay5guxt0st9eetxakcs58n350dhkttnnxu7d4zt9je5540hfsf9stpa3sz",
+    "name": "Terranova 3D",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ytctz49dtpn85fagwut7e2eaw2586j74dn49t3cyadwlpwufl72q70qv75",
+    "name": "Terrans",
+    "symbol": "TRRNS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1e66djga9ku8rcpd6v7ncpt5f0n7fwaw44m05cqrvqq7hv6kg2rjsjvwk4v",
+    "name": "TERRANS",
+    "symbol": "TRN",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1c5umwtky59ypk2ad2jr3c95jwz2rp9r8h2fyselzxsq84yjj95asly9aq2",
+    "name": "Terrans: Limited Edition",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1v04p5nzya7727th4eesmyj34sjwtvt78ht7q7uc8xsmxses75x4qhm0kyj",
+    "name": "Terrapins on Terra",
+    "symbol": "PINS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ncyaafj4kt5m50tj3pftga2auuq62zzguwlntk5mtl2mdusagpkst9gmgl",
+    "name": "Terrapins on Terra Eggs",
+    "symbol": "EGGS",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1khf570xnp6g7lnf70ufwax69e9ll446avyhffqh22y4kssr02yds3522gj",
+    "name": "TerraPrints [MIR]",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra1rfqm5zwkep3jk845nf565yyua66uj654y2vzx3",
@@ -5471,783 +12457,93 @@
     "decimals": "6"
   },
   {
-    "id": "null",
+    "id": "terra12hq58scmmx04vzjlw9sywal7zv6pm6wjjy2m7zwxc990pplc5rpq3ck6k7",
     "name": "terraswap liquidity token",
     "symbol": "uLP",
     "decimals": "6"
   },
   {
-    "id": "terra1079zf52uyn4hnxdrst38fvd9ga582xcjrmenw8",
+    "id": "terra13yp5jufdd2n5gez84fy26tujq540alr29cm4tpntcsaqg7h660cqwe8dx9",
     "name": "terraswap liquidity token",
     "symbol": "uLP",
     "decimals": "6"
   },
   {
-    "id": "terra10jmlz5uwz6w5hks8y9tretjjk4f8ad2me44lve",
+    "id": "terra154lszr3g2cmstw7me6pmv57jjug3ddqy2lac87eyptv83z9ul25svefc2y",
     "name": "terraswap liquidity token",
     "symbol": "uLP",
     "decimals": "6"
   },
   {
-    "id": "terra10l54yyxus354jl80v57npylas00ktj7vpedml7",
+    "id": "terra179w0ny7mv7qn5h5q4rz6k6jhvspeau5fmkuqpvmtn6qx6l36pu5qe06wr0",
     "name": "terraswap liquidity token",
     "symbol": "uLP",
     "decimals": "6"
   },
   {
-    "id": "terra10zkfrqvgqvsh026ljcswe59lwh88yc5v43yc9q",
+    "id": "terra1adyqxpz0vseur93xct7k4sgfjfqf9drhrxt58k2z2p7vvsh4wt5qpmc8dg",
     "name": "terraswap liquidity token",
     "symbol": "uLP",
     "decimals": "6"
   },
   {
-    "id": "terra122asauhmv083p02rhgyp7jn7kmjjm4ksexjnks",
+    "id": "terra1fn29pxsueea3zt3xw909gpgjmzcwfxw7q55jgcsfh7v5rh4y3a6s2s69k8",
     "name": "terraswap liquidity token",
     "symbol": "uLP",
     "decimals": "6"
   },
   {
-    "id": "terra1237hndgalhuukzuccfvfjj538az8739td5cnaw",
+    "id": "terra1gjmpaqvm5ns4pap0enqdtsm78m0rc9n3wxsecq8rsjxdv6chwvfqmpnwyn",
     "name": "terraswap liquidity token",
     "symbol": "uLP",
     "decimals": "6"
   },
   {
-    "id": "terra1283mf36gl6zks6yxr50mc5cvzvg26qg50mq74s",
+    "id": "terra1l8z9t0hny99z9ncumpn4uqvd7k6sk6l90m68pu9mgvddmyr4vrwqdqcrp7",
     "name": "terraswap liquidity token",
     "symbol": "uLP",
     "decimals": "6"
   },
   {
-    "id": "terra12awas0yfsn4r4ppzp4agqu8rp8gyw8weglpuca",
+    "id": "terra1s80jffm4a5awzed0dfjvkjz79rcs25wfttezgefmpzju6rmgt5eq43x5l8",
     "name": "terraswap liquidity token",
     "symbol": "uLP",
     "decimals": "6"
   },
   {
-    "id": "terra12dnl585uxzddjw9hw4ca694f054shgpg93cg90",
+    "id": "terra1wmqka38647dus86jxsscc8j87ltykwsysl76gs8gq2kqxzkwa2aszfz6em",
     "name": "terraswap liquidity token",
     "symbol": "uLP",
     "decimals": "6"
   },
   {
-    "id": "terra12ndzg4g6k6q48hasdrrk7rul428npl88ljugtf",
+    "id": "terra1x3ee5rwurm703j2dx0qgwanntszty4egpcylwz6de5jarlr080jsv4hc0r",
     "name": "terraswap liquidity token",
     "symbol": "uLP",
     "decimals": "6"
   },
   {
-    "id": "terra13dvh4d653c6tyu7f30hwcpjnrz8xhx87yduphr",
+    "id": "terra1yph6hsldjpc7up5q87jjqyzxnpfllpewzc89r0yk30t065ajv8nq5rz5mx",
     "name": "terraswap liquidity token",
     "symbol": "uLP",
     "decimals": "6"
   },
   {
-    "id": "terra14dgkwkplgmw9tkdf4rc72ppk6q5p2mu0uhfl09",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra14uaqudeylx6tegamqmygh85lfq8qg2jmg7uucc",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra15hus6hg88440lypz37a8u90t8twdjmwnp92yfn",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra15pclv9fqytszqlmjymshyk9cfytaaqrs4h87sf",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra15qmh9jl388v2hr2yn75v8psdj0q9ghfwwxzckg",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra165k229vdtpng40rhdfn3tqtqphwxeyjx5wrwxw",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra166h9t9xrsy0wq8t7hpdjx52eecze4gcussgr44",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16auz7uhnuxrj2dzrynz2elthx5zpps5gs6tyln",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16c2lh2lr0xe92ayf558rgzw47gf8cmqh58v06n",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16ejsp5mhav3kppkj7w438spp0eawknsj0afhvx",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16j09nh806vaql0wujw8ktmvdj7ph8h09ltjs2r",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra16ledesd9tn24fte454883p577qvr24hngmfefg",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra178cf7xf4r9d3z03tj3pftewmhx0x2p77s0k6yh",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra17dkr9rnmtmu7x4azrpupukvur2crnptyfvsrvr",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra17gjf2zehfvnyjtdgua9p9ygquk6gukxe7ucgwh",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra17smg3rl9vdpawwpe7ex4ea4xm6q038gp2chge5",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra17tlyml4tq2hw922aq2dq4dhnjcu296mlkgrx6n",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra17vddhyh8zulk4yx2zapsk9z5y5r5mjaf9w6egv",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra18qgqfp2pay886vakll5duudytylazyy9eh89yq",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra19t9e42yxukxuuqzyekccm5jpu3gek3nttdsz8f",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra19zju3mkymrhfefd9lv7mq0u9ke0xmveemuu33g",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1aeusm5e93ptz2twem0vpfy370c7d7vy2dp0vke",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1azk43zydh3sdxelg3h4csv4a4uef7fmjy0hu20",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1c9wr85y8p8989tr58flz5gjkqp8q2r6murwpm9",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1cmrl4txa7cwd7cygpp4yzu7xu8g7c772els2y8",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1cvwy6kx24fhpeq4gjuyp2ynwcsxu8gtvk3mde7",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1d2muut0rea9fkff6y304yn6qkr2uacau7ltggc",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1d34edutzwcz6jgecgk26mpyynqh74j3emdsnq5",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1d5j958a4vrfmv20gddyp0gz0f6yx0kpd702qke",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1dmuw5wyluxe6hf85x7waepwuqjgs2460fmj8qn",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1dsj8lxhuvtz8k8vt9v7zjm85cca4qjhsqgvced",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1e7d7325sjpfk02vnzqkwsnlu0xqejydleeh2h8",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1e92r33fhkft6p8fyamwu3zp300t5l35cjxf5tf",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ekd58y58vq4gmxlzpc27dwuhw7wmms928ftuep",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1f2mpaw7jmm7jzhkgf2x7yg50vr9m4aplu7gkxg",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1f7jzky244gwy220xp7cdd0vzhu6l5ncafderaf",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1fa6hue6yjt90ytjuxqv6mlsmrm2agc7w6vjhd4",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1falkl6jy4087h4z567y2l59defm9acmwcs70ts",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1fc5a5gsxatjey9syq93c2n3xq90n06t60nkj6l",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ftd4p3rfcry6sgrwjs78s0562kmut3p6cpnq77",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1fxzmf732l2mj23wq3aryww50xg7gclhelvs2k3",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1gecs98vcuktyfkrve9czrpgtg0m3aq586x6gzm",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1gk602sa0jwk73xlr8tpkd3fpukhfa8hjety68r",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1hl09j27s27407wkct646lqnxg3qskpl2ehuvn9",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1hqpfh2g457fuzrm8e0skagwwh79pffr3zzqwek",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1hvz34zmk4h6k896t94vd8d5qjdchhnkdndunzx",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1jh2dh4g65hptsrwjv53nhsnkwlw8jdrxaxrca0",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1jl4vkz3fllvj6fchnj2trrm9argtqxq6335ews",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1jl875nm4p2z4jgapz6al2h74ug0fpf59n7pfjg",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1jmauv302lfvpdfau5nhzy06q0j2f9te4hy2d07",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1jmzlups5p4upfx995j824vyngnahsx5tjpk3m7",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1jnn5xpmeythug88hu66pwl3x9fz2s0ms034aw6",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1jqqegd35rg2gjde54adpj3t6ecu0khfeaarzy9",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1juspa927c7kdr0jf7wc0lxg6wfjz2cersm9r82",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1jvewsf7922dm47wr872crumps7ktxd7srwcgte",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1k5kumxd24cyvhf52r5u4ywlr3ztktj657wnf7a",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1k5z9y8h9jr4ex63cmmlazn3kjc7mncn66xrrk4",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1k67ut87c2up66tury4qc4n96d85t43u20v24sy",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1klc5n2zy79ttxur0mdvhqldyzhkmcehaqm877w",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1klgaa9lyrcgdwudd9mvu0ys2spdsxd8mk55ure",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1knrlem7cg0ywg5hldmghlj8eqh0f8lw2fhc599",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ktckr8v7judrr6wkwv476pwsv8mht0zqzw2t0h",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1l0yxvzzszzfcrfcle55wdf2xxmalc9eg5c28ej",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1l8jgxd9uv430rdt2u58h4h7kdfxsle4w6w2ecq",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1m4q5lr2s3j5eylf2jq06d8vw0au3trgdadezfc",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1m5gwp6ujj0frnwkgxlkmhwu5we9xaysnwa6f8s",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1m8mr9u3su46ezxwf7z7xnvm0jsapl2jd8vgefh",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1mljg7dvzknqh3gc62emagf7hwxxg8efemennp8",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1mnj6zstfk2ne0htcre9cvjv9ut0zd5t95wyagy",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1mtvslkm2tgsmh908dsfksnqu7r7lulh24a6knv",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1mv3pgkzs4krcennqj442jscg6jv84cejrs50n2",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1mwu3cqzvhygqg7vrsa6kfstgg9d6yzkgs6yy3t",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1my49papxtmataag9arh9wdrqyyuqyjfw7cc44v",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1mzpxqr5vwnzl822sjd3yskaekz2lyvfpavush6",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1n8fwsrf3qruwx99eg87dmw7x4pjc8n0a35vlef",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1na4sgkt5ft37s72l9hd6wsa7hdql0j75er0u7l",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ndlx5ndkknvmgj6s5ggmdlhjjsz0w6wrnwn5cf",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1nuy34nwnsh53ygpc4xprlj263cztw7vc99leh2",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1p60datmmf25wgssguv65ltds3z6ea3me74nm2e",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1p6fhh4n9keyyhzq6stytvn0qs6etj8md6mwe72",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1pjgzke6h5v4nz978z3a92gqajwhn8yyh5kv4zv",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1prswk9yyayfkkq99fpaz5zs7h0lhcpsqa4swj9",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ptsj2ufnvp5nv5lf8gtxek7c44rlztppedepfu",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1q7m2qsj3nzlz5ng25z5q5w5qcqldclfe3ljup9",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1q7n7hzd9dsmakmzjql2mdg5gfrnx42a9hj8665",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qjlakmnnswdzmssfzurpdg48ygu5cnw4lg9h80",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1qxlp0q3z20llu0gz9c7urzw7rmlnchm23yk8xc",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1rqkyau9hanxtn63mjrdfhpnkpddztv3qav0tq2",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1s0dgcsdy9kgunnf3gnwl40uwy9rxtmc39mhy2m",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1stfeev27wdf7er2uja34gsmrv58yv397dlxmyn",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1t0mgl6lns0ff6wva27zjwqfpqrjdzw550ed652",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1t46rhfcgqpz9xkx33qpzk55yudp7wdaygj7yfw",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1t4xype7nzjxrzttuwuyh9sglwaaeszr8l78u6e",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1t8qmg9p583jcp2f7uuhga73yh7ze0u4ny7kmzy",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1tmw02ugjulhezj868pu4s6mhlmshlez7thzane",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1ungyyyachxaszce53zstctel0mpzactmtz8hdp",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1utf3tm35qk6fkft7ltcnscwml737vfz7xghwn5",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1uwhf02zuaw7grj6gjs7pxt5vuwm79y87ct5p70",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1veqh8yc55mhw0ttjr5h6g9a6r9nylmrc0nzhr7",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1vkjgr2rsagh52jdcur4zgjyj7ag5xrfmyekne2",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1wd25umnrgnfydwd7k7m364ykk79r76tclm5v4n",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1wdjsxymg424mw4sv6zmw4luqajwxa5e7qfvfxw",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1wdmkqdhqmyv9csgwfdh8739fu65qpay7jj5vvh",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1wfms03rc04cdc0xvs7rh8z3s498ns2zgqctq7y",
-    "name": "terraswap liquidity token",
+    "id": "terra1ecaxgghq46wg0rr66ema6dp8thf5dn5n8e40p2uaqljx04sf8gjqnyqzf9",
+    "name": "terraswap liquidity token (Wormhole)",
     "symbol": "uLP",
     "decimals": "6"
   },
   {
-    "id": "terra1wg3dhzz6m5q3dm738u6sxzxhld60l0chgvpele",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1whdv289y72n38x8sevz5erze8zys493ha2fd0a",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1x3musrr03tl3dy9xhagm6r5nthwwxgx0hezc79",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1xqeym28j9xgv0p93pwwt6qcxf9tdvf9ztfxf0w",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1xsv563k2wyuqkwza0mrz6ye8exx4a9r0hdvxs6",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1xxracarga8mf8yadf8s25hekr4kd92l3wr35vm",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1y097nnhjger6l3ds9r96xfdpq7vcdp5yh70n6x",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1y6x3mh07l8xdpxap7xw2u5pclrenjaulpcfh36",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1y9kxxm97vu4ex3uy0rgdr5h2vt7aze5sqx7jyl",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1yg09m7lcj739wvr3ns6d67znhyp4jexvpx2vkg",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
+    "id": "terra1tu96pg7j0affaqezmlspkeeqnvrkrtcmqhag0up8cm6z4k7wx5csg4ar5s",
+    "name": "terrausd (Wormhole)",
+    "symbol": "terrausd",
+    "decimals": "8"
   },
   {
-    "id": "terra1ygazp9w7tx64rkx5wmevszu38y5cpg6h3fk86e",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1yqnd70kvrdfazu7aplalwqdp3ksnu35fv9cv9m",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1z0z6hz96au9lr027uedxay3s09ry36md3wpm0v",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
-    "decimals": "6"
-  },
-  {
-    "id": "terra1zy5sjsw4aswykccwtvkaq27s2eedspvakut7gw",
-    "name": "terraswap liquidity token",
-    "symbol": "uLP",
+    "id": "terra1gsd4wtmpkcdlmkr4kpm4c2fe9syx8qyv5r3qykx708kv4850vqssgtvx44",
+    "name": "TerraUSD (Wormhole)",
+    "symbol": "UST",
     "decimals": "6"
   },
   {
@@ -6263,6 +12559,12 @@
     "name": "TerraWeed",
     "symbol": "TerraWeed",
     "decimals": "6"
+  },
+  {
+    "id": "terra1g76gzatrn8jnhv7lhmx7aqm6afja4750rpmvypjp3vcw03amva5swskrs0",
+    "name": "TerraWhales",
+    "symbol": "WHALES",
+    "decimals": "0"
   },
   {
     "id": "terra14yyepy06yw57f4x564xrfwxvv460vq0su5ype8",
@@ -6304,12 +12606,10 @@
     "decimals": "6"
   },
   {
-    "id": "terra14y5affaarufk3uscy2vr6pe6w6zqf2wpjzn5sh",
-    "name": "Tesla, Inc.",
+    "id": "terra1sffdl730nq509rv5k0dm62sc0taa3yk7va2v3ngqhhl34gsmfuhsca3jff",
+    "name": "Tesla (Wormhole)",
     "symbol": "mTSLA",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra14y5affaarufk3uscy2vr6pe6w6zqf2wpjzn5sh/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/TSLA.png"
+    "decimals": "6"
   },
   {
     "id": "terra14rq6etqgza9qqpgz9yjfmsclgnzhk9jsafdtyc",
@@ -6354,6 +12654,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra1dm53vefj2g2trw5t8glyjzxthtfg7qhq57l5ky7l26flcnswprzq4x7fsy",
+    "name": "Test",
+    "symbol": "TTT",
+    "decimals": "0"
+  },
+  {
     "id": "terra1ghkclqug2jhanmjsx46x0vymcglchcesg98057",
     "name": "Test",
     "symbol": "Test",
@@ -6363,6 +12669,12 @@
     "id": "terra1gqmd09k8g3lggxxdzu9z94vqcxtr5zylvs95ke",
     "name": "Test",
     "symbol": "Test",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ry68wdl4hgkt0ddg52m0gnj3d8l35nlers08p3lajl7gsn8tmj0qdt2k89",
+    "name": "Test",
+    "symbol": "TEST",
     "decimals": "6"
   },
   {
@@ -6382,6 +12694,24 @@
     "name": "TEST",
     "symbol": "TEST",
     "decimals": "3"
+  },
+  {
+    "id": "terra16vajmyc2zc8nhy7c7z9lxym5rp7qw4lkptuccp4tfqqywkqppdsqc7zkat",
+    "name": "Test 2",
+    "symbol": "TTTT",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1dakfhvgv5rwxngh7wecennfpn7jfyd74nq6cuyfzx8f400nz244sfuzwch",
+    "name": "Test Col",
+    "symbol": "TESTIE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1mma39sqn43aen4jh2sdmka84mv94uk7v7xw3ype2fdvlay6emrlqweyf5u",
+    "name": "Test Cw20 TOKEN",
+    "symbol": "TCW",
+    "decimals": "6"
   },
   {
     "id": "terra1d3pmqshpe6n5cs7d6mnffdun4tg0k05zfy99zh",
@@ -6576,10 +12906,40 @@
     "decimals": "6"
   },
   {
+    "id": "terra1lcvpawl4q8dxwmj4m9fcg7hln95q0g4y8fs2hdvwl2cxnva9vllqh2cpjj",
+    "name": "Test Migration",
+    "symbol": "test",
+    "decimals": "6"
+  },
+  {
+    "id": "terra128v4wvntlyskezlvjqyec89femjva5ksyxtpswxmt5680amlyy3sy3f84g",
+    "name": "test new UI",
+    "symbol": "TNU",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19ng225hv9jp4ty8gt7d3g0er4chga8z96tya5ksmsz68rllp268qry2jyt",
+    "name": "Test nft",
+    "symbol": "BH",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1ycw04kktq9l0ywqr85suuvg9t80h3nr94juxxkuxhh4sha7r8fuscyxyqa",
+    "name": "Test nft",
+    "symbol": "BH",
+    "decimals": "0"
+  },
+  {
     "id": "terra1j8nxezl70lfekdzaeanzyzn75htf4sz9vmwhu7",
     "name": "TEST SVG",
     "symbol": "SVG",
     "decimals": "6"
+  },
+  {
+    "id": "terra168csa8g2prpcthh0qx4wmdfndwq49ef347tf0asy9qasf3zadq0s0flscj",
+    "name": "Test Terra2 NFT",
+    "symbol": "TMT",
+    "decimals": "0"
   },
   {
     "id": "terra1fd2f52tmq59mc093nrawdaey5mzgjnwyu7hwqz",
@@ -6598,6 +12958,12 @@
     "name": "test token",
     "symbol": "TEST",
     "decimals": "3"
+  },
+  {
+    "id": "terra12nxvzzqv0yeh80z6eya0gcufyn36ntrkcalnjl",
+    "name": "Test Token",
+    "symbol": "TTN",
+    "decimals": "0"
   },
   {
     "id": "terra12yvwzt5ayh396hgmyd0rwnamgg4g3mxrdgg7c6",
@@ -6648,6 +13014,12 @@
     "decimals": "3"
   },
   {
+    "id": "terra1kz9rs4gurgrsv7qsm4ekmqvwysphnpf043wqj2u4r8n9j9xv3egsmj9ft4",
+    "name": "test1",
+    "symbol": "test",
+    "decimals": "6"
+  },
+  {
     "id": "terra1xp4uhylkhwgam5tc97m0xfaxarajgf6wtcqwp9",
     "name": "testabc",
     "symbol": "testabc",
@@ -6657,6 +13029,12 @@
     "id": "terra1cxusd4uhgpgk2sp99rexrcknpn08anak3v9tz7",
     "name": "testC",
     "symbol": "testC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16wr7gqnzm0e9z4kz92gwaq9wqx2xuusfd02xrrjsks9y4zlyk66q4tt7md",
+    "name": "testdaotoken",
+    "symbol": "test",
     "decimals": "6"
   },
   {
@@ -6732,6 +13110,12 @@
     "decimals": "6"
   },
   {
+    "id": "terra1ery8l6jquynn9a4cz2pff6khg8c68f7urt33l5n9dng2cwzz4c4qj3spm2",
+    "name": "Tether",
+    "symbol": "USDT",
+    "decimals": "6"
+  },
+  {
     "id": "terra1eqvq3thjhye7anv6f6mhxpjhyvww8zjvqcdgjx",
     "name": "Tether USD (Portal from Avalanche)",
     "symbol": "USDTav",
@@ -6746,11 +13130,23 @@
     "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/USDTso_wh.png"
   },
   {
+    "id": "terra12ezq5402h5n3skhdshjp4f49zzg0saxum8fvvhjhauzas2ezyyrqpznqny",
+    "name": "Tether USD (Wormhole)",
+    "symbol": "USDT",
+    "decimals": "8"
+  },
+  {
     "id": "terra1ce06wkrdm4vl6t0hvc0g86rsy27pu8yadg3dva",
     "name": "Tether USD (Wormhole)",
     "symbol": "weUSDT",
     "decimals": "6",
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/Dn4noZ5jgGfkntzcQSUZ8czkreiZ1ForXYoV2H8Dm7S1/logo.png"
+  },
+  {
+    "id": "terra1p2wm9d7lp4pf32pmwzm5ll59q9sqj48p0u66cnfavuzj78gusdeskdgms2",
+    "name": "Tether USD (Wormhole)",
+    "symbol": "USDT",
+    "decimals": "6"
   },
   {
     "id": "terra1a8k3jyv3wf6k3zngza5h6srrxcckdf7zv90p6u",
@@ -6801,10 +13197,76 @@
     "icon": "https://terrafloki.io/ticket6_logo.svg"
   },
   {
+    "id": "terra14n3adwz0pstwqtfgxr62uvdvfqkyctyec8jahf6pl7hwqer80aksk0hwl5",
+    "name": "TFM",
+    "symbol": "TFM",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qg5ega6dykkxc307y25pecuufrjkxkaggkkxh7nad0vhyhtuhw3slg2he2",
+    "name": "The 420 NFT",
+    "symbol": "420",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1wug8sewp6cedgkmrmvhl3lf3tulagm9hnvy8p0rppz9yjw0g4wtqgj2ctk",
+    "name": "The 69 NFT",
+    "symbol": "69",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1dcj2st2qhljnl0llxp64n0dex6xn7fusu0ku83ewxasqunzkwgqsz6wkzz",
+    "name": "The Crypto Drugs",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra19xk3rsesaupv72se69y8v6y6m04fl8yj6vnmtv",
     "name": "The Edward Coin",
     "symbol": "EDWARD",
     "decimals": "6"
+  },
+  {
+    "id": "terra1sp32et72dz2yh4ny48txy637gz7drvkmpel29j8lunfzy7xh47vq6e2lka",
+    "name": "The Factory Lives",
+    "symbol": "TFL",
+    "decimals": "0"
+  },
+  {
+    "id": "terra130cpevp2eyqskcsh6xs3nrqkrkeczzfg95xykyp06zt52cdkyeaq4ahe6y",
+    "name": "The Fallen Guardians",
+    "symbol": "FG",
+    "decimals": "0"
+  },
+  {
+    "id": "terra13cja66m0429yp6s6knrn565weskxgmlgm9pwws8r8lvuc6twd25qxvy6fn",
+    "name": "The Gorilla Legue",
+    "symbol": "TGL",
+    "decimals": "0"
+  },
+  {
+    "id": "terra19kpvm4ru3979lkkan2atjas9pdpr4s0w3tnlm02eew5yk8tmh6wqs3rh7h",
+    "name": "The Lab",
+    "symbol": "LAB",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1j0qdr5m3t87p05k93qsfrzcvtu6k2ht6wr3ntnksrqjup9l67j9smm73ut",
+    "name": "The Lab",
+    "symbol": "LAB",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1zm7fylkhyvhrvpnpdec8ak8wlugafrguxg0z8dw6ru7pkg3hvzjqh60gh7",
+    "name": "The Lab",
+    "symbol": "LAB",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1vang7yw0aywnlged2v4jh8xndguqhyr9gv38mqe3rsdjm077qznsu50qkz",
+    "name": "The very essence of Cantonese",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
   },
   {
     "id": "terra149755r3y0rve30e209awkhn5cxgkn5c8ju9pm5",
@@ -6813,6 +13275,18 @@
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra149755r3y0rve30e209awkhn5cxgkn5c8ju9pm5/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
     "icon": "https://whitelist.mirror.finance/icon/DIS.png"
+  },
+  {
+    "id": "terra1w2958rqnrz4qh39m4sfh3y2xl8jf5js4rz8r7dug7nv2gw2damgsplw3z8",
+    "name": "The Walt Disney Company (Wormhole)",
+    "symbol": "mDIS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1x0u4zwpa0lmmez0adc7zt4amaz04wu6jryhefcav6cdzpqx8ht0svzdkf8",
+    "name": "The Walt Disney Company (Wormhole)",
+    "symbol": "mDIS",
+    "decimals": "6"
   },
   {
     "id": "terra1gtjtyyhj2cu0ekzju4rj86vsvg7d2uu576rrl7",
@@ -6860,9 +13334,33 @@
     "decimals": "6"
   },
   {
+    "id": "terra16xt3d7m8qhhvj9w8dpcf5qhq8wx0jdnhk4n3x5f9spauzxs9at7sgndjdl",
+    "name": "TimeTerra",
+    "symbol": "TMT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra177phs7fn4hq0apnv3usttn0r05pty573548glh5jqkr00hks0ewqf2ekjc",
+    "name": "TimeTerra",
+    "symbol": "TMX",
+    "decimals": "6"
+  },
+  {
     "id": "terra15q3lzrnfstr3rqgh55cqmp95z4xr3we5tfyqm9",
     "name": "TinyDick Kwon",
     "symbol": "tdKWON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17jfvm266af58rxtapch6gmrgv7zz8t45p46ftulsdk4m2nf85e2qusujaf",
+    "name": "TKNA-ULUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1mqp9jdghpmprs9sc6ujh0juw6h7k7sp2evs0weh6q2u37ys3lf2srxjclc",
+    "name": "TKNB-ULUN-LP",
+    "symbol": "uLP",
     "decimals": "6"
   },
   {
@@ -6884,6 +13382,12 @@
     "decimals": "3"
   },
   {
+    "id": "terra1z9nj8auy33nh8fjp2f40up5qz5qrmwt7tfk3r9a0e27dd40vhues8zrcfa",
+    "name": "TNT (Wormhole)",
+    "symbol": "TNT",
+    "decimals": "6"
+  },
+  {
     "id": "terra12fctlld90cakzkuhd2c3h246zxrhwqd6kp546g",
     "name": "Tobin",
     "symbol": "TOBIN",
@@ -6899,6 +13403,18 @@
     "id": "terra1h8hmr0em0avkz4kzuwgakyxrdvxqwg5d3cg4sd",
     "name": "Token test dont buy",
     "symbol": "LLL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1nchx6x3xtmme9sq6gxtj0tuux9l3mh05ce0hmmm7ge35vl8zsdeshkn7z5",
+    "name": "TokenA",
+    "symbol": "TKNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16er279t0mgumskzqp2eq5wju9ge68v6y7ylq4qju35rj5as6gwaqpf70xu",
+    "name": "TokenB",
+    "symbol": "TKNB",
     "decimals": "6"
   },
   {
@@ -6950,9 +13466,39 @@
     "decimals": "1"
   },
   {
+    "id": "terra1ntgzf3mp5223jmv4452qx7lvgfga9q0x89zsm5y8kpktwjdsxyws6x8e67",
+    "name": "Toxic Labs Governance",
+    "symbol": "TLT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra150qtrrrta74ewt9glydumq2fz4463hrcqm087vex2ynv97xz95gsha38dl",
+    "name": "TPT-BLUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16h880ss964j75erdsctgy7eyp62e2ladtaqw3x0qapzae8wrgyjqmgnwqm",
+    "name": "TPT-ORNE-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra1u4gx4v0nqgzm2kcajk3xf0d35gutwcvdyyjrnc",
     "name": "TRhea",
     "symbol": "TRh",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lu6wy88xv5huk35yq55e2an9k5h2me4nad20cetqsr73ez6vs84quysx2y",
+    "name": "Tricky Dick",
+    "symbol": "NIXON",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1c47hfvyk8pug2qj5wppzfndehptwm9vq2xrus66junwkxhjuucdqcfcmep",
+    "name": "TT DAO Token",
+    "symbol": "TTD",
     "decimals": "6"
   },
   {
@@ -6969,6 +13515,18 @@
     "icon": "https://tuna.money/content/images/2022/06/icon-2.png"
   },
   {
+    "id": "terra1ludp8erwgrd7ytelkycfprhvcnz0y54vjmgp6dausuty0lqmw8nspk6vyv",
+    "name": "Tuna Money (Wormhole)",
+    "symbol": "TUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qx284aak0wl7vrvlsc6cwcsn6xwajragkh6cjqj87m9p34hx5l2s22p3cp",
+    "name": "Tuna Token",
+    "symbol": "TUNA",
+    "decimals": "6"
+  },
+  {
     "id": "terra1v2s7gkylfrnwsdcx8s83k5475nj3jykzs9gsqm",
     "name": "TWhiteShiba (TerraShiba.com)",
     "symbol": "TWShiba",
@@ -6981,17 +13539,21 @@
     "decimals": "6"
   },
   {
-    "id": "terra1cc3enj9qgchlrj34cnzhwuclc4vl2z3jl7tkqg",
-    "name": "Twitter, Inc.",
-    "symbol": "mTWTR",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1cc3enj9qgchlrj34cnzhwuclc4vl2z3jl7tkqg/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/TWTR.png"
-  },
-  {
     "id": "terra158y6aypem94yj34ycvgdm3py23afhnu2dj24ak",
     "name": "TXXC Token",
     "symbol": "TXXC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vz7sw3gd5yf4ak755jt9kvshp7jnjc9l3rv6gaf8fehud2xnnltsqtsq2u",
+    "name": "U\\\"\\ (Wormhole) (Wormhole)",
+    "symbol": "U\\\"\\",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yjmqq3urg2cvkrdhax3qgawjgjpss492amcsruwylht6hdxxwylqad54qv",
+    "name": "U||| (Wormhole) (Wormhole)",
+    "symbol": "U|||",
     "decimals": "6"
   },
   {
@@ -7001,11 +13563,77 @@
     "decimals": "6"
   },
   {
+    "id": "terra1qhlxwadl2k4jj7lx7wzezyt9ys534j3n03dcrvkeqpuzu7gaxwmqj845c3",
+    "name": "UGBT (Wormhole) (Wormhole)",
+    "symbol": "UGBT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v76yk6j4qsrs3p2w6uu83fq6a2zjz9p966e8jmf8mt89ju0a9tqq6sm5hy",
+    "name": "UKRT (Wormhole) (Wormhole)",
+    "symbol": "UKRT",
+    "decimals": "6"
+  },
+  {
     "id": "terra1fyjsxx73jrufw8ufgtuswa773dvdkny92k70wa",
     "name": "Ultimatalioniscoin",
     "symbol": "ULC",
     "decimals": "18",
     "icon": "https://img1.wsimg.com/blobby/go/f561f953-0bdd-48bf-a39b-982ecbd1698b/downloads/Ultimatalioniscoin225x225.png?ver=1649021019249"
+  },
+  {
+    "id": "terra1gl7a3jvk5ajnxs2rrdyjqz5ea99wf56qjuxct7cjwzf5cs675wlse2qf6v",
+    "name": "ULUN-BTC-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra138fc79ldpkzgswzuuts49xr82y02x078hajjhlnav8982e7z7t7sg3rrf8",
+    "name": "ULUN-DINH-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1f6lmzz9caag00uqssw4dlczrvlaeva4afn2yl3cxfd0ncawpelnqwmtj2d",
+    "name": "ULUN-FRGY-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1w33n04crhh843ly5nh0km58w8zhz5ygstm9taqw6wgwkv57zfaas4w78a8",
+    "name": "ULUN-YLUN-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17vaenrsjh76yt8dcnlwzn0856k9fzk6h252j32ghr3k898pjyrdq9h55h9",
+    "name": "uluna (Wormhole)",
+    "symbol": "uluna",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1cm09997cnkfylgjz4wg0mk6wj2vd77a5qed67wvhxra0h8smzkds38uzq4",
+    "name": "uluna (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "8"
+  },
+  {
+    "id": "terra19glrs2vtgxaxww39cq5acxapgv2v8hyw562zmsk7ucn4yznmyv3sljewv9",
+    "name": "uluna-ASTRO-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rlmjwapg7y3p39aucq2rq5rffyns7z94twm8acl59na4d9aehu9sl2dfkc",
+    "name": "uluna-ibc/B350...C9E4-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lt586fhwyuccktk58v8k96ugzp9szurhqvmlnjxhyn6yapa6v2jsmc468d",
+    "name": "uluna-LunaX-LP",
+    "symbol": "uLP",
+    "decimals": "6"
   },
   {
     "id": "terra1v7vp6ywlymprx9mk7ngm4uf0xgrz2ektg5wd6z",
@@ -7027,18 +13655,22 @@
     "decimals": "6"
   },
   {
-    "id": "terra1lvmx8fsagy70tv0fhmfzdw9h6s3sy4prz38ugf",
-    "name": "United States Oil Fund, LP",
-    "symbol": "mUSO",
-    "decimals": "6",
-    "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1lvmx8fsagy70tv0fhmfzdw9h6s3sy4prz38ugf/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/USO.png"
-  },
-  {
     "id": "terra1av9tfs7k5gfuzm04e7p0d4ezrc53vq9mn3m08z",
     "name": "UNIX",
     "symbol": "UNIX",
     "decimals": "3"
+  },
+  {
+    "id": "terra1dsxs0u8thjngph6k60k5cepfkv90jtt776hsx7eyvl9x5gnepjjsfjnwyn",
+    "name": "Unstables: Unstable Kwon",
+    "symbol": "UNSTB:3",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1p5ll4frszlw63d7apaf3ghyd2k28dz2phnu4t359ey04xwcra5vq7kuemk",
+    "name": "Unstables: Unstable Kwon",
+    "symbol": "UNSTB:3",
+    "decimals": "0"
   },
   {
     "id": "terra1d9ec4gm0c03p74d3qd95qvny2ptf0ge5twqpdk",
@@ -7047,11 +13679,41 @@
     "decimals": "6"
   },
   {
+    "id": "terra1q4r4zzde2tg52306qevhnaf3qw76a68hnyzw404uuvvzx09n3ckqe2ylrm",
+    "name": "USD ",
+    "symbol": "USD",
+    "decimals": "6"
+  },
+  {
     "id": "terra1yljlrxvkar0c6ujpvf8g57m5rpcwl7r032zyvu",
     "name": "USD Coin (Portal from BSC)",
     "symbol": "USDCbs",
     "decimals": "8",
     "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/USDCbs_wh.png"
+  },
+  {
+    "id": "terra1ezxp0nhct6mqsctckujttfkcsknux2aktv7knn6fjtprl3np74js7tzeqt",
+    "name": "USD Coin (PoS) (Wormhole)",
+    "symbol": "USDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra10eqslzgvzl5grau5zuhs0hv6v0c8pj8va6lclrgxgzs9mhvfc2zq5hsdmx",
+    "name": "USD Coin (Wormhole)",
+    "symbol": "USDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra17em5mehxz6wj4ya65ns0kf28zgf0xlz8qp4n0ykd2favszalr63sydrwyl",
+    "name": "USD Coin (Wormhole)",
+    "symbol": "USDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1cmsh9ju4hk58hhdtlv5k7cqu8dmu0eucpaw5n9ynpwzuw4jluptsvyz8eh",
+    "name": "USD Coin (Wormhole)",
+    "symbol": "USDC",
+    "decimals": "6"
   },
   {
     "id": "terra1e6mq63y64zcxz8xyu5van4tgkhemj3r86yvgu4",
@@ -7068,15 +13730,105 @@
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/A9mUU4qviSctJVPJdBJWkb28deg915LYJKrzQ19ji3FM/logo.png"
   },
   {
+    "id": "terra1uylw76ux3h502muaml8l32j3e7d9v2ne0npwsgt0s46d5l3hpz4swsv2fc",
+    "name": "USD Coin (Wormhole)",
+    "symbol": "USDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vzd98s9kqdkatahxs7rsd8m474lf2f8ct39zdgd6shj4nh5e6kuskaz2gy",
+    "name": "USD Coin (Wormhole)",
+    "symbol": "USDC",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1tzaw5m79em9juj0lf4dxr6phxxht79jt770mn77ltvx5e6ww4vpss6hvnu",
+    "name": "USD stable ",
+    "symbol": "USDc",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15x3mm9gl5z89w9d96fgpsqds0pa2eqdsnyp47rat0vey826fjj8svgqthd",
+    "name": "USD Token(Wormhole) (Wormhole)",
+    "symbol": "USD",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1uc3r74qg44csdrl8hrm5muzlue9gf7umgkyv569pgazh7tudpr4qdtgqh6",
+    "name": "USDC",
+    "symbol": "USDC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1pgtc0jsag7ax6cyyd55ntcva3kfnh6t805jtwcnrdm7szkx35pdqvycak5",
+    "name": "USDT (Wormhole)",
+    "symbol": "USDT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rcmvfsn77pd6m04ctqj3wcu66pvrw9p265cdl72w4zarfup2rv7qjxhkzl",
+    "name": "USDT on terra2",
+    "symbol": "USDT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jznfc58qvl8f0dldhm4pl505srpz98mwedlullt5rhv6petxwdpqn97n6v",
+    "name": "ust",
+    "symbol": "ust",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zwv6feuzhy6a9wekh96cd57lsarmqlwxdypdsplw6zhfncqw6ftqynf7kp",
+    "name": "UST",
+    "symbol": "UST",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1rwg5kt6kcyxtz69acjgpeut7dgr4y3r7tvntdxqt03dvpqktrfxq4jrvpq",
+    "name": "UST (Wormhole)",
+    "symbol": "UST",
+    "decimals": "6"
+  },
+  {
     "id": "terra1z49dpvu5g4st7t4j5lsaxaq7v9u6f390m28ap9",
     "name": "UST Puppy",
     "symbol": "UPU",
     "decimals": "6"
   },
   {
+    "id": "terra10tclyxjfcx7u0wd0d0he4muqvhd6nn6d7lr2ktmga275tq0axamqs6gxnj",
+    "name": "UUSK (Wormhole) (Wormhole)",
+    "symbol": "UUSK",
+    "decimals": "6"
+  },
+  {
+    "id": "terra15zmzk6qc9w9cwvjwec2x5jyyredntalv8zuz46c7xhd07k5jvh4qtcpsch",
+    "name": "UUST (Wormhole)",
+    "symbol": "UUST",
+    "decimals": "6"
+  },
+  {
     "id": "terra1l2stn9sszzg6qwfqd6ckfa5n58hs4x5wwjaehh",
     "name": "UUZ Token",
     "symbol": "UUZ",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1vapchnf63wx972v07jkjl0kfunft0ztyjuf5kqxgj2xx3mxfuw8s3gprxs",
+    "name": "V Collection",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1xepgy0lp0lkt9dq89pfe3sqwnfyln29r2zj5qqkp75l2egthmmkqkn36vv",
+    "name": "Valkyrian Pass",
+    "symbol": "vVP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16qlqgly543fpnp5eg6v8elfz3762us49xqt89y86htkrs6t0pams7jy3y6",
+    "name": "Valkyrie Token (Wormhole)",
+    "symbol": "VKR",
     "decimals": "6"
   },
   {
@@ -7136,15 +13888,51 @@
     "icon": "https://raw.githubusercontent.com/vitelabs/crypto-info/master/tokens/vitc/tti_22d0b205bed4d268a05dfc3c.png"
   },
   {
+    "id": "terra1n993kulwk0hj0pe06nhp0n9ll97qynwh2swzcjek6y5qngz0qqhq3c2qsv",
+    "name": "VKR-BUSD-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1xx87xd4wl496gm48e9s4wygehx69z6cwju22zu32dl672ufh2rlsznsu05",
+    "name": "VKR-VVP-LP",
+    "symbol": "uLP",
+    "decimals": "6"
+  },
+  {
     "id": "terra1ezkr298e3lef6hh5pzmvrtw0qd0kc6u7dgl5rc",
     "name": "Void Finance",
     "symbol": "VOID",
     "decimals": "6"
   },
   {
+    "id": "terra1c6pzq0s8lr4vwmah8vauhn6mje4uz5ta62wvcpgtp259pxx5qevsgsu3jr",
+    "name": "VoxeLPunk Cards Print #1",
+    "symbol": "VXLPNK",
+    "decimals": "0"
+  },
+  {
+    "id": "terra1cfwepxxkhfnypztquswu2e5vu5x2wg0exzfln8gl48c9hfaj6u6qkht5su",
+    "name": "VoxeLPunks Card Game",
+    "symbol": "TALIS_GNRC",
+    "decimals": "0"
+  },
+  {
     "id": "terra18ejpjp9eyx9t8j07jd7kzah9p0rvkzdfeeva6n",
     "name": "VPRIS",
     "symbol": "VPRIS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1uq59f5lhzg6ut605ntevvf2a8kg9t2xk2873lgx6pweagkw76r4sdzj6ap",
+    "name": "W-boneLuna",
+    "symbol": "wbLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra173z5ggu6k6slyumrrf59rd3ywmpu6hdfftwpqlkc7fp549yk9fmqzqyepj",
+    "name": "W-Eris Amplified LUNA",
+    "symbol": "wampLUNA",
     "decimals": "6"
   },
   {
@@ -7172,6 +13960,24 @@
     "decimals": "3"
   },
   {
+    "id": "terra1x0vlryaz27jr4ncxc7ufd735fvs8uwrprp2kmz7l3pxf2jhkgpysml0yz9",
+    "name": "Warp token",
+    "symbol": "WARP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1y86ynggjnfp9xfjhcxhj3gexkgqzd3f0vcsf5nzh7jl5hu90tjgq3vws3p",
+    "name": "Warp token",
+    "symbol": "WARP",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z85035h0fptflnn004dvaw8c2q754qrnulsd5qwhzen4rtzr9juq5ef6ny",
+    "name": "Warp token",
+    "symbol": "WARP",
+    "decimals": "6"
+  },
+  {
     "id": "terra1c6jwuklh3262naafvnlw8llvns9856uvc50z95",
     "name": "We are Hive",
     "symbol": "HIVE",
@@ -7187,6 +13993,12 @@
     "id": "terra16pektynpxqrs66gk6cgqpwr7rjsudyfzustm6s",
     "name": "WELCOMETOHELL",
     "symbol": "HELL",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v8pm45c8mecaasuj73wemvl9z7394lh8n92xla5vetwaqtcqsshq8jum8n",
+    "name": "WETH-UETH-LP",
+    "symbol": "uLP",
     "decimals": "6"
   },
   {
@@ -7207,6 +14019,24 @@
     "name": "White Whale Protocol",
     "symbol": "WWP",
     "decimals": "6"
+  },
+  {
+    "id": "terra1z2vjfumarm9ea75ahlwxzxw5ya3x5hh7zjg372j05v9lvxgygqsquzl2w2",
+    "name": "WHT (Wormhole)",
+    "symbol": "WHT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19ney3d0rgy2qw2sj4s4xjruvex0e098rnpdlmg4q4yj0km9aqn2s5smwgq",
+    "name": "Wicca",
+    "symbol": "WIC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1sxqeul6tr7902ru8x9tum55a7xgfv6l6z770cnpwya78rngfu8xszad92j",
+    "name": "Wicca Badge",
+    "symbol": "WB",
+    "decimals": "0"
   },
   {
     "id": "terra1laczhlpxlgmrwr9un9ds74qxd2fj4754nf82dn",
@@ -7288,6 +14118,30 @@
     "icon": "https://static.lido.fi/stSOL/stSOL.png"
   },
   {
+    "id": "terra1psyhchq2u0lp66xu7rlrvdz4kwtjlf9rhwgad0d6mf7llx8ajrzsmk8hyj",
+    "name": "Wormhole:Luna (Wormhole)",
+    "symbol": "whLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra16ncvcsl3kysux35vxq06uwtfv5mfghwrshz69sazzd8t5ees5jgslz9eqc",
+    "name": "Wormhole:LUNA (Wormhole)",
+    "symbol": "whLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qdtez5zysmsj4l96g9e2t8h4mu43a5jesjjg28zgx8rwy9q9vaws9xpnj5",
+    "name": "Wormhole:LUNA (Wormhole)",
+    "symbol": "whLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1q57xmgzpcwnaznpft9qpaf9gxgsjt97ueskywxhpk764jdckqktqhpykmh",
+    "name": "Wormhole:LUNA (Wormhole) (Wormho (Wormhole)",
+    "symbol": "whLUNA",
+    "decimals": "6"
+  },
+  {
     "id": "terra15a9dr3a2a2lj5fclrw35xxg9yuxg0d908wpf2y",
     "name": "Wormhole:Magic Internet Money",
     "symbol": "whMIM",
@@ -7305,6 +14159,12 @@
     "name": "Wormhole:Sarcophagus",
     "symbol": "whSARCO",
     "decimals": "8"
+  },
+  {
+    "id": "terra13eqda0j9a70z8kdhx3j9es9mtwn7aswvuyenednc7xxrlwgj0ghsc7we0d",
+    "name": "Wormhole:TerraUSD (Wormhole)",
+    "symbol": "whUST",
+    "decimals": "6"
   },
   {
     "id": "terra1p5k0vl2g22zv0r07fxm627pf8u5frazevqgkw5",
@@ -7360,11 +14220,41 @@
     "decimals": "6"
   },
   {
+    "id": "terra19hq58hctw2m2mj6262n97x8gevas75pzmtkucf7gvgu4a0mcswnswj6tjz",
+    "name": "Wrapped Bitcoin (Sollet) (Wormhole)",
+    "symbol": "BTC",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1yn9grhzsq2rqe3a4tccxhva8pxqgd66arhhanju8vfx0p86y2nuscpyn3r",
+    "name": "Wrapped BNB",
+    "symbol": "WBNB",
+    "decimals": "18"
+  },
+  {
+    "id": "terra14kg73j92u8af2uwdp76cd7wnr54ray55k0kmcd0qqg7cd2me8ugqzv387z",
+    "name": "Wrapped BNB (Wormhole)",
+    "symbol": "WBNB",
+    "decimals": "8"
+  },
+  {
     "id": "terra1cetg5wruw2wsdjp7j46rj44xdel00z006e9yg8",
     "name": "Wrapped BNB (Wormhole)",
     "symbol": "wbWBNB",
     "decimals": "8",
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/9gP2kCy3wA1ctvYWQk75guqXuHfrEomqydHLtcTCqiLa/logo.png"
+  },
+  {
+    "id": "terra1xc7ynquupyfcn43sye5pfmnlzjcw2ck9keh0l2w2a4rhjnkp64uq4pr388",
+    "name": "Wrapped BNB (Wormhole)",
+    "symbol": "WBNB",
+    "decimals": "8"
+  },
+  {
+    "id": "terra172d2q6knsjaz2rkkeevnfekcxvnyuggak8l5ltld64gf8pc5fnqqhngdud",
+    "name": "Wrapped BNB (Wormhole) (Wormhole)",
+    "symbol": "WBNB",
+    "decimals": "8"
   },
   {
     "id": "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55",
@@ -7374,11 +14264,71 @@
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh/logo.png"
   },
   {
+    "id": "terra178rlf3yqng4r4pgvwngh52gl4cwm9ms7gwv3fmmqdywmzt66mamqznassf",
+    "name": "Wrapped Ether (Wormhole) (Wormhole)",
+    "symbol": "WETH",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1f509skqv3aumpwkrgjhnjpyew4mhhxrm6h3ce6zs45r7zme9e8eqwjeqwa",
+    "name": "Wrapped Ethereum",
+    "symbol": "WETH",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ufj34v4agxlazv6gv36fsdm5e8y4kclqgp0qt0l8ureql9pcwssspma238",
+    "name": "Wrapped LUNA",
+    "symbol": "WLUNA",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1he6juwnty79eys2lszamkznek9yf4qu302dqf8qfws0sn03vyk0qfd4cz2",
+    "name": "Wrapped LUNA 2.0 (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "8"
+  },
+  {
+    "id": "terra12rglpa9u5jcatztvjsr4wfcx9pvgpa4vtz4c6z3n3sx2ynggggdscnt94y",
+    "name": "Wrapped Luna 2.0 Token (Wormhole)",
+    "symbol": "LUNA2",
+    "decimals": "8"
+  },
+  {
+    "id": "terra14axlvgd5mawznhukwf0dq93xhtfjfzq5cpn7pyah7lk5wf4g87tqx5whjg",
+    "name": "Wrapped LUNA Token (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1fxlqv06d7efj8qa3g9r6fz5kel4a9n9d3xtd5ws6zsmm4d2wyp2q426p2g",
+    "name": "Wrapped LUNA Token (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1sfhku0xmw62t8aau3r5rudjxmfxecr8j0ekvpfes6wed2q97yjdqrdnv6n",
+    "name": "Wrapped LUNA Token (Wormhole)",
+    "symbol": "LUNA",
+    "decimals": "8"
+  },
+  {
+    "id": "terra12g9t09vv7gdj0qpz043shtqgug5u80l5mrxm57kwncmxts96vhtqvfw8ep",
+    "name": "Wrapped LUNA Token (Wormhole) (Wormhole)",
+    "symbol": "wLUNA",
+    "decimals": "8"
+  },
+  {
     "id": "terra1dtqlfecglk47yplfrtwjzyagkgcqqngd5lgjp8",
     "name": "Wrapped Matic (Wormhole)",
     "symbol": "WMATIC",
     "decimals": "8",
     "icon": "https://raw.githubusercontent.com/certusone/wormhole-token-list/main/assets/MATICpo_wh.png"
+  },
+  {
+    "id": "terra1dnatg47sl457qz6p20mdcm4p3x5djsfysnyk955agkdst2nhpdqs70lmzw",
+    "name": "Wrapped ROSE (Wormhole)",
+    "symbol": "wROSE",
+    "decimals": "8"
   },
   {
     "id": "terra190tqwgqx7s8qrknz6kckct7v607cu068gfujpk",
@@ -7388,15 +14338,39 @@
     "icon": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/So11111111111111111111111111111111111111112/logo.png"
   },
   {
+    "id": "terra17udtzsrzsrtg2uhr73zf6xmd3whda2wfg3qt2wtfru4x8dgv2gkqc9axuy",
+    "name": "Wrapped UST (Wormhole) (Wormhole)",
+    "symbol": "wUST",
+    "decimals": "8"
+  },
+  {
+    "id": "terra1j4jen7gtnaec6fqc0kf0c3ku2yahywz0djjhw07596nz5hj9fzrqyhza66",
+    "name": "Wrapped UST Token (PoS) (Wormhole)",
+    "symbol": "UST",
+    "decimals": "8"
+  },
+  {
     "id": "terra1jl0egxpdfw0eqkzsgedzzet9zgwmhet2rd3s6u",
     "name": "WrappedOrion",
     "symbol": "wORION",
     "decimals": "6"
   },
   {
+    "id": "terra1pm6s5x770t27xajnj2qqkn6mku8s4k44ujs0m53h9epqqcarulnqwva8nt",
+    "name": "WW Vault uluna LP token",
+    "symbol": "uLP-uluna",
+    "decimals": "6"
+  },
+  {
     "id": "terra1vm507q46f2sm8jltjcvp3dtncttquwld0tfkdl",
     "name": "XADW Token",
     "symbol": "XADWS",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1wnceq4l76f50xgeatwrs8xvl9v7dzmuaxclrwd0jhzhj0z3lwlys8cgtja",
+    "name": "XAST-CLUN-LP",
+    "symbol": "uLP",
     "decimals": "6"
   },
   {
@@ -7429,6 +14403,18 @@
     "id": "terra162k5t3hl204lrwe8xvalh4pv4gdrjvdrjlgxst",
     "name": "XRUNE, The People's Launchpad",
     "symbol": "XRUNE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra122u87x6k75sa3p4ynsfvk7fs520v2gw4jrwfnupfuw57vcdqsdps6zjed5",
+    "name": "xSAYVE",
+    "symbol": "xSAYVE",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1z2y3vv5mn69ep3k5wu90cmwuh2t6e9vp565j59x35d4fq2rh06esqf37ek",
+    "name": "xSAYVE",
+    "symbol": "xSAYVE",
     "decimals": "6"
   },
   {
@@ -7494,6 +14480,138 @@
     "decimals": "6"
   },
   {
+    "id": "terra10l76clm9psp4whuhzheqhcrng53lzgu9za8hxntpu89ahepr6zqsuq6p4e",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1328565ayxaxcqjmw000v3va943jafszxjcqe0nfz5gf4huavym4qmj39qw",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra14q94v3fycwq6vmfyvd7200gx79483lhtp03wlhdwr6clu27jkxdqclzpuw",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19kf5647manlwql4kez5mwdlwfr4k9vsglcefyp0xxwce7aaztlrq55mu0y",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra19wdfeem79sxej2j7rxqk744axlpfn6egfu6wg9w0j83a0twvuj5sr2ev8n",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1celav7mac6ues3737mfrpgrurqkvmx5xx2yvq3jw5e4fcjpktq3syumv48",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1crat0mf78vtdvf752nk349pr9kjxutuewnakxrp0n5f40z4lmzxsgarjtx",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1elwcevx5x8nstnn460dhxqnahfzfvnjp3ssmuxqrj0j839z20k6skmwdz0",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1fanpvu7kefjl8mdlvjvnnxvq4wawtxxherkpycfrrzm23wjs4pasktjcdd",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1frmvm9fn4y67vgwx35qavs9ch69ly66y90qyp087cpftsp6zdrgquemc2v",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1gs5fpkpgdlwtvs9wqthm6ayu5shynkphp8sqe5zhr8n6gr2rctqsczzv9r",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1h6d2s0qpdx6zd9t2utkhdqsyk2nmln3tg3mxnwcplu2uvzmwmfrq4fd3rc",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1h8y42ee6p7yk2qks09dafd32up2evz3vx8tjf52fshv5s7dz9q6ssy06x3",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hng4rdkphpr3cn5gghwj7ly8tjl29hcs2ellt9w7yymd62ljql3sh8qr2a",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1hywcdx2qyjjpvfggcsvswn20uy8vxc8dy6vhuqq9szhlr3fm0efq56hvkx",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1js0uheej983dch0w804s53433ta8whngwkatv5kjyk8angw6u3eqlhy32z",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1jwdkhxx8jwce2rex2aw98nj65twe4pnnr9frrqva8y6cavs8fats84w2dm",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1k32vua65agvr4am52f3gkrgjrx0svyacdw6kc4k74j6040tfs5ssfvhaey",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1ntlycx2ar0xfcekxw7pkhahcun3dz4vdcxqyxqffk9javdccvsaqgfxaek",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1qs6xr9uk3u2kpfqlkaera5evjrvnf7w4jxracpkncyawlv2r2r0sys0j2u",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1v0x26p9ncyclu2ln5n6kh3wr5552se677k7q7f3d4sug87vxc48s04ggta",
+    "name": "yield",
+    "symbol": "yToken",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1lmkpcg09dan6ll6vkh84zd088fxl98nhm3a62a4gj74qvnwaennqpjsr89",
+    "name": "YourGirls",
+    "symbol": "KNOWHERE",
+    "decimals": "0"
+  },
+  {
     "id": "terra13gdkkedrnd48kel0fc8sr08usdfpdce9ku6qku",
     "name": "yout_token_name",
     "symbol": "SYMBOL",
@@ -7533,6 +14651,18 @@
     "id": "terra1gazefv0j5m0hhalp0qea5smypej2r0matncl88",
     "name": "ZERG",
     "symbol": "ZUG",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1zjqd9jey003003jl30jkvccqn99jt4hhyw7xjl60cvkydwvajvascetjyj",
+    "name": "МT (Wormhole)",
+    "symbol": "МT",
+    "decimals": "6"
+  },
+  {
+    "id": "terra1msjxnah55lv7f279pnnpklkm6sfauk2sj0y4yhr38axyk3d8j6dqylf8zm",
+    "name": "저스티스 킹스맨 다오",
+    "symbol": "JKD",
     "decimals": "6"
   }
 ]

--- a/terraclassic/asset.json
+++ b/terraclassic/asset.json
@@ -35,10 +35,7 @@
     "symbol": "ASTRO",
     "decimals": "6",
     "circ_supply_api": "https://api.astroport.fi/public/astro-token/circulating_supply",
-    "icon": "https://astroport.fi/astro_logo.png",
-    "website": "https://astroport.fi/",
-    "telegram": "https://t.me/astroport_fi",
-    "twitter": "https://twitter.com/astroport_fi"
+    "icon": "https://astroport.fi/astro_logo.png"
   },
   {
     "id": "terra1uxqd9gmtxz45yq53t2m9vrs74twwfrjmrqmdjd",
@@ -70,10 +67,7 @@
     "symbol": "bLUNA",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.anchorprotocol.com/logo/bLUNA.png",
-    "website": "https://anchorprotocol.com/",
-    "telegram": "https://t.me/anchor_official",
-    "twitter": "https://twitter.com/anchor_protocol"
+    "icon": "https://whitelist.anchorprotocol.com/logo/bLUNA.png"
   },
   {
     "id": "ibc/18ABA66B791918D51D33415DA173632735D830E2E77E63C91C11D3008CFD5262",
@@ -127,10 +121,7 @@
     "symbol": "KUJI",
     "decimals": "6",
     "circ_supply_api": "https://api.kujira.app/api/kuji/supply",
-    "icon": "https://assets.kujira.app/kuji.svg",
-    "website": "https://kujira.app",
-    "telegram": "https://t.me/team_kujira",
-    "twitter": "https://twitter.com/TeamKujira"
+    "icon": "https://assets.kujira.app/kuji.svg"
   },
   {
     "id": "terra1r8ak49p50g76zamn25h3u7lkmn9n4maq2k2le2",
@@ -168,11 +159,7 @@
     "symbol": "ORNE",
     "decimals": "6",
     "circ_supply_api": "https://orne.io/api/",
-    "icon": "https://orne.io/img/token_icon.png",
-    "website": "https://orne.io",
-    "telegram": "https://t.me/orne_io",
-    "twitter": "https://twitter.com/orne_i_o",
-    "coingecko": "https://www.coingecko.com/en/coins/orne"
+    "icon": "https://orne.io/img/token_icon.png"
   },
   {
     "id": "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B",
@@ -210,10 +197,7 @@
     "symbol": "SAYVE",
     "decimals": "6",
     "circ_supply_api": "https://lcd.terra.dev/wasm/contracts/terra1c0ml4nvpapkuex28yuh40n38cq3zyugszsw59e/store?query_msg=%7B%22check_balance%22%3A%7B%22addr%22%3A+%22terra14v9wrjs55qsn9lkvylsqela3w2ytwxzkycqzcr%22%7D%7D",
-    "icon": "https://i.ibb.co/5xC39ym/sayve.png",
-    "website": "https://www.sayve.money/",
-    "telegram": "https://t.me/SayveProtocolChat",
-    "twitter": "https://www.twitter.com/sayve_protocol"
+    "icon": "https://i.ibb.co/5xC39ym/sayve.png"
   },
   {
     "id": "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09",
@@ -246,12 +230,7 @@
     "symbol": "LunaX",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://raw.githubusercontent.com/stader-labs/assets/main/terra/LunaX_1.png",
-    "website": "https://staderlabs.com/",
-    "telegram": "https://t.me/staderlabs",
-    "twitter": "https://twitter.com/staderlabs",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/stader/",
-    "coingecko": "https://www.coingecko.com/en/coins/stader"
+    "icon": "https://raw.githubusercontent.com/stader-labs/assets/main/terra/LunaX_1.png"
   },
   {
     "id": "terra1ustvnmngueq0p4jd7gfnutgvdc6ujpsjhsjd02",
@@ -268,8 +247,7 @@
     "symbol": "STEAK",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1rl4zyexjphwgx6v3ytyljkkc4mrje2pyznaclv/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://larry.engineer/assets/steak.svg",
-    "twitter": "https://twitter.com/st4k3h0us3"
+    "icon": "https://larry.engineer/assets/steak.svg"
   },
   {
     "id": "terra13j2k5rfkg0qhk58vz63cze0uze4hwswlrfnm0fa4rnyggjyfrcnqcrs5z2",
@@ -293,11 +271,7 @@
     "symbol": "TFLOKI",
     "decimals": "6",
     "circ_supply_api": "https://api.terrafloki.io/supply/circulating",
-    "icon": "https://terrafloki.io/terrafloki_logo.png",
-    "website": "https://terrafloki.io/",
-    "telegram": "https://t.me/terrafloki",
-    "twitter": "https://twitter.com/TerraFloki",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/terrafloki/"
+    "icon": "https://terrafloki.io/terrafloki_logo.png"
   },
   {
     "id": "terra1vl3khh0w2fydtd72ly03vjmlll4nr0ldcl9u4z",
@@ -320,10 +294,7 @@
     "symbol": "VKR",
     "decimals": "6",
     "circ_supply_api": "https://api.valkyrieprotocol.com/circulating-supply",
-    "icon": "https://app.valkyrieprotocol.com/icon_vkr.png",
-    "website": "https://valkyrieprotocol.com",
-    "telegram": "https://t.me/valkyrie_protocol",
-    "twitter": "https://twitter.com/valkyrie_money"
+    "icon": "https://app.valkyrieprotocol.com/icon_vkr.png"
   },
   {
     "id": "terra1l9pdkujwe6rteefdhprv5lns49cptcglffhpf3",
@@ -493,10 +464,7 @@
     "symbol": "mAMD",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra18ej5nsuu867fkx4tuy2aglpvqjrkcrjjslap3z/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/AMD.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/AMD.png"
   },
   {
     "id": "terra12qxyx2l90c37kylw4jqe8t40ppnrnu8wqmx940",
@@ -510,10 +478,7 @@
     "symbol": "mABNB",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1g4x2pzmkc9z3mseewxf758rllg08z3797xly0n/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/ABNB.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/ABNB.png"
   },
   {
     "id": "terra1xc5ll57yu269x8ysxvdpjmvxmac3js7pst5ddr",
@@ -527,10 +492,7 @@
     "symbol": "mBABA",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1w7zgkcyt7y4zpct9dw8mw362ywvdlydnum2awa/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/BABA.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/BABA.png"
   },
   {
     "id": "terra14xulq5g99rfmrm6qkgzmrrspvknupajdqyd92k",
@@ -564,10 +526,7 @@
     "symbol": "mGOOGL",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1h8arz2k547uvmpxctuwush3jzc8fun4s96qgwt/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/GOOGL.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/GOOGL.png"
   },
   {
     "id": "terra17azgr4x2gz20uquy7vdacfdgjjkgd0h9lm377v",
@@ -581,10 +540,7 @@
     "symbol": "ALTE",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://gblobscdn.gitbook.com/spaces%2F-Mf4Y6TIGwMtHEN3AaXV%2Favatar-1626907729941.png?alt=media",
-    "website": "https://alteredprotocol.com/",
-    "telegram": "https://t.me/Altered_ALTE",
-    "twitter": "https://twitter.com/Altered_ALTE"
+    "icon": "https://gblobscdn.gitbook.com/spaces%2F-Mf4Y6TIGwMtHEN3AaXV%2Favatar-1626907729941.png?alt=media"
   },
   {
     "id": "terra1q93ws00plywc5prwv7mf2gdf7alhuqgk5w68lq",
@@ -610,10 +566,7 @@
     "symbol": "mAMZN",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra165nd2qmrtszehcfrntlplzern7zl4ahtlhd5t2/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/AMZN.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/AMZN.png"
   },
   {
     "id": "terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy",
@@ -621,10 +574,7 @@
     "symbol": "mAMC",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/AMC.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/AMC.png"
   },
   {
     "id": "terra1fx6ffswrmgyuf5nsxruce5gertr8vgsm7krrp7",
@@ -652,12 +602,7 @@
     "symbol": "ANC",
     "decimals": "6",
     "circ_supply_api": "https://api.anchorprotocol.com/api/v1/anc",
-    "icon": "https://whitelist.anchorprotocol.com/logo/ANC.png",
-    "website": "https://anchorprotocol.com/",
-    "telegram": "https://t.me/anchor_official",
-    "twitter": "https://twitter.com/anchor_protocol",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/anchor-protocol/",
-    "coingecko": "https://www.coingecko.com/en/coins/anchor-protocol"
+    "icon": "https://whitelist.anchorprotocol.com/logo/ANC.png"
   },
   {
     "id": "terra1587zn7hagaylrp22x5edz25zpqfn6szfmvtym4",
@@ -688,10 +633,7 @@
     "name": "Angel Protocol",
     "symbol": "HALO",
     "decimals": "6",
-    "icon": "https://i.ibb.co/q9krLwC/halo-token.png",
-    "website": "https://www.angelprotocol.io/",
-    "telegram": "https://t.me/angelprotocoI",
-    "twitter": "https://twitter.com/angelprotocol"
+    "icon": "https://i.ibb.co/q9krLwC/halo-token.png"
   },
   {
     "id": "terra15xf5wqprgzl59ckfyjtgavh7rqtxcju7gn57rc",
@@ -711,10 +653,7 @@
     "symbol": "APOLLO",
     "decimals": "6",
     "circ_supply_api": "https://price-api-mainnet.apollo.farm/v1/apollo/supply",
-    "icon": "https://i.ibb.co/VC517zj/apollo.png",
-    "website": "https://apollo.farm/",
-    "telegram": "https://t.me/apollodao",
-    "twitter": "https://twitter.com/ApolloDAO"
+    "icon": "https://i.ibb.co/VC517zj/apollo.png"
   },
   {
     "id": "terra10jgqgc3vt34w79t4puharnzjxxv7s3fq8tmnkp",
@@ -740,10 +679,7 @@
     "symbol": "mAAPL",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1vxtwu4ehgzz77mnfwrntyrmgl64qjs75mpwqaz/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/AAPL.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/AAPL.png"
   },
   {
     "id": "terra1vyusa796w86yh99l67dpd5g3hfva759vyuhn5z",
@@ -757,10 +693,7 @@
     "symbol": "mARKK",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1qqfx5jph0rsmkur2zgzyqnfucra45rtjae5vh6/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/ARKK.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/ARKK.png"
   },
   {
     "id": "terra1yjlqptvn3al5402jp600l7n3l5yl8man8d4kex",
@@ -787,10 +720,7 @@
     "symbol": "ATLO",
     "decimals": "6",
     "circ_supply_api": "https://atlo.app/api/atlo-circulating-supply",
-    "icon": "https://assets.atlo.app/images/atlo-logo.svg",
-    "website": "https://atlo.app",
-    "telegram": "https://t.me/Atlo_protocol",
-    "twitter": "https://twitter.com/atlo_protocol"
+    "icon": "https://assets.atlo.app/images/atlo-logo.svg"
   },
   {
     "id": "terra1y6mgy2ha0fwhtkd06jdca7hpep7z8hz9n2jz8t",
@@ -943,10 +873,7 @@
     "symbol": "mBTC",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/BTC.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/BTC.png"
   },
   {
     "id": "terra1vpehfldr2u2m2gw38zaryp4tfw7fe2kw2lryjf",
@@ -959,11 +886,7 @@
     "name": "Bitlocus Token",
     "symbol": "BTL",
     "decimals": "6",
-    "icon": "https://bitlocus.com/assets/btl-token.png",
-    "website": "https://btl.bitlocus.com/",
-    "telegram": "https://t.me/bitlocus_official",
-    "twitter": "https://twitter.com/bitlocus",
-    "coingecko": "https://www.coingecko.com/en/coins/bitlocus"
+    "icon": "https://bitlocus.com/assets/btl-token.png"
   },
   {
     "id": "terra1ss460ny4hl5zew0tlvywnw38rsy2ql3n420lv2",
@@ -1020,10 +943,7 @@
     "symbol": "bETH",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.anchorprotocol.com/logo/bETH.png",
-    "website": "https://anchorprotocol.com/",
-    "telegram": "https://t.me/anchor_official",
-    "twitter": "https://twitter.com/anchor_protocol"
+    "icon": "https://whitelist.anchorprotocol.com/logo/bETH.png"
   },
   {
     "id": "terra17wgmccdu57lx09yzhnnev39srqj7msg9ky2j76",
@@ -1291,10 +1211,7 @@
     "symbol": "mCOIN",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra18wayjpyq28gd970qzgjfmsjj7dmgdk039duhph/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/COIN.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/COIN.png"
   },
   {
     "id": "terra1n8awtfqa0wphx90pd2zc9v8vccc65f0gvv6rq5",
@@ -1517,11 +1434,7 @@
     "name": "Digipharm",
     "symbol": "DPH",
     "decimals": "6",
-    "icon": "https://digipharm.io/wp-content/uploads/2021/02/digipharm_etherscan_logo.png",
-    "website": "https://digipharm.io/",
-    "telegram": "https://t.me/digipharm",
-    "twitter": "https://twitter.com/DigipharmTeam",
-    "coingecko": "https://www.coingecko.com/en/coins/digipharm"
+    "icon": "https://digipharm.io/wp-content/uploads/2021/02/digipharm_etherscan_logo.png"
   },
   {
     "id": "udkk",
@@ -1548,9 +1461,7 @@
     "name": "Dogballoon",
     "symbol": "DOGB",
     "decimals": "6",
-    "icon": "https://i.ibb.co/4fDrx1n/dogballoon.jpg",
-    "telegram": "https://t.me/realdogballoon",
-    "twitter": "https://twitter.com/DogBalloon_"
+    "icon": "https://i.ibb.co/4fDrx1n/dogballoon.jpg"
   },
   {
     "id": "terra14kat7dptmcydvhn0l5ur3g3evs65n33925n7w7",
@@ -1605,10 +1516,7 @@
     "name": "DogeKwon Terra",
     "symbol": "DKWON",
     "decimals": "6",
-    "icon": "https://dogekwon.com/wp-content/uploads/2021/10/cropped-logo_new.png",
-    "website": "https://dogekwon.com/",
-    "telegram": "https://t.me/dogekwon_official",
-    "twitter": "https://twitter.com/dogekwon"
+    "icon": "https://dogekwon.com/wp-content/uploads/2021/10/cropped-logo_new.png"
   },
   {
     "id": "terra17zhwz3s95dwcw373eklrscvn4jr6f7sd7qpk7y",
@@ -1694,10 +1602,7 @@
     "symbol": "DOSH",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra14mvkydkwm2pzz62cgrkpeusphm4trrqrzd88ju/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://dogeshib.xyz/static/media/shiba-doge.0f2ade2f.png",
-    "website": "https://dogeshib.xyz",
-    "telegram": "https://t.me/TerraDogeShib",
-    "twitter": "https://twitter.com/TerraDOSH"
+    "icon": "https://dogeshib.xyz/static/media/shiba-doge.0f2ade2f.png"
   },
   {
     "id": "terra1ewesd6y7dswxd8qdfff7vxl8g2p0dfwpanf5fv",
@@ -1752,12 +1657,7 @@
     "name": "DragonSB",
     "symbol": "SB",
     "decimals": "6",
-    "icon": "https://s2.coinmarketcap.com/static/img/coins/64x64/14451.png",
-    "website": "https://dragonsb.finance/",
-    "telegram": "https://t.me/dragonsb_offical",
-    "twitter": "https://twitter.com/DragonSBFinance",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/dragonsb/",
-    "coingecko": "https://www.coingecko.com/en/coins/dragonsb"
+    "icon": "https://s2.coinmarketcap.com/static/img/coins/64x64/14451.png"
   },
   {
     "id": "terra1nh6theuhf4pv67pcyqnz58czljr382mxrp2rdh",
@@ -1952,10 +1852,7 @@
     "symbol": "mETH",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/ETH.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/ETH.png"
   },
   {
     "id": "ueur",
@@ -1977,10 +1874,7 @@
     "symbol": "mFB",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1mqsjugsugfprn3cvgxsrr8akkvdxv2pzc74us7/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/FB.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/FB.png"
   },
   {
     "id": "terra17nekftv2yp8n4lsex85008sphchs4t3rnfcqzf",
@@ -2205,10 +2099,7 @@
     "symbol": "mGLXY",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/GLXY.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/GLXY.png"
   },
   {
     "id": "terra1hytrupk3argcrsl5x7dv55gyda0tn7f2qqlwkl",
@@ -2228,10 +2119,7 @@
     "symbol": "mGME",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1m6j6j9gw728n82k78s0j9kq8l5p6ne0xcc820p/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/GME.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/GME.png"
   },
   {
     "id": "ugbp",
@@ -2285,9 +2173,7 @@
     "symbol": "GLOW",
     "decimals": "6",
     "circ_supply_api": "https://glowyield.com/api/supply",
-    "icon": "https://glowyield.com/assets/img/icons/glow.png",
-    "website": "https://glowyield.com/",
-    "twitter": "https://twitter.com/glowyield"
+    "icon": "https://glowyield.com/assets/img/icons/glow.png"
   },
   {
     "id": "terra1ruz2e26humerfnd9uhurc9766a4at8x8e3m2e4",
@@ -2349,10 +2235,7 @@
     "symbol": "mGS",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra137drsu8gce5thf6jr5mxlfghw36rpljt3zj73v/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/GS.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/GS.png"
   },
   {
     "id": "terra1d633fx8wlpgqnns9j4xw66cq6ypdy4u8r0rr7j",
@@ -2585,10 +2468,7 @@
     "symbol": "mQQQ",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1csk6tc7pdmpr782w527hwhez6gfv632tyf72cp/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/QQQ.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/QQQ.png"
   },
   {
     "id": "terra1enj2np0785hw3vt2gn2yga9y75306g6e9lq799",
@@ -2602,10 +2482,7 @@
     "symbol": "mIAU",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra10h7ry7apm55h4ez502dqdv9gr53juu85nkd4aq/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/IAU.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/IAU.png"
   },
   {
     "id": "terra12lvpnlphqh3q0cxp8y47e5km8k2ad5ydw5asu4",
@@ -2618,10 +2495,7 @@
     "name": "iShares Gold Trust (Delisted)",
     "symbol": "mIAU",
     "decimals": "6",
-    "icon": "https://whitelist.mirror.finance/icon/IAU.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/IAU.png"
   },
   {
     "id": "terra1kscs6uhrqwy6rx5kuw5lwpuqvm3t6j2d6uf2lp",
@@ -2629,10 +2503,7 @@
     "symbol": "mSLV",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1kscs6uhrqwy6rx5kuw5lwpuqvm3t6j2d6uf2lp/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/SLV.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/SLV.png"
   },
   {
     "id": "terra1td527f09l7lgf55fqtr0zvtx5ek0yl0fdrx574",
@@ -2689,10 +2560,7 @@
     "symbol": "mJNJ",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1ptdxmj3xmmljzx02nr4auwfuelmj0cnkh8egs2/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/JNJ.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/JNJ.png"
   },
   {
     "id": "terra1t5y4xm7xdc7csud2j2aezxs6e4uuj3lqpqk7jy",
@@ -2731,9 +2599,7 @@
     "name": "Juta Club Token",
     "symbol": "JUTA",
     "decimals": "2",
-    "icon": "https://raw.githubusercontent.com/terraswap/terraswap-web-app/main/public/images/CW20/JUTA.png",
-    "website": "https://juta.club/",
-    "twitter": "https://twitter.com/JutaClub"
+    "icon": "https://raw.githubusercontent.com/terraswap/terraswap-web-app/main/public/images/CW20/JUTA.png"
   },
   {
     "id": "terra1kujvztl5p8a45k56u42fq39jxldxcvuejtpfq5",
@@ -2776,10 +2642,7 @@
     "name": "Kinetic Token",
     "symbol": "KNTC",
     "decimals": "6",
-    "icon": "https://app.astroport.fi/tokens/kinetic.svg",
-    "website": "https://kinetic.money/",
-    "telegram": "https://t.me/kinetic_money",
-    "twitter": "https://twitter.com/kinetic_money"
+    "icon": "https://app.astroport.fi/tokens/kinetic.svg"
   },
   {
     "id": "terra18glhvftntrqg00hv96qkpx3r37g34qh8qytnps",
@@ -2793,10 +2656,7 @@
     "symbol": "KINGS",
     "decimals": "6",
     "circ_supply_api": "https://polar-inlet-12758.herokuapp.com/",
-    "icon": "https://kingsmandao.com/wp-content/uploads/2021/10/kingsman-logo-transparent_1@0.5x.png",
-    "website": "https://kingsmandao.com/",
-    "telegram": "https://t.me/kingsmandao",
-    "twitter": "https://twitter.com/kingsmandao"
+    "icon": "https://kingsmandao.com/wp-content/uploads/2021/10/kingsman-logo-transparent_1@0.5x.png"
   },
   {
     "id": "terra1c5fr3wdf2trj3dkxcckhmzzxlnnpepqn8cu8f8",
@@ -2971,9 +2831,7 @@
     "name": "Local Terra Token",
     "symbol": "LOCAL",
     "decimals": "6",
-    "icon": "https://localterra.money/local-logo-dark.png",
-    "website": "https://localmoney.io/",
-    "twitter": "https://twitter.com/TeamLocalMoney"
+    "icon": "https://localterra.money/local-logo-dark.png"
   },
   {
     "id": "terra14s3g6jmytjjg2jcxmmaj6k837vcr6h98muxc07",
@@ -2987,10 +2845,7 @@
     "symbol": "LOOP",
     "decimals": "6",
     "circ_supply_api": "https://loop-api.loop.markets/v1/contracts/circulating-supply",
-    "icon": "https://loop.markets/token/logo2.png",
-    "website": "https://dex.loop.markets/",
-    "telegram": "https://t.me/loopfinance",
-    "twitter": "https://twitter.com/loop_finance"
+    "icon": "https://loop.markets/token/logo2.png"
   },
   {
     "id": "terra1ew3yvrg0ejpgvswyw70gcqqp3g2j45d24se5xq",
@@ -3003,20 +2858,14 @@
     "name": "LOOPR Token",
     "symbol": "LOOPR",
     "decimals": "6",
-    "icon": "https://loop.markets/token/logo3.png",
-    "website": "https://dex.loop.markets/",
-    "telegram": "https://t.me/loopfinance",
-    "twitter": "https://twitter.com/loop_finance"
+    "icon": "https://loop.markets/token/logo3.png"
   },
   {
     "id": "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr",
     "name": "LoTerra",
     "symbol": "LOTA",
     "decimals": "6",
-    "icon": "https://loterra.io/LOTA.png",
-    "website": "https://loterra.io/",
-    "telegram": "https://t.me/LoTerra",
-    "twitter": "https://twitter.com/LoTerra_LOTA"
+    "icon": "https://loterra.io/LOTA.png"
   },
   {
     "id": "terra182740uw8nh6tk3yjfcf7gu5phg3kqryhtuxp0p",
@@ -3090,10 +2939,7 @@
     "symbol": "LUART",
     "decimals": "6",
     "circ_supply_api": "https://api.luart.io/luart-token/circulating-supply",
-    "icon": "https://staking.luart.io/token-white.svg",
-    "website": "https://luart.io/",
-    "telegram": "https://t.me/luart_io",
-    "twitter": "https://twitter.com/luart_io"
+    "icon": "https://staking.luart.io/token-white.svg"
   },
   {
     "id": "terra1z454qecteghkd8m3shgd48cdc7j7vtnsgxh4z7",
@@ -3149,12 +2995,7 @@
     "symbol": "LUNC",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/v1/circulatingsupply/luna",
-    "icon": "https://assets.terra.money/icon/svg/LUNC.svg",
-    "website": "https://www.terra.money/",
-    "telegram": "https://t.me/TerraLunaChat",
-    "twitter": "https://twitter.com/terra_money",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-luna/",
-    "coingecko": "https://www.coingecko.com/en/coins/terra-luna"
+    "icon": "https://assets.terra.money/icon/svg/LUNC.svg"
   },
   {
     "id": "terra1ex5age9gqd5em86wg8hu0ak5wrqez9yufvlrat",
@@ -3203,10 +3044,7 @@
     "name": "Lunart",
     "symbol": "ARTS",
     "decimals": "6",
-    "icon": "https://i.ibb.co/K9Q53VQ/lunart.png",
-    "website": "https://www.lunart.io/",
-    "telegram": "https://t.me/LunArtProtocol",
-    "twitter": "https://twitter.com/LunArt_NFT"
+    "icon": "https://i.ibb.co/K9Q53VQ/lunart.png"
   },
   {
     "id": "terra1fj06x3hq2xum56htlrdeame70knzl765cq4txr",
@@ -3232,12 +3070,7 @@
     "symbol": "LUV",
     "decimals": "6",
     "circ_supply_api": "https://source.lunaverse.io/circulation",
-    "icon": "https://lunaverse.io/assets/images/logo.png",
-    "website": "https://lunaverse.io/",
-    "telegram": "https://t.me/lunaverse_chat",
-    "twitter": "https://twitter.com/Lunaverse_io",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/lunaverse/",
-    "coingecko": "https://www.coingecko.com/en/coins/lunaverse"
+    "icon": "https://lunaverse.io/assets/images/logo.png"
   },
   {
     "id": "terra1kd4rfff04cvw7vae0szgawj0xye90fkchljv7y",
@@ -3269,12 +3102,7 @@
     "name": "LUNI",
     "symbol": "LUNI",
     "decimals": "6",
-    "icon": "https://d2s3n99uw51hng.cloudfront.net/static/100_100_LUNI_logo.png",
-    "website": "https://www.luniofficial.com/",
-    "telegram": "https://t.me/LUNIonTerra",
-    "twitter": "https://twitter.com/LUNIonTerra",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/luni",
-    "coingecko": "https://www.coingecko.com/en/coins/luni"
+    "icon": "https://d2s3n99uw51hng.cloudfront.net/static/100_100_LUNI_logo.png"
   },
   {
     "id": "terra1ykl7ee0dakfev97ektynnup8hscyuhc9kly9k4",
@@ -3294,9 +3122,7 @@
     "name": "MAGA Coin",
     "symbol": "MAGA",
     "decimals": "6",
-    "icon": "https://i.gyazo.com/6384718f275295789378e3794e9b23d1.png",
-    "telegram": "https://t.me/joinchat/G4zK5BmHQWBiZTc5",
-    "twitter": "https://twitter.com/Terra_MAGA"
+    "icon": "https://i.gyazo.com/6384718f275295789378e3794e9b23d1.png"
   },
   {
     "id": "terra1ehcjwxwf96c278n2ks84zes3ece5fqy78fa749",
@@ -3348,12 +3174,7 @@
     "symbol": "MARS",
     "decimals": "6",
     "circ_supply_api": "https://api.marsprotocol.io/graphql",
-    "icon": "https://marsprotocol.io/MARSTokenMini.svg",
-    "website": "https://marsprotocol.io/",
-    "telegram": "https://t.me/martiannews",
-    "twitter": "https://twitter.com/mars_protocol",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/mars-protocol/",
-    "coingecko": "https://www.coingecko.com/en/coins/mars-protocol"
+    "icon": "https://marsprotocol.io/MARSTokenMini.svg"
   },
   {
     "id": "terra1qs7h830ud0a4hj72yr8f7jmlppyx7z524f7gw6",
@@ -3465,10 +3286,7 @@
     "symbol": "MIAW",
     "decimals": "6",
     "circ_supply_api": "https://miaw-graph.com/graphql",
-    "icon": "https://www.miaw-trader.com/logo.png",
-    "website": "https://www.miaw-trader.com",
-    "telegram": "https://t.me/miawtrader",
-    "twitter": "https://twitter.com/miawtrader"
+    "icon": "https://www.miaw-trader.com/logo.png"
   },
   {
     "id": "terra1pshxc56zwgm6j78mhjgn2rgkj5d32aa887l7j6",
@@ -3488,10 +3306,7 @@
     "symbol": "mMSFT",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1227ppwxxj3jxz8cfgq00jgnxqcny7ryenvkwj6/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/MSFT.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/MSFT.png"
   },
   {
     "id": "terra1yrch507vhsmd9rue6q3v8pz4pe445jl09nrvz6",
@@ -3541,10 +3356,7 @@
     "symbol": "MINT",
     "decimals": "6",
     "circ_supply_api": "https://europe-west1-mintdao-app.cloudfunctions.net/circulatingSupply",
-    "icon": "https://mintdao.io/assets/token.svg",
-    "website": "https://mintdao.io",
-    "telegram": "https://t.me/mintdaoio",
-    "twitter": "https://twitter.com/mintdao_io"
+    "icon": "https://mintdao.io/assets/token.svg"
   },
   {
     "id": "terra137qvfdvlkj9vfhrctz4rlkk7lmgql7xalqlwpw",
@@ -3558,12 +3370,7 @@
     "symbol": "MIR",
     "decimals": "6",
     "circ_supply_api": "https://graph.mirror.finance/graphql",
-    "icon": "https://whitelist.mirror.finance/icon/MIR.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/mirror-protocol/",
-    "coingecko": "https://www.coingecko.com/en/coins/mirror-protocol"
+    "icon": "https://whitelist.mirror.finance/icon/MIR.png"
   },
   {
     "id": "terra1h4hvry62zk4zh0udecqmatfg02phnyu6hq74xd",
@@ -3676,10 +3483,7 @@
     "symbol": "NEB",
     "decimals": "6",
     "circ_supply_api": "https://supply.neb.money",
-    "icon": "https://assets.neb.money/icons/NEB.png",
-    "website": "https://app.neb.money",
-    "telegram": "https://t.me/nebula_protocol",
-    "twitter": "https://twitter.com/nebula_protocol"
+    "icon": "https://assets.neb.money/icons/NEB.png"
   },
   {
     "id": "terra1cczv3ck2r909w64n9rdqs3gh5gsmwumh4utz49",
@@ -3693,10 +3497,7 @@
     "symbol": "mNFLX",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1jsxngqasf2zynj5kyh0tgq9mj3zksa5gk35j4k/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/NFLX.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/NFLX.png"
   },
   {
     "id": "terra1nagqpmyw55yjphea4rhntlfv87ugmeaj8ym756",
@@ -3745,10 +3546,7 @@
     "symbol": "nETH",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra178v546c407pdnx5rer3hu8s2c0fc924k74ymnn/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://terra.nexusprotocol.app/nEth.svg",
-    "website": "https://nexusprotocol.app/",
-    "telegram": "https://t.me/NexusProtocol",
-    "twitter": "https://twitter.com/NexusProtocol"
+    "icon": "https://terra.nexusprotocol.app/nEth.svg"
   },
   {
     "id": "terra1f887h6wqygswcp4arjjak6mpdhwlrv6nj8y9wt",
@@ -3762,10 +3560,7 @@
     "symbol": "nLUNA",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra10f2mt82kjnkxqj2gepgwl637u2w4ue2z5nhz5j/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://terra.nexusprotocol.app/nLuna.svg",
-    "website": "https://nexusprotocol.app/",
-    "telegram": "https://t.me/NexusProtocol",
-    "twitter": "https://twitter.com/NexusProtocol"
+    "icon": "https://terra.nexusprotocol.app/nLuna.svg"
   },
   {
     "id": "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
@@ -3773,10 +3568,7 @@
     "symbol": "Psi",
     "decimals": "6",
     "circ_supply_api": "https://api.nexusprotocol.app/getPsiCirculationSupply",
-    "icon": "https://terra.nexusprotocol.app/assets/psi.png",
-    "website": "https://nexusprotocol.app/",
-    "telegram": "https://t.me/NexusProtocol",
-    "twitter": "https://twitter.com/NexusProtocol"
+    "icon": "https://terra.nexusprotocol.app/assets/psi.png"
   },
   {
     "id": "terra15z4tj56cdpdk5jxf28nep3ep0myu0frhlh6f3u",
@@ -3977,12 +3769,7 @@
     "symbol": "ORION",
     "decimals": "8",
     "circ_supply_api": "https://app.orion.money/circulating-supply.txt",
-    "icon": "https://orion.money/assets/ORION-LOGO-2.1-GREEN@256x256.png",
-    "website": "https://orion.money/",
-    "telegram": "https://t.me/Orion_Money",
-    "twitter": "https://twitter.com/orion_money",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/orion-money/",
-    "coingecko": "https://www.coingecko.com/en/coins/orion-money"
+    "icon": "https://orion.money/assets/ORION-LOGO-2.1-GREEN@256x256.png"
   },
   {
     "id": "terra1yhlhrea3rgyx2xdnsswsfakn28qa8z7yp5gmhd",
@@ -4053,10 +3840,7 @@
     "symbol": "mPYPL",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/PYPL.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/PYPL.png"
   },
   {
     "id": "terra1rjf3c4ayvx2d6pej6fanjhe54a2ds8dlh9f69s",
@@ -4119,10 +3903,7 @@
     "symbol": "PLY",
     "decimals": "6",
     "circ_supply_api": "https://playnity.io/api/?q=circulating-supply",
-    "icon": "https://i.ibb.co/Snt8gXx/Projekt-bez-tytu-u-3.png",
-    "website": "https://playnity.io/",
-    "telegram": "https://t.me/PLAYNITY",
-    "twitter": "https://twitter.com/play_nity"
+    "icon": "https://i.ibb.co/Snt8gXx/Projekt-bez-tytu-u-3.png"
   },
   {
     "id": "terra1kdkcxnsldqmj50ll77gmq5x26u69z8m69hdas6",
@@ -4148,10 +3929,7 @@
     "symbol": "mDOT",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/DOT.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/DOT.png"
   },
   {
     "id": "terra130fhr9jz0nylzhdvuwcpp3hne2s5qlft6hfzgv",
@@ -4171,10 +3949,7 @@
     "symbol": "cLUNA",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://home.prismprotocol.app/cluna.png",
-    "website": "https://prismprotocol.app/",
-    "telegram": "https://t.me/Prism_Protocol",
-    "twitter": "https://twitter.com/prism_protocol"
+    "icon": "https://home.prismprotocol.app/cluna.png"
   },
   {
     "id": "terra12y2uzvrn3j4y5390kfljtpq6z3wqflyg0wls2z",
@@ -4194,10 +3969,7 @@
     "symbol": "xPRISM",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1042wzrwg2uk6jqxjm34ysqquyr9esdgm5qyswz/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://prismprotocol.app/xprism.png",
-    "website": "https://prismprotocol.app/",
-    "telegram": "https://t.me/Prism_Protocol",
-    "twitter": "https://twitter.com/prism_protocol"
+    "icon": "https://prismprotocol.app/xprism.png"
   },
   {
     "id": "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
@@ -4205,10 +3977,7 @@
     "symbol": "pLUNA",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://home.prismprotocol.app/pluna.png",
-    "website": "https://prismprotocol.app/",
-    "telegram": "https://t.me/Prism_Protocol",
-    "twitter": "https://twitter.com/prism_protocol"
+    "icon": "https://home.prismprotocol.app/pluna.png"
   },
   {
     "id": "terra1krg7amkeenvqwkaarp4r4grmrnldd83lmkl26u",
@@ -4228,10 +3997,7 @@
     "symbol": "PRISM",
     "decimals": "6",
     "circ_supply_api": "https://api.extraterrestrial.money/v1/api/prices?symbol=PRISM",
-    "icon": "https://prismprotocol.app/prism.png",
-    "website": "https://prismprotocol.app/",
-    "telegram": "https://t.me/Prism_Protocol",
-    "twitter": "https://twitter.com/prism_protocol"
+    "icon": "https://prismprotocol.app/prism.png"
   },
   {
     "id": "terra1jn0w9ttjavzqeqmp79jzx3da6dx3p6jwmm6tk2",
@@ -4245,10 +4011,7 @@
     "symbol": "yLUNA",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra17wkadg0tah554r35x6wvff0y5s7ve8npcjfuhz/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://home.prismprotocol.app/yluna.png",
-    "website": "https://prismprotocol.app/",
-    "telegram": "https://t.me/Prism_Protocol",
-    "twitter": "https://twitter.com/prism_protocol"
+    "icon": "https://home.prismprotocol.app/yluna.png"
   },
   {
     "id": "terra1djd0hmv2hq8s0g9hs53s7gmc2phgg33kqq4uul",
@@ -4280,10 +4043,7 @@
     "symbol": "mVIXY",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra19cmt6vzvhnnnfsmccaaxzy2uaj06zjktu6yzjx/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/VIXY.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/VIXY.png"
   },
   {
     "id": "terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45",
@@ -4291,10 +4051,7 @@
     "symbol": "mVIXY",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/VIXY.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/VIXY.png"
   },
   {
     "id": "terra128pe5jpempxu0nws5lw28se9zknhsr78626cpn",
@@ -4358,12 +4115,7 @@
     "symbol": "MINE",
     "decimals": "6",
     "circ_supply_api": "https://api.pylon.money/api/mine/v1/overview",
-    "icon": "https://assets.pylon.rocks/logo/MINE.png",
-    "website": "https://www.pylon.money/",
-    "telegram": "https://t.me/pylon_protocol",
-    "twitter": "https://twitter.com/pylon_protocol",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/pylon-protocol/",
-    "coingecko": "https://www.coingecko.com/en/coins/pylon-protocol"
+    "icon": "https://assets.pylon.rocks/logo/MINE.png"
   },
   {
     "id": "terra1u9hgxjw5k0aje9xjf0ejfu6uwmamc2k8ylzd7l",
@@ -4402,10 +4154,7 @@
     "symbol": "RCT",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra17n223dxpkypc5c48la7aqjvverczg82ga3cr93/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://reactor.money/assets/logo.svg",
-    "website": "https://reactor.money/",
-    "telegram": "https://t.me/RCTannouncement",
-    "twitter": "https://twitter.com/reactor_money"
+    "icon": "https://reactor.money/assets/logo.svg"
   },
   {
     "id": "terra1tdc7hmydg3es6lmn2asfwfgs8ykq7xa0nz9rkh",
@@ -4457,10 +4206,7 @@
     "symbol": "mHOOD",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra18yqdfzfhnguerz9du5mnvxsh5kxlknqhcxzjfr/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/HOOD.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/HOOD.png"
   },
   {
     "id": "terra19qad83kr29qg89fpl4qh8m02wapmlwzpw5hvc4",
@@ -4474,12 +4220,7 @@
     "symbol": "ROBO",
     "decimals": "6",
     "circ_supply_api": "https://robohero-io-api.vercel.app/token/circulatingsupply",
-    "icon": "https://i.ibb.co/nmhRXB9/token.png",
-    "website": "https://robohero.io",
-    "telegram": "https://t.me/robohero",
-    "twitter": "https://twitter.com/RoboHero_io",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/robohero/",
-    "coingecko": "https://www.coingecko.com/en/coins/robohero"
+    "icon": "https://i.ibb.co/nmhRXB9/token.png"
   },
   {
     "id": "terra1gpwkclxwwuzd5wyjw2qn3km0r5ge4t4f4mnf0x",
@@ -4774,30 +4515,21 @@
     "name": "Space Dollars",
     "symbol": "SDOLLAR",
     "decimals": "2",
-    "icon": "https://spacedollars.money/wp-content/uploads/2021/10/spacedollars512x512.png",
-    "website": "https://spacedollars.money/",
-    "telegram": "https://t.me/space_dollars",
-    "twitter": "https://twitter.com/space_dollars"
+    "icon": "https://spacedollars.money/wp-content/uploads/2021/10/spacedollars512x512.png"
   },
   {
     "id": "terra1z2u9p4x9cnp7c44rnntxzhgqlnepv8elmde43d",
     "name": "Space Dollars Ticket - Lootopians",
     "symbol": "SDLTIC",
     "decimals": "6",
-    "icon": "https://terrafloki.io/SDTIC2-logo.svg",
-    "website": "https://spacedollars.money/",
-    "telegram": "https://t.me/space_dollars",
-    "twitter": "https://twitter.com/space_dollars"
+    "icon": "https://terrafloki.io/SDTIC2-logo.svg"
   },
   {
     "id": "terra15uc875u7uu8xyqf833nxwh5x4dm2kmu29u04vl",
     "name": "Space Dollars Ticket - SpacePets",
     "symbol": "SDTICI",
     "decimals": "6",
-    "icon": "https://terrafloki.io/SDOLLAR_ticket.png",
-    "website": "https://spacedollars.money/",
-    "telegram": "https://t.me/space_dollars",
-    "twitter": "https://twitter.com/space_dollars"
+    "icon": "https://terrafloki.io/SDOLLAR_ticket.png"
   },
   {
     "id": "terra1j3w0tswl56yxduhen4gnela7m4we86w9xkwaee",
@@ -4817,10 +4549,7 @@
     "symbol": "mSPY",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/SPY.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/SPY.png"
   },
   {
     "id": "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr",
@@ -4828,12 +4557,7 @@
     "symbol": "SPEC",
     "decimals": "6",
     "circ_supply_api": "https://api.spec.finance/api/stat?format=txt&type=circulation",
-    "icon": "https://terra.spec.finance/assets/SPEC.png",
-    "website": "https://terra.spec.finance/vaults",
-    "telegram": "https://t.me/spec_finance",
-    "twitter": "https://twitter.com/SpecProtocol",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/spectrum-token/",
-    "coingecko": "https://www.coingecko.com/en/coins/spectrum-token"
+    "icon": "https://terra.spec.finance/assets/SPEC.png"
   },
   {
     "id": "terra1k9ltsdc6e4ay4g8f8nt8qd7my9yyd27m7eh82d",
@@ -4853,10 +4577,7 @@
     "symbol": "mSQ",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1u43zu5amjlsgty5j64445fr9yglhm53m576ugh/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/SQ.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/SQ.png"
   },
   {
     "id": "terra16gnk7mpqr84f4mnmqjklpdxxe602dn0fjslwhy",
@@ -4961,10 +4682,7 @@
     "symbol": "sKUJI",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra188w26t95tf4dz77raftme8p75rggatxjxfeknw/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://assets.kujira.app/skuji.png",
-    "website": "https://kujira.app",
-    "telegram": "https://t.me/team_kujira",
-    "twitter": "https://twitter.com/TeamKujira"
+    "icon": "https://assets.kujira.app/skuji.png"
   },
   {
     "id": "terra1rg8f993m9834afwazersesgx7jjxv4p87q9wvc",
@@ -4985,10 +4703,7 @@
     "symbol": "mSBUX",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1246zy658dfgtausf0c4a6ly8sc2e285q4kxqga/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/SBUX.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/SBUX.png"
   },
   {
     "id": "terra13xujxcrc9dqft4p9a8ls0w3j0xnzm6y2uvve8n",
@@ -4996,12 +4711,7 @@
     "symbol": "STT",
     "decimals": "6",
     "circ_supply_api": "https://api.starterra.io/cmc?q=circulating",
-    "icon": "https://starterra.io/assets/100x100_starterra.png",
-    "website": "https://starterra.io",
-    "telegram": "https://t.me/starterraofficial",
-    "twitter": "https://twitter.com/StarTerra_io",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/starterra/",
-    "coingecko": "https://www.coingecko.com/en/coins/starterra"
+    "icon": "https://starterra.io/assets/100x100_starterra.png"
   },
   {
     "id": "terra146fhkmq8d7ae3e6jemufy4h5eq9zerftm8wzmt",
@@ -5069,10 +4779,7 @@
     "name": "Synthetic UST Token",
     "symbol": "kUST",
     "decimals": "6",
-    "icon": "https://app.astroport.fi/tokens/kUST.svg",
-    "website": "https://kinetic.money/",
-    "telegram": "https://t.me/kinetic_money",
-    "twitter": "https://twitter.com/kinetic_money"
+    "icon": "https://app.astroport.fi/tokens/kUST.svg"
   },
   {
     "id": "terra10vvl9llw4p7ca2zhmcdljk5el9fkpp9hg6qy53",
@@ -5355,8 +5062,7 @@
     "name": "Terra META",
     "symbol": "TMeta",
     "decimals": "6",
-    "icon": "https://i.imgur.com/4H10ALI.jpeg",
-    "twitter": "https://twitter.com/meta_terra"
+    "icon": "https://i.imgur.com/4H10ALI.jpeg"
   },
   {
     "id": "terra1qv98rklgrdv89gvf47rrzx2lzehd43uwz2rus4",
@@ -5399,10 +5105,7 @@
     "name": "Terra Moon",
     "symbol": "MOON",
     "decimals": "6",
-    "icon": "https://moon.gl/logo.png",
-    "website": "https://moon.gl/",
-    "telegram": "https://t.me/TerraMoonOfficial",
-    "twitter": "https://twitter.com/TheTerraMoon"
+    "icon": "https://moon.gl/logo.png"
   },
   {
     "id": "terra1tht79ct6uqe4ngg6wwjpxcu4ep3wdjhlttkthz",
@@ -5439,10 +5142,7 @@
     "name": "Terra Name Service",
     "symbol": "TNS",
     "decimals": "6",
-    "icon": "https://tns.money/static/images/token-logo.svg",
-    "website": "https://tns.money/",
-    "telegram": "https://t.me/tnsmoney",
-    "twitter": "https://twitter.com/tns_money"
+    "icon": "https://tns.money/static/images/token-logo.svg"
   },
   {
     "id": "terra1xy2gf523j92khfn8nx0uurkmkguul2u95cwv8v",
@@ -5497,10 +5197,7 @@
     "name": "Terra Reflection - Hold2Earn",
     "symbol": "H2E",
     "decimals": "6",
-    "icon": "https://static.wixstatic.com/media/cc2bf7_93413983a23e4cf58679d1155069a2db~mv2.png/v1/fill/w_281,h_281,al_c,q_85,usm_0.66_1.00_0.01/cc2bf7_93413983a23e4cf58679d1155069a2db~mv2.webp",
-    "website": "https://www.hold2earnterra.com",
-    "telegram": "https://t.me/terrah2e",
-    "twitter": "https://twitter.com/Hold2EarnTerra"
+    "icon": "https://static.wixstatic.com/media/cc2bf7_93413983a23e4cf58679d1155069a2db~mv2.png/v1/fill/w_281,h_281,al_c,q_85,usm_0.66_1.00_0.01/cc2bf7_93413983a23e4cf58679d1155069a2db~mv2.webp"
   },
   {
     "id": "terra1ulzl6vfexrk39vaje0qryarzlq2ahy80cdl4fz",
@@ -5513,10 +5210,7 @@
     "name": "Terra Shiba",
     "symbol": "tSHIBA",
     "decimals": "3",
-    "icon": "https://terrashiba.money/terra-shiba.png",
-    "website": "https://terrashiba.money/",
-    "telegram": "https://t.me/terrashiba",
-    "twitter": "https://twitter.com/terrashiba"
+    "icon": "https://terrashiba.money/terra-shiba.png"
   },
   {
     "id": "terra14lmsae6e4d5lu74yt67pkfsdaut4csjtq32a7x",
@@ -5584,10 +5278,7 @@
     "symbol": "TWD",
     "decimals": "6",
     "circ_supply_api": "https://api.terraworld.me/twd",
-    "icon": "https://app.terraworld.me/static/media/logo.f81b8104.png",
-    "website": "https://terraoffice.world",
-    "telegram": "https://t.me/twdoffices",
-    "twitter": "https://twitter.com/terraworldme"
+    "icon": "https://app.terraworld.me/static/media/logo.f81b8104.png"
   },
   {
     "id": "terra1dmkfkt5em3heh003hc9e0sqmplh2cp7vmuxv59",
@@ -5679,10 +5370,7 @@
     "symbol": "TKUB",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1sn208s2cmya87707w4r9hf36znv8ml8dcnhr2d/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://terrakub.io/wp-content/uploads/2021/10/TerraKUB_LOGO_200x200_KUBHEAD.png",
-    "website": "https://terrakub.io/",
-    "telegram": "https://t.me/TerraKubCoin",
-    "twitter": "https://twitter.com/TerraKubCoin"
+    "icon": "https://terrakub.io/wp-content/uploads/2021/10/TerraKUB_LOGO_200x200_KUBHEAD.png"
   },
   {
     "id": "terra14pv5z9j9auwf7p4dg3ds0gch8sr8gnnf0psk8c",
@@ -5732,11 +5420,7 @@
     "symbol": "TLAND",
     "decimals": "6",
     "circ_supply_api": "https://terraland.io/api/tland/statistics/circulating-supply",
-    "icon": "https://terralandio-site.s3.eu-central-1.amazonaws.com/TerraLand-logo-v1c-4x.png",
-    "website": "https://terraland.io/",
-    "telegram": "https://t.me/terra_land",
-    "twitter": "https://twitter.com/Terra_Land",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/terra-land/"
+    "icon": "https://terralandio-site.s3.eu-central-1.amazonaws.com/TerraLand-logo-v1c-4x.png"
   },
   {
     "id": "terra19y395vzlylv3s3nasr7cu4yey7s22ghqd35ps8",
@@ -6598,8 +6282,7 @@
     "symbol": "TND",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1wuchppam64t2chrfmevv9tv64mur2ls395qa44/store?query_msg=eyJzdGF0ZSI6e319",
-    "icon": "https://terrnado.cash/logo.png",
-    "website": "https://terrnado.cash/"
+    "icon": "https://terrnado.cash/logo.png"
   },
   {
     "id": "terra1n9k2he20h5vpyn4mgv7pg4pzvw2n3wc4a86v3g",
@@ -6626,10 +6309,7 @@
     "symbol": "mTSLA",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra14y5affaarufk3uscy2vr6pe6w6zqf2wpjzn5sh/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/TSLA.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/TSLA.png"
   },
   {
     "id": "terra14rq6etqgza9qqpgz9yjfmsclgnzhk9jsafdtyc",
@@ -7077,20 +6757,14 @@
     "name": "TFloki NFT TICKET",
     "symbol": "TFTIC",
     "decimals": "6",
-    "icon": "https://terrafloki.io/ticket_logo.png",
-    "website": "https://terrafloki.io/",
-    "telegram": "https://t.me/terrafloki",
-    "twitter": "https://twitter.com/TerraFloki"
+    "icon": "https://terrafloki.io/ticket_logo.png"
   },
   {
     "id": "terra1xt9fgu7965kgvunnjts9zkprd8986kcc444q86",
     "name": "TFloki NFT TICKET 2",
     "symbol": "TFTICII",
     "decimals": "6",
-    "icon": "https://terrafloki.io/ticket2_logo.png",
-    "website": "https://terrafloki.io",
-    "telegram": "https://t.me/terrafloki",
-    "twitter": "https://twitter.com/TerraFloki"
+    "icon": "https://terrafloki.io/ticket2_logo.png"
   },
   {
     "id": "terra16t8cdhps9sxk7sje2w77fay8lh4se3p4gqjeya",
@@ -7103,40 +6777,28 @@
     "name": "TFloki NFT TICKET 3",
     "symbol": "TFTICIII",
     "decimals": "6",
-    "icon": "https://terrafloki.io/ticket3_logo.png",
-    "website": "https://terrafloki.io",
-    "telegram": "https://t.me/terrafloki",
-    "twitter": "https://twitter.com/TerraFloki"
+    "icon": "https://terrafloki.io/ticket3_logo.png"
   },
   {
     "id": "terra1pmf2x6gp8u979q672lkkkruuhe9zarxyu5w7t2",
     "name": "TFloki NFT TICKET 4",
     "symbol": "TFTICIV",
     "decimals": "6",
-    "icon": "https://terrafloki.io/ticket4_logo.svg",
-    "website": "https://terrafloki.io",
-    "telegram": "https://t.me/terrafloki",
-    "twitter": "https://twitter.com/TerraFloki"
+    "icon": "https://terrafloki.io/ticket4_logo.svg"
   },
   {
     "id": "terra1mzxr59qj8qr5plgd8kmqx9vn937qr5vzjd055w",
     "name": "TFloki NFT TICKET 5",
     "symbol": "TFTICV",
     "decimals": "6",
-    "icon": "https://terrafloki.io/ticket5_logo.svg",
-    "website": "https://terrafloki.io",
-    "telegram": "https://t.me/terrafloki",
-    "twitter": "https://twitter.com/TerraFloki"
+    "icon": "https://terrafloki.io/ticket5_logo.svg"
   },
   {
     "id": "terra1yzj58vsvryarrasx6rkf9deyn5h60zlm7lzv8r",
     "name": "TFLOKI NFT TICKET D6",
     "symbol": "TFTICVI",
     "decimals": "6",
-    "icon": "https://terrafloki.io/ticket6_logo.svg",
-    "website": "https://terrafloki.io/",
-    "telegram": "https://t.me/terrafloki",
-    "twitter": "https://twitter.com/TerraFloki"
+    "icon": "https://terrafloki.io/ticket6_logo.svg"
   },
   {
     "id": "terra19xk3rsesaupv72se69y8v6y6m04fl8yj6vnmtv",
@@ -7324,10 +6986,7 @@
     "symbol": "mTWTR",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1cc3enj9qgchlrj34cnzhwuclc4vl2z3jl7tkqg/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/TWTR.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/TWTR.png"
   },
   {
     "id": "terra158y6aypem94yj34ycvgdm3py23afhnu2dj24ak",
@@ -7373,10 +7032,7 @@
     "symbol": "mUSO",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1lvmx8fsagy70tv0fhmfzdw9h6s3sy4prz38ugf/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://whitelist.mirror.finance/icon/USO.png",
-    "website": "https://mirror.finance/",
-    "telegram": "https://t.me/mirror_protocol",
-    "twitter": "https://twitter.com/mirror_protocol"
+    "icon": "https://whitelist.mirror.finance/icon/USO.png"
   },
   {
     "id": "terra1av9tfs7k5gfuzm04e7p0d4ezrc53vq9mn3m08z",
@@ -7544,10 +7200,7 @@
     "name": "Whale Token",
     "symbol": "WHALE",
     "decimals": "6",
-    "icon": "https://whitewhale.money/logo-small.svg",
-    "website": "https://whitewhale.money/",
-    "telegram": "https://t.me/WhiteWhaleTerra",
-    "twitter": "https://twitter.com/WhiteWhaleTerra"
+    "icon": "https://whitewhale.money/logo-small.svg"
   },
   {
     "id": "terra19v4cg3w698qprsjwzw52cns6245vkxug74q9lc",
@@ -7598,24 +7251,14 @@
     "name": "Wormhole:CREDI",
     "symbol": "whCREDI",
     "decimals": "8",
-    "icon": "https://i.ibb.co/M7JKGWM/e1-Qb-Z4q-Q-400x400.jpg",
-    "website": "https://credefi.finance/",
-    "telegram": "https://t.me/credefi",
-    "twitter": "https://twitter.com/credefi_finance",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/credefi/",
-    "coingecko": "https://www.coingecko.com/en/coins/credefi"
+    "icon": "https://i.ibb.co/M7JKGWM/e1-Qb-Z4q-Q-400x400.jpg"
   },
   {
     "id": "terra1efjugpjc50d8sha7lr8s48cr7wmsthz94eevcl",
     "name": "Wormhole:DAO Maker",
     "symbol": "whDAO",
     "decimals": "8",
-    "icon": "https://etherscan.io/token/images/daomaker_128.png",
-    "website": "https://daomaker.com/",
-    "telegram": "https://t.me/daomaker",
-    "twitter": "https://twitter.com/thedaomaker",
-    "coinmarketcap": "https://coinmarketcap.com/currencies/dao-maker/",
-    "coingecko": "https://www.coingecko.com/en/coins/dao-maker"
+    "icon": "https://etherscan.io/token/images/daomaker_128.png"
   },
   {
     "id": "terra1gtjr689cyaau20k8ezdxy8eup34tntun5xr9l2",
@@ -7708,10 +7351,7 @@
     "name": "Wormhole:XDEFI",
     "symbol": "whXDEFI",
     "decimals": "8",
-    "icon": "https://github.com/sushiswap/assets/blob/master/blockchains/ethereum/assets/0x72B886d09C117654aB7dA13A14d603001dE0B777/logo.png?raw=true",
-    "website": "https://www.xdefi.io/",
-    "telegram": "https://t.me/xdefi_io",
-    "twitter": "https://twitter.com/xdefi_wallet"
+    "icon": "https://github.com/sushiswap/assets/blob/master/blockchains/ethereum/assets/0x72B886d09C117654aB7dA13A14d603001dE0B777/logo.png?raw=true"
   },
   {
     "id": "terra133q7a0uctlld9kru6put3hk99qvxm9qzmklu9f",
@@ -7771,10 +7411,7 @@
     "symbol": "XMARS",
     "decimals": "6",
     "circ_supply_api": "https://fcd.terra.dev/terra/wasm/v1beta1/contracts/terra1a04v570f9cxp49mk06vjsm8axsswndpwwt67k4/store?query_msg=eyJ0b2tlbl9pbmZvIjp7fX0%3D",
-    "icon": "https://marsprotocol.io/xMARSTokenMini.svg",
-    "website": "https://marsprotocol.io/",
-    "telegram": "https://t.me/martiannews",
-    "twitter": "https://twitter.com/mars_protocol"
+    "icon": "https://marsprotocol.io/xMARSTokenMini.svg"
   },
   {
     "id": "terra103ws85fnvy3j9vr3ss9va2zr26vepemqx2n88u",
@@ -7805,10 +7442,7 @@
     "name": "xterra",
     "symbol": "XTRA",
     "decimals": "6",
-    "icon": "https://terraworld.me/assets/XTRA.png",
-    "website": "https://app.terraworld.me/Gov",
-    "telegram": "https://t.me/twdoffice",
-    "twitter": "https://twitter.com/terraworldme"
+    "icon": "https://terraworld.me/assets/XTRA.png"
   },
   {
     "id": "terra1tw845kgt0uq0gfmavawacfvaq5t9fa9v57g6m9",
@@ -7839,9 +7473,7 @@
     "name": "xyz Bonus Token",
     "symbol": "xyzBONUS",
     "decimals": "6",
-    "icon": "https://pbs.twimg.com/profile_images/1437844740452589578/jKbfh-rM.jpg",
-    "website": "https://planets.collectxyz.com/",
-    "twitter": "https://twitter.com/collectxyznft"
+    "icon": "https://pbs.twimg.com/profile_images/1437844740452589578/jKbfh-rM.jpg"
   },
   {
     "id": "terra15pv3xxp2d5f65qeu2v27vqf9zpqjx0fuztfwcu",

--- a/terraclassic/entity.json
+++ b/terraclassic/entity.json
@@ -38,11 +38,6 @@
     "name": "Gidorah"
   },
   {
-    "name": "Gravity Bridge",
-    "website": "https://t.co/rSb0msPbRI",
-    "twitter": "https://twitter.com/gravity_bridge"
-  },
-  {
     "name": "Juno",
     "website": "https://www.junonetwork.io/",
     "telegram": "https://t.me/JunoNetwork",
@@ -56,6 +51,12 @@
   },
   {
     "name": "Luna Bird"
+  },
+  {
+    "name": "Mirror Protocol",
+    "website": "https://mirror.finance/",
+    "telegram": "https://t.me/mirror_protocol",
+    "twitter": "https://twitter.com/mirror_protocol"
   },
   {
     "name": "Orne"
@@ -100,12 +101,6 @@
     "website": "https://app.steak.club/",
     "telegram": "https://t.me/+PadO-WwMDxNjMGEx",
     "twitter": "https://twitter.com/st4k3h0us3"
-  },
-  {
-    "name": "Terra Money",
-    "website": "https://www.terra.money/",
-    "telegram": "https://t.me/TerraNetworkLobby",
-    "twitter": "https://twitter.com/terra_money"
   },
   {
     "name": "Terra Poker",

--- a/terraclassic/pool.json
+++ b/terraclassic/pool.json
@@ -1,14342 +1,14342 @@
 [
   {
     "id": "terra102t6psqa45ahfd7wjskk3gcnfev32wdngkcjzd",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra10y0jqynfchuadr7cycl3qqaugl2jd6s76660w7",
-    "lp_token_id": "terra1vchyrrx3nwgary8aq36rc2uxt3y56ex5x3qkhd",
     "asset_ids": [
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1vchyrrx3nwgary8aq36rc2uxt3y56ex5x3qkhd"
   },
   {
     "id": "terra14q0cgunptuym048a4y2awt8a7fl9acudmfzk5e",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rl4zyexjphwgx6v3ytyljkkc4mrje2pyznaclv",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra15rx5ghq4nxrv62fqvdvm78kuasfkl95c6mcmqs",
-    "lp_token_id": "terra16aurvlp5xctv0ftcelaseypyc89ylf4y0s5q0y",
     "asset_ids": [
       "terra1g53pyke8jtmt4lwvk4yl0xaqc4u0qlsl8dz3ex",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra16aurvlp5xctv0ftcelaseypyc89ylf4y0s5q0y"
   },
   {
     "id": "terra18fl6aywx2c8xlfp5epl40dygqnrvqp9a678a9c",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1c868juk7lk9vuvetf0644qgxscsu4xwag6yaxs",
-    "lp_token_id": "terra198en0xuzldzyark7pqz409p3u2d2g3y3k8u3py",
     "asset_ids": [
       "terra1042wzrwg2uk6jqxjm34ysqquyr9esdgm5qyswz",
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra198en0xuzldzyark7pqz409p3u2d2g3y3k8u3py"
   },
   {
     "id": "terra1cc6kqk0yl25hdpr5llxmx62mlyfdl7n0rwl3hq",
-    "lp_token_id": "terra1yf9hh2zrpydwqnqaw4p5hqfzzhgv49jj24prew",
     "asset_ids": [
       "terra1e6mq63y64zcxz8xyu5van4tgkhemj3r86yvgu4",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1yf9hh2zrpydwqnqaw4p5hqfzzhgv49jj24prew"
   },
   {
     "id": "terra1cevdyd0gvta3h79uh5t47kk235rvn42gzf0450",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kkyyh7vganlpkj0gkc2rfmhy858ma4rtwywe3x",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1dawj5mr2qt2nlurge30lfgjg6ly4ls99yeyd25",
-    "lp_token_id": "terra1cxmdyn5srv8uwvhgz5ckqf28zf8c7uwyz08f2j",
     "asset_ids": [
       "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n",
       "terra1a04v570f9cxp49mk06vjsm8axsswndpwwt67k4"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1cxmdyn5srv8uwvhgz5ckqf28zf8c7uwyz08f2j"
   },
   {
     "id": "terra1gxjjrer8mywt4020xdl5e5x7n6ncn6w38gjzae",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1h2g2mldq2fskq0sqdhupnzpfj396d03ds2yfkd",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kkyyh7vganlpkj0gkc2rfmhy858ma4rtwywe3x",
       "terra1pepwcav40nvj3kh60qqgrk8k07ydmc00xyat06"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1j66jatn3k50hjtg2xemnjm8s7y8dws9xqa5y8w",
-    "lp_token_id": "terra1htw7hm40ch0hacm8qpgd24sus4h0tq3hsseatl",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1htw7hm40ch0hacm8qpgd24sus4h0tq3hsseatl"
   },
   {
     "id": "terra1n5jzjvqlylw4kz9cfed2djqvz5qsjlz4kvmkmz",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1pxexyejamkg856vmspyttcy4sva84qgyaq445z",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hj8de24c3yqvcsv9r8chr03fzwsak3hgd8gv3m",
       "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1qmxkqcgcgq8ch72k6kwu3ztz6fh8tx2xd76ws7",
-    "lp_token_id": "terra1hkm7w33fpmnruxka9tykfsntl4s692kwr8hj27",
     "asset_ids": [
       "terra1pvel56a2hs93yd429pzv9zp5aptcjg5ulhkz7w",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1hkm7w33fpmnruxka9tykfsntl4s692kwr8hj27"
   },
   {
     "id": "terra1qswfc7hmmsnwf7f2nyyx843sug60urnqgz75zu",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1szt6cq52akhmzcqw5jhkw3tvdjtl4kvyk3zkhx",
-    "lp_token_id": "terra186cxwpreuzqm9nhmaltycxfyqxz379aef752qw",
     "asset_ids": [
       "terra1skjr69exm6v8zellgjpaa2emhwutrk5a6dz7dd",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra186cxwpreuzqm9nhmaltycxfyqxz379aef752qw"
   },
   {
     "id": "terra1wgdjvp388mlvhad8u7ly5d34ga4zyyfvf3e5j8",
-    "lp_token_id": "terra19tmtkl0w6kfgvxj6tt3dg0vepzrzugh0x9yfpk",
     "asset_ids": [
       "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
       "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra19tmtkl0w6kfgvxj6tt3dg0vepzrzugh0x9yfpk"
   },
   {
     "id": "terra1x0ulpvp6m46c5j7t40nj24mjp900954ys2jsnu",
-    "lp_token_id": "terra1lapdj4fcg936fpgdwewx55h7n79p4p9tzrg4lw",
     "asset_ids": [
       "terra1pepwcav40nvj3kh60qqgrk8k07ydmc00xyat06",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "stable"
+    "type": "stable",
+    "lp_token_id": "terra1lapdj4fcg936fpgdwewx55h7n79p4p9tzrg4lw"
   },
   {
     "id": "terra10cw43kz2ujn4ur938u2qsrr9duhsqydkrxl07p",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hqr3l4je2yvn3l790ly0y6r0vgfs7yukwwj0ak",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra10k05ec24u8nrd3889c6zydr8tlv73cyhaufs4t",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14ec8v4c5dnwu2pq9plfquaffutu59tq9hld77e",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra124yter7w9e5mf6m843erql48xy5szsxd75zjxw",
-    "lp_token_id": "terra1p7l5qx277ql2rql6lxz3wsgusc53lfv097ckyq",
     "asset_ids": [
       "terra17e6sxcxxxp6j2xf6rzhcwnafk6sggrrl5wdvw3",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1p7l5qx277ql2rql6lxz3wsgusc53lfv097ckyq"
   },
   {
     "id": "terra12sf5en42qlfc3qle4m4pew6n4vjc6lrpwvhh2h",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1cl7whtrqmz5ldr553q69qahck8xvk80fm33qjx",
       "terra1jn0w9ttjavzqeqmp79jzx3da6dx3p6jwmm6tk2"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra12z67dhctkvsw8u8pr95rlefr5zcs2d2dwa0pth",
-    "lp_token_id": "terra1vwdjaak7rtqc7wc0zf9car40rt0qv79dppyxyt",
     "asset_ids": [
       "terra1p0w9hh9aea5mg26mjnx7tl695ldwxfksvw4yn4",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1vwdjaak7rtqc7wc0zf9car40rt0qv79dppyxyt"
   },
   {
     "id": "terra130w5j5yu7rc29wuc49qdcm2su72pljl77jlmk6",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra16x6mn6ulxzg4pgg7gpachkkgrkuac59vl7xgyl",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1366x8d5h0mexk83c8hjkqafk72a4rcwwwdk62h",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xmd43yrfxm4xy3lnptc7kr4rr93pzh5u0z0wgt",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra14m6dv3w66u8nk6nmrmvh4lxyd7fnw98tfm8qh9",
-    "lp_token_id": "terra1jd99306zw03cp937l7cugennqcscqz920vqftx",
     "asset_ids": [
       "terra1779kwh0aux9mesns3l7laxtu7njjpzqd7k7m3r",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1jd99306zw03cp937l7cugennqcscqz920vqftx"
   },
   {
     "id": "terra152655kx8ff6fa393h642uu075mmu9dz8xlfqvv",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rwph273axfefh8gh57scw3jfm7kn4s7t5hlu03",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra152wlyd53nfcltuwcje9ale8qv3hpyna4sv9mvg",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1mpq5zkkm39nmjrjg9raknpfrfmcfwv0nh0whvn",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra15av79vdec34egtwt9dhyuy73pdhfztazacs2tw",
-    "lp_token_id": "terra1pctrnkng8ev6swvjmg5vfu5uwv6zcznutcjpct",
     "asset_ids": [
       "terra1w724lm9qt5q8rz9n0kqlfglkulz7z98yjvxzn8",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1pctrnkng8ev6swvjmg5vfu5uwv6zcznutcjpct"
   },
   {
     "id": "terra15pehlkssvyu8e7x6s9gz0j9x8q2qthvcf6hdqh",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pc253zfn4zns6awk7eks779uk3m7dna7y4cmlf",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra167lmzjrfvrqm59ycxvr4f937vgap4uytnkyrat",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1mely4fttd94g5kgjmz05dmclgdahq45xnv5n22",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra16af3ksetslvny2ypwe0nync0lahs87t9csvyz7",
-    "lp_token_id": "terra1xer502ejxn9g3elanqgrh4cl7zzk9dzxkwmy9q",
     "asset_ids": [
       "terra1n6eltvex47mta0me66ygqw0fgvjx2ul7qm9fjp",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1xer502ejxn9g3elanqgrh4cl7zzk9dzxkwmy9q"
   },
   {
     "id": "terra16lle05y09g2eazntxdx89m6u8d4y68t2tglmk3",
-    "lp_token_id": "terra10fwytprs0lnnwtdkvst0dpy9v5ql6ydwq278l7",
     "asset_ids": [
       "terra103ws85fnvy3j9vr3ss9va2zr26vepemqx2n88u",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra10fwytprs0lnnwtdkvst0dpy9v5ql6ydwq278l7"
   },
   {
     "id": "terra17ds7t9z2pu3cyqtlnklhfpruc0nnahddzr49wn",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vfhh44f57a72vaqdk69k2y9pllwlrhkv32n6nr",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra17umn0xctu4qj8w6psqfjfp20nx454csspuvdur",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1e6mq63y64zcxz8xyu5van4tgkhemj3r86yvgu4",
       "terra1pepwcav40nvj3kh60qqgrk8k07ydmc00xyat06"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra17w79y5ptp63dlr79tup9rkh6294qe448phup3f",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17ktj9hq69ae9mj49dwqfzmj05t6eqlkyywukf8",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1awy55useu780l3hsprulg0s26maxgtx2pjkev0",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1zce4mxwwdyk04txa2f3aqepzsq8jy7ca50gn8w",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ccwy34ygpj9qav05y2d5akzeeflvz6lzvsz9l9",
-    "lp_token_id": "terra1rm36n8c5zacf83aljwzzxtq8ctge7wlym689we",
     "asset_ids": [
       "terra1a07n2cp4wd49ezxdgm9xgtfrnpmxfcdp4yrdnv",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1rm36n8c5zacf83aljwzzxtq8ctge7wlym689we"
   },
   {
     "id": "terra1cylvlytxzjywy0wpf5mrtua3q37esduhqfk9w9",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vyusa796w86yh99l67dpd5g3hfva759vyuhn5z",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1d5uhps2w38fqnx2zzfrkhk96sw4j4twjpr5s46",
-    "lp_token_id": "terra1ztj6x5exa33w7dsvjxmdxam8w7j7t2phglmpea",
     "asset_ids": [
       "terra15k5r9r8dl8r7xlr29pry8a9w7sghehcnv5mgp6",
       "terra18vl2cypy8pdys2qdqlg7pzmcmpqmur8lmrnk2c"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ztj6x5exa33w7dsvjxmdxam8w7j7t2phglmpea"
   },
   {
     "id": "terra1dleq0ve3wlkcqsj93d63u4t7c8h8d65uztnfl0",
-    "lp_token_id": "terra192nxzlpw8kgtppmrr9uqzn27cphpyaqauxd6qw",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "terra1kujvztl5p8a45k56u42fq39jxldxcvuejtpfq5"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra192nxzlpw8kgtppmrr9uqzn27cphpyaqauxd6qw"
   },
   {
     "id": "terra1e46tre2rxhuxq58ygxsxm2m8djup7f3gasen6w",
-    "lp_token_id": "terra1r0wdunh0nrn65863hrs0p72us2502x525m62sg",
     "asset_ids": [
       "terra157n30a667ethsknneaavga2txtze58eajyfv45",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1r0wdunh0nrn65863hrs0p72us2502x525m62sg"
   },
   {
     "id": "terra1egk8w9eeta7dehmhsf4v3fjkrxucc6ygamj5sz",
-    "lp_token_id": "terra1jy6r3knmz2a62k5vpy6f65smm6nrgsaqreqj0d",
     "asset_ids": [
       "terra1h0jk42weh0urhgdtjql93rrvgdccspnp7vyf49",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1jy6r3knmz2a62k5vpy6f65smm6nrgsaqreqj0d"
   },
   {
     "id": "terra1eguektu6mgqqc8rxprsk5nadpxpr7v5k7ttpqx",
-    "lp_token_id": "terra175jguvthv6m7xj20eqc609ftcnddk9mhxkhmkc",
     "asset_ids": [
       "terra1hauj2lpsnye4jsxxww8kpze4mzyq76e5cjr2wp",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra175jguvthv6m7xj20eqc609ftcnddk9mhxkhmkc"
   },
   {
     "id": "terra1equ0rx0hhk4q22v2rlg779war57rhgt7d8vwls",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12qgpr0fw773gc8lrkys3knnw6nkgdlc8ggaty9",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1eqv7ldavhp8lvgesk0083g6jwqktgwp7cm6hq6",
-    "lp_token_id": "terra1ntcs04cq40vqyj5qjr8w43yrhqx5zcwx0nm2kd",
     "asset_ids": [
       "terra1ew3yvrg0ejpgvswyw70gcqqp3g2j45d24se5xq",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ntcs04cq40vqyj5qjr8w43yrhqx5zcwx0nm2kd"
   },
   {
     "id": "terra1f37ftdeeke582crsdc9exf8n6m05awzpjjm60c",
-    "lp_token_id": "terra1tr6l7vugxjtzm2jtmm53rguxh6j7qdu46jnatu",
     "asset_ids": [
       "terra1mfek3m9s0sazd40kjraw5qv3963t5n3gwk408u",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1tr6l7vugxjtzm2jtmm53rguxh6j7qdu46jnatu"
   },
   {
     "id": "terra1f87y5r6xmt37sf09nl0fw3mgnk0xsnnyeecgnn",
-    "lp_token_id": "terra1ylug28lxeykpag00rl59ethqy8tq2n65stld3d",
     "asset_ids": [
       "terra1teh62le6cndl2ch9yw5vkjk30h2fd4mhkrt5wc",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ylug28lxeykpag00rl59ethqy8tq2n65stld3d"
   },
   {
     "id": "terra1fqqtkhx8c3jxfl94jzzldvjmu4u9jeuyful6ma",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1jp4r38w4j2qkxavjs9ypqv6mv833wdar3tywe2",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1gpel5uny2f2hw3e7kln4y3mluwtdlcpukaeukk",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ypgjelmtp0mv5akzwmnj5xhukhd3fy9gd28wpj",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1hhpgcp2stvzx952zfxtxg4dhgf60yfzchesj3e",
-    "lp_token_id": "terra1kt26adtzwu4yefw37snr73n393vsu8w0hmazxc",
     "asset_ids": [
       "uusd",
       "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1kt26adtzwu4yefw37snr73n393vsu8w0hmazxc"
   },
   {
     "id": "terra1j3se2lhn7kwzu0zpa9zgc2sk9r20gmrrxz0n88",
-    "lp_token_id": "terra1tzlc5g00ny7vh78mc8fnw2qqe4wmy7mmjgv497",
     "asset_ids": [
       "terra1krg7amkeenvqwkaarp4r4grmrnldd83lmkl26u",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1tzlc5g00ny7vh78mc8fnw2qqe4wmy7mmjgv497"
   },
   {
     "id": "terra1lnr6aacxfng34m69076s2mdfjzt8nev2p6z5q0",
-    "lp_token_id": "terra1rx4xd94l74jupghnrn27r8ymauap9fy7tr3js7",
     "asset_ids": [
       "terra1dw6yapjv8k8anef2kg43hewg3g73wle22ncaje",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1rx4xd94l74jupghnrn27r8ymauap9fy7tr3js7"
   },
   {
     "id": "terra1mxd85ljdjcm7ddfh8qvnxx8tyggnh3zsahy7aa",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17n223dxpkypc5c48la7aqjvverczg82ga3cr93",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1nq6ty6lppp7kz58nkshhmyfe8tv4p85ueh50mp",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1tf6ukhukcqwfasm6e3ae2406c87vc8zhrh5ex7",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1nvzgfu8yyzcsm7a3je2hnn597ndz74g9a22zzl",
-    "lp_token_id": "terra14jqrnf75jaqwyz5q6j4fk4503qyvfult6juytl",
     "asset_ids": [
       "terra16ygrvq7q2zxw7jj3f96racur50w0g7r0mj6e2y",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra14jqrnf75jaqwyz5q6j4fk4503qyvfult6juytl"
   },
   {
     "id": "terra1qkzw4cfr74d0n5s9mf865vcpuchv0ssygkmvuy",
-    "lp_token_id": "terra1vhustrxwexul87cj7yk5wr993rk68p8mkwuvkw",
     "asset_ids": [
       "terra1nq9epqtswmj7uaymsw59w9n5h5e78k9rwduets",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1vhustrxwexul87cj7yk5wr993rk68p8mkwuvkw"
   },
   {
     "id": "terra1qpu9ve7lle9wl7npkqq745j8fwekw5ghfnttkj",
-    "lp_token_id": "terra1zejyjpwf6fpeg7fpa42vu0d5fjwejv7tx4ts3z",
     "asset_ids": [
       "terra17ckx25kqhwzf3fudprs78kqgp3lhpr2w74yf7t",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1zejyjpwf6fpeg7fpa42vu0d5fjwejv7tx4ts3z"
   },
   {
     "id": "terra1qv0j5udg2lcnqkuy5rqt2n6n2z9m2zps6zfx2v",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "terra18ky9ln4g6x3n9f9s8a5ttshynv6lgzfppmrmyg"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1r49ew9xrpauml4chelxd6mt32xwpywlmcnt853",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1gjuhc34ccr6ajq7dm5266xyedu96sgkv4qnley",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1r5m5h9nvnw0hhzwn4gzz9p2wzg78q2jsq0alvp",
-    "lp_token_id": "terra1l6jgxephuj6uggg4hvdvcg8ys0twkm7t68j0kz",
     "asset_ids": [
       "terra1e6mq63y64zcxz8xyu5van4tgkhemj3r86yvgu4",
       "terra1kkyyh7vganlpkj0gkc2rfmhy858ma4rtwywe3x"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1l6jgxephuj6uggg4hvdvcg8ys0twkm7t68j0kz"
   },
   {
     "id": "terra1r5xu0edlqgjd9t7smsaww0tr7jvqh0805x8nd4",
-    "lp_token_id": "terra1t4fsj0eu0jg9h9um8wmj9c9r05mjj2pvcevyp5",
     "asset_ids": [
       "terra1fx6ffswrmgyuf5nsxruce5gertr8vgsm7krrp7",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1t4fsj0eu0jg9h9um8wmj9c9r05mjj2pvcevyp5"
   },
   {
     "id": "terra1shgwa4xwdegsxvtr0qaergjq689sakzvn87fvy",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1l385362dg276797k7lzsfktskfssg22n7hn4at",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1suwlj0tlfqngq67gy2pjyqjwx3rfry2klvtxe5",
-    "lp_token_id": "terra1pth0gsyh8j0x08zv2fqq930xq6assges0zg82u",
     "asset_ids": [
       "terra1cvsfc32dkdvmla6urrscrtfceztecj0u5tvlvz",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1pth0gsyh8j0x08zv2fqq930xq6assges0zg82u"
   },
   {
     "id": "terra1sz988qp6vma3j0xj5w7fsskqcuc8kjn0mmtcqc",
-    "lp_token_id": "terra152e9whmpjlgenfhjj6rm4lcffcpdfgqc0u5qx2",
     "asset_ids": [
       "uusd",
       "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra152e9whmpjlgenfhjj6rm4lcffcpdfgqc0u5qx2"
   },
   {
     "id": "terra1t59ywlkkmvy7rmkdmdpy0z7wdqez5tne9mrd0r",
-    "lp_token_id": "terra1jxhmcjh3ymd32v7e8f5uar92pg3e05yts8z6lf",
     "asset_ids": [
       "terra1pepwcav40nvj3kh60qqgrk8k07ydmc00xyat06",
       "terra10f2mt82kjnkxqj2gepgwl637u2w4ue2z5nhz5j"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1jxhmcjh3ymd32v7e8f5uar92pg3e05yts8z6lf"
   },
   {
     "id": "terra1uqsny2clznnhrmq2rvlhv72l78lmlss32uzuyh",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18ejpjp9eyx9t8j07jd7kzah9p0rvkzdfeeva6n",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1v67ycjhzup787j9efpygr4fcky7rpxgkfkf89d",
-    "lp_token_id": "terra1nxgs0pfu89wyx6wfg3yssmeykg3nuh5mae4uyx",
     "asset_ids": [
       "terra17nekftv2yp8n4lsex85008sphchs4t3rnfcqzf",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1nxgs0pfu89wyx6wfg3yssmeykg3nuh5mae4uyx"
   },
   {
     "id": "terra1v6vmpgpq3lky0w9jhmqn8ccr0sgetkgus70e62",
-    "lp_token_id": "terra1zadxq9h0aw40tna7ytrnn57ymc57chwluxkhyc",
     "asset_ids": [
       "terra1kggysvv0q3tq2r58f5nt03hqa8pqj87c2m8k09",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1zadxq9h0aw40tna7ytrnn57ymc57chwluxkhyc"
   },
   {
     "id": "terra1v7hcllx3l7namvvffg3jfl7vc3ksy089yr3ewu",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1mh7nlhzvvesgc4whcx7dg2nhj3p0dhl9fwrexu",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1vfxjj237nsyxu8034syv46d4gzmrajksrdnvdc",
-    "lp_token_id": "terra1xlrclrh3zu8vpjmnlnkjealnw6ggtf287ms3ly",
     "asset_ids": [
       "terra1lyppcm0cjc5nrge6hmwdkkeqeh4m9cat8nyf3e",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1xlrclrh3zu8vpjmnlnkjealnw6ggtf287ms3ly"
   },
   {
     "id": "terra1wau74j4ykmx5nfjad4wjra8m02x9vg5h8g7ym2",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13kr45ssru9cqhp2kaaan88wfaa7f2h3jfvuldp",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1x2l3qhtcp2jlgn3duwrt7f6pqaz3tq3qydmkp4",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra153u8c40h2mm8nvs0daqxsnwgvpw43muxj3c28h",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1xckx7r8ay8hr6qneqlftcejzaqme4jw0k35e0l",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1fhsljj6qc8f7cnu62e8uxqt82czflztge05dwk",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1xhewlp3h0kh82t2n33x2cc200t3zcxmhmrsyqk",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1z4pfv9rrm53tg72cwkcv6ddvd4x6wcce43nua2",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1y6e5xmqxcq9zm9mdncf4nwneyp27d98awgqjv7",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vm507q46f2sm8jltjcvp3dtncttquwld0tfkdl",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ymh8xk3uv522vs2g7m8j6v059s7cmcxyr5vqtc",
-    "lp_token_id": "terra13fwa5e5m95tye2jtnkxjmwe3632hp2pampxjk7",
     "asset_ids": [
       "terra1ult8nl3u83p7vdjdehtjfn9ylkm6u606nmdry3",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra13fwa5e5m95tye2jtnkxjmwe3632hp2pampxjk7"
   },
   {
     "id": "terra1092tamrn3w8j7qp0uu2ltml7sjts7z9hkj2wga",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1unewn6sa7hg3z0pvhrc9u9rmph7z975h4nrfvq",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra10lv5wz84kpwxys7jeqkfxx299drs3vnw0lj8mz",
-    "lp_token_id": "terra1t53c8p0zwvj5xx7sxh3qtse0fq5765dltjrg33",
     "asset_ids": [
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
       "terra10f2mt82kjnkxqj2gepgwl637u2w4ue2z5nhz5j"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1t53c8p0zwvj5xx7sxh3qtse0fq5765dltjrg33"
   },
   {
     "id": "terra10nfk6fcz5nc5uru964qmpels9ctg6j0vczjgl7",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra10xczfpmpryl3m434jjvvv0rre70yyscw98pueu",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17n223dxpkypc5c48la7aqjvverczg82ga3cr93",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra126j4psud93ee83n6uyxq5m9zd40yzlmjvmsf94",
-    "lp_token_id": "terra1q5pw834sfnxw6htcng58pgugl3cm6g3506yf0w",
     "asset_ids": [
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1q5pw834sfnxw6htcng58pgugl3cm6g3506yf0w"
   },
   {
     "id": "terra1296jw27cq8svlg4ywm8t84u448p3zs7mcqg9ra",
-    "lp_token_id": "terra1c7upd2p5p294dtdj7xx0dd9yu5cm2ak4lgz2h0",
     "asset_ids": [
       "terra1vchw83qt25j89zqwdpmdzj722sqxthnckqzxxp",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1c7upd2p5p294dtdj7xx0dd9yu5cm2ak4lgz2h0"
   },
   {
     "id": "terra12k8d0uzrgcqn4ge4k8ntr4aaycpwunz7pu2umj",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra12qna5j5nehx7wamqelxg7pup877wd3jwd0dnpz",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uluna",
       "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra132qwlqxffksjfg6ntzp4m5786lrlmgrufzx5c6",
-    "lp_token_id": "terra1x869hqq8483tc3qc6pdhnmcqnfkccftvwqvp8d",
     "asset_ids": [
       "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1x869hqq8483tc3qc6pdhnmcqnfkccftvwqvp8d"
   },
   {
     "id": "terra134m8n2epp0n40qr08qsvvrzycn2zq4zcpmue48",
-    "lp_token_id": "terra16unvjel8vvtanxjpw49ehvga5qjlstn8c826qe",
     "asset_ids": [
       "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra16unvjel8vvtanxjpw49ehvga5qjlstn8c826qe"
   },
   {
     "id": "terra13krvk2ujpkfx8zk8sqsjq6nmzul287jfwy9e26",
-    "lp_token_id": "terra129dd20k60vaw9wu4lhesj9hwaumcczpggqg5nr",
     "asset_ids": [
       "terra1z3fvf7tae0586jjn5ve580thc3pyj9vwandw4n",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra129dd20k60vaw9wu4lhesj9hwaumcczpggqg5nr"
   },
   {
     "id": "terra13uwsn7sp0559lgpppyjkvf63kzdyuaqe2dc50d",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1atagmw0ssv6wlgmrjjdaa22p7h4wmsy33eljgw",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra13xz77zwk9jvulch92uwzuk3astcp0uvymh7f2p",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra13yftwgefkggq3u627gphq98s6ufwh9u85h5kmg",
-    "lp_token_id": "terra16zy9g2eym8rghxx95ny60c3dyrwqsfx0ypmu5y",
     "asset_ids": [
       "terra1hnezwjqlhzawcrfysczcxs6xqxu2jawn729kkf",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra16zy9g2eym8rghxx95ny60c3dyrwqsfx0ypmu5y"
   },
   {
     "id": "terra13zduyt3rzuhlkzcax0a8djpvfdvtnw59e8st3f",
-    "lp_token_id": "terra1dkryxdrs2a5jjx97c4u5t37c4h6kfwv736rv74",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1dkryxdrs2a5jjx97c4u5t37c4h6kfwv736rv74"
   },
   {
     "id": "terra143az0w2e504n56q7k43qyh2fu69fh3rhup32n3",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vwz7t30q76s7xx6qgtxdqnu6vpr3ak3vw62ygk",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra143xxfw5xf62d5m32k3t4eu9s82ccw80lcprzl9",
-    "lp_token_id": "terra17trxzqjetl0q6xxep0s2w743dhw2cay0x47puc",
     "asset_ids": [
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17trxzqjetl0q6xxep0s2w743dhw2cay0x47puc"
   },
   {
     "id": "terra144p2hh09v4y9ytj7x3r97jl5etrrg9lrgyf8yn",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1fyxs23jdlj5qgfp4hv2qqv4d3csmvqxsva573m",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1476fucrvu5tuga2nx28r3fctd34xhksc2gckgf",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra169edevav3pdrtjcx35j6pvzuv54aevewar4nlh",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra14glht7py7e3zp09wex9awej5cu4jql90yygdw0",
-    "lp_token_id": "terra1tr7w28vzsx6pl7z8wvps6t57k3uw29fc735rnc",
     "asset_ids": [
       "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1tr7w28vzsx6pl7z8wvps6t57k3uw29fc735rnc"
   },
   {
     "id": "terra14pds7y2xdal7l96heq03mhfsadt6ezes8wyvn6",
-    "lp_token_id": "terra17msxjffsm37etkna34n7yltzdmzf9akz26w6lj",
     "asset_ids": [
       "terra1yy0w2w8rkrfn5ul967rhpjrj4a0hpjy6m7end7",
       "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17msxjffsm37etkna34n7yltzdmzf9akz26w6lj"
   },
   {
     "id": "terra14rnschsdlllt00yk8fxvxmcqgzhme3cx06t2x4",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "ibc/18ABA66B791918D51D33415DA173632735D830E2E77E63C91C11D3008CFD5262",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra14sal7lg7ny207yz0ue4dc02mdqs03zytegsn2r",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1yeyr6taynkwdl85ppaggr3zr8txhf66cny2ang"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra14xxxh8mq4rkxr6uy0q78chn5nu2jkj2uk09fwd",
-    "lp_token_id": "terra1geh0qnt0u8e8jqug08cnfmkwnjyrpv3t65ur64",
     "asset_ids": [
       "terra17rwgygp5y7tx83xyclwuxu654vjt2whpwxx688",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1geh0qnt0u8e8jqug08cnfmkwnjyrpv3t65ur64"
   },
   {
     "id": "terra15env0fa3z9jsc65cun7m37dhjypzwejqpy80vp",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra15s2wgdeqhuc4gfg7sfjyaep5cch38mwtzmwqrx",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dy9kmlm4anr92e42mrkjwzyvfqwz66un00rwr5",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1605aqnlpve2tes8vzqajg0ntzm5vx470vgrhta",
-    "lp_token_id": "terra1yej0l2y3sqy4alzcvymcxx7vmq5nvc7qswq4es",
     "asset_ids": [
       "terra1m3tdguf59xq3pa2twk5fjte5g6szj5y9x5npy7",
       "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1yej0l2y3sqy4alzcvymcxx7vmq5nvc7qswq4es"
   },
   {
     "id": "terra162emskmgmfyc73ryxx43y98gcvcavmprqkhepv",
-    "lp_token_id": "terra1h087pv7lh2pulshddjm3wyem0jcs7cpm0pera9",
     "asset_ids": [
       "terra1rdqy74e080e96qhk5gntnr882awm4pfc7t6dn4",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1h087pv7lh2pulshddjm3wyem0jcs7cpm0pera9"
   },
   {
     "id": "terra16e5tgdxre44gvmjuu3ulsa64kc6eku4972yjp3",
-    "lp_token_id": "terra1x6jws8lh505gw7dl67a7qq077g9mn3cjj3v22r",
     "asset_ids": [
       "terra190tqwgqx7s8qrknz6kckct7v607cu068gfujpk",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1x6jws8lh505gw7dl67a7qq077g9mn3cjj3v22r"
   },
   {
     "id": "terra16gz5fc8d3truesv3ssndgezxfn3p2879tfpwg9",
-    "lp_token_id": "terra1ey4hy3ar4n448pl4dq4yf2ncd6086ec0gajef3",
     "asset_ids": [
       "terra1l0rnt55mf8q87q2nqfn9un3lxnmxkhqrl939x5",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ey4hy3ar4n448pl4dq4yf2ncd6086ec0gajef3"
   },
   {
     "id": "terra16jaryra6dgfvkd3gqr5tcpy3p2s37stpa9sk7s",
-    "lp_token_id": "terra1pme6xgsr0f6sdcq5gm2qs8dsc2v0h6gqzs8js5",
     "asset_ids": [
       "terra1hj8de24c3yqvcsv9r8chr03fzwsak3hgd8gv3m",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1pme6xgsr0f6sdcq5gm2qs8dsc2v0h6gqzs8js5"
   },
   {
     "id": "terra170x0m3vmc7s5pdvpt5lh9n6wfmsz6wcykcr0vg",
-    "lp_token_id": "terra1mzslpzys2j67c2pzmde8kvj27vvkup978ujgcg",
     "asset_ids": [
       "terra1mt2ytlrxhvd5c4d4fshxxs3zcus3fkdmuv4mk2",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mzslpzys2j67c2pzmde8kvj27vvkup978ujgcg"
   },
   {
     "id": "terra174q0k4ynjuz6tewjjep2yhzzw55aw6gq82q4c6",
-    "lp_token_id": "terra170qpzy04ad3dnahw53ng43grcervgr7caglvyz",
     "asset_ids": [
       "terra1epz3d7rmltreyt6chgnuv28cy8e0d3yad75xh8",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra170qpzy04ad3dnahw53ng43grcervgr7caglvyz"
   },
   {
     "id": "terra17sswfv8mvvdx75j9q33l83j3cnahnta3wqqpa3",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kqf8ua7al5tdnkz95ue4zkuv4gcu52pt63ya54",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1820d2zqjqu3jkkdatsf4lktrkjkxslr4t4qf76",
-    "lp_token_id": "terra1aqndpg3rhqkc0qwyef5luh04s2anutsa08fr8g",
     "asset_ids": [
       "uusd",
       "terra143gyjf53a8ksn6r4nulaa69ld0dp6yety5gkmx"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1aqndpg3rhqkc0qwyef5luh04s2anutsa08fr8g"
   },
   {
     "id": "terra18dq84qfpz267xuu0k47066svuaez9hr4xvwlex",
-    "lp_token_id": "terra1cgvlpz6vltqa49jlj3yr2ddnwy22xw62k4433t",
     "asset_ids": [
       "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1cgvlpz6vltqa49jlj3yr2ddnwy22xw62k4433t"
   },
   {
     "id": "terra18e20cuvqex2h662talchnura7v48rz0ey7xc4v",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rdqy74e080e96qhk5gntnr882awm4pfc7t6dn4",
       "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra18hjdxnnkv8ewqlaqj3zpn0vsfpzdt3d0y2ufdz",
-    "lp_token_id": "terra1pjfqacx7k6dg63v2h5q96zjg7w5q25093wnkjc",
     "asset_ids": [
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
       "terra178v546c407pdnx5rer3hu8s2c0fc924k74ymnn"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1pjfqacx7k6dg63v2h5q96zjg7w5q25093wnkjc"
   },
   {
     "id": "terra18hq940rwpc94692tw90vyuxucp465e9gdd2ewm",
-    "lp_token_id": "terra19x53slg4ax56mvxuqtk369vrhef23zrsw6zckh",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19x53slg4ax56mvxuqtk369vrhef23zrsw6zckh"
   },
   {
     "id": "terra190jp9g28h5ntm2ekfecyfgwlf2y7qj4809gys7",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kqf8ua7al5tdnkz95ue4zkuv4gcu52pt63ya54",
       "terra1rdqy74e080e96qhk5gntnr882awm4pfc7t6dn4"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra19rcpzd2w35trvtwkjt4lrckqeqdstlplnqz2ny",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1a8an0aqzjghcukqrdgnkt3ygzhmaaqza03mc3h",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra19wauh79y42u5vt62c5adt2g5h4exgh26t3rpds",
-    "lp_token_id": "terra1ww6sqvfgmktp0afcmvg78st6z89x5zr3tmvpss",
     "asset_ids": [
       "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ww6sqvfgmktp0afcmvg78st6z89x5zr3tmvpss"
   },
   {
     "id": "terra1a75f02tqk6pf6xzkjgyxcpkpm9l5dzmqud5ely",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1aa68js6yxavg9zzzle2zaynem9cstvmaj3xyu3",
-    "lp_token_id": "terra12kf0s56pz2xhus9cqs4wva2xgz8wdkuqmh396s",
     "asset_ids": [
       "terra17wkadg0tah554r35x6wvff0y5s7ve8npcjfuhz",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra12kf0s56pz2xhus9cqs4wva2xgz8wdkuqmh396s"
   },
   {
     "id": "terra1arqxm8dp00z8sy36q30ve7rmw2wl2wfavwkk7g",
-    "lp_token_id": "terra153p2zvds95vavrenmtcrv8xqxy2sm8xhrl3784",
     "asset_ids": [
       "uusd",
       "terra1545laqy9s6jcej2pgts32rhqy6dzq62umk8g9q"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra153p2zvds95vavrenmtcrv8xqxy2sm8xhrl3784"
   },
   {
     "id": "terra1c9yy9ftxpdg3drk9upg60hykyw2ardrgus00ew",
-    "lp_token_id": "terra1j495mkdh6tjxexkatae9xq4300dw0jga3p4xzs",
     "asset_ids": [
       "terra19qad83kr29qg89fpl4qh8m02wapmlwzpw5hvc4",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1j495mkdh6tjxexkatae9xq4300dw0jga3p4xzs"
   },
   {
     "id": "terra1crat7ql0q4z0wc3uhqvnckenlgjvjcduecdegg",
-    "lp_token_id": "terra1cdddc8u5l4ytscuz7m9wxvk3hx53rqcs2vgh30",
     "asset_ids": [
       "terra1qlan324u6rsdevvc6ye3m02ump7dtp3z67uhqy",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1cdddc8u5l4ytscuz7m9wxvk3hx53rqcs2vgh30"
   },
   {
     "id": "terra1ctvlz7cqc6h7davlj46j9dne8ewc4hp2sqkmts",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1n2rujfc5lscglry30zaptfgncfc0gq4n8my0gv",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1d3t80j3d4raeg8m94erljaqehutve52yelw7r3",
-    "lp_token_id": "terra1jr7ca9vpxkhxwe8uk2649640t0gx5xcy4xknxg",
     "asset_ids": [
       "terra1zdpymdwpyg5gj5ye4uvr0mqmxw8c88k5vqegfr",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1jr7ca9vpxkhxwe8uk2649640t0gx5xcy4xknxg"
   },
   {
     "id": "terra1d4xrsa5rsyjy689mjf7c7hr8vg74d6q6gk3p6m",
-    "lp_token_id": "terra16n47ledvk4ye47r7z4hwmdz0fpphavamslv0ej",
     "asset_ids": [
       "uusd",
       "terra149tus2mxyak6ec9tm0fqs6eumeryga2ps9w7ku"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra16n47ledvk4ye47r7z4hwmdz0fpphavamslv0ej"
   },
   {
     "id": "terra1d7028vhd9u26fqyreee38cj39fwqvcyjps8sjk",
-    "lp_token_id": "terra1l40w4g5fea0qhlh304uzsyv03hanhpnsmrv0a9",
     "asset_ids": [
       "terra1mpq5zkkm39nmjrjg9raknpfrfmcfwv0nh0whvn",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1l40w4g5fea0qhlh304uzsyv03hanhpnsmrv0a9"
   },
   {
     "id": "terra1daxuedmyeu8cak0ds43u6emj7srkgjeka0twe4",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1e76nq6ll0vzy4apprphh0k5wqzzsndjakwd6x0",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rz964297kvt86rteajhtp4hsffhcum0ye8eljh",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1eck465e7u33y95flte0sld8ndrhk2yssnkea37",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1edurrzv6hhd8u48engmydwhvz8qzmhhuakhwj3",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1egwcnkeqsf28y4k8wg399ptz5zcsek52qypgzp",
-    "lp_token_id": "terra1v30r6lju6hs2kxrj2z0wdt2q38uwflh6mydx6k",
     "asset_ids": [
       "uluna",
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1v30r6lju6hs2kxrj2z0wdt2q38uwflh6mydx6k"
   },
   {
     "id": "terra1esm0pztzdq6hqgtj72w9dsnlfwtm343c7axvxu",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1f57qu9cavwv9522gkr4pcpe78t8rmwxq7w5weg",
-    "lp_token_id": "terra140eypk8cxgkrpvx4lfldqrtfwdakxgng3uwzc0",
     "asset_ids": [
       "uusd",
       "terra102cjx95xvww7cl9l6usxltk75ww3mpxtyw4lpm"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra140eypk8cxgkrpvx4lfldqrtfwdakxgng3uwzc0"
   },
   {
     "id": "terra1ffjjxeu5l9f027qtkwseulgz6ddx5f04czyf0w",
-    "lp_token_id": "terra1u45sf0k8xr2dn5fl2hpll7tjrv0pn3l30c4jnt",
     "asset_ids": [
       "terra1u2k0nkenw0p25ljsr4ksh7rxm65y466vkdewwj",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1u45sf0k8xr2dn5fl2hpll7tjrv0pn3l30c4jnt"
   },
   {
     "id": "terra1fx2w5w8yfvncc7newqg5l08png5wln6s5k7qwy",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rz964297kvt86rteajhtp4hsffhcum0ye8eljh",
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1gfvp0tynfdeux2rlfryqjrurcjyqfadw7sl502",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1gj2l0vrna4g73e0500hexzyy444g46vre3eaa3",
-    "lp_token_id": "terra1waafz57kdr2y6y8wcqq0rx72cjwkj0pg5f64au",
     "asset_ids": [
       "terra1ustvnmngueq0p4jd7gfnutgvdc6ujpsjhsjd02",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1waafz57kdr2y6y8wcqq0rx72cjwkj0pg5f64au"
   },
   {
     "id": "terra1gs2zrwxz0szra07ks8xze04g4clwjsj6jjaq90",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vchw83qt25j89zqwdpmdzj722sqxthnckqzxxp",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1gxluuw67zmflr7qun7vxgk04lqam8mt42m4945",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1h574pqdsnj42scyyc66ec54757mlpsnn6gefjv",
-    "lp_token_id": "terra1rljlrtce6acd6m58audxsxmjxqnga5ltrzwmg5",
     "asset_ids": [
       "terra1n8awtfqa0wphx90pd2zc9v8vccc65f0gvv6rq5",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1rljlrtce6acd6m58audxsxmjxqnga5ltrzwmg5"
   },
   {
     "id": "terra1hasy32pvxmgu485x5tujylemqxynsv72lsu7ve",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1hlq6ye6km5sq2pcnmrvlf784gs9zygt0akwvsu",
-    "lp_token_id": "terra1kp4n4tms5w4tvvypya7589zswssqqahtjxy6da",
     "asset_ids": [
       "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn",
       "terra188w26t95tf4dz77raftme8p75rggatxjxfeknw"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1kp4n4tms5w4tvvypya7589zswssqqahtjxy6da"
   },
   {
     "id": "terra1hn8d8ldzu2v2td5uj335pz32phanm90a4kjfal",
-    "lp_token_id": "terra1cmvmemsas2rrmytq6wtvt7jf0nrg7dpc804jws",
     "asset_ids": [
       "terra1hj8de24c3yqvcsv9r8chr03fzwsak3hgd8gv3m",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1cmvmemsas2rrmytq6wtvt7jf0nrg7dpc804jws"
   },
   {
     "id": "terra1hpgsgua62a9r2lsc9esfpxypw080ts93k8zxkg",
-    "lp_token_id": "terra1478nzcqhdpzmg6ztjkdjfkycdwrmeegn5r0yku",
     "asset_ids": [
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1478nzcqhdpzmg6ztjkdjfkycdwrmeegn5r0yku"
   },
   {
     "id": "terra1jfuq655fmqp7uhkkqanmljqj26r9acs68drn2s",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1cdc6nlsx0l6jmt3nnx7gxjggf902wge3n2z76k",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1jkjpcgn4wywcytpnq0y7wq9jsythz6azmyw5ec",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vsyyg4rs483uzd7jzw5fqqlm2q5n2yd37yylfc",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1jlvyyp6hhy60g0um3cx4wq989rtcxqars5jyy7",
-    "lp_token_id": "terra1c65pnllhe0ac89ha255kslnhu58ypgvw3efj8l",
     "asset_ids": [
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1c65pnllhe0ac89ha255kslnhu58ypgvw3efj8l"
   },
   {
     "id": "terra1jusmcruce9q3xu9y9mkxspm9rawvaa67w7fsd5",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1jvvc4gh5ksydjqgryrdph2msa2aj0qgxj4pzhq",
-    "lp_token_id": "terra15vacdmpxgpmcrrmlwqz2vl95rky0v855nykatw",
     "asset_ids": [
       "terra1vsyyg4rs483uzd7jzw5fqqlm2q5n2yd37yylfc",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra15vacdmpxgpmcrrmlwqz2vl95rky0v855nykatw"
   },
   {
     "id": "terra1k4wvysv90yndgl98udr0eq4nmdp92u4zrpr46m",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1rck0zefy4juahqjjk5q0wz2ykp7028hjwvzcaj"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1k8lvj3w7dxzd6zlyptcj086gfwms422xkqjmzx",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14v9wrjs55qsn9lkvylsqela3w2ytwxzkycqzcr",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1l7xu2rl3c7qmtx3r5sd2tz25glf6jh8ul7aag7",
-    "lp_token_id": "terra17n5sunn88hpy965mzvt3079fqx3rttnplg779g",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17n5sunn88hpy965mzvt3079fqx3rttnplg779g"
   },
   {
     "id": "terra1lk3tj2xyhr0ju9nhsarw79j3wpnntnzcxzvsdw",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1n2rujfc5lscglry30zaptfgncfc0gq4n8my0gv",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ls8hsss7tp3cna6nd95reevtmstm4uc644akxx",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pkp0pkxp9mtlan7cg0qatu65hmkgyq2342g27g",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ltf9ss5syeeu5schnw6ah3t4arfqmj53kgtc3k",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1mpq5zkkm39nmjrjg9raknpfrfmcfwv0nh0whvn",
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1m32zs8725j9jzvva7zmytzasj392wpss63j2v0",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1m6ywlgn6wrjuagcmmezzz2a029gtldhey5k552",
-    "lp_token_id": "terra1m24f7k4g66gnh9f7uncp32p722v0kyt3q4l3u5",
     "asset_ids": [
       "uusd",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1m24f7k4g66gnh9f7uncp32p722v0kyt3q4l3u5"
   },
   {
     "id": "terra1m95udvvdame93kl6j2mk8d03kc982wqgr75jsr",
-    "lp_token_id": "terra14p4srhzd5zng8vghly5artly0s53dmryvg3qc6",
     "asset_ids": [
       "terra13xujxcrc9dqft4p9a8ls0w3j0xnzm6y2uvve8n",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14p4srhzd5zng8vghly5artly0s53dmryvg3qc6"
   },
   {
     "id": "terra1mcvdrnnv7zxmnr4vnm9rwu8gr56wvfnx7hg0c5",
-    "lp_token_id": "terra13xujwys2afj6uzryv8g4cq6pvh6s50w7ueuhu7",
     "asset_ids": [
       "terra1kx73zld4tmv24r66h7jp8gaz2rrl4asxlzq2g4",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra13xujwys2afj6uzryv8g4cq6pvh6s50w7ueuhu7"
   },
   {
     "id": "terra1mm772kftkt7yhx68t2edm736rnel83c8eqf6ee",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
       "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1mv04l9m4xc6fntxnty265rsqpnn0nk8aq0c9ge",
-    "lp_token_id": "terra160jxnp3qfxrrjrfhul3xens4ggw6le7p4m4e6g",
     "asset_ids": [
       "terra1fpfn2kkr8mv390wx4dtpfk3vkjx9ch3thvykl3",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra160jxnp3qfxrrjrfhul3xens4ggw6le7p4m4e6g"
   },
   {
     "id": "terra1mxyp5z27xxgmv70xpqjk7jvfq54as9dfzug74m",
-    "lp_token_id": "terra1w80npmymwhdtvcmrg44xmqqdnufu3gyfaytr9z",
     "asset_ids": [
       "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1w80npmymwhdtvcmrg44xmqqdnufu3gyfaytr9z"
   },
   {
     "id": "terra1myl709y74vrdcyuxy6g9wv5l2sgah4e9lstnwe",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1mzw4s868sagj2hgh5kfc4e722pug95wea3f87w",
-    "lp_token_id": "terra1waun82g7fzqxee75dwqsmwds8zauz6mhhlylaf",
     "asset_ids": [
       "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1waun82g7fzqxee75dwqsmwds8zauz6mhhlylaf"
   },
   {
     "id": "terra1n2n5gumwuf3d3j2yxje6pczdykwx47y090vr5u",
-    "lp_token_id": "terra17npwjcgl3g4pv3xjv8xmmw67y49xeqhyw2n63q",
     "asset_ids": [
       "terra1tmar57largkrtts55q8szey2q78zc9em43ej5n",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17npwjcgl3g4pv3xjv8xmmw67y49xeqhyw2n63q"
   },
   {
     "id": "terra1namdguuyt2tngpwfyxsnjwaym2kts0svlvgdc6",
-    "lp_token_id": "terra1fvvfypp5v8r2nu30rducnuqn6rsp7tnwhxdnja",
     "asset_ids": [
       "terra1wctr29t5gul8qq6qvk6lue2lucymuptvcn9avl",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fvvfypp5v8r2nu30rducnuqn6rsp7tnwhxdnja"
   },
   {
     "id": "terra1netea00ej9gplmk063dwgd96qpmdy08lvd4ds0",
-    "lp_token_id": "terra1haar7vwrpwtgrzzrvntdrvm0gyxtlsus46zr37",
     "asset_ids": [
       "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1haar7vwrpwtgrzzrvntdrvm0gyxtlsus46zr37"
   },
   {
     "id": "terra1ng5xg5p63c3qvjpwqsmry2dz8mr9n39v8eztv9",
-    "lp_token_id": "terra1whaysztdqq27q6smnf7uknpfh0uus4suv3y0wa",
     "asset_ids": [
       "terra1gpwkclxwwuzd5wyjw2qn3km0r5ge4t4f4mnf0x",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1whaysztdqq27q6smnf7uknpfh0uus4suv3y0wa"
   },
   {
     "id": "terra1ng6rcmjcdcpde8jy3k37wm8kzgr7zgpqx72lud",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra133r6snp000sw0qhuspkua39fjc4c6pux82cnxh",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ngs0xlmxan6ktqwtcj8c2l2ddp3z00wpxt43vr",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1nujm9zqa4hpaz9s8wrhrp86h3m9xwprjt9kmf9",
-    "lp_token_id": "terra1ryxkslm6p04q0nl046quwz8ctdd5llkjnaccpa",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ryxkslm6p04q0nl046quwz8ctdd5llkjnaccpa"
   },
   {
     "id": "terra1p2fxxmkxsct97spt3f82acytxw2vpvm2f4f7t3",
-    "lp_token_id": "terra1jp2v2h82nd3rghm0hwgtegjg0hhe0xnnshcwqg",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1jp2v2h82nd3rghm0hwgtegjg0hhe0xnnshcwqg"
   },
   {
     "id": "terra1p99huvu9wskfuum8grftx5pmcunl4ruv8v0wvv",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1pzemhnxtmtp7z7hlecafjqpnrt29czhmyhyd2z",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1q0eh3pct8da820t0san35pcg0sqqtmz4k532xh",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1q843tspwkcec87n5xrwdx8ygnmjjk7kj0lc7p3",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "terra1hnezwjqlhzawcrfysczcxs6xqxu2jawn729kkf"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1qr2k6yjjd5p2kaewqvg93ag74k6gyjr7re37fs",
-    "lp_token_id": "terra1wmaty65yt7mjw6fjfymkd9zsm6atsq82d9arcd",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1wmaty65yt7mjw6fjfymkd9zsm6atsq82d9arcd"
   },
   {
     "id": "terra1qvq38uhmtdqh5tu3ratganwapnjefs2elxduy4",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yy0w2w8rkrfn5ul967rhpjrj4a0hpjy6m7end7",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1qzqzvsr3hvgsfkvcl4jgv0l4lsdhap8skawqt4",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "ibc/18ABA66B791918D51D33415DA173632735D830E2E77E63C91C11D3008CFD5262",
       "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1r0u977a90c5l8dxq8hu00eydm4ahl0mqwms9a8",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1l4uygw365sgdgvasmckkd7lcawyemzn9k83lrh",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1r2xwh4fd0gyrr3403v72j89354qtryvrg0rjc9",
-    "lp_token_id": "terra1pmn4f2fcrhgtuetqr0wt3nldgr7zlufu688pfd",
     "asset_ids": [
       "terra1jxypgnfa07j6w92wazzyskhreq2ey2a5crgt6z",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1pmn4f2fcrhgtuetqr0wt3nldgr7zlufu688pfd"
   },
   {
     "id": "terra1r6fchdsr8k65082u3cyrdn6x2n8hrpyrp72je0",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1repcset8dt8z9wm5s6x77n3sjg8hduem9tntd6",
-    "lp_token_id": "terra1yfwpk58tlvgzxx7zfrutlskgcp0cdqxtngpp6y",
     "asset_ids": [
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
       "terra1jxypgnfa07j6w92wazzyskhreq2ey2a5crgt6z"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1yfwpk58tlvgzxx7zfrutlskgcp0cdqxtngpp6y"
   },
   {
     "id": "terra1rhk92dvz3tjayymy8pl08gpkmamnud7ttzc03h",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1f0us6p9axmzacwq2fn7sm5ke8k302tx7hg7s49",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1rjql89achu0aq3e69nxz78qnj7xfdjewndsk2v",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uluna",
       "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ruu2gxsuplha5r2uzh0fnxqyd4svx23njwy74k",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uluna",
       "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1t0qdxv523fxkuyhk9yv6hgal33cwnwh9hmzq55",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1tehmd65kyleuwuf3a362mhnupkpza29vd86sml",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1cetg5wruw2wsdjp7j46rj44xdel00z006e9yg8",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1tkcnky57lthm2w7xce9cj5jeu9hjtq427tpwxr",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1tlmqtwj5lq27knn7x932mqwmwdlnppesvwt5pa",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yy0w2w8rkrfn5ul967rhpjrj4a0hpjy6m7end7",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1tteawchaue7myplvgm46ghszymh2wd4ghhcjq3",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1uf36lmgl3jut9xfg50cel2fh67ja6e5gqd98kj",
-    "lp_token_id": "terra1lt284v0t2psk9m9pj3ext0srtrzar6jsg70g8t",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1lt284v0t2psk9m9pj3ext0srtrzar6jsg70g8t"
   },
   {
     "id": "terra1v5ct2tuhfqd0tf8z0wwengh4fg77kaczgf6gtx",
-    "lp_token_id": "terra1cspx9menzglmn7xt3tcn8v8lg6gu9r50d7lnve",
     "asset_ids": [
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1cspx9menzglmn7xt3tcn8v8lg6gu9r50d7lnve"
   },
   {
     "id": "terra1vfpfncl2wcxjhatl08mt0j8ppx5vzr6eek0wj2",
-    "lp_token_id": "terra1ggz8vxgngjc8atv8z70kdfhmlg534gg0zevfcf",
     "asset_ids": [
       "terra12flsr4mk5sxmu8yk7m8zc5f44tfx00yjvzj7v4",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ggz8vxgngjc8atv8z70kdfhmlg534gg0zevfcf"
   },
   {
     "id": "terra1wdwg06ksy3dfvkys32yt4yqh9gm6a9f7qmsh37",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1wr07qcmfqz2vxhcfr6k8xv8eh5es7u9mv2z07x",
-    "lp_token_id": "terra1n32fdqslpyug72zrcv8gwq37vjj0mxhy9p4g7z",
     "asset_ids": [
       "terra1dtqlfecglk47yplfrtwjzyagkgcqqngd5lgjp8",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1n32fdqslpyug72zrcv8gwq37vjj0mxhy9p4g7z"
   },
   {
     "id": "terra1xf44m98wgzn8gx9a3et0k52wnrrlh2gs0m05jq",
-    "lp_token_id": "terra106wpdmc228c5yd2w59lfzm5mfc2pyfuma2xk6c",
     "asset_ids": [
       "terra1vjgnhlv9h0nlta2v7s5hts75h2mc065c6ap3j5",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra106wpdmc228c5yd2w59lfzm5mfc2pyfuma2xk6c"
   },
   {
     "id": "terra1xg60dmxqzt0c8hxuzgnlmpzqnnmux97xjrdzwf",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uluna",
       "terra14v9wrjs55qsn9lkvylsqela3w2ytwxzkycqzcr"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1xpzusa4cqukutgra7fysjfyh4pkds5euepfe3q",
-    "lp_token_id": "terra16g6tt59pwqqmdknckmapy3k09qpqy6ky7hw3rm",
     "asset_ids": [
       "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra16g6tt59pwqqmdknckmapy3k09qpqy6ky7hw3rm"
   },
   {
     "id": "terra1xrj6cy0jewpw0gt7zfcfpk9j54w30ycz869lcy",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
       "uluna"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1yh5pcqpedv3uz6zuas2e9s944z3whhlh3lfq0j",
-    "lp_token_id": "terra12hjjangazdveuxr6l839dd67kprzfkwkmc7fj2",
     "asset_ids": [
       "terra1q96cf9rkt5aa4eqhun35d0u8pqwwyuqzlzjxps",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra12hjjangazdveuxr6l839dd67kprzfkwkmc7fj2"
   },
   {
     "id": "terra1z7634s8kyyvjjuv7lcgkfy49hamxssxq9f9xw6",
-    "lp_token_id": "terra1sw3kfuzd84t89krrshqusylqqvqw6amavp7rsu",
     "asset_ids": [
       "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1sw3kfuzd84t89krrshqusylqqvqw6amavp7rsu"
   },
   {
     "id": "terra1zh8m6yu8nrvryu2g9gyyzqenrv6h034puqss49",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1zjj37anlqt99tv5hwhsew0x7e007hcg3fsm8sx",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1cf9ey4pm9ugeeehat50gadlze9s0mvluxws2c2",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1zpnhtf9h5s7ze2ewlqyer83sr4043qcq64zfc4",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra100yeqvww74h4yaejj6h733thgcafdaukjtw397",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra106a00unep7pvwvcck4wylt4fffjhgkf9a0u6eu",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra10jzrptpsx9y6uam6vfrxpmppyelevdkm39yxay",
-    "lp_token_id": "terra1newvwvd9w7hs3zl9pmweegrkqxzaedh045cyku",
     "asset_ids": [
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1newvwvd9w7hs3zl9pmweegrkqxzaedh045cyku"
   },
   {
     "id": "terra10s94a5gesvayqlekgn570r3nsnmr8q7lf5zkjp",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15a9dr3a2a2lj5fclrw35xxg9yuxg0d908wpf2y",
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra123neekasfmvcs4wa70cgw3j3uvwzqacdz2we03",
-    "lp_token_id": "terra19rvwt8gjqjpgwhg6h0hpvrrrxe3ljll8savt6t",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19rvwt8gjqjpgwhg6h0hpvrrrxe3ljll8savt6t"
   },
   {
     "id": "terra12aazc56hv7aj2fcvmhuxve0l4pmayhpn794m0p",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
       "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra13ay3hftcft25uazl76q8gmdk993y9nyv9avu2h",
-    "lp_token_id": "terra1v5zv0wupmweke89hsamyk3426rdr4uzmkg3hza",
     "asset_ids": [
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1v5zv0wupmweke89hsamyk3426rdr4uzmkg3hza"
   },
   {
     "id": "terra13eggta6zqfg03mxgqg9p5paqka7tgaaxnkhuuu",
-    "lp_token_id": "terra1jf6s2xm7q6eh77r2lykvfrzlue6m8x9zxrg3zk",
     "asset_ids": [
       "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1jf6s2xm7q6eh77r2lykvfrzlue6m8x9zxrg3zk"
   },
   {
     "id": "terra13f87x4c87ct5545t3j4mqw4k6jmgds5609z92c",
-    "lp_token_id": "terra1ddtvrwcv3s5z3w6j6vpxg95p7nxjzmprpmk6jf",
     "asset_ids": [
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
       "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ddtvrwcv3s5z3w6j6vpxg95p7nxjzmprpmk6jf"
   },
   {
     "id": "terra13qkgx03lu38p49yefnw7sr7xyy0k0ngamr8p2u",
-    "lp_token_id": "terra14gwvrtqc5rwjwyxd4ux30ulykz83dfvzq7nqqu",
     "asset_ids": [
       "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14gwvrtqc5rwjwyxd4ux30ulykz83dfvzq7nqqu"
   },
   {
     "id": "terra13tm0yrhn4wqptuhdc6fu4vh7gnqgtg2vw6c4uc",
-    "lp_token_id": "terra1rsc8l6xxn6f843cwzwctc2fm4x2xzqe0v5hjhu",
     "asset_ids": [
       "ibc/18ABA66B791918D51D33415DA173632735D830E2E77E63C91C11D3008CFD5262",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1rsc8l6xxn6f843cwzwctc2fm4x2xzqe0v5hjhu"
   },
   {
     "id": "terra154jt8ppucvvakvqa5fyfjdflsu6v83j4ckjfq3",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1jx4lmmke2srcvpjeereetc9hgegp4g5j0p9r2q",
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra15568nqrqcawm263yqcuuuvj5mh763tp8jyscq3",
-    "lp_token_id": "terra1r566wqak92thyz2ka72p33fcup4uz35kdm64v0",
     "asset_ids": [
       "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1r566wqak92thyz2ka72p33fcup4uz35kdm64v0"
   },
   {
     "id": "terra15xxfkxldxse9atz8ce7ne2a047pp09dy428njm",
-    "lp_token_id": "terra148gu0mqheqlx8t3kz0ldq0e0a5d84vkqnuj8wm",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra148gu0mqheqlx8t3kz0ldq0e0a5d84vkqnuj8wm"
   },
   {
     "id": "terra16j5f4lp4z8dddm3rhyw8stwrktyhcsc8ll6xtt",
-    "lp_token_id": "terra1mynsfcksuhe5nmum6wsz8gxemsutlqs0q3eywr",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "uluna"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mynsfcksuhe5nmum6wsz8gxemsutlqs0q3eywr"
   },
   {
     "id": "terra178yhudw6cwtnrn4fq593z87y385m0xe9n6x423",
-    "lp_token_id": "terra1d6a90q0stwcp4pvqeasqnl8l8kkjt0mgjt9pk9",
     "asset_ids": [
       "terra17jnhankdfl8vyzj6vejt7ag8uz0cjc9crkl2h7",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1d6a90q0stwcp4pvqeasqnl8l8kkjt0mgjt9pk9"
   },
   {
     "id": "terra17e0aslpj3rrt62gwh7utj3fayas4h8dl3y8ju3",
-    "lp_token_id": "terra1429u2vanflm8u0vtl4ejftadcgdunkzknhw72a",
     "asset_ids": [
       "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1429u2vanflm8u0vtl4ejftadcgdunkzknhw72a"
   },
   {
     "id": "terra17kmgn775v2y9m35gunn3pnw8s2ggv6h95wvkxr",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra18r6rdnkgrg74zew3d8l9nhk0m4xanpeukw3e20",
-    "lp_token_id": "terra1de9dy3wnh0aq87knh8chejaxvkpxq3sjxx23ug",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1de9dy3wnh0aq87knh8chejaxvkpxq3sjxx23ug"
   },
   {
     "id": "terra18zh29lwx36uxh4a4ff5at9ysm6n0da4puz7z62",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
       "terra17wkadg0tah554r35x6wvff0y5s7ve8npcjfuhz"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1a26j00ywq0llvms707hqycwlkl9erwhacr6jve",
-    "lp_token_id": "terra1qrwmv46n0dxw6ejyyc8ffalnlzth5mulznkrpw",
     "asset_ids": [
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
       "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qrwmv46n0dxw6ejyyc8ffalnlzth5mulznkrpw"
   },
   {
     "id": "terra1a3x69h7gj72l2vt35psv64kerpsu2fuafrxhrl",
-    "lp_token_id": "terra1a52wc4q9y5fcz00d3j9plsp37jl7ncjrjylrkj",
     "asset_ids": [
       "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1a52wc4q9y5fcz00d3j9plsp37jl7ncjrjylrkj"
   },
   {
     "id": "terra1cpzkckgzz90pq8fkumdjc58ee5llrxt2yka9fp",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1dttfsvgwvpz0zy9x52zyxnc4pa5lcx7l7pzguc",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1jxypgnfa07j6w92wazzyskhreq2ey2a5crgt6z",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1dw5j23l6nwge69z0enemutfmyc93c36aqnzjj5",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1jx4lmmke2srcvpjeereetc9hgegp4g5j0p9r2q",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1efvhm927dehrka0cgpcptt5gvjfdgqm07smawu",
-    "lp_token_id": "terra18m6fzarqv4klla35a4npad0nw7ytzda4s29jn2",
     "asset_ids": [
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra18m6fzarqv4klla35a4npad0nw7ytzda4s29jn2"
   },
   {
     "id": "terra1f6d3pggq7h2y7jrgwxp3xh08yhvj8znalql87h",
-    "lp_token_id": "terra1a3scsw0gr4wjvhnrg94g3yteg5cwxu92dr8rgz",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1a3scsw0gr4wjvhnrg94g3yteg5cwxu92dr8rgz"
   },
   {
     "id": "terra1fdalk97tmgxlku6cepfs333frj9rt46pnvuyuv",
-    "lp_token_id": "terra1tqj36ektc8y3dcpx7g2edt6f6sp65643avt9hx",
     "asset_ids": [
       "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B",
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1tqj36ektc8y3dcpx7g2edt6f6sp65643avt9hx"
   },
   {
     "id": "terra1fgc8tmys2kxzyl39k3gtgw9dlxxuhlqux7k38e",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55",
       "uluna"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ga8dcmurj8a3hd4vvdtqykjq9etnw5sjglw4rg",
-    "lp_token_id": "terra1fsp4mrxtae6ay8lps5qpq3aq9hrv48h30cnyje",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "uluna"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fsp4mrxtae6ay8lps5qpq3aq9hrv48h30cnyje"
   },
   {
     "id": "terra1jcewm66crare2lsv9fmdkxenf6gqamp2wxz5n5",
-    "lp_token_id": "terra1c4gjx7tgrajsk8vekjg6ppcs6l7f05xh8dtkml",
     "asset_ids": [
       "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09",
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1c4gjx7tgrajsk8vekjg6ppcs6l7f05xh8dtkml"
   },
   {
     "id": "terra1jfp5ew4tsru98wthajsqegtzaxt49ty4z2qws0",
-    "lp_token_id": "terra1waxv8terfksh59mx6yrpqjvgr4t4z5mad2ukfd",
     "asset_ids": [
       "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1waxv8terfksh59mx6yrpqjvgr4t4z5mad2ukfd"
   },
   {
     "id": "terra1jkr0ef9fpghdru38ht70ds6jfldprgttw6xlek",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1k4aud54tprawf9l2uleh4ndjuf940m283yxvzt",
-    "lp_token_id": "terra18rppdamu2e8afe05pyllvdclslnsrlqp7mc599",
     "asset_ids": [
       "ibc/18ABA66B791918D51D33415DA173632735D830E2E77E63C91C11D3008CFD5262",
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra18rppdamu2e8afe05pyllvdclslnsrlqp7mc599"
   },
   {
     "id": "terra1kw95x0l3qw5y7jw3j0h3fy83y56rj68wd8w7rc",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
       "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1l60336rkawujnwk7lgfq5u0s684r99p3y8hx65",
-    "lp_token_id": "terra1mc9zszumqwscqwa5aak0fjezl3tx79u6jpzut5",
     "asset_ids": [
       "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn",
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mc9zszumqwscqwa5aak0fjezl3tx79u6jpzut5"
   },
   {
     "id": "terra1lgazu0ltsxm3ayellqa2mhnhlvgx3hevkqeqy2",
-    "lp_token_id": "terra16j3v7gkczclh46p6uwymrtufnq5ca4psdl04sj",
     "asset_ids": [
       "terra13xujxcrc9dqft4p9a8ls0w3j0xnzm6y2uvve8n",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra16j3v7gkczclh46p6uwymrtufnq5ca4psdl04sj"
   },
   {
     "id": "terra1me6a35xuzf9ycjaaqyj7798g5tewunp6dzg27e",
-    "lp_token_id": "terra1mvfyxwdxrs8ntvfkuau44dry0uzt2pspe8r0tr",
     "asset_ids": [
       "terra15a9dr3a2a2lj5fclrw35xxg9yuxg0d908wpf2y",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mvfyxwdxrs8ntvfkuau44dry0uzt2pspe8r0tr"
   },
   {
     "id": "terra1n6rn6cn8a3rqad8v2mth3u3qwgq9styt84wv4u",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1np5jr05v08vjk5f665qu5xjxak8dyxnswtujn6",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1p0ne6gzy3mamyepm5c0r0wvwyac2cexrmvkz0p",
-    "lp_token_id": "terra1k6y57qfvq20mlf020s6v98gghaypy34v0q4rqh",
     "asset_ids": [
       "terra1g0pm8xm5c2dq4qtv8j9a80hg4mhe5ndy8qad07",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1k6y57qfvq20mlf020s6v98gghaypy34v0q4rqh"
   },
   {
     "id": "terra1p4lz9qcs8wp4pxpgd5uugvfvcrxdjtyhs9wuw7",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1pmmfz205es7axymwpl4jj2ruxnevufu3462f02",
-    "lp_token_id": "terra1azzqn88w3cc6x8jwl2mapuspjzdkzpz26qe2lk",
     "asset_ids": [
       "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
       "uluna"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1azzqn88w3cc6x8jwl2mapuspjzdkzpz26qe2lk"
   },
   {
     "id": "terra1sgu6yca6yjk0a34l86u6ju4apjcd6refwuhgzv",
-    "lp_token_id": "terra1t599xaj0lyyyjza86uskcqdy9aqy2txzdezyln",
     "asset_ids": [
       "uluna",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1t599xaj0lyyyjza86uskcqdy9aqy2txzdezyln"
   },
   {
     "id": "terra1tadgrmh5al0dy4wtjj8ks5jsa8chhjzjcch95w",
-    "lp_token_id": "terra1chestqf8qj0jgvl0aa3ke2jutk940htytrmy0n",
     "asset_ids": [
       "terra15k5r9r8dl8r7xlr29pry8a9w7sghehcnv5mgp6",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1chestqf8qj0jgvl0aa3ke2jutk940htytrmy0n"
   },
   {
     "id": "terra1tksv8cn7j95mecxjhj3dgcz3xtylcw5xkarre7",
-    "lp_token_id": "terra1z0qvh70fnt0yu99tjmkhcet7u4ml9mny3t0p2r",
     "asset_ids": [
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
       "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1z0qvh70fnt0yu99tjmkhcet7u4ml9mny3t0p2r"
   },
   {
     "id": "terra1tus5ec9qsdht8dapq9ldfnsf8eehnfmwvsut83",
-    "lp_token_id": "terra1eas9qze4j0lhasc6g0hjykvcyksakvsun4ndyv",
     "asset_ids": [
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
       "uluna"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1eas9qze4j0lhasc6g0hjykvcyksakvsun4ndyv"
   },
   {
     "id": "terra1um8zappwu8csxv6c7zmadjvnf5rs7xgnc573fx",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
       "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ur6yyha884t5rhpf6was9xlr7xpcq40aw2r5jx",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
       "uluna"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1utds4jwyg2x0ajpuvxu358ry3v5zx98e345cat",
-    "lp_token_id": "terra1g2vxl25yg5vs5gc7zg8vtw3ase6qqmc524wqlf",
     "asset_ids": [
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
       "uluna"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1g2vxl25yg5vs5gc7zg8vtw3ase6qqmc524wqlf"
   },
   {
     "id": "terra1v93ll6kqp33unukuwls3pslquehnazudu653au",
-    "lp_token_id": "terra1yy46j5xy7fykt6q58aa4u4y39h4fxc7jke2spd",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "uluna"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1yy46j5xy7fykt6q58aa4u4y39h4fxc7jke2spd"
   },
   {
     "id": "terra1vdc7mxx549pqpelcdkwydp2px3e4vvlrcvdjz9",
-    "lp_token_id": "terra1cmzuu60x2e47etp8rldxr447xxw03jytqq3a7k",
     "asset_ids": [
       "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1cmzuu60x2e47etp8rldxr447xxw03jytqq3a7k"
   },
   {
     "id": "terra1w7hny2catfwsv6dq8gfm4zgazx3hmpl3xwzxya",
-    "lp_token_id": "terra1e7625lctv0dpalqah9jzqgw7m3cmvfeky5nvp7",
     "asset_ids": [
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1e7625lctv0dpalqah9jzqgw7m3cmvfeky5nvp7"
   },
   {
     "id": "terra1wh2jqjkagzyd3yl4sddlapy45ry808xe80fchh",
-    "lp_token_id": "terra13nvzpqauc5u84yv5qd5jaqvsumhfnfxywa5m8t",
     "asset_ids": [
       "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra13nvzpqauc5u84yv5qd5jaqvsumhfnfxywa5m8t"
   },
   {
     "id": "terra1whns5nyc8sw328uw3qqnyafxd5yfqsytkdkgqz",
-    "lp_token_id": "terra1u32ccknva07y3er2npf05tk0euu7qjvhpv2csp",
     "asset_ids": [
       "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1u32ccknva07y3er2npf05tk0euu7qjvhpv2csp"
   },
   {
     "id": "terra1wseaux4kpjle6andsvfzj4jv0a8tgmzeteapll",
-    "lp_token_id": "terra1xudur2f8x9vedlfu2s6gygjcyvnqehk7rxh6q6",
     "asset_ids": [
       "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1xudur2f8x9vedlfu2s6gygjcyvnqehk7rxh6q6"
   },
   {
     "id": "terra1wznq6n5rw2jlyh274l0pmkq6chqfx5qqaduwwn",
-    "lp_token_id": "terra1jnqkemcayxupynwx7ul95yjcsgzntk6qh3302e",
     "asset_ids": [
       "terra17wkadg0tah554r35x6wvff0y5s7ve8npcjfuhz",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1jnqkemcayxupynwx7ul95yjcsgzntk6qh3302e"
   },
   {
     "id": "terra1x4msd26x8ncqcng3dapx8306rmgwuwtlg30a2j",
-    "lp_token_id": "terra1yyu8g58ks4q688j7paz8kehky94dx29dw7fmal",
     "asset_ids": [
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
       "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1yyu8g58ks4q688j7paz8kehky94dx29dw7fmal"
   },
   {
     "id": "terra1xew5epfvlzqc9zz8urhupnql5k2wls0p5dd0rg",
-    "lp_token_id": "terra14krnra4ysnyx7c32plectj6cac5h0vwwjtzmp9",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14krnra4ysnyx7c32plectj6cac5h0vwwjtzmp9"
   },
   {
     "id": "terra1yjg0tuhc6kzwz9jl8yqgxnf2ctwlfumnvscupp",
-    "lp_token_id": "terra17pzt8t2hmx6587zn6yh5ensylm3s9mm4m72v2n",
     "asset_ids": [
       "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq",
       "uusd"
     ],
     "dex": "Loop",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17pzt8t2hmx6587zn6yh5ensylm3s9mm4m72v2n"
   },
   {
     "id": "terra19d2alknajcngdezrdhq40h6362k92kz23sz62u",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "uusd"
     ],
     "dex": "PRISM Swap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1czynvm64nslq2xxavzyrrhau09smvana003nrf",
-    "lp_token_id": "terra1zuv05w52xvtn3td2lpfl3q9jj807533ew54f0x",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "terra1042wzrwg2uk6jqxjm34ysqquyr9esdgm5qyswz"
     ],
     "dex": "PRISM Swap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1zuv05w52xvtn3td2lpfl3q9jj807533ew54f0x"
   },
   {
     "id": "terra1kqc65n5060rtvcgcktsxycdt2a4r67q2zlvhce",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "terra17wkadg0tah554r35x6wvff0y5s7ve8npcjfuhz"
     ],
     "dex": "PRISM Swap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1persuahr6f8fm6nyup0xjc7aveaur89nwgs5vs",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2"
     ],
     "dex": "PRISM Swap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1r38qlqt69lez4nja5h56qwf4drzjpnu8gz04jd",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "uluna"
     ],
     "dex": "PRISM Swap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1yxgq5y6mw30xy9mmvz9mllneddy9jaxndrphvk",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau"
     ],
     "dex": "PRISM Swap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra10whh69k8p9df2ccchvq03ddqqdpxlsxhte99j7",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pmf2x6gp8u979q672lkkkruuhe9zarxyu5w7t2",
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra13wgvm70z5py4gee5r03statmxp4hjtc6we80jq",
-    "lp_token_id": "terra1e9s5wklrlw44xl76p5e4gxvj7symsk0c3s8273",
     "asset_ids": [
       "terra15uc875u7uu8xyqf833nxwh5x4dm2kmu29u04vl",
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1e9s5wklrlw44xl76p5e4gxvj7symsk0c3s8273"
   },
   {
     "id": "terra18lvan2ywhr40ql7tt6t40ck6vx4hlh0xamtqpm",
-    "lp_token_id": "terra1lsrjcwupdpzayeg3suc3kmtrr3yq405pppja0s",
     "asset_ids": [
       "terra1l0y8yg0s86x299nqw0p6fhh7ngex3r4phtjeuq",
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1lsrjcwupdpzayeg3suc3kmtrr3yq405pppja0s"
   },
   {
     "id": "terra19l0hnypxzdrp76jdyc2tjd3yexwmhz3es4uwvz",
-    "lp_token_id": "terra1hr08ry5nmm65m74cyp3jq3c2vr89rm958s4rpz",
     "asset_ids": [
       "terra1a8k3jyv3wf6k3zngza5h6srrxcckdf7zv90p6u",
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1hr08ry5nmm65m74cyp3jq3c2vr89rm958s4rpz"
   },
   {
     "id": "terra1a5lj0yacwz2gdmsk8acwmc6hlkv23dzykmksjv",
-    "lp_token_id": "terra1yf8aduaysgfde4d4g4qrg5z3qxutk4cdwyfz28",
     "asset_ids": [
       "terra1xt9fgu7965kgvunnjts9zkprd8986kcc444q86",
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1yf8aduaysgfde4d4g4qrg5z3qxutk4cdwyfz28"
   },
   {
     "id": "terra1hkh0mr4y0y0gjf8t9c55arnvy0m79s80297d9z",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1z2u9p4x9cnp7c44rnntxzhgqlnepv8elmde43d",
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1k8pflcvj3mhrmthrgux2pk9a9ytthsr5trnq7z",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yzj58vsvryarrasx6rkf9deyn5h60zlm7lzv8r",
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1lq94l6w3eft9c95kj3rcex9h702ssp35qyaha3",
-    "lp_token_id": "terra1gtaly35ppahnheejtpcav38gd43ck8kmjmvepq",
     "asset_ids": [
       "terra1mzxr59qj8qr5plgd8kmqx9vn937qr5vzjd055w",
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1gtaly35ppahnheejtpcav38gd43ck8kmjmvepq"
   },
   {
     "id": "terra1rjwzkud2xtltyqamkq0md0esdk3qkhjwey5xzk",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vte2xv7dr8sfnrnwdf9arcyprqgr0hty5ads28",
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1t9ffaw69tfensrn2s0hx79tm68g7hps30unys8",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1u2k0nkenw0p25ljsr4ksh7rxm65y466vkdewwj",
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1wez50a5t3658m6zyydaeyprtwwt8gtt0dcswlw",
-    "lp_token_id": "terra1jer5s9ykl64cm7xxp6zea9myjgru6vp38h9yzf",
     "asset_ids": [
       "terra16wggm67a34msdxasg2vergm2pt289y7930wv7d",
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1jer5s9ykl64cm7xxp6zea9myjgru6vp38h9yzf"
   },
   {
     "id": "terra1yjmpu9c3dzknf8axtp6k74nvkwrd457u7p2sdr",
-    "lp_token_id": "terra1auxjy8f8al78g9ecmv85agaynj8wkjp5kjce2p",
     "asset_ids": [
       "terra1u2k0nkenw0p25ljsr4ksh7rxm65y466vkdewwj",
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1auxjy8f8al78g9ecmv85agaynj8wkjp5kjce2p"
   },
   {
     "id": "terra1ar2lwxegfnap7umqx9ljp0wytt3t76yyc8ys2z",
-    "lp_token_id": "terra1633wdygwlds5dj3e97vyp3x8lhsnrwa8msc5tw",
     "asset_ids": [
       "uusd",
       "terra1efjugpjc50d8sha7lr8s48cr7wmsthz94eevcl"
     ],
     "dex": "Terraformer",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1633wdygwlds5dj3e97vyp3x8lhsnrwa8msc5tw"
   },
   {
     "id": "terra1nmheu06jz6mxsg5n8nnmyn6fxgnvxzk28femx2",
-    "lp_token_id": "terra1g9esdhg0kjlzvmm7pwznwux0h7vpcclgjdx4wf",
     "asset_ids": [
       "uusd",
       "terra193c42lfwmlkasvcw22l9qqzc5q2dx208tkd7wl"
     ],
     "dex": "Terraformer",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1g9esdhg0kjlzvmm7pwznwux0h7vpcclgjdx4wf"
   },
   {
     "id": "terra1rvvz9r8ys755wy9hat39es03d6h25rtz2u329l",
-    "lp_token_id": "terra1ktwelwele8sfyqksk2863wslg68mrn2e9d4tgp",
     "asset_ids": [
       "uusd",
       "terra1948uvsah8aw40dhsa9mhl3htq8lraj0smlh77g"
     ],
     "dex": "Terraformer",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ktwelwele8sfyqksk2863wslg68mrn2e9d4tgp"
   },
   {
     "id": "terra1uccez5grl2sr8xd4rswtgtc7ewf8ugfvcfutv5",
-    "lp_token_id": "terra1rttu7tzn7mnus9kw40j05nlzr0ef469lw43yfg",
     "asset_ids": [
       "uusd",
       "terra1lrdzs5tgllwqgawtq2emuzn7snpxq87fzzl44y"
     ],
     "dex": "Terraformer",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1rttu7tzn7mnus9kw40j05nlzr0ef469lw43yfg"
   },
   {
     "id": "terra1vsd2sgk47tm262q7l3eq74u9rrek4ucn2w2jm5",
-    "lp_token_id": "terra1x604xhmxr5lfwze3s4fsxl50vy5gps47k9e6q3",
     "asset_ids": [
       "uusd",
       "terra1vpws4hmpmpsqwnz3gljn8zj42rv7rkpc5atgt4"
     ],
     "dex": "Terraformer",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1x604xhmxr5lfwze3s4fsxl50vy5gps47k9e6q3"
   },
   {
     "id": "terra1x3fcujqgk8uvn8vssw52jtwtanlu3shgj3ftlk",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra18xyl0ees6ueyhkhn0mjdtrm82e393ult2dazl3"
     ],
     "dex": "Terraformer",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra100k5zacnuzl0ksxrn6lclmdl0u7w6l8qalcn6e",
-    "lp_token_id": "terra1yg09m7lcj739wvr3ns6d67znhyp4jexvpx2vkg",
     "asset_ids": [
       "terra1amehwqrzcdrwmwdz9apz9mmctckez66ns67k5s",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1yg09m7lcj739wvr3ns6d67znhyp4jexvpx2vkg"
   },
   {
     "id": "terra103kw7gde0cu8v7xm5fwm54dp7uyq8d58svtf8t",
-    "lp_token_id": "terra1q88d7swxfd36kcfeqhgdncjrht9rsh7c0a9vm3",
     "asset_ids": [
       "uusd",
       "terra1q93ws00plywc5prwv7mf2gdf7alhuqgk5w68lq"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1q88d7swxfd36kcfeqhgdncjrht9rsh7c0a9vm3"
   },
   {
     "id": "terra105cnw8azykz23ec9gtm06prssq9aqxg8pchjq4",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10jyyy0ylv34lafqv2mldcuxhk4qpdmnckgfls2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra105lwyhfuw0p0q39tghg2hxnjdarg6uy6n9s24n",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xc5ll57yu269x8ysxvdpjmvxmac3js7pst5ddr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra108hz9wugglvu2rjty2xaddvwtr09ukd7kwm78n",
-    "lp_token_id": "terra1nzlw9mny82p598ue0d4skguwlffhl5vdszjr86",
     "asset_ids": [
       "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1nzlw9mny82p598ue0d4skguwlffhl5vdszjr86"
   },
   {
     "id": "terra10a9jdeled7uev64ugtmc8kzjlg9xv6eeey88xh",
-    "lp_token_id": "terra16qlxlx3h5ty2t2fmdwrh8a35yqngg6hlmv0w56",
     "asset_ids": [
       "terra1ewesd6y7dswxd8qdfff7vxl8g2p0dfwpanf5fv",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra16qlxlx3h5ty2t2fmdwrh8a35yqngg6hlmv0w56"
   },
   {
     "id": "terra10apggvnqewuu3zg03l8nzqemuwtnfhnsp7pup4",
-    "lp_token_id": "terra1y02yk8gwl7efuv76le3lrct9fn3uzs5a7nq4xh",
     "asset_ids": [
       "terra1gukawnd63qd9ptuqe0ejm0vvweql45084lx4pq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1y02yk8gwl7efuv76le3lrct9fn3uzs5a7nq4xh"
   },
   {
     "id": "terra10dua387cxqwuulwwpcvk6atwe5alkh6qky7xhu",
-    "lp_token_id": "terra1kdqt7wfvem3nmdsrr5pwqlnhzl6w8xklqey35v",
     "asset_ids": [
       "terra18ys4xv4yjy6c7984mv4sz08p3rpl8cdtxxhuhw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1kdqt7wfvem3nmdsrr5pwqlnhzl6w8xklqey35v"
   },
   {
     "id": "terra10f9t46rjhxjdm3324kkadhsm6adqhzva3y2g4j",
-    "lp_token_id": "terra1tdhcdlugvx4wwx9metx92nqpumahw9mzn7mhrs",
     "asset_ids": [
       "terra1nxwnngqr0ks3j842jlr6pnrmd79kztjqyycer2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1tdhcdlugvx4wwx9metx92nqpumahw9mzn7mhrs"
   },
   {
     "id": "terra10jnrtfv5vle4gdknnu55d2p8trd6lxzwc5shp5",
-    "lp_token_id": "terra1v7wyvflxcxchx2zxu2n7e858wlx9u72pkku3hv",
     "asset_ids": [
       "terra1f3nc4md37vcy9l89qte2p5tej42pr8rzch8mfe",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1v7wyvflxcxchx2zxu2n7e858wlx9u72pkku3hv"
   },
   {
     "id": "terra10mwe766az3rz5u84h53z6u0hxq9jp6jx54z3jh",
-    "lp_token_id": "terra1tnj6gg7ntn9wht35uqxz5dpe6nw4fd92ukmhyl",
     "asset_ids": [
       "terra1j9zvn74s7v2kylvv2xcg4p0s69pvejrw5qzv7j",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1tnj6gg7ntn9wht35uqxz5dpe6nw4fd92ukmhyl"
   },
   {
     "id": "terra10qeuxxj46luwqk8huh4gcp2r0ve7w5vh3hrtev",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ft9qff9fgumdca5qluxu3e8fh8xc7d4hfek8s2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra10qnu9yudvcnm7we04xj8lu3mjrgx5lc247h0y2",
-    "lp_token_id": "terra1xra8v827ml3m6zfylvzfv5g72mj4qhdk7snchy",
     "asset_ids": [
       "terra17ktj9hq69ae9mj49dwqfzmj05t6eqlkyywukf8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1xra8v827ml3m6zfylvzfv5g72mj4qhdk7snchy"
   },
   {
     "id": "terra10rqw6xrzq2y3whp2r9q44zxyu5f8cdk0f4qa63",
-    "lp_token_id": "terra139kpcz9239c35dulyqkkyqsdhnx99vhfk6q4fe",
     "asset_ids": [
       "terra120v2mhzge3mxat8nsz8ctqgy6f0cnnfjymsgum",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra139kpcz9239c35dulyqkkyqsdhnx99vhfk6q4fe"
   },
   {
     "id": "terra10ups2qsazavszk2ml0ed52rqdstuwr2qtuxdjd",
-    "lp_token_id": "terra170c9286vqw9vddvfg4pemue5nxx6vdswxyccmx",
     "asset_ids": [
       "terra17pc8eq0u35yslg7zulkqzc2mvxryfj3hw7nmsr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra170c9286vqw9vddvfg4pemue5nxx6vdswxyccmx"
   },
   {
     "id": "terra10v3f4lprsjx7wsxnmmah99vx0xw8q5zeq8zhvc",
-    "lp_token_id": "terra1v0wxjtv45n0emx87mlx8y8qy5e449wcj3t3gt2",
     "asset_ids": [
       "terra1n4g9jamjrxhe5yssczrlq55syhxvwqkx7jpkjl",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1v0wxjtv45n0emx87mlx8y8qy5e449wcj3t3gt2"
   },
   {
     "id": "terra10yg2w6s5c38shu0l6mx0gn8u8ctdp8lr9xdplp",
-    "lp_token_id": "terra163fswxeuysgmnflm2hl75elytulp9qnxu4muqk",
     "asset_ids": [
       "terra1j3w0tswl56yxduhen4gnela7m4we86w9xkwaee",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra163fswxeuysgmnflm2hl75elytulp9qnxu4muqk"
   },
   {
     "id": "terra10zgqdcpxhj0rgvm98w2slu9z09t8rk4fs5r8da",
-    "lp_token_id": "terra1ces0z6rlujzjw2f6axxjxaqav8v8kh8tqmhpqk",
     "asset_ids": [
       "terra1r5c53q49wu2vqerecdvua2zpvy9k8vlw7cnx25",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ces0z6rlujzjw2f6axxjxaqav8v8kh8tqmhpqk"
   },
   {
     "id": "terra1238lf7cayjp4f4fxle5v87eat6vekqn2zfh9w2",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17qy9f5h35504jxexwprsf6gtj009d3gjcml5pp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra127zvfgggng7zx3taaj8myslx28rrq28ffycqxp",
-    "lp_token_id": "terra14un4rp20aqq7h07zpgzxrz2fcwsplj8jp0jham",
     "asset_ids": [
       "terra1ttm7w640scqrarn0qxqz26798d84u94sg7gshw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra14un4rp20aqq7h07zpgzxrz2fcwsplj8jp0jham"
   },
   {
     "id": "terra128s8lplqeqepy8vh55cr0rzdhe66v9h3n52qk3",
-    "lp_token_id": "terra1ekfxyvagzayn32m6jcqylzefdtjnhkcnwjvwre",
     "asset_ids": [
       "terra1lnucwh7feutx0y8dgh3lu759a6netxx4wjzm4w",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ekfxyvagzayn32m6jcqylzefdtjnhkcnwjvwre"
   },
   {
     "id": "terra12guk0mlt4jknln7mu8y7kjdaglqehu2r2kk6d3",
-    "lp_token_id": "terra1jcu9exrj6ejq8a4u67xf9htmrn2dup8gg9kwts",
     "asset_ids": [
       "terra1fc38stp3xzjh5q8u0nrlk4n0gagxrnen35rsq8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1jcu9exrj6ejq8a4u67xf9htmrn2dup8gg9kwts"
   },
   {
     "id": "terra12lvqty3v0ncnxn3s4agekcp94akp95n7qgv289",
-    "lp_token_id": "terra1va79wsdl4zrs2f9z2eef3c76p7akhuk3n654gc",
     "asset_ids": [
       "terra1kdkcxnsldqmj50ll77gmq5x26u69z8m69hdas6",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1va79wsdl4zrs2f9z2eef3c76p7akhuk3n654gc"
   },
   {
     "id": "terra12qgav8q2qa5x8me759ajhf3j64525qumznc8h7",
-    "lp_token_id": "terra1u3m39v7vs066wazhl3manl8ztmyxpafw7ysdr2",
     "asset_ids": [
       "terra1572yxtl5yxa9mjyzg44gj6knemudreekplelxh",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1u3m39v7vs066wazhl3manl8ztmyxpafw7ysdr2"
   },
   {
     "id": "terra12uem5pwjtllme9dnw8ccw39ewvgyetrhnlnhtx",
-    "lp_token_id": "terra1vv7cqzr6ppgkueq4qgykfjfjsdlufvpljcxf8x",
     "asset_ids": [
       "terra19245ct3nfz95j3peem0zxy0e8e0w2uq4n4ssr3",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1vv7cqzr6ppgkueq4qgykfjfjsdlufvpljcxf8x"
   },
   {
     "id": "terra12vqe3zqn9t7j7k7r3u22mpr3pjq9w3gnmx6pd6",
-    "lp_token_id": "terra1y097nnhjger6l3ds9r96xfdpq7vcdp5yh70n6x",
     "asset_ids": [
       "terra1e05lrpp2tl6sfm8p095mgn8hqu9c42f9sn0eh5",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1y097nnhjger6l3ds9r96xfdpq7vcdp5yh70n6x"
   },
   {
     "id": "terra12xwh5s8nxl2tr9lvshtv5ny02g349sdhgca4zs",
-    "lp_token_id": "terra1hqz4rpdymf0vdmmg54r8fzr95uwtq7m7stsqzs",
     "asset_ids": [
       "terra16mvysduudq3ys8vn08c5ts8yx08g5vahjaylq4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1hqz4rpdymf0vdmmg54r8fzr95uwtq7m7stsqzs"
   },
   {
     "id": "terra12y07m3ra6x6qgl4jl5jt5t0qvk7smft3ye4l3h",
-    "lp_token_id": "terra1jv5v6cskf8atvn0hlnmuhp3vpqypk76qjw9xxn",
     "asset_ids": [
       "terra1nccuq0ujp4hc84kjmfwjc3002z2q7xzmdu6crm",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1jv5v6cskf8atvn0hlnmuhp3vpqypk76qjw9xxn"
   },
   {
     "id": "terra1323sdyuhfl05jkhlk47ypmhtyx2chzv92tnsn6",
-    "lp_token_id": "terra1phcujfuv584t5mrmmxtag00pn36kscspec80gy",
     "asset_ids": [
       "terra1tmar57largkrtts55q8szey2q78zc9em43ej5n",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1phcujfuv584t5mrmmxtag00pn36kscspec80gy"
   },
   {
     "id": "terra132hq2uqczg2d7l4czhtcdwwlgl6cga6rs3nv6p",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18zqpuua4d8u9q9d6zsn8fqtjj5k8hk845prz9v",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra134jare8j7annsu6fgtkpu6zp8gmfau88jrsnaz",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19fd35n93667mg020fj5lupws9rhkw59cw459wm",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1390zekgvzfwdvjfghh9fxmaxq4tzfzux59slpp",
-    "lp_token_id": "terra14uuhfjnxewphya674fgf7t0g3cn32uryrgkm5k",
     "asset_ids": [
       "uusd",
       "terra1t8wkdq7kth8ngxgrpltwam0gv0h88ajh0get5c"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra14uuhfjnxewphya674fgf7t0g3cn32uryrgkm5k"
   },
   {
     "id": "terra139j7k5lfre6kwy6lh2d37tkvyj07h7aafke3qj",
-    "lp_token_id": "terra1rcdp0wd0qww62h69kex8f9c99549902dp7huf6",
     "asset_ids": [
       "terra1z3ejshh0vwkdr35wt9eyxetsqm6mnraya8myxs",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1rcdp0wd0qww62h69kex8f9c99549902dp7huf6"
   },
   {
     "id": "terra13eclwgxxns9v0m6nxveug7m54v49fsfx9fn88d",
-    "lp_token_id": "terra1jmzlups5p4upfx995j824vyngnahsx5tjpk3m7",
     "asset_ids": [
       "terra1wdz268njqhhpy30qcd6zxmvtu5y0xr06cnkdqq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1jmzlups5p4upfx995j824vyngnahsx5tjpk3m7"
   },
   {
     "id": "terra13ha9p29fpj4cckj6jr3m743d9h9v9nv3xcmded",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1atagmw0ssv6wlgmrjjdaa22p7h4wmsy33eljgw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra13kqma6mk7ylcvg8u4qmfcwyw3wfytdgwwszmqc",
-    "lp_token_id": "terra1p9gjvxkdefm98aghrv98nj5g3j8vp2qq22kg6m",
     "asset_ids": [
       "terra1uf95uwdtg7rp734pmadujg2ukmuc88fph2925c",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1p9gjvxkdefm98aghrv98nj5g3j8vp2qq22kg6m"
   },
   {
     "id": "terra13l4d3vq7kurmyah9fxcjv8zdqdpndm9n0zs954",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1nywvm8avu8medrj84x9dxdc4gfdqd2zg8gv049",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra13l96rf63hd9ysruu9ma0vpjwwnjuk4e05tj7xy",
-    "lp_token_id": "terra1f6jappjsusascekd2uk8djncfwsh6ygp07h7mq",
     "asset_ids": [
       "terra1fd2f52tmq59mc093nrawdaey5mzgjnwyu7hwqz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1f6jappjsusascekd2uk8djncfwsh6ygp07h7mq"
   },
   {
     "id": "terra13le0pfhey5ltg42z8e2cq2yt8jxu4ry3tdmwu0",
-    "lp_token_id": "terra1klgaa9lyrcgdwudd9mvu0ys2spdsxd8mk55ure",
     "asset_ids": [
       "terra1vnkmt0cwd5k870ny0e2crt2yrkmj0cfd3sylvc",
       "ukrw"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1klgaa9lyrcgdwudd9mvu0ys2spdsxd8mk55ure"
   },
   {
     "id": "terra13lnw7ytlt0cjtjtakgewfzydq3nmx7n9q60gs8",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1extnklxgx3sylp25zplvxsfarmvh3r4k6grskj",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra13r4plx4hme32jmzlmsyah9ulewyrq56krxh84j",
-    "lp_token_id": "terra1qje7t49vxtulwq8lw5re455hnj3r266uc7lquh",
     "asset_ids": [
       "terra1g36mr60pqf8x4hr3ulpsptrg84w088m0eunsw0",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1qje7t49vxtulwq8lw5re455hnj3r266uc7lquh"
   },
   {
     "id": "terra13tngwuhz27g97gue2wg36nsc73agv9axnjrmd2",
-    "lp_token_id": "terra12zfj4sczu849y7q3kzdlxxd9x7y3wjx5xtjmau",
     "asset_ids": [
       "terra19k974ngjsml8dtmk56cdhuy6pplr94rxqdt95p",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra12zfj4sczu849y7q3kzdlxxd9x7y3wjx5xtjmau"
   },
   {
     "id": "terra13vj9z3cjvtg0v7uu00m4pwd7qw5faznuvr6mhf",
-    "lp_token_id": "terra120vlcdqz23ssmpvdeysq75a47pjy5shlxya4zv",
     "asset_ids": [
       "terra158gqaxafjche7vtew0f4zk9g80224qr07kwfsk",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra120vlcdqz23ssmpvdeysq75a47pjy5shlxya4zv"
   },
   {
     "id": "terra13vkjx8agphchqzlntq7qn3et86ev4nga6uz9dh",
-    "lp_token_id": "terra12ms0jp4kt9r3s4g2w5dphu8vqf027x6u0t9z25",
     "asset_ids": [
       "terra1pjnfhsvg7g52hfkdegr4apz7ax9x9xn0n2eayj",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra12ms0jp4kt9r3s4g2w5dphu8vqf027x6u0t9z25"
   },
   {
     "id": "terra13zhrlgpz2zmw6c9vd8lgc60qfysdn97sgf2hej",
-    "lp_token_id": "terra10j58rxwrw5fqurt3yludmp9j7xxgxtn9k2thk2",
     "asset_ids": [
       "terra1h067erdar0vs6466jafpjsd7nahzwghtemn6y0",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra10j58rxwrw5fqurt3yludmp9j7xxgxtn9k2thk2"
   },
   {
     "id": "terra140dcz7t06l4llh38u62wh8rcm0gus9dd93envl",
-    "lp_token_id": "terra13ynn6xnvm6pj9hgaw0ywkewr0nv33qgc0pt8dp",
     "asset_ids": [
       "uluna",
       "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra13ynn6xnvm6pj9hgaw0ywkewr0nv33qgc0pt8dp"
   },
   {
     "id": "terra1452cjwwujuejcyy2jujmw54aae96dsyg063ycl",
-    "lp_token_id": "terra1gzu6j09js98082arj8a0nxlz47enzp4m0sp588",
     "asset_ids": [
       "uusd",
       "terra1y5ffh484f3jcy62zuslx3qlv0n6c4zsffjapm8"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1gzu6j09js98082arj8a0nxlz47enzp4m0sp588"
   },
   {
     "id": "terra14572czl65ta5gqhpjfehk47yytdxerpntw2h5w",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1efu7hut9pywcgwj74klay9mlzswp542s6fa0zq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra14cqsw04rl6lu5dghdzqz5984rjd3rryc2psu2d",
-    "lp_token_id": "terra1s9rf42yddzzxqr60l0a3dtf0qqkhq7cukql3p0",
     "asset_ids": [
       "terra1jw43a4x2jdftvk9ylfyuqhy9asam4ymjufme44",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1s9rf42yddzzxqr60l0a3dtf0qqkhq7cukql3p0"
   },
   {
     "id": "terra14fgsnt4y6x7npwnnpq7nepk85fzz59vqn562v2",
-    "lp_token_id": "terra1q03qkg493g267tyympe6qx5l5v4de20uwupnn4",
     "asset_ids": [
       "terra1c5p65p6q6ekfav0k72h5ez23mpntve5am07mpr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1q03qkg493g267tyympe6qx5l5v4de20uwupnn4"
   },
   {
     "id": "terra14fkcayxsf0xg4dwvn7xgtsyhzff97zckpzlzhv",
-    "lp_token_id": "terra1ce4u5ecla5klh9a68mjugq2aj2zqffrar4vzwh",
     "asset_ids": [
       "terra1udknntc8sjm4ntxezhlqe6p9atct00r296aw95",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ce4u5ecla5klh9a68mjugq2aj2zqffrar4vzwh"
   },
   {
     "id": "terra14gsl8tl6pwe4xmtuc4c78w356n66klmh8xn26w",
-    "lp_token_id": "terra1uasdrlm92p47mvgtawcjmn24ut2a44mykyfz6j",
     "asset_ids": [
       "terra1ra0ljqpyt59k7z4xrx93ef5jvpy67f56lhudf9",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1uasdrlm92p47mvgtawcjmn24ut2a44mykyfz6j"
   },
   {
     "id": "terra14j82htz2rhn47jasltna6tnqy4gy2097zf2pat",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra153u8c40h2mm8nvs0daqxsnwgvpw43muxj3c28h",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra14m9xq2tvculdx22kunc40te7gfhylx0v44qj3r",
-    "lp_token_id": "terra14t4pe3avwql7s3d7euz3jrpsjzrgrl50x4asv0",
     "asset_ids": [
       "terra1elkjjsg4vm5u4tnesqcj3dzgvhanzld48lkqv2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra14t4pe3avwql7s3d7euz3jrpsjzrgrl50x4asv0"
   },
   {
     "id": "terra14ma9cyp3xt9rj3jz6nmz8zteujuphuyssv7vvj",
-    "lp_token_id": "terra14nszv45yz78hm2n69rq69g5xa2l4cznak4aa4z",
     "asset_ids": [
       "terra1smeev4u44zhv94cn4pyy9dtsshup53n9xefayx",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra14nszv45yz78hm2n69rq69g5xa2l4cznak4aa4z"
   },
   {
     "id": "terra14pq5tphkfpd2wphq47g7mrwmvt7x63nskmkkrc",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1m2ar36pnymh6h4n0p7l2w4uxswc70e9auyvxh6",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra14qtsl0gqwnlz5z72cl9yc52lt8q464zhsx08tq",
-    "lp_token_id": "terra1fpaehunc4mdk0vmkn4g32epcf7yl523nujrjsw",
     "asset_ids": [
       "terra1atcayac92cwn9x6fcpxnjzycvmkkhwsk53tg29",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1fpaehunc4mdk0vmkn4g32epcf7yl523nujrjsw"
   },
   {
     "id": "terra14t9rgrx4t53un932r8jtcsgtrqqvvucndte4cg",
-    "lp_token_id": "terra1ga4yfg9uclqmaeg8trv8yaydm9ufh82cdqea40",
     "asset_ids": [
       "terra145nmjpjhergp4uw02hp079phtnedslmxv4v3n5",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ga4yfg9uclqmaeg8trv8yaydm9ufh82cdqea40"
   },
   {
     "id": "terra14tzfka0vjjw8sttpkg0nqlrs5a078ngmqxjv5h",
-    "lp_token_id": "terra12nl2t220t5504dgaxl7yj68vfs39xky7zux2pa",
     "asset_ids": [
       "terra1dd2qt59v86gwgzl2e6u3xexefvrkjmgd8mu638",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra12nl2t220t5504dgaxl7yj68vfs39xky7zux2pa"
   },
   {
     "id": "terra14u4v5ms29m94jvu2nn37jep35frmg5u6a2qw8h",
-    "lp_token_id": "terra1fwx3235vfpcwkv68nu2vv0cm2sda3dxtdtnpuh",
     "asset_ids": [
       "terra1fhsljj6qc8f7cnu62e8uxqt82czflztge05dwk",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1fwx3235vfpcwkv68nu2vv0cm2sda3dxtdtnpuh"
   },
   {
     "id": "terra14u72dnthxnct8gqx8zxjpqza8dkr8nlc7w2dk8",
-    "lp_token_id": "terra1zrlt4v8jzrsst0zq4ug98xaz0rmerpajff63yf",
     "asset_ids": [
       "terra1rwph273axfefh8gh57scw3jfm7kn4s7t5hlu03",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1zrlt4v8jzrsst0zq4ug98xaz0rmerpajff63yf"
   },
   {
     "id": "terra14v7q4ujj95wx0leltqsxdxy97gzgw4g4q9656s",
-    "lp_token_id": "terra1fj8zwe73graryv3jlmgtt8a74agw849jrl3tfg",
     "asset_ids": [
       "terra1uv3298xevlfdcjthfv4me7tn7gjxd3drv6ejvt",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1fj8zwe73graryv3jlmgtt8a74agw849jrl3tfg"
   },
   {
     "id": "terra150cw99qkvwafxw95vyef7d9upswsmr2wf7xyh7",
-    "lp_token_id": "terra1nu25e6fzs456lh27gpzyq4gn3vpedf7cut5020",
     "asset_ids": [
       "terra1z49dpvu5g4st7t4j5lsaxaq7v9u6f390m28ap9",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1nu25e6fzs456lh27gpzyq4gn3vpedf7cut5020"
   },
   {
     "id": "terra150scqwurj3m6d5n0yt82zer4w8vsdf6hzl6fcc",
-    "lp_token_id": "terra12ndzg4g6k6q48hasdrrk7rul428npl88ljugtf",
     "asset_ids": [
       "terra1hwcnalcf35p48lvj3wt7tztkzh5szmpnxwyvdc",
       "ukrw"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra12ndzg4g6k6q48hasdrrk7rul428npl88ljugtf"
   },
   {
     "id": "terra1558wqfc8ffq37qj3cjfkgfj6r5xflh7gnfytw9",
-    "lp_token_id": "terra17ntlqfva06ga9jdmz0t6mhqsmvr5lqrekrxnug",
     "asset_ids": [
       "terra1tdvvjf700gerwvkwncjc7nzythdewstk47ah93",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra17ntlqfva06ga9jdmz0t6mhqsmvr5lqrekrxnug"
   },
   {
     "id": "terra156h9adaua27vcqtguttxk6pg3st07nrypcmy6f",
-    "lp_token_id": "terra17a0zdmq6xf9jgac89y2nyqcytkcchnneefu8nc",
     "asset_ids": [
       "terra1zfvr6uszt8khnf4damxrujfkhgl0mep0khcs7w",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra17a0zdmq6xf9jgac89y2nyqcytkcchnneefu8nc"
   },
   {
     "id": "terra156wnmhqelwxwcmkfcn0j5fehj59ktjv6w4xca8",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra109vclyh90fkj77ruk299pkk460sjm54vs9x6et",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra15c30300aaa2gt43svqy40jedyh7mqgn02tyukg",
-    "lp_token_id": "terra10xqkk0p4nmgmpkh7faudc0ftmkcx6lhd23vc3g",
     "asset_ids": [
       "terra14qs03ha38aya45vac8q9wn8pjy92knwta2exdx",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra10xqkk0p4nmgmpkh7faudc0ftmkcx6lhd23vc3g"
   },
   {
     "id": "terra15czn3ttmcsn9xl72hfx6muyr23u8h3nhgc5e2y",
-    "lp_token_id": "terra1gp5dpf7lqmx46ravzh64a6azarewy3n8tff6a9",
     "asset_ids": [
       "terra1qgt75fpc097an2vtqufx52anfcsu33n57wjkac",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1gp5dpf7lqmx46ravzh64a6azarewy3n8tff6a9"
   },
   {
     "id": "terra15ledqp3plgp9gqkalkf9p2skdg3kg7l7zd7uhc",
-    "lp_token_id": "terra1peq4pvfc0jzpgdnutdkpu5ad420zyr9lyrqr2n",
     "asset_ids": [
       "terra1pmc29k34jrv96wde08znhmjq4v2rmzy78y6dhg",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1peq4pvfc0jzpgdnutdkpu5ad420zyr9lyrqr2n"
   },
   {
     "id": "terra15p4lwjtk9jkkvkz33pf5xelnrnqahac5ksj8cj",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10jgqgc3vt34w79t4puharnzjxxv7s3fq8tmnkp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra15vy6lhftmg8jnhnsnyazxl44fkutx9yawemeq4",
-    "lp_token_id": "terra1u9nnlnvlqfgz04hvu7w2nqah034m0qjukfvrx2",
     "asset_ids": [
       "terra1ez8x6k2rru42w3z8lnfkzjs778rllmq6xhgf7a",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1u9nnlnvlqfgz04hvu7w2nqah034m0qjukfvrx2"
   },
   {
     "id": "terra15waumwnpjw488cgchv3x5j7g7qlca73sd4zmp6",
-    "lp_token_id": "terra12cwf2ge7mxjsaylmvpnpcy0q8t65fhevhasuxs",
     "asset_ids": [
       "terra1hvv3qzmzmmr9qkf2xj928hhy2yxuledwzn2v5u",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra12cwf2ge7mxjsaylmvpnpcy0q8t65fhevhasuxs"
   },
   {
     "id": "terra15ytncdwh7yqttvvxjmw7cd2phj9a7cyldv8547",
-    "lp_token_id": "terra1wl74zp9lyhznusz7p3xcag9jur58njc7fqa0nz",
     "asset_ids": [
       "terra1kp8vne240370hn722ec5sacsdluyt2j0gc5nph",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1wl74zp9lyhznusz7p3xcag9jur58njc7fqa0nz"
   },
   {
     "id": "terra15z794we063zfzxtvlxzetnq9cv7ftymglqh0g6",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10722f40cxl8tkxjk7f88uj0ehkcw6lu2j504f0",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra15zfs6kf7c0f8u4layzwnwkzpqnkj8lrm86q8un",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1gjuhc34ccr6ajq7dm5266xyedu96sgkv4qnley",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra160vz23qwte45w6dcgkkae05fqpap8l4s4alaax",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12jhul3zlafuvl4fd54pvaax4ls872z8p06p8qv",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra162ccsqcru4zy55r4u52rlm46plwzvzc2x67meg",
-    "lp_token_id": "terra14x387d844rddafa4v2swz89tljm2ux59qz954z",
     "asset_ids": [
       "terra1krtfgcavw64dc8nhnz89eafpqm5pdz95l9a89f",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra14x387d844rddafa4v2swz89tljm2ux59qz954z"
   },
   {
     "id": "terra162cf20c6hrag6fhy9aqwaq9cvrp5lq5ffpvuez",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1qup6c3w83xjrfdtzujqkh5j8pcar96up8f0pdy",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1632r5htxk5ctf4srh7v2teguz47aen7ygkvphr",
-    "lp_token_id": "terra1uz9zfvrltmy3gawmsedg790xjl25jpgdm6fl3y",
     "asset_ids": [
       "terra1veke25wgg7xk34c3gxsweuxsdqajemr307e8df",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1uz9zfvrltmy3gawmsedg790xjl25jpgdm6fl3y"
   },
   {
     "id": "terra163ddeunmzqr90qw4j2nxxmk0fmz56mhly4g07e",
-    "lp_token_id": "terra1cw640zur4svu6942kq9eu6ruxupryjmz5sd9yh",
     "asset_ids": [
       "terra19j57fzwjahvf52wxffgrajd0jjm9m8akfsl0qw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1cw640zur4svu6942kq9eu6ruxupryjmz5sd9yh"
   },
   {
     "id": "terra166j8s9pehm35egpmdfkrvlqj9a4248wqcg5s08",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yx2z4j3wr55k7jns06qhn2hsw6agskvcke6zu6",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra166lp9jpsca40cqhh78f9ve8t4nx446yxp6ra2s",
-    "lp_token_id": "terra1zqnywcumfdnueyccgzp9qjzcaf7zuzc8hu2fts",
     "asset_ids": [
       "terra19ur0s3h72v7t2qmy58z60e0cl0epkal3mle4mu",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1zqnywcumfdnueyccgzp9qjzcaf7zuzc8hu2fts"
   },
   {
     "id": "terra167d8as4vjhgn3m04x3jzl80re5sytn89lr8s2j",
-    "lp_token_id": "terra1em445q3t0ckevthda8enkd7v8v0wlncqyls06t",
     "asset_ids": [
       "terra1tj9zrn3myxvkct20ehzje5whu5j75c94s8r666",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1em445q3t0ckevthda8enkd7v8v0wlncqyls06t"
   },
   {
     "id": "terra16c42gghky97m3g5nj80h3528m3l7m099xjlh0h",
-    "lp_token_id": "terra19unte8ca7uu34q5e0lktrd6esm7wq9j3cmfl4r",
     "asset_ids": [
       "terra1uwsnmc4fpalrv3xgvf0aedx8tfn22xcyrx4467",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra19unte8ca7uu34q5e0lktrd6esm7wq9j3cmfl4r"
   },
   {
     "id": "terra16d99plysndjucurqz87d8p0my7z3kffuhehl30",
-    "lp_token_id": "terra10rnu02fhw7lg7eka8f2yw2wn9j7kn3mgqs860s",
     "asset_ids": [
       "terra1j8nxezl70lfekdzaeanzyzn75htf4sz9vmwhu7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra10rnu02fhw7lg7eka8f2yw2wn9j7kn3mgqs860s"
   },
   {
     "id": "terra16edju746kt6k44meljuql30scd6ml0ey0qwj8v",
-    "lp_token_id": "terra18kq50rff38rr6xt6etkkjvhv59msdst23pf9dv",
     "asset_ids": [
       "terra13l9e6lelggxjzm7dxhgkfgqwutwr67y5qvc7mr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra18kq50rff38rr6xt6etkkjvhv59msdst23pf9dv"
   },
   {
     "id": "terra16g8fsnjsmys6dl25s7wvl4r7y68drvfjc7pszl",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18vl2cypy8pdys2qdqlg7pzmcmpqmur8lmrnk2c",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra16k9sv0425t8prauxk680sj8aecgh4t948v8ktf",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1534wdj9s0c3c64pmgqk8544usm0jvfysn9zq2k",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra16l746rd5nspcav63emsj9uem7v7s7jflrf4mv7",
-    "lp_token_id": "terra1emk8xeed780j8extpdd5q42h0grdj0ad4ce849",
     "asset_ids": [
       "terra1vyusa796w86yh99l67dpd5g3hfva759vyuhn5z",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1emk8xeed780j8extpdd5q42h0grdj0ad4ce849"
   },
   {
     "id": "terra16ll0n5lm5j4vp94mjr0xa4tqxfpvvgx57mdtg3",
-    "lp_token_id": "terra1tqgkra60jq5jzear9e3zm6knwwzdxvwl2hn5vd",
     "asset_ids": [
       "terra17rwgygp5y7tx83xyclwuxu654vjt2whpwxx688",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1tqgkra60jq5jzear9e3zm6knwwzdxvwl2hn5vd"
   },
   {
     "id": "terra16qj6hfx9t2st567eg0hzfd0vq3dtvvc8y0knxj",
-    "lp_token_id": "terra179nsfzyw6gpd4aqjxk644y662geq0rdyt90cay",
     "asset_ids": [
       "terra1wlwkuyv9g7d320dm5cqg6wsygplmt8tjjglc6w",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra179nsfzyw6gpd4aqjxk644y662geq0rdyt90cay"
   },
   {
     "id": "terra16qjw56mjdzurqualderrjh4p0gprm66yd02dar",
-    "lp_token_id": "terra1ks60j2lj62jrpcn69eejtzvg0gatjmz44x0l6y",
     "asset_ids": [
       "terra14ldz32u9l0s9lh07zqqqxgmnzwyww04hmvs923",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ks60j2lj62jrpcn69eejtzvg0gatjmz44x0l6y"
   },
   {
     "id": "terra16s7w70jm98htj2v6mkhcx8uy03l7d4w5mjfnf7",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vjgnhlv9h0nlta2v7s5hts75h2mc065c6ap3j5",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra16u0mmxkx0tm7ll5674dqazj0rznft6jfeku0ve",
-    "lp_token_id": "terra1cxefedc77znngtrw5lfrf87kk6u7wus6mrf4ly",
     "asset_ids": [
       "terra1ufxgdde0fkmmc7mvmkuaxps9raua78r7f0vm3x",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1cxefedc77znngtrw5lfrf87kk6u7wus6mrf4ly"
   },
   {
     "id": "terra16v3cxjng86zd4hmahglj89k9gejh04nghnyavx",
-    "lp_token_id": "terra12sv6yvas2w2wrtjzly647h074tq8g48lxlqpaz",
     "asset_ids": [
       "terra1s44vplvv5fphrrv4g68gx46xwrmvnqm9e0hazl",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra12sv6yvas2w2wrtjzly647h074tq8g48lxlqpaz"
   },
   {
     "id": "terra16yrzqhe84x86jzgaav5hszfsu4mhxjk0aqlk2g",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19m0xqgdaltwkesdt6m383jkqh3m9xyxwtp0f6f",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra170hht9lwe50ugfhnruzjaezpj29l7nvw3l6725",
-    "lp_token_id": "terra1wdfhtdvsvjazrjnd37uyfzg45j2e0v32vz3ez7",
     "asset_ids": [
       "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1wdfhtdvsvjazrjnd37uyfzg45j2e0v32vz3ez7"
   },
   {
     "id": "terra170lzdyflaamashcqkst23k9ew773dtg67tfu5m",
-    "lp_token_id": "terra1t8qmg9p583jcp2f7uuhga73yh7ze0u4ny7kmzy",
     "asset_ids": [
       "terra1p8y9f7dpmyzy85ldv3k8xccuw0u87lsn9fl86l",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1t8qmg9p583jcp2f7uuhga73yh7ze0u4ny7kmzy"
   },
   {
     "id": "terra170uexnuckv87q2fl392269m6nt847fczs0yzuy",
-    "lp_token_id": "terra10klhxjnafqnt5mu6jugrcqs0kaepprmf425c8q",
     "asset_ids": [
       "terra1znvnhtdxxsy9vkvmqv85nscujeqmmtjlp2a3wj",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra10klhxjnafqnt5mu6jugrcqs0kaepprmf425c8q"
   },
   {
     "id": "terra172nqk47g4vc3zfde06nkq0em69lcwf6dp9uj92",
-    "lp_token_id": "terra14e8sutnxhzgfzt4gdq84dqjymz422k75nglnp7",
     "asset_ids": [
       "terra18lk5y974rsknqmcqlruj636mvg57yln93ay0h8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra14e8sutnxhzgfzt4gdq84dqjymz422k75nglnp7"
   },
   {
     "id": "terra17cfpltkk9ja3rcv3x9rwqzxdeqs9r67ga607lw",
-    "lp_token_id": "terra1udh2534z6lu609dtvlfp8y42w6tswvs5e9034d",
     "asset_ids": [
       "terra1jz9plajrq6knks3vgv9px4ezwshzaxsr2xz7jn",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1udh2534z6lu609dtvlfp8y42w6tswvs5e9034d"
   },
   {
     "id": "terra17ds00wg6xtgy9f7apfl59f4978svh626f00238",
-    "lp_token_id": "terra1knn3f89x8tnf6h9aglz5rhz96wa2cgwfsx3mwy",
     "asset_ids": [
       "terra192dse96aslp5cduzvjqly4j7jaka6dlv2xx7f8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1knn3f89x8tnf6h9aglz5rhz96wa2cgwfsx3mwy"
   },
   {
     "id": "terra17fwqk93kurqedvdyrly3a0c9g2v8eax3j7l5ek",
-    "lp_token_id": "terra1k6mgu6smngvqhq63stjgj2vq9e49umxvr0e6cn",
     "asset_ids": [
       "terra1gdze0yyar2y6vs3un79my828cery0jea8mzn07",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1k6mgu6smngvqhq63stjgj2vq9e49umxvr0e6cn"
   },
   {
     "id": "terra17g2lqz62y4p40hp6f0caup374m7v0uptw38vev",
-    "lp_token_id": "terra1chlp9faqplsyc5y886trcffyzxhnsvuvj9qv5k",
     "asset_ids": [
       "terra1a54dqqqh4qlz70m43n3a0vqeu2dv5tkz6t2zan",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1chlp9faqplsyc5y886trcffyzxhnsvuvj9qv5k"
   },
   {
     "id": "terra17gh85ddky3gqyzg5lh8xry0d4ee497wju497m3",
-    "lp_token_id": "terra15q4ypjhljlfkfmz86xddkd6y0vnwyh03mj6q6p",
     "asset_ids": [
       "terra1ayxfyasd2ursa5gt5zgzgfywsw999dz4yykjn7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra15q4ypjhljlfkfmz86xddkd6y0vnwyh03mj6q6p"
   },
   {
     "id": "terra17hfwmsfq7xmecrlzaqgqqsymzr6jz4urcvd9sq",
-    "lp_token_id": "terra1enjwdma23v5f7rm5xc7zqq8rra00ggmr464nkf",
     "asset_ids": [
       "terra10ewuq49hkk438jhd7q79hfetqpkkt04tfm7rzc",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1enjwdma23v5f7rm5xc7zqq8rra00ggmr464nkf"
   },
   {
     "id": "terra17j0yumlretpyprsxh3qk5zwyzfrdydgnpt0zh7",
-    "lp_token_id": "terra1c063gh7d06rdwem37tqvmqhfvwce7m2aypyrhf",
     "asset_ids": [
       "terra185fgz0v2wm79ujn58tm3qeucnvlnfuffa4wpjp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1c063gh7d06rdwem37tqvmqhfvwce7m2aypyrhf"
   },
   {
     "id": "terra17jaq2p66s2n40wad52mfudk0z6u5tmyanhkc2g",
-    "lp_token_id": "terra1rkewqq6kkvpp787ltvpeccvz4qsqh4w7fv57xj",
     "asset_ids": [
       "terra12a39fn0k0duteqefme6zgr5efg0g5ya7eglvyu",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1rkewqq6kkvpp787ltvpeccvz4qsqh4w7fv57xj"
   },
   {
     "id": "terra17lvnk2k34us38zflqz4zze6zkn7vrktpeuszcy",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10aey3n8rwxup6l2x68fa7fwdurxnu9hwxf0k7f",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra17nht56uc42wj73z8u0gs5n2x9d74ur7z76vmz6",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1je4ll79zmy03zpl4wdhgmadvznqr08tzrncpqw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra17qag5rxkfraheygnsq0xy6y4a8ay0vrmm5cftm",
-    "lp_token_id": "terra1l58a2w22pv0fgukypvqt9fdmkn3ktd0jznexyl",
     "asset_ids": [
       "terra1dxt75lk0m5g0wpucg0mz905akta99fjhuhafqa",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1l58a2w22pv0fgukypvqt9fdmkn3ktd0jznexyl"
   },
   {
     "id": "terra17rduyemsyel8jl5pvyh7j33ee78606zqzkzh8l",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra17rt5kvtt7vgdnxyelqhctaa4p0wwszjqx4etr3",
-    "lp_token_id": "terra1q2xj2w477fd8vx4n4psa449hj03m8py8la423q",
     "asset_ids": [
       "terra15pv3xxp2d5f65qeu2v27vqf9zpqjx0fuztfwcu",
       "100000000000"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1q2xj2w477fd8vx4n4psa449hj03m8py8la423q"
   },
   {
     "id": "terra17sh5yr9tcfl2qsltrm2tulnlpzz0c6ufk683dc",
-    "lp_token_id": "terra153k57e8cka9mutkp5g6f0elje02qtmh75nshny",
     "asset_ids": [
       "terra17t0uuy2cg7apfsqj4xqn6w5scxkd2ajgns9xvz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra153k57e8cka9mutkp5g6f0elje02qtmh75nshny"
   },
   {
     "id": "terra17supgps4aqq7nfkcqt97y0jxzh5u6mrzqlg936",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hn8mghxm4qm2g654m3h4rmqccgs2wcdsvsex82",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra17v05w2qmmxy864ltjtts0nzqlzw32gp6uynh0y",
-    "lp_token_id": "terra1wdmkqdhqmyv9csgwfdh8739fu65qpay7jj5vvh",
     "asset_ids": [
       "terra1d9ec4gm0c03p74d3qd95qvny2ptf0ge5twqpdk",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1wdmkqdhqmyv9csgwfdh8739fu65qpay7jj5vvh"
   },
   {
     "id": "terra17y80pnvqu3kd3g5jwn5kpkfp6hh2stzxmvazjw",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18we4g8y6u55x7atttzu5xgx46zzss0tpmktf9s",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra182n2psy6gl9u90gltznv2r0h6t5sz7ajgu4dl2",
-    "lp_token_id": "terra1xp7l5hahtcl23ghx5u6sw5fa7cds4anmarj5nn",
     "asset_ids": [
       "terra18m523525ntva277qramnc6x2hh56a28w0vndjf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1xp7l5hahtcl23ghx5u6sw5fa7cds4anmarj5nn"
   },
   {
     "id": "terra183kl26dv4ymz55cytumj77z5u6m383wgfvsrvd",
-    "lp_token_id": "terra10uz6jgxmj3ywj9xndsnreula337h05jpkzppnx",
     "asset_ids": [
       "terra1vn8rmcu3yywfndh2ze43v5h2wg28rycdekdr6u",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra10uz6jgxmj3ywj9xndsnreula337h05jpkzppnx"
   },
   {
     "id": "terra1854dxe6nw9pktdd5j5ulesv74k3ztqgdx6mcxe",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17etsw9uywcmw79st5yp4saar97z22l3np0m3zz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra18573lxn0gjcs3fh2dc6qfv7l3afrws2k2dk2zz",
-    "lp_token_id": "terra1asqt56e65cw3dmszq47ru7vzrkua6spg9au4mt",
     "asset_ids": [
       "terra1epzqhvam83e7lfqtdmgzatlvlzwu23x8kd4t4v",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1asqt56e65cw3dmszq47ru7vzrkua6spg9au4mt"
   },
   {
     "id": "terra1867v6pwuaachav723ukq9sajaxgtpe7w3aefm7",
-    "lp_token_id": "terra1jmap9tuf59k5mmr5shgmywqfxmcmlzxusn49vl",
     "asset_ids": [
       "terra1ry60wuc8a7a4ujt3tmrp3upxzf6a4awj88eys3",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1jmap9tuf59k5mmr5shgmywqfxmcmlzxusn49vl"
   },
   {
     "id": "terra18atry8rvvpu35pp2tm87exk7y56jm2yhza4fgp",
-    "lp_token_id": "terra1ynzjmya27v8f2clle2dl5vw909ffxqlkxgcyfw",
     "asset_ids": [
       "terra1tvs43r9ry6s6g6j5mnmruw97s3fjhqxpc540hu",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ynzjmya27v8f2clle2dl5vw909ffxqlkxgcyfw"
   },
   {
     "id": "terra18cwjyccu8snhk2tknk962h2vdvnmerwhrn57cn",
-    "lp_token_id": "terra1xdgsm8apwxuxgql7ll5uc34h4w3y0tnywvsg25",
     "asset_ids": [
       "terra1tesjetjz6q7s2etc0pa93ep6fwhzqqtcvreccl",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1xdgsm8apwxuxgql7ll5uc34h4w3y0tnywvsg25"
   },
   {
     "id": "terra18f5npedpgufd4zyq8gae05c3htnkex7sld2rkf",
-    "lp_token_id": "terra148se8h985hfw3s3jl86vf95qgfz7hztdj0u7qp",
     "asset_ids": [
       "terra1xzk97nrq0ma7dzgy6aj5tm04sg92q720lq2yum",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra148se8h985hfw3s3jl86vf95qgfz7hztdj0u7qp"
   },
   {
     "id": "terra18g4d309jykk54l43k58fjqq8h2qdpzgdctxfwf",
-    "lp_token_id": "terra1mzpxqr5vwnzl822sjd3yskaekz2lyvfpavush6",
     "asset_ids": [
       "terra18neulu99zm7kj040tndhavjskjm7aaxsk240rx",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1mzpxqr5vwnzl822sjd3yskaekz2lyvfpavush6"
   },
   {
     "id": "terra18jkyaayc7s3an3gn6xhz9ue75pdy46zrvzwle2",
-    "lp_token_id": "terra1ldy8tjaqa9zjq6h2290ac2k40ta94e4hky8caa",
     "asset_ids": [
       "terra1l4uygw365sgdgvasmckkd7lcawyemzn9k83lrh",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ldy8tjaqa9zjq6h2290ac2k40ta94e4hky8caa"
   },
   {
     "id": "terra18k700765d9kyglezc07n64wnkdcfzf9d6juccz",
-    "lp_token_id": "terra1l6nvej775vwnlmf84gzv5utyjw6rh0unyyc2y0",
     "asset_ids": [
       "terra10rv8jte682eec8s3fyd522hhq577cl75zghx83",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1l6nvej775vwnlmf84gzv5utyjw6rh0unyyc2y0"
   },
   {
     "id": "terra18kf909r8usm8l29t6krwtexyzd8wr3vrqqd9vm",
-    "lp_token_id": "terra1cu947swy2q3re6er4f8stuxlxdeljx0umlq9my",
     "asset_ids": [
       "terra1hxcsd8ttymrqzp5uh5f5885j0ms0tnzux9jzsc",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1cu947swy2q3re6er4f8stuxlxdeljx0umlq9my"
   },
   {
     "id": "terra18kwhhu4fxcc2x7lwtct8jatwv9843n6de33g6r",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rkn2d2yc0946a0gx0w0hwf3l2j32ve39egsjkd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra18nz2gztwduce3u40wuuafl8xj8e4s63nty75ym",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zs7w76g0u4qgagcen6vq92wxuvgfucr3dy4tm",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra18paw08s6xkw23swl76w6njga2rq6kh80zch24h",
-    "lp_token_id": "terra1vwa9j8y76ew90v7ukh5slz9euj50dq22cs0qvs",
     "asset_ids": [
       "terra1duggxa56m97yfcat99ew27z3q4rnax4w4u8waw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1vwa9j8y76ew90v7ukh5slz9euj50dq22cs0qvs"
   },
   {
     "id": "terra190r2p96klarzvdssdg77r6sd4nfutjra7wwz8d",
-    "lp_token_id": "terra1hl09j27s27407wkct646lqnxg3qskpl2ehuvn9",
     "asset_ids": [
       "terra1ma4frxgvc974je0xsxrzpa52j34h9swlww2yed",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1hl09j27s27407wkct646lqnxg3qskpl2ehuvn9"
   },
   {
     "id": "terra1947q02rc7dcynzgywduaudwjmr9nucjzkd7l6e",
-    "lp_token_id": "terra1sedpm809sp8spmk7svhnxqdqyu0tzxn6h0zltn",
     "asset_ids": [
       "terra1aszsg6mzlzkydqtm46u42mf8zxur9m4ydh9vrr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1sedpm809sp8spmk7svhnxqdqyu0tzxn6h0zltn"
   },
   {
     "id": "terra194d6fn47g5lztfxl42fq37mwlnd4lqwestky0x",
-    "lp_token_id": "terra16wlnwhhd0x0jp9lxqnms2ssmsdhg4v206uwysv",
     "asset_ids": [
       "terra152mtjjndwpwvtszd4cxnhvjm8nzxv6kdwtdugg",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra16wlnwhhd0x0jp9lxqnms2ssmsdhg4v206uwysv"
   },
   {
     "id": "terra1970uk99ys24x9xsck497709n4tzeaa5lgkw0ye",
-    "lp_token_id": "terra1d83udzk95gnk2np5wklqj3hxdq59r0ely8tdea",
     "asset_ids": [
       "terra1sf5tt6p6wnlhm0jqlflan8lw7pmv3f82sffsja",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1d83udzk95gnk2np5wklqj3hxdq59r0ely8tdea"
   },
   {
     "id": "terra19825apq06ve8ae5mhdtljcssm77xrtdkvm55gk",
-    "lp_token_id": "terra1lm3mk44nft4mn74hajn0p8x4enp6e38yyf4ey9",
     "asset_ids": [
       "terra1yg4qw00d3cpdvs9zyhyh32jkfcl8un8nxc3f08",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1lm3mk44nft4mn74hajn0p8x4enp6e38yyf4ey9"
   },
   {
     "id": "terra199cwj22qrsuqnuv4slrmhc3dfydxjh3894tajt",
-    "lp_token_id": "terra1yjvdd73lsjq49v7x80rhe3kyltg27gew5nrls8",
     "asset_ids": [
       "terra1mq6sw9dt57hlpe7ffjm2z3pytr98l4a00lnxp6",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1yjvdd73lsjq49v7x80rhe3kyltg27gew5nrls8"
   },
   {
     "id": "terra19ak9slt8fmlv5p09j0y9edswgpvmk07p8nplrl",
-    "lp_token_id": "terra102pj92vh6cem9hyzyep465k0dw3ng4hqaaqsj4",
     "asset_ids": [
       "terra1thrmc4qul2e02y2rskm7583g6guvtrvc8pnlmx",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra102pj92vh6cem9hyzyep465k0dw3ng4hqaaqsj4"
   },
   {
     "id": "terra19hmp39k3dlwtywtqcs4nrr4lal66kzwc7ea42r",
-    "lp_token_id": "terra17jrxg9srhvhu2rcf5umt2lnrvahtgxwate8gej",
     "asset_ids": [
       "terra18jv5j86hjhc0zx280wu3kjggd9dvfyl9v4t04k",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra17jrxg9srhvhu2rcf5umt2lnrvahtgxwate8gej"
   },
   {
     "id": "terra19luytfs7wt8l2e5fgg7del39m93sm64qsmufsy",
-    "lp_token_id": "terra1jfrngqdwqkfs25sgcmuxrlk6a7y8058purc4hx",
     "asset_ids": [
       "terra17w68lnnp47k4zkfkpcyzu2xeu6qw576ksfpp4r",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1jfrngqdwqkfs25sgcmuxrlk6a7y8058purc4hx"
   },
   {
     "id": "terra19mzvauzmythgn8d8vl944vczh5egrlnqfqygke",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ruz2e26humerfnd9uhurc9766a4at8x8e3m2e4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra19nhjua64eq04ulurrdayj3u0f6yw5qw6t4mc8g",
-    "lp_token_id": "terra1h30mmqyw6gu5dnresfzdcwsr2ahec5usf0vst2",
     "asset_ids": [
       "terra1n3l6xg66m9t342qcvgdqk6md5cqvtatgg8tw39",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1h30mmqyw6gu5dnresfzdcwsr2ahec5usf0vst2"
   },
   {
     "id": "terra19rsnccnawx00kzynaxexxh4540qp5y6atfrkjj",
-    "lp_token_id": "terra19pztt2p6wuy63dehanjeuyf7vx399ptwdq93zj",
     "asset_ids": [
       "terra18ky9ln4g6x3n9f9s8a5ttshynv6lgzfppmrmyg",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra19pztt2p6wuy63dehanjeuyf7vx399ptwdq93zj"
   },
   {
     "id": "terra19ujj2teuw6m45v9c2wk33wzl4mjr22jlw3nqrs",
-    "lp_token_id": "terra1exs7v9pvkl90zjyd5h7lu26hzszwczfsedc3hj",
     "asset_ids": [
       "terra1rctv4sdztvscdxw890us4ewcuvh77t8wydxkxr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1exs7v9pvkl90zjyd5h7lu26hzszwczfsedc3hj"
   },
   {
     "id": "terra19ypukqk0v8l2f04qjsc9pwullq7r24eufm6led",
-    "lp_token_id": "terra1yhlgg0kkm7vngmj68suf0jmx5fj7v7hpxy4udn",
     "asset_ids": [
       "terra1tdc7hmydg3es6lmn2asfwfgs8ykq7xa0nz9rkh",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1yhlgg0kkm7vngmj68suf0jmx5fj7v7hpxy4udn"
   },
   {
     "id": "terra1a5pqgv432f3u25zu5q5r0t6e00pwd6xa8unwp3",
-    "lp_token_id": "terra13hcayvzgxur5f43qwauz3jsnf4j353ee9s7qq3",
     "asset_ids": [
       "terra172qlk30wwyux37m45w5c7mkypn7ks0t0s3d0ms",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra13hcayvzgxur5f43qwauz3jsnf4j353ee9s7qq3"
   },
   {
     "id": "terra1a5s9cgdzw4pz4nf8rxyqp77q0wuegahs78tpfd",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12qgpr0fw773gc8lrkys3knnw6nkgdlc8ggaty9",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1a8t3w4ts39fu5su3dg60p9akhr8uf85fzccuxq",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra19hnegq0ed5w0gds64765uakh5huw7jepvjakh5"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1afgh029jj9nxglezr3jxmr0heujj55pgspvx4m",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1cq4lkf7dlygdp23yql8a4daunnxr4xd5tymszl"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ahygklrmejad3mmeugsd0m5lczv9jl8hjepp6r",
-    "lp_token_id": "terra16k9tt8q30dswt9ksp00wrfdmdlze9s2en5y7ts",
     "asset_ids": [
       "terra1478yfcsa6ycykstdfh2mclwdy3d6zpemkyfu4j",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra16k9tt8q30dswt9ksp00wrfdmdlze9s2en5y7ts"
   },
   {
     "id": "terra1ak3u2e0303wvnfsese2z382pn4sxl9etz9rrkj",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
       "luna"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1aqd837959wjcpzssqqr56rhh7dcq2nrqpgqrdm",
-    "lp_token_id": "terra16c2lh2lr0xe92ayf558rgzw47gf8cmqh58v06n",
     "asset_ids": [
       "terra1tc7tcg8u54p3t2r5yfufgf4z340ggwpvlc2rwt",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra16c2lh2lr0xe92ayf558rgzw47gf8cmqh58v06n"
   },
   {
     "id": "terra1c0g493amwrzx47zxa0qcvrks7wyhmqkpsf8u2y",
-    "lp_token_id": "terra13mehc6ldhs2sryy388tuqn5cxq573gdhrq0cjg",
     "asset_ids": [
       "terra1pkfzenexjj6ne68xv2g9t8387s7d6z39c60ghr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra13mehc6ldhs2sryy388tuqn5cxq573gdhrq0cjg"
   },
   {
     "id": "terra1c0hc7ncedxaps2hxl0qazxlh79g4zdre5geq4m",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pmmdfnmhrjnywsgkd6xplgp8nx03fxm6ygma09",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1c3zsqpvlev8x70cmekqxmqjjamvwdw93gzqjlc",
-    "lp_token_id": "terra17xhypskf3f0cqf0knvyqw844vm54fg2j4fxng4",
     "asset_ids": [
       "terra12zzantsa5trfm0ssrgsnhvlram502ats35qtc3",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra17xhypskf3f0cqf0knvyqw844vm54fg2j4fxng4"
   },
   {
     "id": "terra1c4r7vdd7f3cjts6kzjuv0sx4apesxr9p55kqc6",
-    "lp_token_id": "terra1hndks78y9k49jq35x4kwjsvpp8g9hn26e5n7d3",
     "asset_ids": [
       "terra19v4cg3w698qprsjwzw52cns6245vkxug74q9lc",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1hndks78y9k49jq35x4kwjsvpp8g9hn26e5n7d3"
   },
   {
     "id": "terra1c535v3f7fz8a94wu2cev2p9wvzfv7x35uv7tk6",
-    "lp_token_id": "terra1xup47v2ypdhk4lpmjw68k8hlt9s2ejjg4pv83j",
     "asset_ids": [
       "terra1wzxpydn6z4z0us0wpx3n96gcs5p9qqavhw5sqs",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1xup47v2ypdhk4lpmjw68k8hlt9s2ejjg4pv83j"
   },
   {
     "id": "terra1c586ncze76sv75zlg3cqusqdmn6zluukdhc9cx",
-    "lp_token_id": "terra10qpu5aajfmkucfft53hs6hzn96ckaqa0cdmhje",
     "asset_ids": [
       "terra1vsr6l45yyqn58at6nymdx99kph9sw7zql70akr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra10qpu5aajfmkucfft53hs6hzn96ckaqa0cdmhje"
   },
   {
     "id": "terra1c59fgnldauz68wpxzawxy7w650r0yvhq34g6ng",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra158ut7lycly6ep0v334rpjtcjs8hlvwjzf5tfrk",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1c5j97vq48wjln03wgtalfhlmlg6uyczmpj74vj",
-    "lp_token_id": "terra1we6ygtflu43kjgzj8ug6d43f4zkd3fmssax5sx",
     "asset_ids": [
       "terra14rq6etqgza9qqpgz9yjfmsclgnzhk9jsafdtyc",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1we6ygtflu43kjgzj8ug6d43f4zkd3fmssax5sx"
   },
   {
     "id": "terra1c5khrjsj0q9l2pyt75cw7hrwst7xyr9vegutkv",
-    "lp_token_id": "terra1hd9hnlwtqm5s5mkngqdqytdc0a6elquh6n70nk",
     "asset_ids": [
       "terra17zeqmepm87d9g4dujjsctqjrfhz4xjkup26t03",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1hd9hnlwtqm5s5mkngqdqytdc0a6elquh6n70nk"
   },
   {
     "id": "terra1c74x8j9caymapwg30z3gse2jlxvgkm56uhv6zq",
-    "lp_token_id": "terra1cgfghgpw8u832e9xlrya7pqpj0pyyfpyptwdte",
     "asset_ids": [
       "uusd",
       "terra1my0tlq45u0vlpyt2n4qchxkzhzwnxrd2playfq"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1cgfghgpw8u832e9xlrya7pqpj0pyyfpyptwdte"
   },
   {
     "id": "terra1c78mey84ygre2ym4aznw28796qfuytcl32p83j",
-    "lp_token_id": "terra15gpwuqw3uezt69vxa5ftd2dt7yc8ap2fydqhat",
     "asset_ids": [
       "terra15plvf4hfgsrev5athn7wmnqgt6f0lddmduzp90",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra15gpwuqw3uezt69vxa5ftd2dt7yc8ap2fydqhat"
   },
   {
     "id": "terra1c9t0gzff3z4mh62ky9cj9hkunlj8zqz58kqa87",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15q3lzrnfstr3rqgh55cqmp95z4xr3we5tfyqm9",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1cc2w6lgzxarvawywfr7v4q7nq30tfvnfs62u54",
-    "lp_token_id": "terra1zy5sjsw4aswykccwtvkaq27s2eedspvakut7gw",
     "asset_ids": [
       "terra1wdc6xjyng08qwssthzvd5u8a4z58r8jxxn3j5t",
       "ukrw"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1zy5sjsw4aswykccwtvkaq27s2eedspvakut7gw"
   },
   {
     "id": "terra1cdj55x2gj369g50g3w2uqjm6p2fchgy2ehjd0p",
-    "lp_token_id": "terra10z27h35npl969tp9d05qfs49k925rxm3w5sd96",
     "asset_ids": [
       "terra1fkwfm2w8kffl3ged3zulknz849rnfdxnwjgdnk",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra10z27h35npl969tp9d05qfs49k925rxm3w5sd96"
   },
   {
     "id": "terra1cds3ru8n9s6cpuqszd6kupxjghj8r8rqk8jvmq",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1fpfn2kkr8mv390wx4dtpfk3vkjx9ch3thvykl3",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1cf38v8qumxruarhxfsgnylkymz6935c6qhcrkv",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra16pem7c3h7renxuxa4jvw8efv4nhrdc3leguzyn",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1cj2du5dmwr86u56u3xp6kx5u9ww7z2vcz2vrrr",
-    "lp_token_id": "terra1hffx97vzfuj5ysxtpzjpatf5utpaqces0dvm3y",
     "asset_ids": [
       "terra10c4zqj4f7ze4keuwvm6hk2wrdj9p8h07sp4fg5",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1hffx97vzfuj5ysxtpzjpatf5utpaqces0dvm3y"
   },
   {
     "id": "terra1ck5vwpsz9nf95c7t84jjwfgpxtcnpj23aka3ml",
-    "lp_token_id": "terra1l46txnnqf0j4l7g6630dhf0vxqhpxyzzadchfj",
     "asset_ids": [
       "terra1pduqn0tpqce36ndwcv6z6xjlnujdddl6pedz9y",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1l46txnnqf0j4l7g6630dhf0vxqhpxyzzadchfj"
   },
   {
     "id": "terra1cmvp86pqrt2r986v63mm5257ctplnf737rktl7",
-    "lp_token_id": "terra1wqa24s7qzqess0pwrx3q70lh0uj04vajx6uf58",
     "asset_ids": [
       "terra1y6mgy2ha0fwhtkd06jdca7hpep7z8hz9n2jz8t",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1wqa24s7qzqess0pwrx3q70lh0uj04vajx6uf58"
   },
   {
     "id": "terra1cpmqngse0kw0rkgv5pewgg8dvg9ep240xelxc4",
-    "lp_token_id": "terra1uzzyyxp6kj87q2ygm0d9se0pthnrjh7jy75jxd",
     "asset_ids": [
       "terra1f659ez3nysf06765jjjqnl7m65urrqaxx2t40h",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1uzzyyxp6kj87q2ygm0d9se0pthnrjh7jy75jxd"
   },
   {
     "id": "terra1cr5uef9rrl74xcw9vjsqklud2dstdfr4xj7hqm",
-    "lp_token_id": "terra1my49papxtmataag9arh9wdrqyyuqyjfw7cc44v",
     "asset_ids": [
       "terra1ce0z2295uajnvxltll75zuvh5mvecczy3fmlzj",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1my49papxtmataag9arh9wdrqyyuqyjfw7cc44v"
   },
   {
     "id": "terra1cr8m0mpdj5e7m34ekdrqgw59az5v98pgckha4y",
-    "lp_token_id": "terra1dsj8lxhuvtz8k8vt9v7zjm85cca4qjhsqgvced",
     "asset_ids": [
       "terra15tqztw9vjcuc9znkvmxn7rh30ffdnahhnw4vym",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1dsj8lxhuvtz8k8vt9v7zjm85cca4qjhsqgvced"
   },
   {
     "id": "terra1crkwlasutngkqdlfskk7rcgasehpq6aaerarqd",
-    "lp_token_id": "terra196f5vd4s9zn6deqv9shjktk348nk7k4kcl4apd",
     "asset_ids": [
       "terra142yp486a6jjelr87c0kx6vxv22nw6dsvkcnhma",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra196f5vd4s9zn6deqv9shjktk348nk7k4kcl4apd"
   },
   {
     "id": "terra1ct767uq6h75duwd0jl6t9lxt3zn3wvvnec3snh",
-    "lp_token_id": "terra1lkcazx0hn69qsw62tyhj6u0svsnepg73vj553h",
     "asset_ids": [
       "terra1ygrhf4zv86jp7hnyl358uj42llm75gt7w8e9s4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1lkcazx0hn69qsw62tyhj6u0svsnepg73vj553h"
   },
   {
     "id": "terra1ctdwhvfkhrp8z8l78l85h0da6ywlmp2yjtws2e",
-    "lp_token_id": "terra1edy63xnmphdr47p97hw3h6fu72md3u952ra0hk",
     "asset_ids": [
       "terra1s9jnada32ld74gmng8ng5l3zfy9vk8kfds5828",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1edy63xnmphdr47p97hw3h6fu72md3u952ra0hk"
   },
   {
     "id": "terra1cuxd5x9vs0m604pze90c0xgccraucv2kqcwlz2",
-    "lp_token_id": "terra1pgjfhamw0dv2t9a5d9q9eu7fm9etj4zcewyak0",
     "asset_ids": [
       "terra187zprsu04wnfs64pznf69mkls6vefhtmtwt8w6",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1pgjfhamw0dv2t9a5d9q9eu7fm9etj4zcewyak0"
   },
   {
     "id": "terra1cvg3jjepvcxzkv5elvr3x5khk83wllvg4qygfc",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lxpjyl6k60rsyp0x7fa40s8jsl5l0d27ycmwfh",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1cxcxfa5hd60t8t8rphzgpwunwh3dxplzm0xpwj",
-    "lp_token_id": "terra1r099m6j4unzjxv77vxnt05hrszphpm69f5x2rs",
     "asset_ids": [
       "terra1m97d9028kdz002wkq23kp329w68yun7p0x6vlh",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1r099m6j4unzjxv77vxnt05hrszphpm69f5x2rs"
   },
   {
     "id": "terra1dagf0h7ux63pqak79m7rqsnm5yujga48sg37pv",
-    "lp_token_id": "terra1mf2f35qq37pkmq6e657ha0asc6tzxm8zwaxg6r",
     "asset_ids": [
       "terra13yf7ukapmeznh2uamd0342g0hy872my8shc74j",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1mf2f35qq37pkmq6e657ha0asc6tzxm8zwaxg6r"
   },
   {
     "id": "terra1dc84dhqyqrrzpt3tjnkrzsyky2yyzxr5tszzxw",
-    "lp_token_id": "terra1dj5q78dmy35a27dq97sl28ta78yw2qaz275xaj",
     "asset_ids": [
       "terra1tknq3prjtkzttvx2u48hn4r7xfwh7gz9cxzgqf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1dj5q78dmy35a27dq97sl28ta78yw2qaz275xaj"
   },
   {
     "id": "terra1dcqj2agjxrc7gz3zsfqxux8js3r2rz0wumch6t",
-    "lp_token_id": "terra1h0vyhc8ttqe2swxkvwl8v75wpfpp5c3vxwdxxv",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "terra16gx5th8mk5v62xpvgf675xj2vuaf3dg4v75ml5"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1h0vyhc8ttqe2swxkvwl8v75wpfpp5c3vxwdxxv"
   },
   {
     "id": "terra1ddu6j495ephpxm8at7jzg55n6u0zc2yadvuz26",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1v6p9v6dqaql0600hmdl78h592ax5rxmheefgd2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1dfv0ww0tqu432aa9z6r0npucjyslu356602ayr",
-    "lp_token_id": "terra1n0hxydmnc55rzs8kyvefpj0xkp0524wc39euwv",
     "asset_ids": [
       "terra1gkfv34wapjun9w0qpg8f245greudfguzlhp87f",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1n0hxydmnc55rzs8kyvefpj0xkp0524wc39euwv"
   },
   {
     "id": "terra1dj35t0w5w5knw7cq6dj3s68ry724nctq069w5s",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xmd43yrfxm4xy3lnptc7kr4rr93pzh5u0z0wgt",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1djzkg6ghcwmlkcdxpqq7lw42e695ulzljrvavr",
-    "lp_token_id": "terra1u5qgpemcltd5y0mzwqsz44wws5z00zyusa8w7z",
     "asset_ids": [
       "terra1r8ak49p50g76zamn25h3u7lkmn9n4maq2k2le2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1u5qgpemcltd5y0mzwqsz44wws5z00zyusa8w7z"
   },
   {
     "id": "terra1dkhyzytlc99rf43n4jrxttwxcvg0hvmaa477cq",
-    "lp_token_id": "terra1mvht6zch65z2jstqfz6dye5wlazhhmc4eky6gz",
     "asset_ids": [
       "terra1yj7vlx4uj39u8x4ptvvpxhpfnmphypmlhfhq42",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1mvht6zch65z2jstqfz6dye5wlazhhmc4eky6gz"
   },
   {
     "id": "terra1dq27eeasl3rtlc8j3ls5yz8wurnksahj240tsr",
-    "lp_token_id": "terra1prswk9yyayfkkq99fpaz5zs7h0lhcpsqa4swj9",
     "asset_ids": [
       "terra1zva2uegkvwr03p98mdaam4dtrkfxxvu330zwaq",
       "ukrw"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1prswk9yyayfkkq99fpaz5zs7h0lhcpsqa4swj9"
   },
   {
     "id": "terra1dqz4zx0uecwjqafzyej7pzyhhqse2agq767al2",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17qfuwapug8scgw5satxs4n95u3taw6fe8hdgty",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ds7gy9gyf9e7rl8zmmtfjt2e2dm4d6p9szu8tq",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ss460ny4hl5zew0tlvywnw38rsy2ql3n420lv2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ds8u8qrqv87e5mud77up62rl34rtltg3v4w3tc",
-    "lp_token_id": "terra1maal7qmyn8vv4435wc3nx7nryu7swnj0n2v4dp",
     "asset_ids": [
       "terra1qv98rklgrdv89gvf47rrzx2lzehd43uwz2rus4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1maal7qmyn8vv4435wc3nx7nryu7swnj0n2v4dp"
   },
   {
     "id": "terra1dsmz3dfejj47wcxes66gktwqhsvyxe9n2pld0e",
-    "lp_token_id": "terra1cnryfady5636utnsvv9uj429mhnwfqmtr4als0",
     "asset_ids": [
       "uusd",
       "terra162k5t3hl204lrwe8xvalh4pv4gdrjvdrjlgxst"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1cnryfady5636utnsvv9uj429mhnwfqmtr4als0"
   },
   {
     "id": "terra1duyea9eyua7uftths0n0kn5uzrdsguj7mmv666",
-    "lp_token_id": "terra14janxct88y74znp68z4jh5j6hq3nfd6shr3sjl",
     "asset_ids": [
       "terra1ykq4e3ca2e5qgeetk8k8m3w6tk9tclr0xj2st7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra14janxct88y74znp68z4jh5j6hq3nfd6shr3sjl"
   },
   {
     "id": "terra1dvwewun965qpex2k8hrpfpzt8t7qtq3ptwu6j3",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra133j6tpq7gcrjjgvgj4r3fjwda0hegmmrazmwt0",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1dwsngznkraae33wufcz8qu4rd83elrzn9g03el",
-    "lp_token_id": "terra1zky7u7ynn6m67zequu5cgh7jefadg6ux46a22z",
     "asset_ids": [
       "terra1ptmrg9j7tcjphzejzlygehaxwtzrr6ywsu72qq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1zky7u7ynn6m67zequu5cgh7jefadg6ux46a22z"
   },
   {
     "id": "terra1edmq655dxqjk4dh52z6e0h9uajs5g0yl5lk7y7",
-    "lp_token_id": "terra1dt5n5tf9afjzms493nfkt3telqtvp5mmmftu0e",
     "asset_ids": [
       "terra1nh6theuhf4pv67pcyqnz58czljr382mxrp2rdh",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1dt5n5tf9afjzms493nfkt3telqtvp5mmmftu0e"
   },
   {
     "id": "terra1edrk0fflh8ve8d0dn8hna46ftvu9mrruhzeunv",
-    "lp_token_id": "terra1xajvgkhmt8lqkna2f5t28jegsywwkgxvncl988",
     "asset_ids": [
       "terra1d3pmqshpe6n5cs7d6mnffdun4tg0k05zfy99zh",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1xajvgkhmt8lqkna2f5t28jegsywwkgxvncl988"
   },
   {
     "id": "terra1ehdk7m3p7fwpmzhfh8pdnqueqy6ymmccsnjpsd",
-    "lp_token_id": "terra1lxx00gux7zl549dj98cd0rws0xv48ns4qdf2zf",
     "asset_ids": [
       "terra1f8m2ylcpzfeg3675yk7htw90d72jltgk4mkr9t",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1lxx00gux7zl549dj98cd0rws0xv48ns4qdf2zf"
   },
   {
     "id": "terra1ejql0hjel8s7ywxansv3svrrv4hv8t7h0803em",
-    "lp_token_id": "terra16dv8v3v52s7ktxdgltxz6yje67xs8c3azaa9g9",
     "asset_ids": [
       "terra1zzfhavsjlhhx42rnjfvwk6u7taplh4qxqmhgfa",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra16dv8v3v52s7ktxdgltxz6yje67xs8c3azaa9g9"
   },
   {
     "id": "terra1ek0rr6pj76mtrukw9l90wd8xwcuknw8aqp48sj",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1247nlrmskhfu9qpg66zt5w6f8cw250878enl9g",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1eky5etgq3jwhtyz2tqyuykkxpj6rep7jd7v7rq",
-    "lp_token_id": "terra1054t5v3fszukf4hajqvf4zsndcn2rdx4yz8crq",
     "asset_ids": [
       "terra14zj58ljhlyrgshe0n99un3k5ll2s0eucp332nu",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1054t5v3fszukf4hajqvf4zsndcn2rdx4yz8crq"
   },
   {
     "id": "terra1emetwzv9g6pc0gp5ghj7h9wyvwm902wtxj76d4",
-    "lp_token_id": "terra19kadah8p79e4m766e3q869jv5f67s60qfxznmp",
     "asset_ids": [
       "terra1mfek3m9s0sazd40kjraw5qv3963t5n3gwk408u",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra19kadah8p79e4m766e3q869jv5f67s60qfxznmp"
   },
   {
     "id": "terra1emg7lr0fxyqxkytdk7seupa4lvgda2frxjluz6",
-    "lp_token_id": "terra1drarcarn8y5hzw0hkjcpa9nhefpq8gqdfeq3rr",
     "asset_ids": [
       "terra1a8k3jyv3wf6k3zngza5h6srrxcckdf7zv90p6u",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1drarcarn8y5hzw0hkjcpa9nhefpq8gqdfeq3rr"
   },
   {
     "id": "terra1enwvvus429s4yxr0d5umud3k6eyhln6vn57v8z",
-    "lp_token_id": "terra1hp9saxd4mjfrmmzlzmkt9x9jk69vpu7vsh6lwf",
     "asset_ids": [
       "terra1d8uw3zddfrexn06f80nz6hx2cd3f32a7p45agf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1hp9saxd4mjfrmmzlzmkt9x9jk69vpu7vsh6lwf"
   },
   {
     "id": "terra1eryc869znes7ujk8usxrrhy2zru8f77478mn0e",
-    "lp_token_id": "terra16pj9ycwu7yvfwtkrew87ss2tqvr537fl2rl800",
     "asset_ids": [
       "terra1lrqv79tw447kk4ham08suw7vak3a7pf9de2qx0",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra16pj9ycwu7yvfwtkrew87ss2tqvr537fl2rl800"
   },
   {
     "id": "terra1et3se39fd2nmnuygcvls2amujzmv4v6k4xwv69",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1mz858mn7jeglmzj0ay8z5zy6v78fvv7em9tljz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1eu62yulj5zjhs8wa9uvlj5l92a809a2hcp83uv",
-    "lp_token_id": "terra1zaqqruu0ch0qgq2s2djkelywfn9x9yfg7wjet7",
     "asset_ids": [
       "terra18glhvftntrqg00hv96qkpx3r37g34qh8qytnps",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1zaqqruu0ch0qgq2s2djkelywfn9x9yfg7wjet7"
   },
   {
     "id": "terra1evfprrp4l8kratzm3hs2yxnly2t3ps2r5x7jh2",
-    "lp_token_id": "terra16kvs9y46p4lkj0dnyef6ly4fzs7883ztl2l9dk",
     "asset_ids": [
       "terra143dkyw98s3ksxu97zln8z5s220ytatygd5rqdx",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra16kvs9y46p4lkj0dnyef6ly4fzs7883ztl2l9dk"
   },
   {
     "id": "terra1ex4tn8m3g2c8xv3q9q5mlm0d8aa6684g40y3cx",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12mvfnsk4r2chx7n032aztme7zcypyla5pllhzm",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1eyyqh5a5w6sx36q0dgdewmnvxkud8yap2u2xp3",
-    "lp_token_id": "terra1fl4qcp5a3vs5unz3f3kgjwr7rxvq3g393jrk5v",
     "asset_ids": [
       "terra1agkfm4zumwkkudpj0882xaex7fne3rume0775y",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1fl4qcp5a3vs5unz3f3kgjwr7rxvq3g393jrk5v"
   },
   {
     "id": "terra1f27dfgcgx5zpa2f3zd9s79jrjmklwq0l8fa6el",
-    "lp_token_id": "terra1r3hc388xqf83u86ruvhfe3p7pnggz3stf694qc",
     "asset_ids": [
       "terra1e60jlze35lh05dlqrh2yjv3r8z3gktwchykrq0",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1r3hc388xqf83u86ruvhfe3p7pnggz3stf694qc"
   },
   {
     "id": "terra1f3tdduzpsdrg33x6w8cqmzmyytnmhzcvwnharl",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1y8q4jk5xwag3sschctduxa43eesupjkk6kr452",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1fcgvdqe2dcgr7x2a9w3nfc0nhjh07zggzdlnfm",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1paulfn369vuz6s6ty65y56wj8gnamzpdzwk9x3",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1feuaajpy0yyag7zsz2w2yxst6faeemn82mlnrf",
-    "lp_token_id": "terra1gpavmsf3snhltxnf7n6nyz2ehyswtflhsqk7de",
     "asset_ids": [
       "terra1rumme3vcguv9ly60p53j6wg5qanacfa9nl5uyw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1gpavmsf3snhltxnf7n6nyz2ehyswtflhsqk7de"
   },
   {
     "id": "terra1fgn8re8qf9am8ymkmaawgspym43en9f8w50f8c",
-    "lp_token_id": "terra10evwunz82kc0wucnwyxnzq35yjygl9huglrlgu",
     "asset_ids": [
       "terra1m9fuqymdz03umd88guyc79083hd7vppzu74vck",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra10evwunz82kc0wucnwyxnzq35yjygl9huglrlgu"
   },
   {
     "id": "terra1fgwk7tjfzcul8mc8xwdkf3ejswgcxkh7d087ku",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yanmc0xxg9dl387qkudnysjkymgytj3cdhgeek",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1fhgksqjyawsym7myq04ddvm0sgxwzqqlw4pp5j",
-    "lp_token_id": "terra1xsv563k2wyuqkwza0mrz6ye8exx4a9r0hdvxs6",
     "asset_ids": [
       "terra1elveensfjwt270xzt8rcpvwmnhawrrqfx5atj4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1xsv563k2wyuqkwza0mrz6ye8exx4a9r0hdvxs6"
   },
   {
     "id": "terra1fhs5njpe2sy6acf7r3s8qh62mvs0dgs5wntdtu",
-    "lp_token_id": "terra1xapjctwprfuqpcte2h4mnpxtf7nh3jhurgv6sf",
     "asset_ids": [
       "terra10hr9gx9m9tq44xcxk2c5mzzlk7p22zd7x6esr7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1xapjctwprfuqpcte2h4mnpxtf7nh3jhurgv6sf"
   },
   {
     "id": "terra1fjrjynsdxvgqsahquuun46w440d59020vxva9d",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1fcq75y4ezhsws0vudna3cddk20d3k0eg9nznyh",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1fmp455y0fgee5dv68fxwfnylnpux6fv3th4m2f",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10vwyclaux26l47hj2dgnjw2pcsrt4y0ukfgp9u",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1fpnmpty0r6fmyxnfzere7xd62cnjaumslzz7d9",
-    "lp_token_id": "terra1fwcdnx8flnyy4skav4fvurtmrh86ef9mkumgt6",
     "asset_ids": [
       "terra1spe82hmc9j2y2vjl6urue78zhrn9r9xyydkyx4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1fwcdnx8flnyy4skav4fvurtmrh86ef9mkumgt6"
   },
   {
     "id": "terra1fqr0y0djympq8zfgztev9dj7fpp248pff7860f",
-    "lp_token_id": "terra16800h94m9r3n8alhu2rsxxpxyesh9sylu3jgen",
     "asset_ids": [
       "terra16q2hhuva6u0zakfav0pmrdw2fhjsanvqq9y56t",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra16800h94m9r3n8alhu2rsxxpxyesh9sylu3jgen"
   },
   {
     "id": "terra1fvzjp7p8qy0l332qy8rpljcufmsqdxjyvckney",
-    "lp_token_id": "terra1dvkjth7zak3f5kvn7l8vfp9n0cu8dtjnjhdql6",
     "asset_ids": [
       "terra1ua6saapgern9jpmklkvxxq4l06nal2cwd0003t",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1dvkjth7zak3f5kvn7l8vfp9n0cu8dtjnjhdql6"
   },
   {
     "id": "terra1fx82cs3ttpcnd9wg32a70ajkfturmedrgup2vv",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1cxusd4uhgpgk2sp99rexrcknpn08anak3v9tz7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1fydslvtnl4d4dujz5kapslwty6were2aeerd95",
-    "lp_token_id": "terra1q3q8lrucdvs93walj4edxqlaj0lqqyrs2sgk7e",
     "asset_ids": [
       "terra1ejmg85y0vgsxv5r3cd4024j732pqnwudl0v2d2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1q3q8lrucdvs93walj4edxqlaj0lqqyrs2sgk7e"
   },
   {
     "id": "terra1fyrvx3m5njh265wu3xycty3ynf04x8wqhpm2lh",
-    "lp_token_id": "terra1hqpfh2g457fuzrm8e0skagwwh79pffr3zzqwek",
     "asset_ids": [
       "terra1897wmaycufjr9hu894mt0g33ddcgm9vfsfcyyd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1hqpfh2g457fuzrm8e0skagwwh79pffr3zzqwek"
   },
   {
     "id": "terra1g39kq9n6qmjzpls9kfxu86yvcz3p9ajy8fqjp2",
-    "lp_token_id": "terra1da3m78cejl8l396gahuqnllwl4qyxeeysm5vrq",
     "asset_ids": [
       "uusd",
       "terra12y2uzvrn3j4y5390kfljtpq6z3wqflyg0wls2z"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1da3m78cejl8l396gahuqnllwl4qyxeeysm5vrq"
   },
   {
     "id": "terra1g6jmfxv2rangz50u335rfum2fxxqmk4cnl43kw",
-    "lp_token_id": "terra109kmkve0p4ksffjdfkry75d44hy038mk7x6ygc",
     "asset_ids": [
       "terra1866wzpwzmrnmh0s267twyhr8c4tc47tqj5aths",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra109kmkve0p4ksffjdfkry75d44hy038mk7x6ygc"
   },
   {
     "id": "terra1g7an9lfz22gkv74238dhc2j6ymfp4jy0k55yxk",
-    "lp_token_id": "terra1yqnd70kvrdfazu7aplalwqdp3ksnu35fv9cv9m",
     "asset_ids": [
       "terra1qw6sp3rjar2x7mfa0x4uj90ssemwap8p50f8kh",
       "ukrw"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1yqnd70kvrdfazu7aplalwqdp3ksnu35fv9cv9m"
   },
   {
     "id": "terra1gk2nnql0vllx34dev6l9grl425leuehckwpx3d",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14ec8v4c5dnwu2pq9plfquaffutu59tq9hld77e",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1gkrajyr342clv98p2f6dx72eyj5cx0t9pa74f3",
-    "lp_token_id": "terra10q52n4yx9nn7p2arhle32kyujt65euzh3vny4l",
     "asset_ids": [
       "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7",
       "ukrw"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra10q52n4yx9nn7p2arhle32kyujt65euzh3vny4l"
   },
   {
     "id": "terra1gnwt6a5t5vw90q26va9fj3j0rsnjemptht0szr",
-    "lp_token_id": "terra1ewm8kaj2vvh2aknjzlv6cyqm4hjc8j0uvdnah3",
     "asset_ids": [
       "terra15uc875u7uu8xyqf833nxwh5x4dm2kmu29u04vl",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ewm8kaj2vvh2aknjzlv6cyqm4hjc8j0uvdnah3"
   },
   {
     "id": "terra1gqqc9f89a92h75m3hqt4c4hpc8466a5a8z4xt6",
-    "lp_token_id": "terra1dxu9d263z3rxdn3s72uswtszjewx573sh4mq9r",
     "asset_ids": [
       "terra1cvsfc32dkdvmla6urrscrtfceztecj0u5tvlvz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1dxu9d263z3rxdn3s72uswtszjewx573sh4mq9r"
   },
   {
     "id": "terra1gtu7lxdl878r02s2q7fx0thzfu852c3xhxj04n",
-    "lp_token_id": "terra1ekm4u8whtpzvna0arcxjpj5mx2qfcwku70nzgz",
     "asset_ids": [
       "terra1qsjs0a02jmyfhvaeul4zax22sayx5e8dl8527g",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ekm4u8whtpzvna0arcxjpj5mx2qfcwku70nzgz"
   },
   {
     "id": "terra1gy92pyp6kwllkpqv4gmw63l50cglzqmtz2jjnf",
-    "lp_token_id": "terra1s72ztquh9j0rj5w84kxlflkwz0kwyaflgxtstd",
     "asset_ids": [
       "terra19qad83kr29qg89fpl4qh8m02wapmlwzpw5hvc4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1s72ztquh9j0rj5w84kxlflkwz0kwyaflgxtstd"
   },
   {
     "id": "terra1gyrp3pnw34wy0ptyjehfw6akwd9h4ed6kmxmev",
-    "lp_token_id": "terra1v29xuc4he907gkpc3zmrhqhuxcvy3jhfy50wue",
     "asset_ids": [
       "terra1mlhehkx4rgp357jmxhqepy0nr4tjetkje9t686",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1v29xuc4he907gkpc3zmrhqhuxcvy3jhfy50wue"
   },
   {
     "id": "terra1h279dtdp2jal5z46memvs3fqa9syfcnd92whp2",
-    "lp_token_id": "terra1dznxnr2k77nneklkd05jmxugp2j77mtt6v6yjn",
     "asset_ids": [
       "terra1yss9zexptelas8y4mqans2qscmw69cy2g0tycu",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1dznxnr2k77nneklkd05jmxugp2j77mtt6v6yjn"
   },
   {
     "id": "terra1h4mjl52nsy6y04r9snxe23fzdx85vzvpcnu6lz",
-    "lp_token_id": "terra16v0aunfk0tqswrldmyczz8aymwe9r279kknheq",
     "asset_ids": [
       "terra1ckrsweg4dtg47qv55ecayntlax3j8ja956nq2l",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra16v0aunfk0tqswrldmyczz8aymwe9r279kknheq"
   },
   {
     "id": "terra1h9jyaf7wttw6txdy64608wc6k998dt2ny8zjwm",
-    "lp_token_id": "terra1xfq07tcdep6lujx480xqs02q5tk3ka3p4l2m8d",
     "asset_ids": [
       "terra1pmf2x6gp8u979q672lkkkruuhe9zarxyu5w7t2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1xfq07tcdep6lujx480xqs02q5tk3ka3p4l2m8d"
   },
   {
     "id": "terra1h9zcqxdcl89hwvgxh2v6l3e3lfyguawxcvtasw",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pc253zfn4zns6awk7eks779uk3m7dna7y4cmlf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1haarsvn3uxmul3rt5vr8x0856pjj45js6fwkhz",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15fvz44vh89rj4ykamk2tadw0f7wdnccn5qp0ua",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1hakq6c49989jkgpj4qcp4akxqgesazps2ss9lp",
-    "lp_token_id": "terra19c5fhtrdaarv2cly5su7w9a2ud7nk72g2vm0gv",
     "asset_ids": [
       "terra1gqmd09k8g3lggxxdzu9z94vqcxtr5zylvs95ke",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra19c5fhtrdaarv2cly5su7w9a2ud7nk72g2vm0gv"
   },
   {
     "id": "terra1hcqrfwnjvsp6y0hyp9sgfla6k2fqx23g9j9q9s",
-    "lp_token_id": "terra1k9tcrhdgh2q5wpzw8j4ap3fen3ryn6ycdmn4ru",
     "asset_ids": [
       "terra1ktugzem827nn5uh2ccjk8y6xr9z4szvdc7x39r",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1k9tcrhdgh2q5wpzw8j4ap3fen3ryn6ycdmn4ru"
   },
   {
     "id": "terra1hfm049mt76s4kgsdrz7x0au4um4spyvyxe39m3",
-    "lp_token_id": "terra1rvsp3qg4k2vyd432xj9qzxx2p9hs2zzn5u43qg",
     "asset_ids": [
       "terra13zs7w76g0u4qgagcen6vq92wxuvgfucr3dy4tm",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1rvsp3qg4k2vyd432xj9qzxx2p9hs2zzn5u43qg"
   },
   {
     "id": "terra1hjpke0qekl4q7uy758c9z5ve6xwsuzz5n783ek",
-    "lp_token_id": "terra188ff6qfccynwu3ge76ylp0k9hm9ke3fsnacmc5",
     "asset_ids": [
       "terra14g3uqp52dwk9qts40mr2skynkqdxsqwlv0862z",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra188ff6qfccynwu3ge76ylp0k9hm9ke3fsnacmc5"
   },
   {
     "id": "terra1hke7ncmglkcevsgx0txma8a02pz4npypahcc0r",
-    "lp_token_id": "terra1xtxds95gvddytcxqu5larnuvxt5gekwfxclyu2",
     "asset_ids": [
       "terra1ltcad0e9cgf2jgtzqwg82n9k54fre68wdddfll",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1xtxds95gvddytcxqu5larnuvxt5gekwfxclyu2"
   },
   {
     "id": "terra1hn8m4250rgmtpx04uc75sfvqsyvcj4g9fdrmlg",
-    "lp_token_id": "terra140jj5n8yd52ucvntzfh02yslfuys3kxnd47lzr",
     "asset_ids": [
       "uusd",
       "terra1pujanvsuhqsqf8vc7r3ky9ghr8sgeg4e3ngjun"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra140jj5n8yd52ucvntzfh02yslfuys3kxnd47lzr"
   },
   {
     "id": "terra1hq3kf4353m5d858u08mymad5rvgkc4zeqhr8vs",
-    "lp_token_id": "terra1j02hv8ulc5yg7hc79ycsxfhgmys7jjc0m550c0",
     "asset_ids": [
       "terra1kuf3mxgrcwnlh4zfk5p5c6tcv436j5kza70asm",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1j02hv8ulc5yg7hc79ycsxfhgmys7jjc0m550c0"
   },
   {
     "id": "terra1hsyfna6jujxrfd86043w2tcydyvql7dks9v4zr",
-    "lp_token_id": "terra1gjz8xr2z92pffvzgp0khu569njf75jkhe6ta04",
     "asset_ids": [
       "uusd",
       "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1gjz8xr2z92pffvzgp0khu569njf75jkhe6ta04"
   },
   {
     "id": "terra1ht5zgyecp4w7s3jzgq9j4unjx44hx4se94yp62",
-    "lp_token_id": "terra1qts4ddzv4ndsv4mkccazupmfx8q978g0kr459n",
     "asset_ids": [
       "terra159tnr8a3uutvwxhgkea4f2hucm4v24evv2se2t",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1qts4ddzv4ndsv4mkccazupmfx8q978g0kr459n"
   },
   {
     "id": "terra1hv6zykkt9xjhuqzumrkpvp5e9t6hrq0837c576",
-    "lp_token_id": "terra1mjvdm5ahr6l9yg2h6sn0khu6y2dkesfmy9dfnf",
     "asset_ids": [
       "terra1juul8ypgcs4wtuqsc7fjv76g0tq77nc44ymxph",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1mjvdm5ahr6l9yg2h6sn0khu6y2dkesfmy9dfnf"
   },
   {
     "id": "terra1hxekdhzzlqrytzvf7vl7jvz8tk36eldmaygdu7",
-    "lp_token_id": "terra1x32xraswsr08qg9dee6jkkjac4y2j3q557f8q8",
     "asset_ids": [
       "terra10t0rgfryqz5ds93z5tqed740nqh4ele9lm9fhq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1x32xraswsr08qg9dee6jkkjac4y2j3q557f8q8"
   },
   {
     "id": "terra1jccp3z6efd6r4f88p7ewy2qpjtahxtz3glqu6g",
-    "lp_token_id": "terra1lk96dy8w7cq4x09q780cfg7wwpkuxrxtqjpycj",
     "asset_ids": [
       "terra1fd0gy7f5dcgmvdl95mt3z9fh8se48gf0wxs68k",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1lk96dy8w7cq4x09q780cfg7wwpkuxrxtqjpycj"
   },
   {
     "id": "terra1jftv4fh6wyxx8rnfw343vyl5ehcpn47syn8yzh",
-    "lp_token_id": "terra1k597uc4rzvlgmel8xkz434xdw0tsfmt7es0pwy",
     "asset_ids": [
       "terra1mt957lrc2z93f5utk509zma6pgtceaq6tqedc6",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1k597uc4rzvlgmel8xkz434xdw0tsfmt7es0pwy"
   },
   {
     "id": "terra1jgrs4fnevw78q8rvutwyjzxhyy5fzqwtft6jea",
-    "lp_token_id": "terra1kw6qk3wpdzj7aklge6yegqjlmnrm83248v3vwz",
     "asset_ids": [
       "terra1pamyemqvkj8ws0easzq9pkl8usnjt424ddraff",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1kw6qk3wpdzj7aklge6yegqjlmnrm83248v3vwz"
   },
   {
     "id": "terra1jgzc2rkgl0nlxxqgy097wtq55c7qv224ysx2dw",
-    "lp_token_id": "terra1mqhv4thnf8mpwvj6ul7wrrjs2y5vua257yhxns",
     "asset_ids": [
       "terra1gdapfuda0dxtjc98raemhszntcxty7chyr0wpd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1mqhv4thnf8mpwvj6ul7wrrjs2y5vua257yhxns"
   },
   {
     "id": "terra1jq6ud6xdljsrpgnmuhwc8e9sxjut5el6t5z9gr",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1qn4v9nnc2a0mdnkzl73rh60264gvhu6pxusz0r",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1juyxhxne0gm7nma4vrm3pz949lj3p5wg266x55",
-    "lp_token_id": "terra159je5qq2c45l4vl4j2uwpelyxvmf06nnqyyc3y",
     "asset_ids": [
       "terra10aa5cyfu879fm88glc099sjg8unejcp46cv6hd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra159je5qq2c45l4vl4j2uwpelyxvmf06nnqyyc3y"
   },
   {
     "id": "terra1jvq9ufp4vvypp86hl56afvjn7jqgxxu30l5zhd",
-    "lp_token_id": "terra19yfdxaw7qexrzq8lr8mjs478uu53ptmdmgrhad",
     "asset_ids": [
       "terra1r3u50sue9akjnndgvxm7fe0fy5jdtnyxwuetw8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra19yfdxaw7qexrzq8lr8mjs478uu53ptmdmgrhad"
   },
   {
     "id": "terra1jwl5rzg3xe0a3f8r26l0l3d957vlxm833srtcp",
-    "lp_token_id": "terra1srcv0x7huzrxce3awyl4u5g9rpt4fqn5nwcw6m",
     "asset_ids": [
       "terra1gpwkclxwwuzd5wyjw2qn3km0r5ge4t4f4mnf0x",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1srcv0x7huzrxce3awyl4u5g9rpt4fqn5nwcw6m"
   },
   {
     "id": "terra1jx3m7swaseumanezk3z6r73cptucc9dqg6hprk",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pmcr4gjjsu62t2d9e33q6d75sydrhnpt37nayz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1jy57s4anzh959e6cr02dwt5s3vw03ajwtfr2l9",
-    "lp_token_id": "terra17tjnesmzly8gv3aj87mmtdrma77au2z6756x9d",
     "asset_ids": [
       "terra1hytrupk3argcrsl5x7dv55gyda0tn7f2qqlwkl",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra17tjnesmzly8gv3aj87mmtdrma77au2z6756x9d"
   },
   {
     "id": "terra1k2sgkcw0z5drjcy4nl09v40xt6hgf0kpcm4rpc",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1gl3ywddjkukupa3qv86r8xy434frncmxna630k"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1k40xfmkswya285zwcsj0qlamg0f4kyrvn2cd0d",
-    "lp_token_id": "terra1ryc8v8srh8kwclxcay7dgqtkclty3g5n7gj0y5",
     "asset_ids": [
       "terra1xxze8dty562la0d6g9q3srlddh0qemk08kpgfr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ryc8v8srh8kwclxcay7dgqtkclty3g5n7gj0y5"
   },
   {
     "id": "terra1k5gg6rjgmmut6m3klz0sz36x7lt505p977pc9a",
-    "lp_token_id": "terra1y848ua0mxnczs6hslk6gug8tmtx9cmlgf2ju7q",
     "asset_ids": [
       "uusd",
       "terra1t5r5ptw6ympy9npq0z7fa37nrk39n8054c6763"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1y848ua0mxnczs6hslk6gug8tmtx9cmlgf2ju7q"
   },
   {
     "id": "terra1k5rnwftj26qlw6q746nv59jvg964zjr58ddsq4",
-    "lp_token_id": "terra1za869t75aa4tjatrtc8sqxfphymmdj3k56w7fg",
     "asset_ids": [
       "terra1mvgs32slrxy29qhfmd2vn7y6l8knmtw396uxde",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1za869t75aa4tjatrtc8sqxfphymmdj3k56w7fg"
   },
   {
     "id": "terra1k7ugqrw3jkk5auuudpnuf52wtzerx4a7cjjhfg",
-    "lp_token_id": "terra1ch9gwujlyz6pjptuqcdpyawn5a87dtw7a360v2",
     "asset_ids": [
       "terra18gtpe3cu99pp2ej4mmf5hanrfwy6qcvd5x5cmz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ch9gwujlyz6pjptuqcdpyawn5a87dtw7a360v2"
   },
   {
     "id": "terra1k8fkje4xawkgtg0czxkp98qd2gu8uz4xgnuzsv",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra157n30a667ethsknneaavga2txtze58eajyfv45",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ka5d8934txtr2lhpdk40334k30t66hxyqswq37",
-    "lp_token_id": "terra13vxffk8n8a65lr9a24a7g28ls5hzkhcf3kzvtq",
     "asset_ids": [
       "terra133q7a0uctlld9kru6put3hk99qvxm9qzmklu9f",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra13vxffk8n8a65lr9a24a7g28ls5hzkhcf3kzvtq"
   },
   {
     "id": "terra1kafq6reya5v8ksdlnpyzv5gnyax3l3vp9l79wd",
-    "lp_token_id": "terra1g95dha38ht2y8qchz2zqa0kjnr372zpgsyyejx",
     "asset_ids": [
       "terra1g0rda5pawz0duymd37puescqsx2hgqu9hgrp8h",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1g95dha38ht2y8qchz2zqa0kjnr372zpgsyyejx"
   },
   {
     "id": "terra1kag0uhcl2e7tddmzaavqr7agkhr9ukghutryjm",
-    "lp_token_id": "terra134cyuqglj8nmz2us3y7nl7z4mqsmj2dx8f3xq6",
     "asset_ids": [
       "terra19k974ngjsml8dtmk56cdhuy6pplr94rxqdt95p",
       "ust"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra134cyuqglj8nmz2us3y7nl7z4mqsmj2dx8f3xq6"
   },
   {
     "id": "terra1kcdknzuz8q5zjeyzyy30ykfpf3xs4dzxh57vgw",
-    "lp_token_id": "terra1t0mgl6lns0ff6wva27zjwqfpqrjdzw550ed652",
     "asset_ids": [
       "terra1aegvmfgdl4dclgpwtajll6382tcc7r0saa2eek",
       "ukrw"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1t0mgl6lns0ff6wva27zjwqfpqrjdzw550ed652"
   },
   {
     "id": "terra1kd38g9rmfvklwyrszpe43dddhvl8zdgeya6ms4",
-    "lp_token_id": "terra1ek3f48k9xje7zr6ytfdm2p9xe5qkx959kgrle3",
     "asset_ids": [
       "terra10ypru3yma98ukk3anr5cjv02yq839pcvqc476k",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ek3f48k9xje7zr6ytfdm2p9xe5qkx959kgrle3"
   },
   {
     "id": "terra1kedzs6p7mc73lvnw87gvp5aa5azynafthhsxpc",
-    "lp_token_id": "terra1e8nn0zsqmlnhmxfmwe5qz5p3utyx2fljemtrya",
     "asset_ids": [
       "terra1qgvd7llck3nfav7n9k2qh35zcsmjwap073x5et",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1e8nn0zsqmlnhmxfmwe5qz5p3utyx2fljemtrya"
   },
   {
     "id": "terra1kgytwyu7aqah7cm97xeeurvsj3n6kxp0tc9esu",
-    "lp_token_id": "terra105wahgnrx7t2dsxfx9wer2mtcfrvfpr5hjxyt8",
     "asset_ids": [
       "terra1kd4rfff04cvw7vae0szgawj0xye90fkchljv7y",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra105wahgnrx7t2dsxfx9wer2mtcfrvfpr5hjxyt8"
   },
   {
     "id": "terra1kjlt8zsdvmxaw63u38krl658zunaj9hzxwknqs",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1zqyfp259xhhct6q2alp88pke90qrxgr5u2zc7s"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1kljzhnu4edtc8f8xzxu223n03hj82k66xp6mfw",
-    "lp_token_id": "terra1caxrxg3n67egv4u0v6klt66nsz4y90sydlatzr",
     "asset_ids": [
       "terra13k5m9dmcdm8y52j95tuppuz23lvjug6hrh7vjx",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1caxrxg3n67egv4u0v6klt66nsz4y90sydlatzr"
   },
   {
     "id": "terra1klucl4s6jusuvrxag9hyay90cq4h80mkjhkw9j",
-    "lp_token_id": "terra1m28rcqy4fhhu9twwpuv6fdajwmfwlm02lwlzw2",
     "asset_ids": [
       "terra1u2tj2wy6gc8gw9g507a66796ej2csewp9asznk",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1m28rcqy4fhhu9twwpuv6fdajwmfwlm02lwlzw2"
   },
   {
     "id": "terra1klw8gs2ra6tvf0s86kvye26lcv3ztf885p9fwy",
-    "lp_token_id": "terra19uvpg6ppn5jqh85c72rw8ywnyr9ecalgfe20ek",
     "asset_ids": [
       "terra1s56hsyhyvq4xxxvnz8qr0pnktm2dadsm4gkl45",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra19uvpg6ppn5jqh85c72rw8ywnyr9ecalgfe20ek"
   },
   {
     "id": "terra1kneyp2t00kehpwkaxml9w7dg5p7nl703dv65vr",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1gs2pykgl27l04e6lprgqs6uwlr7rm2vjcnya8g",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1kngr9srtrzfwz0y8ckjhx7559xhdgsthu44y2k",
-    "lp_token_id": "terra12wmaguvdvjf225ua9xjwpj5k5euy6nhtu334n3",
     "asset_ids": [
       "terra1q0q09duq6jsth9m0gfj7fpxlxwlj5fcxgchuza",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra12wmaguvdvjf225ua9xjwpj5k5euy6nhtu334n3"
   },
   {
     "id": "terra1kngrh3kmwngq7t4kcnqdustp3qurvenrhphyxa",
-    "lp_token_id": "terra1d49ve0m99xz250uyj848yd9sgwuh5vw30kxm9h",
     "asset_ids": [
       "terra1ypgjelmtp0mv5akzwmnj5xhukhd3fy9gd28wpj",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1d49ve0m99xz250uyj848yd9sgwuh5vw30kxm9h"
   },
   {
     "id": "terra1kphghf722vxe0aq04n4erzflgcpp0pysrvtj0p",
-    "lp_token_id": "terra1ay647sah03j0zv7pn62sp46sys7gqtnawnf3u7",
     "asset_ids": [
       "terra1l0rnt55mf8q87q2nqfn9un3lxnmxkhqrl939x5",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ay647sah03j0zv7pn62sp46sys7gqtnawnf3u7"
   },
   {
     "id": "terra1kvg5qyt25nrgkqeuanz0k7cavxg0qxe2lgjh90",
-    "lp_token_id": "terra1k093hrmpy8l930ehgtvc7hrdkja3pnudr7ue5j",
     "asset_ids": [
       "terra160y9666sr9ctqfzk4mu7useh6g6swet8vnl7uz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1k093hrmpy8l930ehgtvc7hrdkja3pnudr7ue5j"
   },
   {
     "id": "terra1kwhysskh35wqrsuxyv3c02cenwd05l6pm96pnk",
-    "lp_token_id": "terra1zczk7ccfd2wfetyq8y6gkg0qghntahd5pq5qf7",
     "asset_ids": [
       "terra1edualxuj7afpm27uxvv38zr4e0zf4r4z6twfyf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1zczk7ccfd2wfetyq8y6gkg0qghntahd5pq5qf7"
   },
   {
     "id": "terra1kx5dge4hsm5ke5vuxzp06as8lxv0d5dwl54xep",
-    "lp_token_id": "terra1ug8jeyh65zxffe5wwj3j88fntdjdaj8xft6g95",
     "asset_ids": [
       "terra1kx73zld4tmv24r66h7jp8gaz2rrl4asxlzq2g4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ug8jeyh65zxffe5wwj3j88fntdjdaj8xft6g95"
   },
   {
     "id": "terra1ky57u0437dszysa0qchyxcvuxs6ax9f3p6anrv",
-    "lp_token_id": "terra1nq8x3tc9gudc99pp0j58n2q50us7al8v0y9eh8",
     "asset_ids": [
       "terra12gsrt6nmp56x0q9t9h47frgr8praqyaqdvpaan",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1nq8x3tc9gudc99pp0j58n2q50us7al8v0y9eh8"
   },
   {
     "id": "terra1kyrnvh3l0natnqsapzalahmp4t29dz3ylxkp3a",
-    "lp_token_id": "terra1qwyfe8zymqtnhcrt46yhtk290h9cdpynx3gg3m",
     "asset_ids": [
       "terra13u7ddpvnxlephv6ltswy7c7hnq77agz5078l3y",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1qwyfe8zymqtnhcrt46yhtk290h9cdpynx3gg3m"
   },
   {
     "id": "terra1l0ldny298vsdln3gsd8xsfzln8yddgntuc3e4p",
-    "lp_token_id": "terra1g666d8h4hsqhw8s8axdrzeu6n7sul2w2zsgmn8",
     "asset_ids": [
       "terra138d8ek2zl48pp3el4s25jxnxn8m9nl2n4y0glm",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1g666d8h4hsqhw8s8axdrzeu6n7sul2w2zsgmn8"
   },
   {
     "id": "terra1l649ch0y5nxnu5mrkefjfsgyyn5yj9pqjyfgc0",
-    "lp_token_id": "terra1k43ed8sql40cxd3mgaqujachuhhdrpzvuj7tvv",
     "asset_ids": [
       "terra1ddjp4wgu52cktzgzvahwkr4dcd95mxaqad2pmu",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1k43ed8sql40cxd3mgaqujachuhhdrpzvuj7tvv"
   },
   {
     "id": "terra1l6s778y6gljerp0epa8wwmj7dxtlm7qfrmk8h7",
-    "lp_token_id": "terra1070nrsj5mf8qhess7f3vtylcmryhzpn9xqr577",
     "asset_ids": [
       "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1070nrsj5mf8qhess7f3vtylcmryhzpn9xqr577"
   },
   {
     "id": "terra1l7l9grndgnjagmgm7e0wf0aglwrj3wtzgcdtz9",
-    "lp_token_id": "terra10fmk0879fn2hm6728kgc40ytkqgn6cdxfnzyty",
     "asset_ids": [
       "terra1zrfd9hf3z6kwewxrt3rluzdj5d7ymzxnnptc6k",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra10fmk0879fn2hm6728kgc40ytkqgn6cdxfnzyty"
   },
   {
     "id": "terra1l9l4slsr2tllds0r85nuem4fcmqrtjdp655pdt",
-    "lp_token_id": "terra12ncluxlmuwkhq492dkd8y6g8p9kzt50dvdxxtc",
     "asset_ids": [
       "terra13awdw2dt45l958q274ukg0hvvmctghllv343lp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra12ncluxlmuwkhq492dkd8y6g8p9kzt50dvdxxtc"
   },
   {
     "id": "terra1la2j3fggypkv5v7rc3vdrs6f3nm5duexd7y4pj",
-    "lp_token_id": "terra13wn4sj9c09638wdxn73d2hgzlzg2dp5gh4fj4c",
     "asset_ids": [
       "terra1n6eltvex47mta0me66ygqw0fgvjx2ul7qm9fjp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra13wn4sj9c09638wdxn73d2hgzlzg2dp5gh4fj4c"
   },
   {
     "id": "terra1lc2jzj4x8r7f6asy6vf9jlwnjpuz83vuruutkj",
-    "lp_token_id": "terra15s5dsy04dkplkf7k8sggc5nwc40dhnx9eektvt",
     "asset_ids": [
       "terra1k5hx3egz7jnzqs7n2ze0d93mce80y4cndd5saj",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra15s5dsy04dkplkf7k8sggc5nwc40dhnx9eektvt"
   },
   {
     "id": "terra1lku3pluvh5hgdr76d2mmz9uch55uxqkk2nzc42",
-    "lp_token_id": "terra1rxsqmtax455x5628dzhjtflcs0grpxar6hcgvl",
     "asset_ids": [
       "uusd",
       "terra1v7q43s46ntt4p7cpxcvsxjk6srr7uxvldn6vuk"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1rxsqmtax455x5628dzhjtflcs0grpxar6hcgvl"
   },
   {
     "id": "terra1lskrhzzyxtm235j69ty3y4fk7mswczq5f93ntq",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10l407saphqe2tc35ejhzg7xyulqkeqccvvc6uw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1lw2vz28ajmdntvgfz95rdgljq4gc4qw90wc6jm",
-    "lp_token_id": "terra1y0ej8fdyvcy4736m02eu8d9ftr892de78dypwp",
     "asset_ids": [
       "terra1zucgllq5ddqkfgsyjr7qnrfhymu0y4rgqsfyet",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1y0ej8fdyvcy4736m02eu8d9ftr892de78dypwp"
   },
   {
     "id": "terra1lz2uwr6jqjp08yqf6fee8n484hdxa2rzpte2h4",
-    "lp_token_id": "terra1je8e4j30696s3j2tv4rvscnzgsan87uqy694x3",
     "asset_ids": [
       "terra197txx8gsllv9rakjs6zh7pw6hnlgvte8yf8a8t",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1je8e4j30696s3j2tv4rvscnzgsan87uqy694x3"
   },
   {
     "id": "terra1m74nhtm9uj36jc3024y403h9cnh3uvthhpq6zq",
-    "lp_token_id": "terra1hfrwjf66e7ayc90p53t9h5qxcqthtg5ug4yejq",
     "asset_ids": [
       "terra1jvsfc3aedh7cyf3wd6vs7r5fmdsf4v6veh525e",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1hfrwjf66e7ayc90p53t9h5qxcqthtg5ug4yejq"
   },
   {
     "id": "terra1m7n5p8e0mkh370mfp0e93jfk7uc34gxxxqegwn",
-    "lp_token_id": "terra1srwc8xh9d5zx700n7n7unq4eww620vw384pwvg",
     "asset_ids": [
       "terra1cu7zc3q8089cuu4z5ed5nl4c9w59qqhs2mmfyy",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1srwc8xh9d5zx700n7n7unq4eww620vw384pwvg"
   },
   {
     "id": "terra1m8dlx0g0j00xlxvavh972sk0gja2xn5gxjvtu3",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra16ygrvq7q2zxw7jj3f96racur50w0g7r0mj6e2y",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ml720ts5kfg5s9hhsft74hy6clqsevsqkvu0du",
-    "lp_token_id": "terra1vkjgr2rsagh52jdcur4zgjyj7ag5xrfmyekne2",
     "asset_ids": [
       "terra1037zmxv6f73e5mlq6hsyadlev0fj4q462llw3d",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1vkjgr2rsagh52jdcur4zgjyj7ag5xrfmyekne2"
   },
   {
     "id": "terra1mmc2z9znnl92338yquuhwzh2vj7gt9ez66nnt5",
-    "lp_token_id": "terra15hnvcwq69maqesv0497f45fez0lmunmghjqmwf",
     "asset_ids": [
       "terra1g5unnjllx9900hjsx6x3zhhv504ssqktdc82l5",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra15hnvcwq69maqesv0497f45fez0lmunmghjqmwf"
   },
   {
     "id": "terra1mp2d8zjhtenah2rgv7p4g6zaxp3s44pqx9z5ek",
-    "lp_token_id": "terra1zjxyrnfgf93kw5uhamvnqxdfnczqhwsgpe0evv",
     "asset_ids": [
       "terra1spuk4t4lxsmgx8wqq0ltqrxagnrzwvk6lmf4t4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1zjxyrnfgf93kw5uhamvnqxdfnczqhwsgpe0evv"
   },
   {
     "id": "terra1msws3xuf0ey3l0sdt0t3rw49gjcq4nya8h3lad",
-    "lp_token_id": "terra14jaq6qur7mafha4ky8u6ct67xav4zt054p865j",
     "asset_ids": [
       "uusd",
       "terra1ld37cm20t8z3r0zvk7hx2qcfr2cdayteed8089"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra14jaq6qur7mafha4ky8u6ct67xav4zt054p865j"
   },
   {
     "id": "terra1mtt2dpjah3mja54rg9exyexsdkw8u3pljdu34j",
-    "lp_token_id": "terra16ledesd9tn24fte454883p577qvr24hngmfefg",
     "asset_ids": [
       "terra13gdkkedrnd48kel0fc8sr08usdfpdce9ku6qku",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra16ledesd9tn24fte454883p577qvr24hngmfefg"
   },
   {
     "id": "terra1mwsw7mzxqdv33naqg50quz9ataxfveur7u48aj",
-    "lp_token_id": "terra1sdlk96gvztayg9yayxksaghrkwv5hsz3psu3xn",
     "asset_ids": [
       "terra1ep337j8q9xm7t9ypqugr4yhgnvf0jgyjga50tv",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1sdlk96gvztayg9yayxksaghrkwv5hsz3psu3xn"
   },
   {
     "id": "terra1n4kt65x0mmynpfdgcwfz36dwws2v6er3eer6dw",
-    "lp_token_id": "terra1ua0ehzs2z7qq05qehnzvp44gev2w7cc7vnuyh2",
     "asset_ids": [
       "terra1qlan324u6rsdevvc6ye3m02ump7dtp3z67uhqy",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ua0ehzs2z7qq05qehnzvp44gev2w7cc7vnuyh2"
   },
   {
     "id": "terra1n5nzqdktzh6j935y09244rghn6zl3ga6h8ktdk",
-    "lp_token_id": "terra1t32vjs5l5f5452kq78wvtaest5qkhr37vymcfa",
     "asset_ids": [
       "terra1mtm6l7xdmpuelf2q74sq58d2e5gwm72d42algk",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1t32vjs5l5f5452kq78wvtaest5qkhr37vymcfa"
   },
   {
     "id": "terra1n5y7ym6x3ma0en8ff692406gtaagk8e7l4nyzq",
-    "lp_token_id": "terra1dntanjjlturgu2zn3t07evdf6cljepaap3vmfa",
     "asset_ids": [
       "terra1y4yx8w0p9v247w5uv5hfqv2fccda7rmt65mwcd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1dntanjjlturgu2zn3t07evdf6cljepaap3vmfa"
   },
   {
     "id": "terra1n7kaxpxslz5aw36gx2mnc9a30n4yu0us7x2xj7",
-    "lp_token_id": "terra1237hndgalhuukzuccfvfjj538az8739td5cnaw",
     "asset_ids": [
       "terra1xs3pv5rd2xu36w9vg05shkgxcrxkvz40fhnfsv",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1237hndgalhuukzuccfvfjj538az8739td5cnaw"
   },
   {
     "id": "terra1n8jq50xnupyassyc3z4apwc33av3499v45tllv",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lxh32h38lf8xdk6lv7k5w0ewy7gu6psy4gfmnm",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1nayuuwy7mdcjtka7n9xt9gpcpldyqglt0jt5vf",
-    "lp_token_id": "terra17nwqqwfedrq50k779ulvl8da3jncj960xjylns",
     "asset_ids": [
       "terra1lgx3e9f6fhqda47zdyntfs07rdm5arp745mec7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra17nwqqwfedrq50k779ulvl8da3jncj960xjylns"
   },
   {
     "id": "terra1nazuk5vy7u5nwdnlxefcevy75yyr9z4mejq0a9",
-    "lp_token_id": "terra1mw45v6n4n3r4ekcqn73t9wmed9xv45sx526ty3",
     "asset_ids": [
       "terra1m6myw86l5zgw3z58z6rynr8zxaexprfc3m3357",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1mw45v6n4n3r4ekcqn73t9wmed9xv45sx526ty3"
   },
   {
     "id": "terra1nf6wl37jxthskggvesngsp7y50s0jchmur57v3",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dw6yapjv8k8anef2kg43hewg3g73wle22ncaje",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1nfkhe4vy2844352ev350ldpccw06ud88qptxd6",
-    "lp_token_id": "terra18ypccdtr2c57zd2q8l6fu0fw932ewawlx25pzk",
     "asset_ids": [
       "terra1av9tfs7k5gfuzm04e7p0d4ezrc53vq9mn3m08z",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra18ypccdtr2c57zd2q8l6fu0fw932ewawlx25pzk"
   },
   {
     "id": "terra1ng3vjr2av7hgx9029pyc3v6y8l4zy2gf7nrk0c",
-    "lp_token_id": "terra1qwa26w5mdznxf52zug3qegzhq8pggutfqrdq5y",
     "asset_ids": [
       "terra1hnsqjjzerf2leaufj7dt9j54nyjvhyppj7khaq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1qwa26w5mdznxf52zug3qegzhq8pggutfqrdq5y"
   },
   {
     "id": "terra1ng4tm5a9sru4cgwqs77tm5fh47tt4sh6glzd9l",
-    "lp_token_id": "terra167c9s2r2jkze9xe989wfeek2zkc87ggjcu2u7k",
     "asset_ids": [
       "terra14yyepy06yw57f4x564xrfwxvv460vq0su5ype8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra167c9s2r2jkze9xe989wfeek2zkc87ggjcu2u7k"
   },
   {
     "id": "terra1nhsam29a0cnxv0sd7tk8s5x676wq9rar8vpqwn",
-    "lp_token_id": "terra1xgn0ffavkylmh0rh2upgapj0sa9j9apray0eu0",
     "asset_ids": [
       "terra170r0wm50x5eh47zkvlrjkxhajp4g7wrmgsz523",
       "upepe"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1xgn0ffavkylmh0rh2upgapj0sa9j9apray0eu0"
   },
   {
     "id": "terra1nksjldc9ze8ql6e93fms7d2y6t79h8qzv0q4yf",
-    "lp_token_id": "terra1xyzz6yvtvndqx4hp78vuvnzwt82xraw8xd5y6v",
     "asset_ids": [
       "terra1wlhgvtult73t5vpeng4sw9qmsq5jlujfm98gg2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1xyzz6yvtvndqx4hp78vuvnzwt82xraw8xd5y6v"
   },
   {
     "id": "terra1nsdxqpe5upkvy9jegqdkzyhetravf8vl7m496h",
-    "lp_token_id": "terra1e7d7325sjpfk02vnzqkwsnlu0xqejydleeh2h8",
     "asset_ids": [
       "terra1xs3pv5rd2xu36w9vg05shkgxcrxkvz40fhnfsv",
       "ukrw"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1e7d7325sjpfk02vnzqkwsnlu0xqejydleeh2h8"
   },
   {
     "id": "terra1nugs0qddjw9eznndg497ukt04cq0cxurql52qk",
-    "lp_token_id": "terra1fe089wx8cnm3pfk9am2rmexrwu0vkp5skzphnm",
     "asset_ids": [
       "terra1a2f4pxdqd98qclaeafdqxlc3dvnt3wqedx3l77",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1fe089wx8cnm3pfk9am2rmexrwu0vkp5skzphnm"
   },
   {
     "id": "terra1nurx5e8lh8pfg8hnxw35duczvsx6lhdjrxy5e6",
-    "lp_token_id": "terra1e6kja3hn04rhc8lslkdk63ry0gspr6zwufs323",
     "asset_ids": [
       "terra1zfcfvsw9m3gzk5l42cek0ukn5g4dmd8gl4lyra",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1e6kja3hn04rhc8lslkdk63ry0gspr6zwufs323"
   },
   {
     "id": "terra1nvmffcs9l6qv7c9z0unkt69jk2qtadaqw7skp9",
-    "lp_token_id": "terra1yek22pthmx98yn0k3jdgu5t9tevd79c9z8l60l",
     "asset_ids": [
       "terra1vl3khh0w2fydtd72ly03vjmlll4nr0ldcl9u4z",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1yek22pthmx98yn0k3jdgu5t9tevd79c9z8l60l"
   },
   {
     "id": "terra1nvpfq78mfe6emt35f9fgys2vxwcdt3kx28g08a",
-    "lp_token_id": "terra1r2ec9hu0l8d2xrl6nnawy7exmjyrlu4usyr5fh",
     "asset_ids": [
       "terra1gq2yya7grd359c4y0wjfdusgrh805r6ml9jyyl",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1r2ec9hu0l8d2xrl6nnawy7exmjyrlu4usyr5fh"
   },
   {
     "id": "terra1p39xsp5j3e6e9703gguen049pkf4p52rmwf2vm",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lrdzs5tgllwqgawtq2emuzn7snpxq87fzzl44y",
       "uchf"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1p445mk3wsctep477kpzvp6a4xekyzu4fqcc456",
-    "lp_token_id": "terra1zeestkmhgk2vjwq9wg396qpjvryftwqt2u0xt8",
     "asset_ids": [
       "terra18m6fr3fk9xh0u9vrvyeu25w0k40dptfrhw53rh",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1zeestkmhgk2vjwq9wg396qpjvryftwqt2u0xt8"
   },
   {
     "id": "terra1p6nzgyy7gq9hw54errcyrnjkf7p4expcsnmxz3",
-    "lp_token_id": "terra1wd25umnrgnfydwd7k7m364ykk79r76tclm5v4n",
     "asset_ids": [
       "terra1ctfsa4qfanzmz4my78m3u4r9k5qr9gpua9f6hj",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1wd25umnrgnfydwd7k7m364ykk79r76tclm5v4n"
   },
   {
     "id": "terra1p7npd4c5f8vsr47ncvkm50qfkvddanwy4er5ls",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13kr45ssru9cqhp2kaaan88wfaa7f2h3jfvuldp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1p7y8st3wjgs62vs3w9dw2sf603e4777v3jamhn",
-    "lp_token_id": "terra1y3c0z35uju9apsn0faewjdw630tqalhmtpgtc5",
     "asset_ids": [
       "terra1h0jk42weh0urhgdtjql93rrvgdccspnp7vyf49",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1y3c0z35uju9apsn0faewjdw630tqalhmtpgtc5"
   },
   {
     "id": "terra1pcjl6ammvypn4z4srs9dgzd2pgqvsw0xy85fj5",
-    "lp_token_id": "terra1qt6nek5pe7l0l3hwcarjd62mn24a6v7kz8zkxf",
     "asset_ids": [
       "terra1r7e9a5su34ne07e6v0r7n2xp4h6tjkxc8j2lz2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1qt6nek5pe7l0l3hwcarjd62mn24a6v7kz8zkxf"
   },
   {
     "id": "terra1pcwu6flzc3srtu44cyvt8c7dn59lkyckprhqht",
-    "lp_token_id": "terra15ggrlf3z0j7phzunfh90rjscuvrx4hgfljxhf9",
     "asset_ids": [
       "terra1j7p2fxrzryfpzrrsfe585klnkqutg94kca9vtj",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra15ggrlf3z0j7phzunfh90rjscuvrx4hgfljxhf9"
   },
   {
     "id": "terra1pdstq4vkeftz5kmvwk5dzaytpesv5f3kq5q6s5",
-    "lp_token_id": "terra1f0tup70r7ycf682vc9h65p6g59jk8eefvy67qn",
     "asset_ids": [
       "terra1ppuu0devppvm6d75sclj4vwh5ghwyx7grurlvx",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1f0tup70r7ycf682vc9h65p6g59jk8eefvy67qn"
   },
   {
     "id": "terra1pfdfzk3qs55lwtd8l00da7cext07ufpn9fe2c7",
-    "lp_token_id": "terra10skty5urn3fzfkwg3f93z2f56xm52gufh2u76l",
     "asset_ids": [
       "terra1daa3rrcq6nk9vh3ecg08x7rmkx3h6egsfex3ze",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra10skty5urn3fzfkwg3f93z2f56xm52gufh2u76l"
   },
   {
     "id": "terra1pfkanl8ycczuzyj02rjr3vx3sw0us9vxhpr0mt",
-    "lp_token_id": "terra1n4cydpuvk8encunn0ag2h0y0pnzjkh4y8hr0ua",
     "asset_ids": [
       "terra1h4wq9krj88hcl0m2e2kxfn3gznga30g5rrm4qa",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1n4cydpuvk8encunn0ag2h0y0pnzjkh4y8hr0ua"
   },
   {
     "id": "terra1pksem0e9s7xdjf08j9swuyr5m677660qhyhuqk",
-    "lp_token_id": "terra1saxejc25jretqgp4z6wj9me37qx8zg4lgzrmrx",
     "asset_ids": [
       "terra12k6ua9et2dnpmmq2rgz0wn0ugzr9jtyps5l8vt",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1saxejc25jretqgp4z6wj9me37qx8zg4lgzrmrx"
   },
   {
     "id": "terra1pkuqexqszqcxszy9fpmxdnl6gwefjd7vger0jh",
-    "lp_token_id": "terra1w4276v5yzxa94ess4ryyfwanssfr3psgyk4jm3",
     "asset_ids": [
       "terra1u4gx4v0nqgzm2kcajk3xf0d35gutwcvdyyjrnc",
       "100000000000"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1w4276v5yzxa94ess4ryyfwanssfr3psgyk4jm3"
   },
   {
     "id": "terra1pm4gx7u354nlgjdz0xf4kxpx977egdt6z5naca",
-    "lp_token_id": "terra17tdq6g3xqmwpk3q4mgfl0qcuyz7sqaxqa3n0rm",
     "asset_ids": [
       "terra1v58klw3jakaeas2dkppqdh4y4dzd52kzda2fgf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra17tdq6g3xqmwpk3q4mgfl0qcuyz7sqaxqa3n0rm"
   },
   {
     "id": "terra1pqpha5xe3fhtvyplcuwyzhls8hgdupahujpyay",
-    "lp_token_id": "terra1gdndzwhsua4zw90pef309ked5h6npusgcu2j2c",
     "asset_ids": [
       "terra15xf5wqprgzl59ckfyjtgavh7rqtxcju7gn57rc",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1gdndzwhsua4zw90pef309ked5h6npusgcu2j2c"
   },
   {
     "id": "terra1pr0nnzw0elpqk8q2shc5gjnzaz95q4j8qy65w3",
-    "lp_token_id": "terra16znt4xty0md2k7e6evq8thsumhn6lm4kavqzzy",
     "asset_ids": [
       "terra1n8awtfqa0wphx90pd2zc9v8vccc65f0gvv6rq5",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra16znt4xty0md2k7e6evq8thsumhn6lm4kavqzzy"
   },
   {
     "id": "terra1pr6tmhnve5cawzauzyzw5uscz558gzmd3d6wps",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1s8gu8mx2qcxpx9y90fxvdetpwq9mpyrapphw2u",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ps2j3kp3gwjx56fsahnnkmzv2y9e597gqkulfn",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1u02kfjra4q9272p0ckq8yjtfc5qq6584amvrnm",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1psuy4666c74vz9exfxvupsxmkgytneq7gushws",
-    "lp_token_id": "terra13084cqs5f65aal0c7m4zefh7785t3wvvw6dx44",
     "asset_ids": [
       "terra14l9lspj9lp2rpnhp6qjpruwcqst0yvl9cm6l96",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra13084cqs5f65aal0c7m4zefh7785t3wvvw6dx44"
   },
   {
     "id": "terra1pvetz858samujj0gkx7rr5n8m0gcy5gz8lcxz5",
-    "lp_token_id": "terra1kxqugyrr0e4he5furrqrehr8qhzqpfxxnt3vlf",
     "asset_ids": [
       "terra14tc6kg4my06ckzugrukq0r903sup3a6agdmx4y",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1kxqugyrr0e4he5furrqrehr8qhzqpfxxnt3vlf"
   },
   {
     "id": "terra1pxlm7mjmqc4h4ht494jvmmwq840zn77eyex8yd",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14dtgwushpvu2c8d8rtc58z9r2t4p67ug8wl4d7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1py6jq9p9qjjsqfg3sfj3stkpggyxl0sy5a006s",
-    "lp_token_id": "terra186hhp3gfmqf2353pekrcmdpajfveu56j0ej7ft",
     "asset_ids": [
       "terra1u2k0nkenw0p25ljsr4ksh7rxm65y466vkdewwj",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra186hhp3gfmqf2353pekrcmdpajfveu56j0ej7ft"
   },
   {
     "id": "terra1q0vldkwqgc2y2crhrcsdw2pacdt8nnrgvzcsf6",
-    "lp_token_id": "terra12qz82rul3ukhgaw06n2gv32gehermzu4zd8pam",
     "asset_ids": [
       "terra1exgprpvwmn9we9xfxlqzchfqd533wtnafhg0w4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra12qz82rul3ukhgaw06n2gv32gehermzu4zd8pam"
   },
   {
     "id": "terra1q4nynp5mp4yhtxkyzegdkf594h94hhycmgxdq4",
-    "lp_token_id": "terra1s6acdmcz4dnphyw8yctl9qmkxluj8u6snankqq",
     "asset_ids": [
       "terra1hpz206wxjhta4x83ukmk4v9rvk9dky2h0texf3",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1s6acdmcz4dnphyw8yctl9qmkxluj8u6snankqq"
   },
   {
     "id": "terra1q6h4sgkulkxl6tq8tafadl899sc88zp4dj6yd3",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1p2enl6vfmhdfj7ud32p3fkgns22sg62ls9mh2e",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1q7hat4ymhtawg8agg70u74m8eu3q7qsg9rqmr2",
-    "lp_token_id": "terra1m7gu655my73ulr42zhaz466mgl65au8dwvp3vj",
     "asset_ids": [
       "terra15wwvprh6gddrc7yvshghc2g944ufsq79ay94da",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1m7gu655my73ulr42zhaz466mgl65au8dwvp3vj"
   },
   {
     "id": "terra1q9cxc20mhr526qhrct46ucrwxywmv3daa7a36v",
-    "lp_token_id": "terra1fst9xfe8wv8jucvnn5afnsmkzqf3hu6yy2d9y5",
     "asset_ids": [
       "terra1vdpk5k7203r73fgl2ppwsg30vmtu5akgk0emse",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1fst9xfe8wv8jucvnn5afnsmkzqf3hu6yy2d9y5"
   },
   {
     "id": "terra1qgksgy6g76jx9732u8dpdy7epqgwtyy0rwj53n",
-    "lp_token_id": "terra1n45t7tamwtrnr48f43pcq8krul8yf4kap8xfcq",
     "asset_ids": [
       "terra1aa9kg8crxjq86ts54d4un6ku5skec9e98t6tau",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1n45t7tamwtrnr48f43pcq8krul8yf4kap8xfcq"
   },
   {
     "id": "terra1qhpgt8pglujysknesj6jnea5tjc47upuutmee8",
-    "lp_token_id": "terra1gzvdqgg9zrgv92948l923hjnvxgldwaqzshla3",
     "asset_ids": [
       "terra186qt4d07ghj7dm2x64tyc0muw6rl2876jlhv38",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1gzvdqgg9zrgv92948l923hjnvxgldwaqzshla3"
   },
   {
     "id": "terra1qkjrvyzncs8h2w6zyctm7etv743x0vl5syrc3r",
-    "lp_token_id": "terra1uxgl9umfun75qkv4gctl3fk4cqv02crsl5y57w",
     "asset_ids": [
       "terra1vlrerpu78hdezzz8zzx34adpced73lmd0ujyqa",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1uxgl9umfun75qkv4gctl3fk4cqv02crsl5y57w"
   },
   {
     "id": "terra1qksw58xydjsqh9swyv764jptsdfskzx52qvalg",
-    "lp_token_id": "terra1eepaxpggqy23hefzwj57xtfukkaq240mrmlnm8",
     "asset_ids": [
       "terra1v8xzfedstujqexgz6vd902hppykuu2e7ar3pu8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1eepaxpggqy23hefzwj57xtfukkaq240mrmlnm8"
   },
   {
     "id": "terra1qm7vvqg2jh5mwkd696luhvqe4mx96e4xuk60g2",
-    "lp_token_id": "terra1xxj9nsxffy6hcc6mfq84fjfwt9k9e0n4800pgy",
     "asset_ids": [
       "uusd",
       "terra1lj0m5346vc6da9r9ljcyx7letcl3727g7wac62"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1xxj9nsxffy6hcc6mfq84fjfwt9k9e0n4800pgy"
   },
   {
     "id": "terra1qr8vxrmlsyune368pd9nmgfuqt7kdek7yy6kwx",
-    "lp_token_id": "terra1trdcl3lw5ca8ta7nfm5qh7w0mudfn6fdhl2qm6",
     "asset_ids": [
       "uusd",
       "terra1sa0klf6nt77z3afqlx7nq30xrvr7hsfz5jsqmd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1trdcl3lw5ca8ta7nfm5qh7w0mudfn6fdhl2qm6"
   },
   {
     "id": "terra1qrlz2dl224glxn7sqa56wpdx7dz6yn5jlxm02f",
-    "lp_token_id": "terra184waaggxgdg4nevql50lmpeyferkmal7f904eu",
     "asset_ids": [
       "terra1sqagv65dlqj3hlg4fxrljlhfg5wulsp4nm58j7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra184waaggxgdg4nevql50lmpeyferkmal7f904eu"
   },
   {
     "id": "terra1qrrr4kqfqptd7wx0f45sgem6z8ejenh3k7esnx",
-    "lp_token_id": "terra12j3ye47a9jjk9jtjg7k8f0rs09hsvdpp6tpl58",
     "asset_ids": [
       "terra19tvczk4us839rsvet9ncwg8est73nmzecdewkm",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra12j3ye47a9jjk9jtjg7k8f0rs09hsvdpp6tpl58"
   },
   {
     "id": "terra1qsf2sn65fjyc5hvm2v9a65qcyc23fnylr84fsg",
-    "lp_token_id": "terra1cazwgay0h75rt78q2vxr6eggfk25xf4d0fwj7c",
     "asset_ids": [
       "terra18f86dw6n40r6hqzjw0qsfe09nxesqs7vx2jkcx",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1cazwgay0h75rt78q2vxr6eggfk25xf4d0fwj7c"
   },
   {
     "id": "terra1qstd3t9jv9v24ew6v430c42xfx9qf7mg7sg28d",
-    "lp_token_id": "terra18zs698tsn3600gtv4egtzx34uppcahzg7qlh8x",
     "asset_ids": [
       "terra1kh0w04u79rhwvchmjsd7q4xxlm72y5wpf6a87v",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra18zs698tsn3600gtv4egtzx34uppcahzg7qlh8x"
   },
   {
     "id": "terra1quwpd8khrwhuvqqk42mfw0q56nh524gu5zm294",
-    "lp_token_id": "terra1vawsn9qcgq9dcrjwldmqtmp9pj4373eapurm0j",
     "asset_ids": [
       "uusd",
       "terra12wlcu0kgdfrfutjydvvcmhlx8jrfsqhwqarc3d"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1vawsn9qcgq9dcrjwldmqtmp9pj4373eapurm0j"
   },
   {
     "id": "terra1qvy5r6r3fyh6rk9j93e9w63z3qu4wlmxemd0kt",
-    "lp_token_id": "terra1z27p3u53z9tfagnpffqe64js9l77w38ywyvefp",
     "asset_ids": [
       "terra16gnk7mpqr84f4mnmqjklpdxxe602dn0fjslwhy",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1z27p3u53z9tfagnpffqe64js9l77w38ywyvefp"
   },
   {
     "id": "terra1qxvf6f92f38wznvpyjqcd8ncppffuva79rvdeu",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kafnpwanfluj6ne5t8ayg8ykarx060a50l72sw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1qyag7j7s5z0d02em5g09ltgcztxpdguz3pkxjk",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18y93cy77qrxx65vdz959g2ngms55v3s3yythys",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1qzlnxa9mdnxkhs6wwf0xvx0hxqday87dgxn9yq",
-    "lp_token_id": "terra1mfs0xeakt59wemvwyelmh80025a3m06jfylx2e",
     "asset_ids": [
       "terra1ulzl6vfexrk39vaje0qryarzlq2ahy80cdl4fz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1mfs0xeakt59wemvwyelmh80025a3m06jfylx2e"
   },
   {
     "id": "terra1qzrqt3phmawkrrzm8x8hwngz26nrpdgpkw5pmd",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1p0w9hh9aea5mg26mjnx7tl695ldwxfksvw4yn4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1r3cjla7hlktc4vfa0dmzz8489e88k67yxjndpd",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1r66l8vkzyhduuq7dfc8nm6p9wlwtnclve4wpxl",
-    "lp_token_id": "terra10zlafqxy3zyfx2wh35mxh8xepp6fz3f3yl9e8a",
     "asset_ids": [
       "terra10yycj46tjfnfhkk5d6er49gvcn28jpqk0spthr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra10zlafqxy3zyfx2wh35mxh8xepp6fz3f3yl9e8a"
   },
   {
     "id": "terra1r6dcz9whd2dxunau0vtp3g06n0yus9gfaq76pz",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17ckx25kqhwzf3fudprs78kqgp3lhpr2w74yf7t",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1r909kfjzeuj9nhwle2d6kg5jhn2af8j59lcsqj",
-    "lp_token_id": "terra1tc3llqz3ckh4ahepmv4sdxc3s4dvn9vqxtax9l",
     "asset_ids": [
       "terra1pafrxwl8ur3jzjgw5qhts9vku68xsenctgqvkq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1tc3llqz3ckh4ahepmv4sdxc3s4dvn9vqxtax9l"
   },
   {
     "id": "terra1r96mse06m03de6jkx52ku45p36htc9zx8k89l4",
-    "lp_token_id": "terra158g4r6gglcsst7ddua65rzfvzqums08y5m5dym",
     "asset_ids": [
       "terra1vpws4hmpmpsqwnz3gljn8zj42rv7rkpc5atgt4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra158g4r6gglcsst7ddua65rzfvzqums08y5m5dym"
   },
   {
     "id": "terra1rcdumk59pxaem9my3frynyu3jgrkj9v4han9eh",
-    "lp_token_id": "terra1w3z2lk8skrdw7ar9vq2kf5jeam9ar0m257k843",
     "asset_ids": [
       "terra1sdm7qux8u0qtfxa6ukuh3zgppazdxlhmmjks23",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1w3z2lk8skrdw7ar9vq2kf5jeam9ar0m257k843"
   },
   {
     "id": "terra1rfdh5rephrd37ga0x5cry9lek8eutf54umkk04",
-    "lp_token_id": "terra1wq2tmhvx2yn3zqdah26sg3xzlaaxwd3fhsnj2y",
     "asset_ids": [
       "terra1zdpymdwpyg5gj5ye4uvr0mqmxw8c88k5vqegfr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1wq2tmhvx2yn3zqdah26sg3xzlaaxwd3fhsnj2y"
   },
   {
     "id": "terra1rg9p352hcepvclfrxptpk0ua7a0tz4gcc0f0p8",
-    "lp_token_id": "terra1d2muut0rea9fkff6y304yn6qkr2uacau7ltggc",
     "asset_ids": [
       "terra187lnjdwluvfnzxcef4appgr4v7fwljj5d5wdhf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1d2muut0rea9fkff6y304yn6qkr2uacau7ltggc"
   },
   {
     "id": "terra1rjdh8dj7jrjwz5dul7n8m9eyne92rvzftnjueh",
-    "lp_token_id": "terra1684j38r062hr2nlwgf4ludpt9zk5g24g85syzj",
     "asset_ids": [
       "terra15afvt8ch38n8qj4n6wvykwkl2fqvfla826qdqe",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1684j38r062hr2nlwgf4ludpt9zk5g24g85syzj"
   },
   {
     "id": "terra1rjv0jjm9mzgrj3grs2p0gvyuwpuf5qt9p30wwp",
-    "lp_token_id": "terra184ufgqclvjkuycs82j0fp4xha8r6rryp7luj7g",
     "asset_ids": [
       "terra1lesh2dshyf8a7wfm9fkxfrxjxc6yuyqnvspuvw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra184ufgqclvjkuycs82j0fp4xha8r6rryp7luj7g"
   },
   {
     "id": "terra1rn8stwf23aes786t37je7v8vxe9qwyzshrl9ft",
-    "lp_token_id": "terra12eruh2ggjy2q8wutzsg2ww90nrucxm4hmuzdct",
     "asset_ids": [
       "terra16z32tp6cqx2f7lpr8t4scv8hj9zlljagprxfh7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra12eruh2ggjy2q8wutzsg2ww90nrucxm4hmuzdct"
   },
   {
     "id": "terra1rnenevclqn95uhszznh6v25gaqswfejsvcatu2",
-    "lp_token_id": "terra1gmvqnsr262yea2ltxvv6qxqgl26jsl4ah0cw2y",
     "asset_ids": [
       "terra1f887h6wqygswcp4arjjak6mpdhwlrv6nj8y9wt",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1gmvqnsr262yea2ltxvv6qxqgl26jsl4ah0cw2y"
   },
   {
     "id": "terra1rpcz0746qj4f6nwcpap8z5knjpf4fj6wmalupy",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kx4y3y4pn32jssqr90cj0rw89ds98dc0t5eqfp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1rr3rf5kptdtemsmf3g3jl8sy8rtamz2y6mcyh4",
-    "lp_token_id": "terra1syzg420suxvcarx38k7vep65tdqmpnsuth8a5w",
     "asset_ids": [
       "terra1jkrl0xap6ptp8rd5lecp2j2sx3kws8rzxljsxn",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1syzg420suxvcarx38k7vep65tdqmpnsuth8a5w"
   },
   {
     "id": "terra1rvjjnmeq5a9fje6r2guaxuezd7mhghk4t9cw4p",
-    "lp_token_id": "terra1l22rm7mmajqgxep8lv4nuwzvuj9xc0xahfe9lv",
     "asset_ids": [
       "terra1vyenreh8z62r35rydtupkqnmjsalee4tl90vn6",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1l22rm7mmajqgxep8lv4nuwzvuj9xc0xahfe9lv"
   },
   {
     "id": "terra1rwezyr03fs72talr7g2gjgr9jmfew834u7gl5l",
-    "lp_token_id": "terra17v6ravmxwz8v9je9w9c23px3zhcvajk4tndt63",
     "asset_ids": [
       "terra1y273xzgr58qsdkc89xa6qu5y9padxtm265am00",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra17v6ravmxwz8v9je9w9c23px3zhcvajk4tndt63"
   },
   {
     "id": "terra1rwsyvg7e67rald7d45833nsw487f9mt2wk7a23",
-    "lp_token_id": "terra1lyldsl94d3w3jhcenqjwsp4cme9jufur8fahk2",
     "asset_ids": [
       "terra1tewnpkjdtqq37udf5c5wjfrtkpegthfmls8lp7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1lyldsl94d3w3jhcenqjwsp4cme9jufur8fahk2"
   },
   {
     "id": "terra1rx428v0rr62qcwd0cppz0xwj9qrh8zpqkahkj2",
-    "lp_token_id": "terra12awz2khk7ccyzfhstnzzgu5um4vt5yts59z4dz",
     "asset_ids": [
       "terra1ts6qq7va0msf0se3cwjsppt3vkumkh3t6n4d8a",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra12awz2khk7ccyzfhstnzzgu5um4vt5yts59z4dz"
   },
   {
     "id": "terra1rxwlts8xqulfrmx66whcknczmqjh05hdhwm4zj",
-    "lp_token_id": "terra1vhw9kpcshkr2kfrjke3pgp5sr5vsxdu2cjrf43",
     "asset_ids": [
       "terra1ufsyu3ddskufc7nel5p4lyrzhv8qdddg3tl550",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1vhw9kpcshkr2kfrjke3pgp5sr5vsxdu2cjrf43"
   },
   {
     "id": "terra1s0tfy4juc4pj4ke6mr9u68mnmgfapplhr52fr8",
-    "lp_token_id": "terra1aef680pzs5cm30655wdz664v8jgeqtw76ptmcg",
     "asset_ids": [
       "terra10led4w62hglspyngk0ydxjsdvelvwthftevq0f",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1aef680pzs5cm30655wdz664v8jgeqtw76ptmcg"
   },
   {
     "id": "terra1s2tkg3l4h4hrlsq6dnatcfhv97lyutpmxw0uk4",
-    "lp_token_id": "terra1hfad2shn4h26g75t66yjasyg3qh84xlkp5g838",
     "asset_ids": [
       "terra1whwxszdwu6m4pup0glpfn7qhwmnh6a49mrsv2h",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1hfad2shn4h26g75t66yjasyg3qh84xlkp5g838"
   },
   {
     "id": "terra1s846ywp9gdkjfmk48cs8pd0phtsnn842zsgsa5",
-    "lp_token_id": "terra1dkpn37uh5f5j3u9rjp6ynpekm5kzd7ysfffqwq",
     "asset_ids": [
       "uusd",
       "terra1m86rdykfvtwucrd0y0gzlel7wpcdryctak5wyl"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1dkpn37uh5f5j3u9rjp6ynpekm5kzd7ysfffqwq"
   },
   {
     "id": "terra1s9gquy9js5z64eehsf22w2zq7dwr9a7lavuxk7",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hja2d2790m6hynju77t56nhmmyl0w09s5acqhc",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1sez4t0zhe9d7lxlup0j8u4cnkz0qvzr7dj2lf0",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1qrq5r95txaregxpa2c7mhf549u5jkm28rzmvt5",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1sk902qkn05mm3j94eh6qz0rmj2rq4gfj363na0",
-    "lp_token_id": "terra10fh6hy5f9t8mn09qzrps889qtew2km3zs44q9x",
     "asset_ids": [
       "terra1jwjweh50vrd2gg55y8cr50e32jwwc0vuhvdymh",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra10fh6hy5f9t8mn09qzrps889qtew2km3zs44q9x"
   },
   {
     "id": "terra1sprcgsnem4yrnzjd67wunkjnvndjr45jme060w",
-    "lp_token_id": "terra1aa22fmunt253n4hmuerm7p2jmt08trj9l43ne2",
     "asset_ids": [
       "terra1tw845kgt0uq0gfmavawacfvaq5t9fa9v57g6m9",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1aa22fmunt253n4hmuerm7p2jmt08trj9l43ne2"
   },
   {
     "id": "terra1sqaw3rsp5w84r5hwvcvcgweqcxlrhxl3e5a9na",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17azgr4x2gz20uquy7vdacfdgjjkgd0h9lm377v",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1su2magsez6h9xwss3czd8wj6l3c8eujed09d8v",
-    "lp_token_id": "terra1shwul2pfd5x5k8am6ffpts369s533pcspjr7m5",
     "asset_ids": [
       "terra1745fzfxnd8wx5kdrf4uwgj7k0mkqk64pdrh56k",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1shwul2pfd5x5k8am6ffpts369s533pcspjr7m5"
   },
   {
     "id": "terra1svequ729grnrj2d8x609e45axajrdjz87athfh",
-    "lp_token_id": "terra1gm9lk22dcd36c9s86pqdql6ll0w2c8tpnwye0x",
     "asset_ids": [
       "terra1zsaswh926ey8qa5x4vj93kzzlfnef0pstuca0y",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1gm9lk22dcd36c9s86pqdql6ll0w2c8tpnwye0x"
   },
   {
     "id": "terra1svqq5rsjpvsrt6g365wrrxz3xje0jnjljax42r",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra138zs0y4arp48v0vpzqa7r4ehxcy7sk3dpv606e",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1sx3clxk5yhqjq5j5q87jw7qu27cn7en37zk323",
-    "lp_token_id": "terra1hggkcl2v8wxzpy0vzxf2a5chw2h2fh7avl7j86",
     "asset_ids": [
       "terra1k9ltsdc6e4ay4g8f8nt8qd7my9yyd27m7eh82d",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1hggkcl2v8wxzpy0vzxf2a5chw2h2fh7avl7j86"
   },
   {
     "id": "terra1sxxn4rxuqgxn3um6ly5lf9wsjuewrr7j8tvjg0",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lnav098k7vd006lz7d73mychha503pmw35la7l",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1t4ee4m2merzrmz5uwuacuhk773wq82g32v6zu4",
-    "lp_token_id": "terra1fvlf5y9uh3ylxff40eda4j60h52lnkthzhrsdz",
     "asset_ids": [
       "terra1qm5jjajyv5pmap9687sgckc0j9hurlks3xzpx2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1fvlf5y9uh3ylxff40eda4j60h52lnkthzhrsdz"
   },
   {
     "id": "terra1tetfz00c58t656cg2gtyyv23jwh34sd590ue33",
-    "lp_token_id": "terra1ysma0f8sw7254l8nnfylfl4nded9a8wj7mn8up",
     "asset_ids": [
       "terra13zl9thu8cgpkvpsx8r652hvgw4p2v42sahz6t8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ysma0f8sw7254l8nnfylfl4nded9a8wj7mn8up"
   },
   {
     "id": "terra1tf360u087hzhw54yymtat9wd5p5c9a3n5jvhek",
-    "lp_token_id": "terra1xcxlsvm6q2nk003kqnhhddfcfm7dtnze02f3yw",
     "asset_ids": [
       "terra1vg6wky3jm7qnr4w4qtw6hflhlhc0v79z9jvnxu",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1xcxlsvm6q2nk003kqnhhddfcfm7dtnze02f3yw"
   },
   {
     "id": "terra1tg8yu978lhcveq9j4emc9f7agn00dvecvx4wju",
-    "lp_token_id": "terra18c9war4ldlccnast92snzt78ty378e0ggh8a8j",
     "asset_ids": [
       "terra1tgv52cmga9s6ymah2efz877xlpc4v8phq7mn69",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra18c9war4ldlccnast92snzt78ty378e0ggh8a8j"
   },
   {
     "id": "terra1twxv2kaeuyf3uxc6uzpgh3twe4mtagzpmn6sj4",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ghkclqug2jhanmjsx46x0vymcglchcesg98057",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1u2g4fc0k4tq6z6lrdwhm4gry3q55dg8k9anjtw",
-    "lp_token_id": "terra1z0z6hz96au9lr027uedxay3s09ry36md3wpm0v",
     "asset_ids": [
       "terra1qq4lemqmahjfhl68kpzx0kheuuvfyeu4ncnkaq",
       "ukrw"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1z0z6hz96au9lr027uedxay3s09ry36md3wpm0v"
   },
   {
     "id": "terra1u8dt2feqxchklzft7n0s38d7kz2wwx7zqey8z4",
-    "lp_token_id": "terra1quraxjgn87qe63h53mu8ksulqywsdlas648axv",
     "asset_ids": [
       "terra1gwr8mq2ljqzwmufgm55yu58339k55wja9529sg",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1quraxjgn87qe63h53mu8ksulqywsdlas648axv"
   },
   {
     "id": "terra1u9hhdcqsd25q72dqme8hp8jkq6gq67vtg3rdq7",
-    "lp_token_id": "terra18wnz4a622jvlhk5xnwuetk93j5xrkrpy23kqp0",
     "asset_ids": [
       "terra1zpke3t4nprnh4044a4n97hwv384v9vff688cyj",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra18wnz4a622jvlhk5xnwuetk93j5xrkrpy23kqp0"
   },
   {
     "id": "terra1uf6gyusnqzluacssjjdcjt2yme6wvx23ac3hpw",
-    "lp_token_id": "terra1dwnm3mxgp6svmtng5shfkc52m8d0xsagdx6z37",
     "asset_ids": [
       "terra1cp02hkhu2nq7zznz04shwfvh9hdsp3y5334n6t",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1dwnm3mxgp6svmtng5shfkc52m8d0xsagdx6z37"
   },
   {
     "id": "terra1ufrkf9n6nlq35e0gdjyc5s7qx63mfhkxrsxkmc",
-    "lp_token_id": "terra1wm2rpkpd3n0e6mkjxkc3fy3a2nw9mcrrl0npj6",
     "asset_ids": [
       "terra1cqxahw3zls3x5k9sngtyjt5qm8nzmzsleyx8hh",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1wm2rpkpd3n0e6mkjxkc3fy3a2nw9mcrrl0npj6"
   },
   {
     "id": "terra1ufzll076stnpmlmndlss4uezlq58gmwc83c72n",
-    "lp_token_id": "terra1slr9qj73j3gn2muf94aysdaeex6ahk5ghq7ehp",
     "asset_ids": [
       "terra1zfqe2kf0kh8mvyy3ksa29qqnkhc64ncffufg7g",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1slr9qj73j3gn2muf94aysdaeex6ahk5ghq7ehp"
   },
   {
     "id": "terra1umst8uwnuvd42aecxzf26jyy9eutghxk4xvlkn",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rwskqpnk03hrh8z8rrprzdluxhzc5udycdn5g4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1unvncye5u9qeme7amjf8snd889hm9mp93w4m9z",
-    "lp_token_id": "terra1s9gjv7083uvz0l90hdq2mq5d9j8je6w9ttax65",
     "asset_ids": [
       "terra1l0zqxdgs5h6tfdsvhm34mvwrevyt5cuxj6ewzz",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1s9gjv7083uvz0l90hdq2mq5d9j8je6w9ttax65"
   },
   {
     "id": "terra1uqju4mlp0f000atx07xd49y3dlwe50e0d8d4xe",
-    "lp_token_id": "terra19t9e42yxukxuuqzyekccm5jpu3gek3nttdsz8f",
     "asset_ids": [
       "terra1j874eyvev9pm7uxm0h9l82raswe3qwcug8wxuf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra19t9e42yxukxuuqzyekccm5jpu3gek3nttdsz8f"
   },
   {
     "id": "terra1usq239ur4z4utc8s4ecdrk09hd062nrdcdc7yd",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19pz3ehx9f2thr9t9jk5y89aalxmhzuq9j8ak99",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1uukk3m4qemzdjatzh8p0m2qrg95f2yc8wrfzav",
-    "lp_token_id": "terra13ae05947uryk5x2us5l5dgkhmedsxudnxjwfm6",
     "asset_ids": [
       "uusd",
       "terra174c2cy42fl7hags7cap8j4xtsmcc0ql2s8q5du"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra13ae05947uryk5x2us5l5dgkhmedsxudnxjwfm6"
   },
   {
     "id": "terra1uxwgfuyn57xqek4jgxajhd3270khgyusncarnv",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10t5spcvn5m52fs4j5tnjerm6wzsn9vuqdsheje",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1uyd2jx409kdesatvpwrvzkuvfyhfa0es0r9s9g",
-    "lp_token_id": "terra1u47cpzrevxlld30cw6veflzj569k5ayyly4c59",
     "asset_ids": [
       "terra13zemc0wmem8lt0un0lya3qtg4cpf9jcdsgtvf3",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1u47cpzrevxlld30cw6veflzj569k5ayyly4c59"
   },
   {
     "id": "terra1uyq0vtcmzhz754z5rpv62u4skf7s4e7fuancwn",
-    "lp_token_id": "terra17wctee086rxqzng25jsm80u2mf5wx5lnyghuhw",
     "asset_ids": [
       "terra10vvl9llw4p7ca2zhmcdljk5el9fkpp9hg6qy53",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra17wctee086rxqzng25jsm80u2mf5wx5lnyghuhw"
   },
   {
     "id": "terra1v73xl4qu05ahep8c8flf83vvrr437fftdxwn70",
-    "lp_token_id": "terra1p62jdngzanleq5wrwehehwl05nkwzhuuld6nae",
     "asset_ids": [
       "terra1zp4xkexmng539vylktxkf45hxjg68ufx673x8p",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1p62jdngzanleq5wrwehehwl05nkwzhuuld6nae"
   },
   {
     "id": "terra1v8lsm7hmkdwrgcxtlv3ltzvpup0ez6dr8nxdl6",
-    "lp_token_id": "terra12a5st8kc8hlypk7lhe8tquljcs4z89shah98ce",
     "asset_ids": [
       "terra1aas795lj3dt6qrsp8n38fr39ypt43p6czgz3ra",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra12a5st8kc8hlypk7lhe8tquljcs4z89shah98ce"
   },
   {
     "id": "terra1v8mkxsvtjjdln52ltu6u6ak87uvmvgffwvt0vx",
-    "lp_token_id": "terra1fhzyy5jgrjl2adhk3swalzdl4hnh0rmnusk9hz",
     "asset_ids": [
       "terra18lxu0868tj9pek9xn3wlgnlv0hs3s9t6473saz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1fhzyy5jgrjl2adhk3swalzdl4hnh0rmnusk9hz"
   },
   {
     "id": "terra1v9lxv5kje00972tyf67qp7gwdc7msxwr8wf0j2",
-    "lp_token_id": "terra1ty6nleg3m2lq7rfrlsw0adulaevsk76p4mfups",
     "asset_ids": [
       "terra143h4n4h3j36z64t7l8ey7vny6x47ukpz8s2gvs",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ty6nleg3m2lq7rfrlsw0adulaevsk76p4mfups"
   },
   {
     "id": "terra1vd20ymyajdvafp3726ft5wlndnlsqmyfr6pr20",
-    "lp_token_id": "terra1hgr37dvhd2r4mz0x5c2g60z0ggfhxy0a3lq4vd",
     "asset_ids": [
       "terra108fs4ahf6zzy7tqpvczg5yrfjpqw20kxc43pq5",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1hgr37dvhd2r4mz0x5c2g60z0ggfhxy0a3lq4vd"
   },
   {
     "id": "terra1vfwf4vd0yp47renczuqe8n7yrraxa2j7a7q0jf",
-    "lp_token_id": "terra1cps2jsd3flznjzce86qyma34a4d45v0wz0yy4j",
     "asset_ids": [
       "terra192g6ran4vfvyxhz0q7g4yls29fk6379hza6plw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1cps2jsd3flznjzce86qyma34a4d45v0wz0yy4j"
   },
   {
     "id": "terra1vjyvxsunxs6dvu5kh08chk69zffcqcntccgpf8",
-    "lp_token_id": "terra1hyt7x6duee8qxhnuyjdkmf5ucg27a2fjl7tdzw",
     "asset_ids": [
       "uusd",
       "terra16gx5th8mk5v62xpvgf675xj2vuaf3dg4v75ml5"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1hyt7x6duee8qxhnuyjdkmf5ucg27a2fjl7tdzw"
   },
   {
     "id": "terra1vm6whnkl54g5zy82533r34fhuaqp58f9kn826c",
-    "lp_token_id": "terra1g80la29wu6pnme68wj69sskcnnqg7zha69fej4",
     "asset_ids": [
       "terra1aa9kg8crxjq86ts54d4un6ku5skec9e98t6tau",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1g80la29wu6pnme68wj69sskcnnqg7zha69fej4"
   },
   {
     "id": "terra1vn3anrcp54lep043kqwvk9433r0a60xj2tlgpu",
-    "lp_token_id": "terra1h44ahd05f63yamv553rqa0qzmfyp86j56smv4p",
     "asset_ids": [
       "terra1u02lqdhuhdfwph8wsl9yx9r0jupfdsd22q60tc",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1h44ahd05f63yamv553rqa0qzmfyp86j56smv4p"
   },
   {
     "id": "terra1vnrd37f7cjwgu9zgn7whqcjjuclhhd38qrnqlw",
-    "lp_token_id": "terra1e92r33fhkft6p8fyamwu3zp300t5l35cjxf5tf",
     "asset_ids": [
       "terra1c5wn5quxclujf8n38cu0sh2r4hq697lpc9385g",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1e92r33fhkft6p8fyamwu3zp300t5l35cjxf5tf"
   },
   {
     "id": "terra1vqc0pcdz97llaglpf7gfjtykhxy5r00uex0hnz",
-    "lp_token_id": "terra12qzdpl39xj79ra7s8d5l9tvrqmwk4924hphlvz",
     "asset_ids": [
       "uusd",
       "terra1ezkr298e3lef6hh5pzmvrtw0qd0kc6u7dgl5rc"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra12qzdpl39xj79ra7s8d5l9tvrqmwk4924hphlvz"
   },
   {
     "id": "terra1vsyw78g3jfn5kelw09tttxfklrhewgtp62tw0a",
-    "lp_token_id": "terra1xm9vcuuyduxy8cc98tuaknnhv5tjv4x5350jvh",
     "asset_ids": [
       "terra1elt5czsf7sntku3qafxf7xrjxdx309kkkmc8up",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1xm9vcuuyduxy8cc98tuaknnhv5tjv4x5350jvh"
   },
   {
     "id": "terra1vu0hrz47per5rgq3mqjw272z3wgvk2x2qudvcp",
-    "lp_token_id": "terra1v09eme9k7zfqjm8a5yf3wrc5t66qqfvm50x2ks",
     "asset_ids": [
       "terra1w5pzereyvecexd9hsmlsakgnpjnlw56fgrha4s",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1v09eme9k7zfqjm8a5yf3wrc5t66qqfvm50x2ks"
   },
   {
     "id": "terra1vv088zvmzzjv5qgpu25ym9mlgcuxhksqxnrcp2",
-    "lp_token_id": "terra1svsdduee7kk6ghh7hz4c2rk8tkagfkzaplltx6",
     "asset_ids": [
       "terra13j3uuywz8q3tljmqxt6trcgcxy29dd5exrnhtq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1svsdduee7kk6ghh7hz4c2rk8tkagfkzaplltx6"
   },
   {
     "id": "terra1vvvpchwf7rac404q070x2d0jr20l0sxkcgv8y7",
-    "lp_token_id": "terra1ppaywpn8kyde0c0xngdfagjyq9l3jwudmckxw2",
     "asset_ids": [
       "terra1pxuknzmg3kup7790vjzssjjuelrq3a3ys4aml6",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1ppaywpn8kyde0c0xngdfagjyq9l3jwudmckxw2"
   },
   {
     "id": "terra1vzd3vra0zfnug80gtuwlc2j5rtucr87qkh4xmf",
-    "lp_token_id": "terra1cz49n0uhccm0qdyd4crhjgrvrfhtucelr3u0fs",
     "asset_ids": [
       "terra152qpnfe76pnkwe8msfjxf4wjq0tcjtuuunv7eg",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1cz49n0uhccm0qdyd4crhjgrvrfhtucelr3u0fs"
   },
   {
     "id": "terra1vzhsu5x9f9sglyq3acm5vq7hv0deemvdneqqw7",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ex5age9gqd5em86wg8hu0ak5wrqez9yufvlrat",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1w0hm732ejcvyp59pru5e77j6wf92rdnkknf7u3",
-    "lp_token_id": "terra18nvqp4lhezyw30kwuufplp0urggd0z9uge6ucr",
     "asset_ids": [
       "terra19qcznmhmwf88lm75nmrj3prr6cmvtnz02hvu4g",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra18nvqp4lhezyw30kwuufplp0urggd0z9uge6ucr"
   },
   {
     "id": "terra1w2aryua8k5s0a27kt9v8662jpsh4wglctu9z3h",
-    "lp_token_id": "terra1jx0n352z9jhxsu0ung276fukdcn64vvyujyp9u",
     "asset_ids": [
       "terra1pshxc56zwgm6j78mhjgn2rgkj5d32aa887l7j6",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1jx0n352z9jhxsu0ung276fukdcn64vvyujyp9u"
   },
   {
     "id": "terra1w7cyg38vclgtlsw5vxgxxleky2x29p3lh36yru",
-    "lp_token_id": "terra17selfzmc4a3dlgn5ewtwkg99a4hkhgtshh4z7f",
     "asset_ids": [
       "terra19ztfg6l5k22cw8xg2h0uncpg3kwpv84ft9h6t0",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra17selfzmc4a3dlgn5ewtwkg99a4hkhgtshh4z7f"
   },
   {
     "id": "terra1w94sqf77fzlv9eh3fz8j5kmcdv2x230hnz9gj4",
-    "lp_token_id": "terra13tlvdmr6x6fqddezpde0d3aadk3g6ye7u6l0ud",
     "asset_ids": [
       "terra1p0yttugxt3h2zvs9cghysmss3um6dp0mzt9vwd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra13tlvdmr6x6fqddezpde0d3aadk3g6ye7u6l0ud"
   },
   {
     "id": "terra1wcs60r56r743ws6nxv3tn9pgz4xqv3x4lgeqkt",
-    "lp_token_id": "terra1drs4cetuf7hxry0xrh0vz79242f8clmtjpwhft",
     "asset_ids": [
       "terra1s0y8aldsy3t6wtg5tpwe8xzq3lyet5e9grwmlz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1drs4cetuf7hxry0xrh0vz79242f8clmtjpwhft"
   },
   {
     "id": "terra1wgyq7kdeqeq70uzv04effzrgndtmtmevv4p9xr",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19y395vzlylv3s3nasr7cu4yey7s22ghqd35ps8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1wkcrktmkp3wfvwqvydlx0a3g4tywjktke4pva6",
-    "lp_token_id": "terra1hyc2qcu25cgg2fm75zee79a8au038mevhgaaql",
     "asset_ids": [
       "terra17pv5zcuddm96m0nuanw25u4p8nkc9460hz0sy4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1hyc2qcu25cgg2fm75zee79a8au038mevhgaaql"
   },
   {
     "id": "terra1wn34gxq3jyg9qtjxjfzlj42jzjeegvgymdld2c",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1re7as700g3gels30zak6ctnjtsjhhc6vjr93ms",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1wpawa65459fzfvf244rz8c8q56ampvpkjnpe6f",
-    "lp_token_id": "terra1q84pz7rtnmjr02uqkpjt75r5hgcjxf0l8qpwvy",
     "asset_ids": [
       "terra1zpp3fdnpkrhpehjxvzz3wwwujmk0zxw5h4y0rr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1q84pz7rtnmjr02uqkpjt75r5hgcjxf0l8qpwvy"
   },
   {
     "id": "terra1wt43khwmzaeyxm77jnq47hyurrehzczyzxxds8",
-    "lp_token_id": "terra1e0dkhp72ted6rcz2ptnggnvtfea2hw4r2luc5n",
     "asset_ids": [
       "terra1wx4h5qzvgp90ez53fgqr2s9t4rqzzjc03cjxr4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1e0dkhp72ted6rcz2ptnggnvtfea2hw4r2luc5n"
   },
   {
     "id": "terra1wvhxy96s86xk4mynuqggxhm46jaq7h30k8gphu",
-    "lp_token_id": "terra1uz6m6h6seck9q870hnc8g2t8rxtzn5nwg7txts",
     "asset_ids": [
       "terra1zce4mxwwdyk04txa2f3aqepzsq8jy7ca50gn8w",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1uz6m6h6seck9q870hnc8g2t8rxtzn5nwg7txts"
   },
   {
     "id": "terra1wvnw3nkwdx7ut3ua4wwm5u0lf7sl3fqgy8kltl",
-    "lp_token_id": "terra1yh6uxxmr2yhuwrswkhtvq7wq5ra8ecyucdtewh",
     "asset_ids": [
       "terra1klz458efcl7md99vafn5sdxtluauem0q5nqjtn",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1yh6uxxmr2yhuwrswkhtvq7wq5ra8ecyucdtewh"
   },
   {
     "id": "terra1wweezy8awhrmqtszun57zh2xh5yat4pndv9ejz",
-    "lp_token_id": "terra1fxzmf732l2mj23wq3aryww50xg7gclhelvs2k3",
     "asset_ids": [
       "terra1fdg5u7nttkcw2v4sepgzlwsznfffn8pnml35pu",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1fxzmf732l2mj23wq3aryww50xg7gclhelvs2k3"
   },
   {
     "id": "terra1wxl8ay7srh0cuwmtaew5yh7dap54f6vrayhnwj",
-    "lp_token_id": "terra1tyltj0lhs59mekgw8ej2dt49adue7mwa56xa2m",
     "asset_ids": [
       "terra18u4zkkm5ddge6decp83dk9zmkx7lvhv2xkynrr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1tyltj0lhs59mekgw8ej2dt49adue7mwa56xa2m"
   },
   {
     "id": "terra1wysjqge8zc40e5g67vlaw0n2qu865pxxxv9sn3",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13k03g6n38f4m90pchn5h3nmk55xrnzt5ksvsml",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1wzuyqt38l99tdxzttx9grktr3grllgsqe02dz8",
-    "lp_token_id": "terra14936pd4ptv3hkh2280qm3fx940srjvvx6gv8sl",
     "asset_ids": [
       "terra1mfwgs4aglpetsyy4y55k9g9hsnp5xtcykknldk",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra14936pd4ptv3hkh2280qm3fx940srjvvx6gv8sl"
   },
   {
     "id": "terra1x67kglh8uxc5rq4z0dsrv4az0rkfgs6k42fu06",
-    "lp_token_id": "terra1vz850g76xvryz4jhpf2juamv40yey0ugh0pyjf",
     "asset_ids": [
       "terra1epz3d7rmltreyt6chgnuv28cy8e0d3yad75xh8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1vz850g76xvryz4jhpf2juamv40yey0ugh0pyjf"
   },
   {
     "id": "terra1x6dvc72unfrdnrkyzvm8pz6kmugdzkzu66fd9v",
-    "lp_token_id": "terra16ut6d3kh5tw08lu9np7s9fqlxl0z3c2gpsqn64",
     "asset_ids": [
       "terra1t5y4xm7xdc7csud2j2aezxs6e4uuj3lqpqk7jy",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra16ut6d3kh5tw08lu9np7s9fqlxl0z3c2gpsqn64"
   },
   {
     "id": "terra1x6sxgww5nrclca4thc6f7m35fyk5mgepe63pxh",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1a95wwge5ut59aet6wx9m5ukq0alnxj0waf4sgl",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1x8em0g87c30a3s5hqp4ar3ad732q7eclftwlwm",
-    "lp_token_id": "terra152jfl6s4fmte2pe8ct0f0wtdm2k3xu6uesdfj0",
     "asset_ids": [
       "terra124zh80answg0srxqynl8syswgsjx0heh9txxw9",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra152jfl6s4fmte2pe8ct0f0wtdm2k3xu6uesdfj0"
   },
   {
     "id": "terra1x8rmne82kuy2gx26r3ecxrjns97ef8ckf9exvv",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ldrmvk4n0le7tdaxj7r8gk5kny95r6mxw3ask7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1xe69w9cuwz4s8e6nsxsf439pr2jyuhjj24s0ch",
-    "lp_token_id": "terra1dypf4pfqw8a8whlkzhgrzew68f00z50r3hcd63",
     "asset_ids": [
       "terra1677xekxjqc4f3jqut8yr6p29e8h5zfay37et58",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1dypf4pfqw8a8whlkzhgrzew68f00z50r3hcd63"
   },
   {
     "id": "terra1xen8n3l5sr3z9ad7mmmgdrhy8qa36wa00s45kg",
-    "lp_token_id": "terra1fsvjcrmalf6n9lu72p9cv9rum6x6nhg2343ghz",
     "asset_ids": [
       "terra1h56g0tp38whpxlgdwcqdtgmrkkdyqerkymyklp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1fsvjcrmalf6n9lu72p9cv9rum6x6nhg2343ghz"
   },
   {
     "id": "terra1xf5x5gyg5x4n22v9tyv3mtxzxz86hmpd3jkfju",
-    "lp_token_id": "terra1aglpvqsrgcmwy4v93uezlmaftdqu3qvg9htlcc",
     "asset_ids": [
       "terra1rxl2tv8jhv3rkhnesashgk8dwuvfa9kdzv36rp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1aglpvqsrgcmwy4v93uezlmaftdqu3qvg9htlcc"
   },
   {
     "id": "terra1xghv9y36n9nfvqmlksj8seysd3fftfgud3zgm4",
-    "lp_token_id": "terra1cvwy6kx24fhpeq4gjuyp2ynwcsxu8gtvk3mde7",
     "asset_ids": [
       "terra1dgwaqnzp9yt4w4g8l2kwxemrhlwqm50j7eehns",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1cvwy6kx24fhpeq4gjuyp2ynwcsxu8gtvk3mde7"
   },
   {
     "id": "terra1xk2dnaqynl297f6r2yp5xp83yd5k8kk3mv8s7r",
-    "lp_token_id": "terra1mywz0a0fzzv69fxct84jj2777t2err6sn6pyu6",
     "asset_ids": [
       "uusd",
       "terra1atpd4n3u6tl9ttqeqdwk303lcj2j7u8tpnx53p"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1mywz0a0fzzv69fxct84jj2777t2err6sn6pyu6"
   },
   {
     "id": "terra1xlgl3xvkha2y6mssy9s4qe70sq295825sdmt2q",
-    "lp_token_id": "terra165k229vdtpng40rhdfn3tqtqphwxeyjx5wrwxw",
     "asset_ids": [
       "terra1q59h4hyxvfpu2hp3v39r8rpl4wykqe7axrc9rr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra165k229vdtpng40rhdfn3tqtqphwxeyjx5wrwxw"
   },
   {
     "id": "terra1xtaxvdlfjxyea7qpz37f5j3py3cyafkycgy8c5",
-    "lp_token_id": "terra1z364vxmwx7gadv0pd8ywul8k2k68rjahxq0c5w",
     "asset_ids": [
       "terra17n0sj0ed82upz3c38px5hl2zy7mestccskauva",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1z364vxmwx7gadv0pd8ywul8k2k68rjahxq0c5w"
   },
   {
     "id": "terra1xvvrm52lglquyp62kgpcww8489v4wqy9us6skq",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1r2p90ur2zy8javfhnf7ejdvzac60ax3wcvkvxz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1xxrx7rgpzlep532ulyyndpm7g2md3zspgepmfa",
-    "lp_token_id": "terra1m5gwp6ujj0frnwkgxlkmhwu5we9xaysnwa6f8s",
     "asset_ids": [
       "terra1ydznesu47hety3am8athucgp6hl4dcxsxqpka3",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1m5gwp6ujj0frnwkgxlkmhwu5we9xaysnwa6f8s"
   },
   {
     "id": "terra1xzk9vcd53j2eql8zfnds9xfxy6z9c6ran3ld7p",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1e3s670y5lns7vlq3gxdcn9rv8mdpydhd89jdwz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1y03ldlhcscet96kflc0fefnfkvug92ly3xmgr2",
-    "lp_token_id": "terra19hvxtwdprvaadfldxhyc0demuyhhz26z86r54r",
     "asset_ids": [
       "terra1su29mtytdsev3ty2au5xlfrqrjcy696yeqwvcy",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra19hvxtwdprvaadfldxhyc0demuyhhz26z86r54r"
   },
   {
     "id": "terra1y0cfekprajjqmz9jth6veq8pe5t2qurwg9kk4m",
-    "lp_token_id": "terra18vvfrdsxefmheygjlw2d6835p969snpvm2xlar",
     "asset_ids": [
       "terra1z9yq8l5fn7y5msg37rx2p0up0pgkf52ml4uv0q",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra18vvfrdsxefmheygjlw2d6835p969snpvm2xlar"
   },
   {
     "id": "terra1y53r7wkxtajtsmn0zjqu4keqyd2qn5hv3ykmt8",
-    "lp_token_id": "terra1smfcvgpdggf8jp7p3yvaqs0jl25ene6rwynn80",
     "asset_ids": [
       "terra1tn2upc52zce96qprewh0gk5thvqqtuhaz7r6qd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1smfcvgpdggf8jp7p3yvaqs0jl25ene6rwynn80"
   },
   {
     "id": "terra1y6x737xg3q0nrqfgjkzy9ggfjmanu7675vva8s",
-    "lp_token_id": "terra1td4yfemjtq38lq98vqhnywfmjec979z8qxqrx2",
     "asset_ids": [
       "terra1f85kt39ar3tkscq6w8ylxv2t9qh4ktzayw35ta",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1td4yfemjtq38lq98vqhnywfmjec979z8qxqrx2"
   },
   {
     "id": "terra1ya6tdm86gequ9wc7lusx374j2flgldv33426zg",
-    "lp_token_id": "terra1pl7nft4helwl8xt3ev0lknk4rkhrceve4s8lk3",
     "asset_ids": [
       "terra1zpz6dfn24cnykwausjt7qwfdqf87kny0trn94k",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1pl7nft4helwl8xt3ev0lknk4rkhrceve4s8lk3"
   },
   {
     "id": "terra1yag6m3d3q60wnhpd8fm2qhn4uhkzpufazwz6w9",
-    "lp_token_id": "terra1nl5wp6j8tna08ymthheynq0u0eam0gad5pgxku",
     "asset_ids": [
       "terra1g7fa8wpfp56tzdd5mgz5r5jsvqw7hm5e3tdlnq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1nl5wp6j8tna08ymthheynq0u0eam0gad5pgxku"
   },
   {
     "id": "terra1yeh80vf0yezluv2u5nc6e5n8d4phjy4c55zvg3",
-    "lp_token_id": "terra1vtz8425zxtpm8sng8u3grrdq5cruq4zeeh0cn8",
     "asset_ids": [
       "terra12fctlld90cakzkuhd2c3h246zxrhwqd6kp546g",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1vtz8425zxtpm8sng8u3grrdq5cruq4zeeh0cn8"
   },
   {
     "id": "terra1yje5awrwutgx5p4mg3e8vtpnttav5f6y9m3rgh",
-    "lp_token_id": "terra1h3a58p3haxgt95eq8fwkptwscyppq0laque0f3",
     "asset_ids": [
       "terra1mkw8x32086w0emr0wkprrns9j0c82nnxusn7dw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1h3a58p3haxgt95eq8fwkptwscyppq0laque0f3"
   },
   {
     "id": "terra1yqrryqqnvq9wgqad89dhdxwspspqzzj2dy03yy",
-    "lp_token_id": "terra1l7hmc3k3zlg5r6jet9tuv846h735p3xjul2dh8",
     "asset_ids": [
       "terra1x5mhyxzmy8da89rh7dnt3v289qz988hclyl6kk",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1l7hmc3k3zlg5r6jet9tuv846h735p3xjul2dh8"
   },
   {
     "id": "terra1yv9dr0suw8njr88ls6ya34y2pevq45k5yg0vl0",
-    "lp_token_id": "terra1w3xdh7zpllve9d72anjtr5lkxndshggdw3zdke",
     "asset_ids": [
       "terra1my8t2mhxxv5rzjtzc8cppj8y76hy3apvcntttw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1w3xdh7zpllve9d72anjtr5lkxndshggdw3zdke"
   },
   {
     "id": "terra1z0g2y0d3eemtcsd253qd8vpl74a089deqas2hp",
-    "lp_token_id": "terra1uu0xsadf4x7v5q9vpgp2dd9t9x2khwqlal5rl9",
     "asset_ids": [
       "terra1kujvztl5p8a45k56u42fq39jxldxcvuejtpfq5",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1uu0xsadf4x7v5q9vpgp2dd9t9x2khwqlal5rl9"
   },
   {
     "id": "terra1z2p2vs8q95frqntrnqwkwmj9nempl83l3m699n",
-    "lp_token_id": "terra1fnr2j2cfapcuxr90z83sj0qjrtzt88sutz4cpf",
     "asset_ids": [
       "terra17efcrd3glln324tqke56w5wgnfkfn5emz4um8j",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1fnr2j2cfapcuxr90z83sj0qjrtzt88sutz4cpf"
   },
   {
     "id": "terra1z3u6mw3s20kt67ts9txrg2mjkzcwt7tgasp7gw",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12flsr4mk5sxmu8yk7m8zc5f44tfx00yjvzj7v4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1z50d83kx5dke2fw2wtrs4kj6ae8ga2pe5vhwl8",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pfynaj6mslxnlekjx7f6rxgfastl46c4hg3kg7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1z7w93yyhzl0vf6cxvt0c65ta2q48akft53uj3k",
-    "lp_token_id": "terra1naap0c8xly4fh5aq7vhayqrrj6pmt826r0uukn",
     "asset_ids": [
       "terra10722f40cxl8tkxjk7f88uj0ehkcw6lu2j504f0",
       "ubluna"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1naap0c8xly4fh5aq7vhayqrrj6pmt826r0uukn"
   },
   {
     "id": "terra1z96yec8dxc6ummv5kkksft3agxmsaur07zxgq6",
-    "lp_token_id": "terra1fn7psza4kxrmu3vhnelg08629uapvmmr48xnew",
     "asset_ids": [
       "terra1v2s7gkylfrnwsdcx8s83k5475nj3jykzs9gsqm",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1fn7psza4kxrmu3vhnelg08629uapvmmr48xnew"
   },
   {
     "id": "terra1z9d33epxt9jaa4d4ta6rf5fwfysfufeumz4zga",
-    "lp_token_id": "terra1vemqvqr0khzdtfl9909u27v977pthardrwf9zh",
     "asset_ids": [
       "terra1xp4uhylkhwgam5tc97m0xfaxarajgf6wtcqwp9",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1vemqvqr0khzdtfl9909u27v977pthardrwf9zh"
   },
   {
     "id": "terra1zl89gw3t5ykhfxtut3marguhyff9fwupmnmhrl",
-    "lp_token_id": "terra1pq9m7syytshndh2sckgxyrh83wsm59w4gduvg8",
     "asset_ids": [
       "terra1dszjh6392kc6avpztu4vdx8xl0qte4ntmue07r",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1pq9m7syytshndh2sckgxyrh83wsm59w4gduvg8"
   },
   {
     "id": "terra1znka2za38gsj3p8u8etlfejqz4prf3snz36tnr",
-    "lp_token_id": "terra1q7vnlkn4gqgfqucjp8hadz6nzpma759qvjttsx",
     "asset_ids": [
       "terra1wz8w0susqsraw2smttuymzkgr3p8tgkntqhcre",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1q7vnlkn4gqgfqucjp8hadz6nzpma759qvjttsx"
   },
   {
     "id": "terra1zzqkcp3e5apwdpsnavfrdrf6q0qf4esd556xg0",
-    "lp_token_id": "terra1tk7a0hcs3yehfzrscjhw824jq52ndvsv07d7zk",
     "asset_ids": [
       "terra1m9w3pdjst86dmfdamq5tuu4ny99e89eaavdz06",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE"
+    "type": "TODO TYPE",
+    "lp_token_id": "terra1tk7a0hcs3yehfzrscjhw824jq52ndvsv07d7zk"
   },
   {
     "id": "terra102a44aeeq4x78pmv5kj79qxaq2ghtsk24gj6g7",
-    "lp_token_id": "terra1x6dwnqnr890whm0wtzz9td052s7008g2tg8ffp",
     "asset_ids": [
       "terra107pw6g56gfch98r3xw9gr3glcxvmmm8326rdg7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1x6dwnqnr890whm0wtzz9td052s7008g2tg8ffp"
   },
   {
     "id": "terra103ttjgs24wak64epwd7pl5qmqw44jzujr8l3hd",
-    "lp_token_id": "terra1wvnwpt66528vajjps7m9daux600sck8mhx5wmr",
     "asset_ids": [
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
       "terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1wvnwpt66528vajjps7m9daux600sck8mhx5wmr"
   },
   {
     "id": "terra105yxgufwjx5gsapk0n0rkea0dxvykyujx379g0",
-    "lp_token_id": "terra14z7t45phqgnx67n6qdvs4ac4cwy0rvflugzyew",
     "asset_ids": [
       "terra13awdgcx40tz5uygkgm79dytez3x87rpg4uhnvu",
       "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14z7t45phqgnx67n6qdvs4ac4cwy0rvflugzyew"
   },
   {
     "id": "terra108a6djt665wvklxwhyr7lepvy5ej87c7szl99g",
-    "lp_token_id": "terra132njtndm2rjcn4x95tq5qm5h98smn8a7hnvwj7",
     "asset_ids": [
       "terra1qxfl4e8gjnunk0t3kq7a6ladu2p4cddk95s5jj",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra132njtndm2rjcn4x95tq5qm5h98smn8a7hnvwj7"
   },
   {
     "id": "terra108ukjf6ekezuc52t9keernlqxtmzpj4wf7rx0h",
-    "lp_token_id": "terra17smg3rl9vdpawwpe7ex4ea4xm6q038gp2chge5",
     "asset_ids": [
       "uusd",
       "terra137drsu8gce5thf6jr5mxlfghw36rpljt3zj73v"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17smg3rl9vdpawwpe7ex4ea4xm6q038gp2chge5"
   },
   {
     "id": "terra109wt0lvwk560kjpdhuusj3a7ldnzasv028gmvt",
-    "lp_token_id": "terra18tc6j7mmqk6fwt38la3uvespuxvefkw3703xdx",
     "asset_ids": [
       "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra18tc6j7mmqk6fwt38la3uvespuxvefkw3703xdx"
   },
   {
     "id": "terra10css4arzlu5ws98tz8dmsclurck3lawgddu0nz",
-    "lp_token_id": "terra12fprsw8chwm405m92vseldjp72mwge5ldv27nz",
     "asset_ids": [
       "uusd",
       "terra1nkf3aaal2j93pqdtytf73x6dqnpxy2u75ezauh"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra12fprsw8chwm405m92vseldjp72mwge5ldv27nz"
   },
   {
     "id": "terra10dtff8drpwtfx4976m7cxwpptfy87l5p264xgy",
-    "lp_token_id": "terra16gqa7q433a2q7d6ankxz0qk4pwet53fakazqv9",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra16gqa7q433a2q7d6ankxz0qk4pwet53fakazqv9"
   },
   {
     "id": "terra10ex2fzy8wwwykgcdl8p3ruvvh536f4mw8fxzzh",
-    "lp_token_id": "terra1dluesh3lqcgatxpcy4c4jg6hydkcc0echunw0c",
     "asset_ids": [
       "terra1vpws4hmpmpsqwnz3gljn8zj42rv7rkpc5atgt4",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1dluesh3lqcgatxpcy4c4jg6hydkcc0echunw0c"
   },
   {
     "id": "terra10fkdl22gefrydr762n5gah45du54ykwgxw2smx",
-    "lp_token_id": "terra168j6qa84dmcuamp4pv7xuudgp96884ktp3cxuy",
     "asset_ids": [
       "terra1f85kt39ar3tkscq6w8ylxv2t9qh4ktzayw35ta",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra168j6qa84dmcuamp4pv7xuudgp96884ktp3cxuy"
   },
   {
     "id": "terra10h5gc8e59wtz3rxhrngjrk3m9lqvc9xs6hy5gq",
-    "lp_token_id": "terra1mmjzshcvdhtalmtugqalam7l9vk507ncmpu3q2",
     "asset_ids": [
       "uusd",
       "terra1w94fk75p0qeas276kfvy0m0zhnwgcy49c7vu77"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mmjzshcvdhtalmtugqalam7l9vk507ncmpu3q2"
   },
   {
     "id": "terra10jyd2dy3ul5z2qqh9gej2zd3d46kv9dtk7c3a0",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra10k7y9qw63tfwj7e3x4uuzru2u9kvtd4ureajhd",
-    "lp_token_id": "terra12v03at235nxnmsyfg09akh4tp02mr60ne6flry",
     "asset_ids": [
       "uusd",
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra12v03at235nxnmsyfg09akh4tp02mr60ne6flry"
   },
   {
     "id": "terra10l7zllh9hduam4tugygj9x3f6976auj2xeyegp",
-    "lp_token_id": "terra1ftd4p3rfcry6sgrwjs78s0562kmut3p6cpnq77",
     "asset_ids": [
       "terra1vru3mk2ne3jqpwg24wm5mg2356cg5ead0tae2s",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ftd4p3rfcry6sgrwjs78s0562kmut3p6cpnq77"
   },
   {
     "id": "terra10u8rwg2wjj4x2wyyhddjkpkkp8v40thyyg0gwj",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1mqsjugsugfprn3cvgxsrr8akkvdxv2pzc74us7"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra10vatx9jkv4lcksugsrkajstw2duh834j5psxzs",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1r7qpupdxkkh58vw9u8y9n9wjp6d9lr08u39j0z",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra10vpqzvhmy25pjgwkqt9eq22w3t7r7hta60gxgk",
-    "lp_token_id": "terra1y3k5urh9ahwzsxr08dlspds4vpywsat49aklvn",
     "asset_ids": [
       "terra1t7apedqrzywmrl89feackcalpknfzu5mr8t3xg",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1y3k5urh9ahwzsxr08dlspds4vpywsat49aklvn"
   },
   {
     "id": "terra10xafj6lu07e7at9nccfwgjyrqqjfnsp8wp0f9q",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra10xf7yakydjc5q4uye6zuuux8d3hxet2wpfk4se",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1mjhrlgwv8dnvc7mp0cynfxna947hxnm5m4tp6u",
       "uchf"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra10xlgqrh0uhc8tt50wwqv3peh9w5zjjq3cz00n0",
-    "lp_token_id": "terra10q7p02sacknlxay0a26j7fhm75xryx2jppunwj",
     "asset_ids": [
       "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap",
       "uchf"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra10q7p02sacknlxay0a26j7fhm75xryx2jppunwj"
   },
   {
     "id": "terra10xyreshk74gx9ygw4q4j0m9pr9je4spzas0n5f",
-    "lp_token_id": "terra1m9dlyzueyqy3pdl3tzwn60lc7myhum7j0zq5p6",
     "asset_ids": [
       "terra1txlylfvu2s9p3tt2fa82xj6qy6pp86avs0t43w",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1m9dlyzueyqy3pdl3tzwn60lc7myhum7j0zq5p6"
   },
   {
     "id": "terra10ypv4vq67ns54t5ur3krkx37th7j58paev0qhd",
-    "lp_token_id": "terra14uaqudeylx6tegamqmygh85lfq8qg2jmg7uucc",
     "asset_ids": [
       "uusd",
       "terra1227ppwxxj3jxz8cfgq00jgnxqcny7ryenvkwj6"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14uaqudeylx6tegamqmygh85lfq8qg2jmg7uucc"
   },
   {
     "id": "terra10z6670zcw0787a6p5ydxtct5ff37g3tnz2dfaa",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1u43zu5amjlsgty5j64445fr9yglhm53m576ugh"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra10zaw5l7aa8hcgfml5eugkmg3dgvrxhnxnsrtdr",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1afgfjpny09lvxl06llcy7hfu0m2epfddzn0f75",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra10zcf3z97m34kks7ly78ydshrcqf57fttc5sdrt",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1jl0egxpdfw0eqkzsgedzzet9zgwmhet2rd3s6u",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1228ck5ztqu455fye2yg8jwm9nr7w7yzdjqzj8n",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kf3ez7z2kzvvv7z7kte4en35gxm8keurgl09nj",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra123ttrnasfv5htzt88phmm7v0r302z0lqh7l25t",
-    "lp_token_id": "terra1aeusm5e93ptz2twem0vpfy370c7d7vy2dp0vke",
     "asset_ids": [
       "terra1jwnz2uet8f4yjqyntgsfrplp503wutt24n7srk",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1aeusm5e93ptz2twem0vpfy370c7d7vy2dp0vke"
   },
   {
     "id": "terra1240yffve7kq7xam0huv6scn9kdr688lflstkfy",
-    "lp_token_id": "terra1pxst9epy9cz5rmdh3d7f4lvch9xz4xp30xa4sj",
     "asset_ids": [
       "terra1qxfhvu3w83azgs4ghk3v5z2nvmzg8td5gqfd69",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1pxst9epy9cz5rmdh3d7f4lvch9xz4xp30xa4sj"
   },
   {
     "id": "terra124rkw63yj56t38c5y2kahfxm5cwhl8s0zzma2p",
-    "lp_token_id": "terra14cee0hdd45fu3wwvkw5nr942f54dp0jsuta203",
     "asset_ids": [
       "terra1tqjzureahwdezhy64uw7x9vpywgxvxcngexecf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14cee0hdd45fu3wwvkw5nr942f54dp0jsuta203"
   },
   {
     "id": "terra124vedvwx3nrwepzc2kmdhuhqn7j6zxq0jq2p2h",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1uxqd9gmtxz45yq53t2m9vrs74twwfrjmrqmdjd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra126fv7f8e3qgpc0g74vnp0gzks57r8z2ec2jh6j",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra129a0pp22q8m2m9lvd7n93pzx5eyjw2tj0ueunn",
-    "lp_token_id": "terra1w22ns4l6sz3t39tx2z4lvxlnu8ejus20k0f2ts",
     "asset_ids": [
       "terra19th22mng47zxe9ndrtvd470fjkn7n7ymmn28mr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1w22ns4l6sz3t39tx2z4lvxlnu8ejus20k0f2ts"
   },
   {
     "id": "terra12arl49w7t4xpq7krtv43t3dg6g8kn2xxyaav56",
-    "lp_token_id": "terra1hg3tr0gx2jfaw38m80s83c7khr4wgfvzyh5uak",
     "asset_ids": [
       "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz",
       "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1hg3tr0gx2jfaw38m80s83c7khr4wgfvzyh5uak"
   },
   {
     "id": "terra12ch7qqv9nulaak6wey00nlm8mfj6cmuhkgwayw",
-    "lp_token_id": "terra1tp8csj5nsx4m5t4hdn4ff5u8vw96j4wpvz2emv",
     "asset_ids": [
       "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
       "ueur"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1tp8csj5nsx4m5t4hdn4ff5u8vw96j4wpvz2emv"
   },
   {
     "id": "terra12cvs56jef4cp6xgwln62yp33fapqtr2kfa3h2s",
-    "lp_token_id": "terra1yq8pm98kadrxj835eeknhuhzrhzgxv7hy9nelz",
     "asset_ids": [
       "terra1hj9g4kecf9gncxsa2257w4glhwgrdp7vjsnncv",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1yq8pm98kadrxj835eeknhuhzrhzgxv7hy9nelz"
   },
   {
     "id": "terra12eazlqlhzxhmp546vvhd0ukqwqfjzv55es8fgc",
-    "lp_token_id": "terra1wwaj9xx6apx5d3pta8rss4tn6lzgdhavs6wgnu",
     "asset_ids": [
       "terra10qjtgmpsnx7kn53nxmw2mfx626g8y4xaw04pd8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1wwaj9xx6apx5d3pta8rss4tn6lzgdhavs6wgnu"
   },
   {
     "id": "terra12frjaujnaddrfxjdlet09nlf75waxclze5s0rm",
-    "lp_token_id": "terra1s54fm8ttuwavqsc7m9salge348upw5p53jnj8a",
     "asset_ids": [
       "terra182vnsj0rv9dnrc7xnccz0wajp69hu73706h2p4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1s54fm8ttuwavqsc7m9salge348upw5p53jnj8a"
   },
   {
     "id": "terra12gkp648mkgj6esr5y6dwc2q4mftnfzk2pudka8",
-    "lp_token_id": "terra1cahp2lp0zjcuyx25rcau04v8x7jk3qllmmhrx9",
     "asset_ids": [
       "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1cahp2lp0zjcuyx25rcau04v8x7jk3qllmmhrx9"
   },
   {
     "id": "terra12j29ct74f4wx0vrz54c96sl4gvz5a3k7mynzrq",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra178v546c407pdnx5rer3hu8s2c0fc924k74ymnn",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra12jl0hnmgrs9j0tv8u7pfqdey9nukmmk7vehgkz",
-    "lp_token_id": "terra1tq025m6ms5jz6hwhjp9akt420mhe8t3evu0rc4",
     "asset_ids": [
       "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1tq025m6ms5jz6hwhjp9akt420mhe8t3evu0rc4"
   },
   {
     "id": "terra12ka6n7ujku9wzddy56war52dqmk2hfq7ysdwpt",
-    "lp_token_id": "terra15n4mgtumehlzy3h4ldnz5m4vrp7n3z8yu9c005",
     "asset_ids": [
       "terra1j4kt7mns290trwlwyxrun5n7nlfkxxcak57ck2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra15n4mgtumehlzy3h4ldnz5m4vrp7n3z8yu9c005"
   },
   {
     "id": "terra12kuvl9ljytve26q5nd5khnrw2hdkaa68sh5t0j",
-    "lp_token_id": "terra147g92kn88fhyjxgt4lut827smfgtjqngpg8873",
     "asset_ids": [
       "terra172xf4zehmdla56h2x8ergqmejg70f4zczzt74w",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra147g92kn88fhyjxgt4lut827smfgtjqngpg8873"
   },
   {
     "id": "terra12mehtwqlcypjlp6u6mf7k39c2esjd2w4fw4ke2",
-    "lp_token_id": "terra1xy8hnu2rdzl4agj2qraw022z2xy3u6a5ldd4cc",
     "asset_ids": [
       "terra1dameg63csxum2hspscam9h6d33chnqa4wsn3sp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1xy8hnu2rdzl4agj2qraw022z2xy3u6a5ldd4cc"
   },
   {
     "id": "terra12mzh5cp6tgc65t2cqku5zvkjj8xjtuv5v9whyd",
-    "lp_token_id": "terra1hvz34zmk4h6k896t94vd8d5qjdchhnkdndunzx",
     "asset_ids": [
       "terra1vtr50tw0pgqpes34zqu60n554p9x4950wk8f63",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1hvz34zmk4h6k896t94vd8d5qjdchhnkdndunzx"
   },
   {
     "id": "terra12qjaagzpkz28ngtpg5ugelsmcmtl7x4w4nuuz0",
-    "lp_token_id": "terra1uyv9trfhqk2wf9m6x5ksm7j4yq9hfemr5swqnh",
     "asset_ids": [
       "terra1z8ta6q6tfvp3sec0f4yftt8ew656d0x8zhgp66",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1uyv9trfhqk2wf9m6x5ksm7j4yq9hfemr5swqnh"
   },
   {
     "id": "terra12tuqcyr3aw6fuky8l2xfp0uyje5kmdf7yr6spa",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "ueur"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra12wfnxnvzd9fjt3gyw38mhncw027n2kd3p8jf2x",
-    "lp_token_id": "terra1s3v0ftwx0vuhy9482hudf5z8u0vsmrkn4nremh",
     "asset_ids": [
       "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7",
       "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1s3v0ftwx0vuhy9482hudf5z8u0vsmrkn4nremh"
   },
   {
     "id": "terra12xus7trxaqjnd30q4z7xzvvwnqar2ne4f7304w",
-    "lp_token_id": "terra1dp5pt02qxmla9a88alp3ljl5m97p5ge690p50h",
     "asset_ids": [
       "uusd",
       "terra1m6j6j9gw728n82k78s0j9kq8l5p6ne0xcc820p"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1dp5pt02qxmla9a88alp3ljl5m97p5ge690p50h"
   },
   {
     "id": "terra12zwtkdu6qhs4f8jw9zvdgrwl24mwag5kuh7gus",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1ay3729yle6u6wxj3wcm8racn50a2yq5r8vxvkx"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1305xtjl5qtlpdlp8gg0k8u4yl05hj7qvyffvd4",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra132qjgv0evru0em6v2rcwakgxzafjhwfz7fc7hh",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1drsjzvzej4h4qlehcfwclxg4w5l3h5tuvd3jd8"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra133308rh6p96pxw0cztmfln8av2jkxnjlfvfcyq",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n",
       "ueur"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra134ce0ucmswxcsjl0st8p36hgxk0edty06nhhv9",
-    "lp_token_id": "terra1p5qffpcsqjk6t9v0dn3luzj2lhxnep09d8pgep",
     "asset_ids": [
       "terra14kat7dptmcydvhn0l5ur3g3evs65n33925n7w7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1p5qffpcsqjk6t9v0dn3luzj2lhxnep09d8pgep"
   },
   {
     "id": "terra134mvek3w6tp9rzgdklv9pndpdkc2gqvf24um3l",
-    "lp_token_id": "terra1epjldscwcyn3nerwmnf0qnfk8rue7pc73v6u20",
     "asset_ids": [
       "terra1c5fr3wdf2trj3dkxcckhmzzxlnnpepqn8cu8f8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1epjldscwcyn3nerwmnf0qnfk8rue7pc73v6u20"
   },
   {
     "id": "terra134xk6kqtwzw46qchkjsg9dwvufacmnulex2xwr",
-    "lp_token_id": "terra1qvuhgne7qp9gre8zmfrea6ekjgmda8r4hsf9ch",
     "asset_ids": [
       "terra1skjr69exm6v8zellgjpaa2emhwutrk5a6dz7dd",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qvuhgne7qp9gre8zmfrea6ekjgmda8r4hsf9ch"
   },
   {
     "id": "terra136vrkx8kq7x5w0kgklzh9vxmn2x93q0edqe3nf",
-    "lp_token_id": "terra15uzdzdpv7gfzl84yhx53uz6769krhf6krd3s7c",
     "asset_ids": [
       "terra15pv3xxp2d5f65qeu2v27vqf9zpqjx0fuztfwcu",
       "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra15uzdzdpv7gfzl84yhx53uz6769krhf6krd3s7c"
   },
   {
     "id": "terra13awymgywq8nth34qgjaa6rm6junfqv3nxaupnw",
-    "lp_token_id": "terra1aw52tgnmu3dfeguy36vm3we3ju0v6dhnvkj2cg",
     "asset_ids": [
       "uusd",
       "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1aw52tgnmu3dfeguy36vm3we3ju0v6dhnvkj2cg"
   },
   {
     "id": "terra13eyn98smadfflnm0jgt04q5dqzs3dtjg6kjjrj",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hfyxtste6842zulmjv9n92srv803q6rhn7t8d4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra13h83g8cv50e98kk450pkpk76fmjeryd32zvef6",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1w7zgkcyt7y4zpct9dw8mw362ywvdlydnum2awa"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra13hmvr56ld8lhtdxkzw9q08lkzscnjlsa8jff2r",
-    "lp_token_id": "terra18y8qtp8slkdrfdf8hvfjhk6w7rn5vm4hhegngy",
     "asset_ids": [
       "terra14a2t4c4a8us6q24k2hkfm7kdenzxu0yxph35wd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra18y8qtp8slkdrfdf8hvfjhk6w7rn5vm4hhegngy"
   },
   {
     "id": "terra13hprd7adym4cf2hgjmnjdv48akxj8fplelp6pz",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1xzn8e3h9k4qk7082z330sn8ptz99lnghyua9xy"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra13htj4202asg8fdmyq002zm53j7h4my8q4kdddt",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra13kvcwhxa0ym2tpgcchk0rn0zrrl7r7w0mgv74q",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lkszqh6duver9s9h0qfr2dcktj605km3hzfzjd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra13nerldmwsc5gal4jtjr2t04vng02q5d7nthqtj",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra13nwgt8kxyat5pt70faxnm8dje0c67hwsp53d5x",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
       "ueur"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra13rprqshf7dxn48v0aaztv5c7ytct6t6u7djtlw",
-    "lp_token_id": "terra19ahlx8uhyslmt8u6a6tzsugepm8a3kfemjeucl",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19ahlx8uhyslmt8u6a6tzsugepm8a3kfemjeucl"
   },
   {
     "id": "terra13szfqtcjq98yjyalghplmyq0fdlafaga09z40q",
-    "lp_token_id": "terra1egnufc5nzjch6r9nuan4ywc90nmtyr5fqq6cv6",
     "asset_ids": [
       "uusd",
       "terra137drsu8gce5thf6jr5mxlfghw36rpljt3zj73v"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1egnufc5nzjch6r9nuan4ywc90nmtyr5fqq6cv6"
   },
   {
     "id": "terra13x30y5swfdjw4hhwpur83gljsf50s4afmmfrj4",
-    "lp_token_id": "terra1rkqdu7n85zqhgg78ktgv3rj5zvw6vp7m0dkx4y",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1rkqdu7n85zqhgg78ktgv3rj5zvw6vp7m0dkx4y"
   },
   {
     "id": "terra13xh4kjkx2xd0nn5tzwnqpmzwrc9mhrfdvl4axp",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra13yc7dcphaxpgd538msys7r75d3lwa5mu9u6d88",
-    "lp_token_id": "terra17vddhyh8zulk4yx2zapsk9z5y5r5mjaf9w6egv",
     "asset_ids": [
       "terra1z0ewtcsaskfmsp6ue59skulunehzv27ndw5yl0",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17vddhyh8zulk4yx2zapsk9z5y5r5mjaf9w6egv"
   },
   {
     "id": "terra146c06de7zllrc3r960dmxq4m5q076fvw95529p",
-    "lp_token_id": "terra1s0y08x9qxn0xy0ph43lk24h8wchzwx932ewlej",
     "asset_ids": [
       "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1s0y08x9qxn0xy0ph43lk24h8wchzwx932ewlej"
   },
   {
     "id": "terra1473vrcpk28pc2smude02a98ft3ff05gqv5xtl9",
-    "lp_token_id": "terra1p3pky64g3jq6s466g8jskszt2k7e07ygt9z8z2",
     "asset_ids": [
       "terra16hhm24fc3wle66m3529n2jctqqsds57wv4c087",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1p3pky64g3jq6s466g8jskszt2k7e07ygt9z8z2"
   },
   {
     "id": "terra147adm7pj9nzsdulnkqv2pnslp2en2dnpvs24qq",
-    "lp_token_id": "terra102l9yp0zpzrgse96mwgnfyc0rmunpyzrxg7999",
     "asset_ids": [
       "terra17zhwz3s95dwcw373eklrscvn4jr6f7sd7qpk7y",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra102l9yp0zpzrgse96mwgnfyc0rmunpyzrxg7999"
   },
   {
     "id": "terra14c8m8anc8u9llaf2tq0d80986vmeprehkrwpnq",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra16gqgpuy7z64chzz3su2xugjgrhuj3h89wx2z59",
       "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra14czsfcd6j4z8ffyekkgsr4zkpw8tdnec0v9jz5",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "uchf"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra14dvkhl6xzg7dj2e60vasr6vcvh3354wwnfpv0d",
-    "lp_token_id": "terra1s26qlejx4lhqd3ruc7tp2lg3xu40rk2wpxssrn",
     "asset_ids": [
       "terra15pv3xxp2d5f65qeu2v27vqf9zpqjx0fuztfwcu",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1s26qlejx4lhqd3ruc7tp2lg3xu40rk2wpxssrn"
   },
   {
     "id": "terra14eey9rfl9we6hurlf9q44nfffrm2cd8xjkdqmz",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
       "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra14fyt2g3umeatsr4j4g2rs8ca0jceu3k0mcs7ry",
-    "lp_token_id": "terra16auz7uhnuxrj2dzrynz2elthx5zpps5gs6tyln",
     "asset_ids": [
       "uusd",
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra16auz7uhnuxrj2dzrynz2elthx5zpps5gs6tyln"
   },
   {
     "id": "terra14h9hukadz5qwm4jtxjrvnpnj52ynrnrcq6wjfq",
-    "lp_token_id": "terra1rhy9tsda27exlwlwkx62u4t2e6c0uq7469p0el",
     "asset_ids": [
       "terra13km0x6rn7fj23ruqdqdqut7p7p7570xyjz35qe",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1rhy9tsda27exlwlwkx62u4t2e6c0uq7469p0el"
   },
   {
     "id": "terra14hklnm2ssaexjwkcfhyyyzvpmhpwx6x6lpy39s",
-    "lp_token_id": "terra1jqqegd35rg2gjde54adpj3t6ecu0khfeaarzy9",
     "asset_ids": [
       "uusd",
       "terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1jqqegd35rg2gjde54adpj3t6ecu0khfeaarzy9"
   },
   {
     "id": "terra14hpees7gp0addrkgavwpylsr9tnzg57c0vdxav",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1jkkt5638cd5pur0u5jnr2juw0v6hz5d6z8xu8m",
       "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra14lg4pfn3s5p4zcmujnppvpr09n5a7583cz4czd",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
       "uchf"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra14m7prknmsyxjey7mkafl6340ckvnn6ve0uuxlr",
-    "lp_token_id": "terra1e4uxrgeezzcw33cfek64u7kq55jyn5dsartakt",
     "asset_ids": [
       "terra174tuptw39sd3s5yqq466xc5lygh9z8gp05wf4j",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1e4uxrgeezzcw33cfek64u7kq55jyn5dsartakt"
   },
   {
     "id": "terra14n525nzgnsqpy5ne28ffj6e2ul3c3n7hkv5ql9",
-    "lp_token_id": "terra1ktld67cnuc592xd6xjgfh2n4d3f8av4mn53lul",
     "asset_ids": [
       "terra1hmxxq0y8h79f3228vs0czc4uz5jdgjt0appp26",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ktld67cnuc592xd6xjgfh2n4d3f8av4mn53lul"
   },
   {
     "id": "terra14pfzu2umpa3m64ad3qpsxu0qgkvfl42qmq4l6p",
-    "lp_token_id": "terra17cfp93qzf62qyds74jpcyxvs04cvrmf7dd4hau",
     "asset_ids": [
       "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17cfp93qzf62qyds74jpcyxvs04cvrmf7dd4hau"
   },
   {
     "id": "terra14q2h9nce4spj8n74g6kppj3yf86qx8hsrqngfh",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra14rmvvzfs88axcrk0farsdswylj55umpj6kqh79",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra16ea8pnh3hu69kzqqps5gqw0zdd94hgul9tfnzw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra14t6yzxt5vhx4dyjknzj78tge6j8385awnczxpg",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1ucme9gd7wr7lx0sysnydhdhaqtrg4403nrqm0l"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra14tqq6d7n79sfjmeeqgkmewyhq65dvczgym5rhq",
-    "lp_token_id": "terra1z6x7xnsgye3gzs2mlj5v2gmyw8c35amrgu5327",
     "asset_ids": [
       "terra1lm2lwzrpmyyt2qfhkmj7rwvh7yrh0npzpl6k7v",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1z6x7xnsgye3gzs2mlj5v2gmyw8c35amrgu5327"
   },
   {
     "id": "terra14wt2rhghhtuyl07h4ls78hjuh5gk4nxj66u2tp",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vlqeghv5mt5udh96kt5zxlh2wkh8q4kewkr0dd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra14xpe4dx4xt3cxmyhlnnm4rhpn3umhw0peyva5u",
-    "lp_token_id": "terra1h0y6p9c6njvagcd7sar7kazpx4djymuzft3jns",
     "asset_ids": [
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
       "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1h0y6p9c6njvagcd7sar7kazpx4djymuzft3jns"
   },
   {
     "id": "terra14zcs4sshhncym3ahuczw2rg7r70xhd9zl90mzt",
-    "lp_token_id": "terra15ua5xjmgyurtrltn9gp6r7cap79xdfjksxecms",
     "asset_ids": [
       "terra1sussd2d7r3y5k6up6n6sxap3ee75gegxah96up",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra15ua5xjmgyurtrltn9gp6r7cap79xdfjksxecms"
   },
   {
     "id": "terra14zhkur7l7ut7tx6kvj28fp5q982lrqns59mnp3",
-    "lp_token_id": "terra1y8kxhfg22px5er32ctsgjvayaj8q36tr590qtp",
     "asset_ids": [
       "terra178v546c407pdnx5rer3hu8s2c0fc924k74ymnn",
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1y8kxhfg22px5er32ctsgjvayaj8q36tr590qtp"
   },
   {
     "id": "terra150jz4237l3dfhhpppdrnz78hp0kw2ujqczf2e0",
-    "lp_token_id": "terra1vheyufspfcfh3ka9nafmxec0lwzls80cuf3sd7",
     "asset_ids": [
       "uusd",
       "terra12yvwzt5ayh396hgmyd0rwnamgg4g3mxrdgg7c6"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1vheyufspfcfh3ka9nafmxec0lwzls80cuf3sd7"
   },
   {
     "id": "terra153xclqwcvxch99mclac5fxuu4cmeu7w7mamghu",
-    "lp_token_id": "terra1ze0k9tty5hrn0t0m2dt4j0sde7vgjsrttczt7g",
     "asset_ids": [
       "terra10pvdslu4j8x6rqm2uuvh7dwd3rtaw9qq37g7v7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ze0k9tty5hrn0t0m2dt4j0sde7vgjsrttczt7g"
   },
   {
     "id": "terra15587sd3nkaqhlve76nxxhp6a5ep6qejh4lnnca",
-    "lp_token_id": "terra1tpx744z60ysm4ntrpk84whqp9tunmrgzm6utcf",
     "asset_ids": [
       "terra1c6jwuklh3262naafvnlw8llvns9856uvc50z95",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1tpx744z60ysm4ntrpk84whqp9tunmrgzm6utcf"
   },
   {
     "id": "terra155rgjn955ppq9vz5gapcfgwaf6vg9294xp2kcj",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra15hp9pr8y4qsvqvxf3m4xeptlk7l8h60634gqec"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1580sp4lade7khxntaq8856we6480p4gg6xrzw7",
-    "lp_token_id": "terra1nrs4azly4lur2e525pfalvucf5vhe4vgh4htd0",
     "asset_ids": [
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
       "terra1u553zk43jd4rwzc53qrdrq4jc2p8rextyq09dj"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1nrs4azly4lur2e525pfalvucf5vhe4vgh4htd0"
   },
   {
     "id": "terra1583mexe3t5gwfjf97paz3r8m23dxw9gjqa2ap6",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1cjf3m2zsx4lu6c0edhfcvp0v4hps6gfr79hyc4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra15asyerx0su2j3urlsn2xea0klrr5dpd75jamwj",
-    "lp_token_id": "terra1g5pe82m6hv90h2ed8esz5ldw8jpcw6y209k788",
     "asset_ids": [
       "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr",
       "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1g5pe82m6hv90h2ed8esz5ldw8jpcw6y209k788"
   },
   {
     "id": "terra15ge8z5l33w4u2lnq6udk8dpywglcpgxyl0h0dc",
-    "lp_token_id": "terra1fep5kj2pr4t9u4d5552qlfdhuc9m4h0g6g9mam",
     "asset_ids": [
       "uusd",
       "terra149755r3y0rve30e209awkhn5cxgkn5c8ju9pm5"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fep5kj2pr4t9u4d5552qlfdhuc9m4h0g6g9mam"
   },
   {
     "id": "terra15kkctr4eug9txq7v6ks6026yd4zjkrm3mc0nkp",
-    "lp_token_id": "terra1ndlx5ndkknvmgj6s5ggmdlhjjsz0w6wrnwn5cf",
     "asset_ids": [
       "uusd",
       "terra10h7ry7apm55h4ez502dqdv9gr53juu85nkd4aq"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ndlx5ndkknvmgj6s5ggmdlhjjsz0w6wrnwn5cf"
   },
   {
     "id": "terra15n30h56p9zva8gfp7ejd0smw2zf5xlxwelgg95",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1tt9jmf58nvaj8l0lckwfekfl43verjdpywcdwa",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra15n7vemjsxv7w4wgnwqtzufp6tddmycqsklgqe3",
-    "lp_token_id": "terra1e3t3td7uas3ed0gyu9xcyvmh6gxn6xe96yat8w",
     "asset_ids": [
       "terra1esezx70a44cqc4pjq0qt3k7k93ksuvepfksscy",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1e3t3td7uas3ed0gyu9xcyvmh6gxn6xe96yat8w"
   },
   {
     "id": "terra15nqcvvt4mag63ezmejxrdqehsydn7d3520hx7u",
-    "lp_token_id": "terra1d9myqs75njsaymp9yhrnzkkwhg0rsv9gpwcx60",
     "asset_ids": [
       "terra1jm9jv95f0w3e0kk3kxxvtqg50456mf2c92xd7f",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1d9myqs75njsaymp9yhrnzkkwhg0rsv9gpwcx60"
   },
   {
     "id": "terra15qa20t4hrq27ugcyut363mum72hdlgcqnannm2",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra15rl2agmgqjwlx3qqqe9rfjcvs3lxl2e3srzwda",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1a59ns8fnk04sj982ymkvx9ygscmf4jjtm4sltg",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra15sut89ms4lts4dd5yrcuwcpctlep3hdgeu729f",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra15yyefja9as60nfn5dmyqt8tm3flddyvn3apf3s",
-    "lp_token_id": "terra1y4z7u7psjqyxu4uw5rwz8wmhwrpweay4t0le42",
     "asset_ids": [
       "terra130fhr9jz0nylzhdvuwcpp3hne2s5qlft6hfzgv",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1y4z7u7psjqyxu4uw5rwz8wmhwrpweay4t0le42"
   },
   {
     "id": "terra15zv6wcyqkw9ye86qku2yesqdgpr9qsz2xus4yx",
-    "lp_token_id": "terra1ylqfv4ykp65gxxx5e39qe5ahzm52f20u8equxd",
     "asset_ids": [
       "terra1u553zk43jd4rwzc53qrdrq4jc2p8rextyq09dj",
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ylqfv4ykp65gxxx5e39qe5ahzm52f20u8equxd"
   },
   {
     "id": "terra163pkeeuwxzr0yhndf8xd2jprm9hrtk59xf7nqf",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1650mr52prhczyyjz9rec0ye38q5j55v7gq6wc7",
-    "lp_token_id": "terra1srmemhy8etjaam7ksnl2062x9emwg7ykrfvnz2",
     "asset_ids": [
       "terra1js38ca30k0gt9rz53jc8x47yt638l8f86d5lpt",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1srmemhy8etjaam7ksnl2062x9emwg7ykrfvnz2"
   },
   {
     "id": "terra1670lwuaqtzw43q402anw4aj44ud9nqd87d639f",
-    "lp_token_id": "terra1u6ua0t8url95p2dh7tp6kvqp04h48dxx5njclp",
     "asset_ids": [
       "terra172hwjglf7rsgrnwet52zqnzjhg7vjgcpm7nctn",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1u6ua0t8url95p2dh7tp6kvqp04h48dxx5njclp"
   },
   {
     "id": "terra167gwjhv4mrs0fqj0q5tejyl6cz6qc2cl95z530",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1zsaswh926ey8qa5x4vj93kzzlfnef0pstuca0y",
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra169l808rtk42ukexh3wqyx2cgxp4gvn5fqmn5zq",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
       "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra16aunxdkl5pu0ftz8q7sgapmwtlls078lj56r9e",
-    "lp_token_id": "terra1myejqyh8u3q5prx6h8p9hplswdhwtuxuk5stc4",
     "asset_ids": [
       "terra1r6pcn0wdes6lrtxty3xu253c02grcvuxmqg4s9",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1myejqyh8u3q5prx6h8p9hplswdhwtuxuk5stc4"
   },
   {
     "id": "terra16eecm8exp3p82ld5eh5feweup0qvfv8468np6j",
-    "lp_token_id": "terra1yrthzcrf6p0l568rk2uumzfg0355zedywmaf8z",
     "asset_ids": [
       "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
       "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1yrthzcrf6p0l568rk2uumzfg0355zedywmaf8z"
   },
   {
     "id": "terra16jv42g5t95zj2rvddzqvvd5sjvpvtz5fz5sksz",
-    "lp_token_id": "terra1z038v5j6mlwluahjjy6z73q6ckq6rwkllj5xue",
     "asset_ids": [
       "terra1rfqm5zwkep3jk845nf565yyua66uj654y2vzx3",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1z038v5j6mlwluahjjy6z73q6ckq6rwkllj5xue"
   },
   {
     "id": "terra16kgssn83sz92u22mmqtgmd795edtttu7apjsm9",
-    "lp_token_id": "terra1gk602sa0jwk73xlr8tpkd3fpukhfa8hjety68r",
     "asset_ids": [
       "terra17zucl25842g99vytr9yzw0eqmql3wwpql357cx",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1gk602sa0jwk73xlr8tpkd3fpukhfa8hjety68r"
   },
   {
     "id": "terra16pwrn7frj4d8r4dfc3l8y3xkt5uk2505ad7nvm",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "umnt",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra16r4zqs04jzyrert9udg2s8g4qnrqy9syw4kxhp",
-    "lp_token_id": "terra1gjasf5qq2jlmzle066tylul3d0s7vd6g667p7e",
     "asset_ids": [
       "terra1ml4r2ry9pf9evmahn0nh5nzjzntf63wzmnull3",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1gjasf5qq2jlmzle066tylul3d0s7vd6g667p7e"
   },
   {
     "id": "terra16rzrqaa3srgffadx3al0cjf9s6au0dy6ertxtk",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
       "terra1nagqpmyw55yjphea4rhntlfv87ugmeaj8ym756"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra16w76qmlwdevxvt9xnfafmczrjyar6rh5rtsyhw",
-    "lp_token_id": "terra122tkw2svjgx50027hlf52xqca94sq6s4mkk9d8",
     "asset_ids": [
       "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra122tkw2svjgx50027hlf52xqca94sq6s4mkk9d8"
   },
   {
     "id": "terra16wwzrfv28lhqzv7l9m9qnpzyae600dsratzqg7",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yeyr6taynkwdl85ppaggr3zr8txhf66cny2ang",
       "uchf"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra16x00f2haetp736xgj8v0t2p3ju6tgnc4f8pzd8",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1skjr69exm6v8zellgjpaa2emhwutrk5a6dz7dd",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra170athjxhauwzdn3tejfcv49pej3atyv4qwffrm",
-    "lp_token_id": "terra1xhjavlxlfwqw2w5hj4395m7stl4ut5zus6mn4x",
     "asset_ids": [
       "terra1jx4lmmke2srcvpjeereetc9hgegp4g5j0p9r2q",
       "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1xhjavlxlfwqw2w5hj4395m7stl4ut5zus6mn4x"
   },
   {
     "id": "terra1774f8rwx76k7ruy0gqnzq25wh7lmd72eg6eqp5",
-    "lp_token_id": "terra122asauhmv083p02rhgyp7jn7kmjjm4ksexjnks",
     "asset_ids": [
       "uusd",
       "terra1vxtwu4ehgzz77mnfwrntyrmgl64qjs75mpwqaz"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra122asauhmv083p02rhgyp7jn7kmjjm4ksexjnks"
   },
   {
     "id": "terra178jydtjvj4gw8earkgnqc80c3hrmqj4kw2welz",
-    "lp_token_id": "terra1rqkyau9hanxtn63mjrdfhpnkpddztv3qav0tq2",
     "asset_ids": [
       "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1rqkyau9hanxtn63mjrdfhpnkpddztv3qav0tq2"
   },
   {
     "id": "terra17dh7ekvz3qeghj50rqphx9es33qr5z5c5dhgdz",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra17eakdtane6d2y7y6v0s79drq7gnhzqan48kxw7",
-    "lp_token_id": "terra1azk43zydh3sdxelg3h4csv4a4uef7fmjy0hu20",
     "asset_ids": [
       "uusd",
       "terra1m6j6j9gw728n82k78s0j9kq8l5p6ne0xcc820p"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1azk43zydh3sdxelg3h4csv4a4uef7fmjy0hu20"
   },
   {
     "id": "terra17ef74ttzva3fg7kc29w8na3nut8ugcdmxyycw2",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "uchf"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra17gtlmwdasc0p8rzms7wzhts4nshu47f5xud05w",
-    "lp_token_id": "terra17mwkhsau43y602yev5nmgzjhel5jsen433wf22",
     "asset_ids": [
       "terra1vchw83qt25j89zqwdpmdzj722sqxthnckqzxxp",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17mwkhsau43y602yev5nmgzjhel5jsen433wf22"
   },
   {
     "id": "terra17lrhh6zh99g2u2d92y77xn8sg3j4sp9frkga3d",
-    "lp_token_id": "terra1fwj38qsjpj7huatrms3ptp5spgnmz03ghmdhtw",
     "asset_ids": [
       "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
       "terra1hj8de24c3yqvcsv9r8chr03fzwsak3hgd8gv3m"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fwj38qsjpj7huatrms3ptp5spgnmz03ghmdhtw"
   },
   {
     "id": "terra17mu25k7a2lj7pn8vjgtc5vjvah6gkt6njgh4q5",
-    "lp_token_id": "terra1yjvlgj80jkzwakqv65tzfwctdehqav4jujgx37",
     "asset_ids": [
       "uusd",
       "terra1ptdxmj3xmmljzx02nr4auwfuelmj0cnkh8egs2"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1yjvlgj80jkzwakqv65tzfwctdehqav4jujgx37"
   },
   {
     "id": "terra17mwfdz84uee5vsq28463vng93s9w9v08l2m83r",
-    "lp_token_id": "terra1z9xh489wp8wksdqh43wsmmyvm9qepdltq87aqy",
     "asset_ids": [
       "terra1dwvauhhpsmhwjf2x32uqeukg3zdgm89zy6004g",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1z9xh489wp8wksdqh43wsmmyvm9qepdltq87aqy"
   },
   {
     "id": "terra17nntay5n5c7za2yzgrgfcl9jaytyq37qzrwg6z",
-    "lp_token_id": "terra1ydqalj4l3ztvn3pr0rmz42d6wam95nae2e2xz5",
     "asset_ids": [
       "terra1tm2jhnfh6hmnpvzsyfteqhcn6h5uw2qafr48yh",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ydqalj4l3ztvn3pr0rmz42d6wam95nae2e2xz5"
   },
   {
     "id": "terra17q7jut5sw89jcad93ww25m8xmqxfx4hymdk4c9",
-    "lp_token_id": "terra1757aqwhfgdjdadpwvy9hv324g4ss73nn43eqp4",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1757aqwhfgdjdadpwvy9hv324g4ss73nn43eqp4"
   },
   {
     "id": "terra17rmhzak7ymvwlwr275neppvxkrr3xl6vj0dczr",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1e6lfxnuyqg3wxvczuz0zkmvr40ldvqx26eqk5g",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra17rvtq0mjagh37kcmm4lmpz95ukxwhcrrltgnvc",
-    "lp_token_id": "terra1p60datmmf25wgssguv65ltds3z6ea3me74nm2e",
     "asset_ids": [
       "uusd",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1p60datmmf25wgssguv65ltds3z6ea3me74nm2e"
   },
   {
     "id": "terra17vk5j4mhxnpl74xmndmyjfma3ynpef6kj7jhuj",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1zawrkv57eh7rne45zjta7s876jqc59slrev9xy",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra17y0ujwl2far0rtm5qqjlx6ghtndcpyzqulur3e",
-    "lp_token_id": "terra14r3jnk537uwkgvuwg227jj3z50xcetwtjcj7sh",
     "asset_ids": [
       "terra1u72jtyujxu8dmpxedrrtmt5tekn0usf09r2a9h",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14r3jnk537uwkgvuwg227jj3z50xcetwtjcj7sh"
   },
   {
     "id": "terra17zp4dqu3d2sj9kq8uqnsvwy4ll66g7380uh03s",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dwyd6vds479kv54f7kucevny97lge20c3s9w2k",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra180jp452au9sfwq4kuxtsd9q2wzjfu6v9ghrkax",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1dj2cj02zak0nvwy3uj9r9dhhxhdwxnw6psse6p"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1830q85e520kyhh5e0a254gvt88z8ngxa05tj6q",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1h8hmr0em0avkz4kzuwgakyxrdvxqwg5d3cg4sd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra187406r5f8nl09xskt0p6zeq54hs86m6j04q35f",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra187pxc9su35stqfdd02xy2r778qd83lruaey3fq",
-    "lp_token_id": "terra1lcrpz5rgtqu6dejec7nrglh6qqgt8326ecwral",
     "asset_ids": [
       "terra19mcqz609t5vcudfatwexuhta0mrs49fu9dqj2s",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1lcrpz5rgtqu6dejec7nrglh6qqgt8326ecwral"
   },
   {
     "id": "terra188xye9e9w0yg39qtxq8tnzfmprjz6h646zgz72",
-    "lp_token_id": "terra1hdthg6xxx5svjh079x0frrzwl5wyytw2l5qm65",
     "asset_ids": [
       "terra1gxztmp6dlu8xv8kdlty6259gl845mw53gakw9t",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1hdthg6xxx5svjh079x0frrzwl5wyytw2l5qm65"
   },
   {
     "id": "terra1896hql9gx7m8wpxaulqk453jm9r9fcm2q2jrlk",
-    "lp_token_id": "terra1f0zagera2smyvl3qr6vr3uvtsem8m2t60lufr2",
     "asset_ids": [
       "uusd",
       "terra1cc3enj9qgchlrj34cnzhwuclc4vl2z3jl7tkqg"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1f0zagera2smyvl3qr6vr3uvtsem8m2t60lufr2"
   },
   {
     "id": "terra18adm0emn6j3pnc90ldechhun62y898xrdmfgfz",
-    "lp_token_id": "terra1x3musrr03tl3dy9xhagm6r5nthwwxgx0hezc79",
     "asset_ids": [
       "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1x3musrr03tl3dy9xhagm6r5nthwwxgx0hezc79"
   },
   {
     "id": "terra18cxcwv0theanknfztzww8ft9pzfgkmf2xrqy23",
-    "lp_token_id": "terra1m8mr9u3su46ezxwf7z7xnvm0jsapl2jd8vgefh",
     "asset_ids": [
       "uusd",
       "terra18ej5nsuu867fkx4tuy2aglpvqjrkcrjjslap3z"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1m8mr9u3su46ezxwf7z7xnvm0jsapl2jd8vgefh"
   },
   {
     "id": "terra18dtgqxmc30g92pshm2u2pj9h64q2v4snqh8tma",
-    "lp_token_id": "terra1h70xcjaq5a4p4r02qjwqgvvpe9k5l9aafnyelh",
     "asset_ids": [
       "terra1ffute26m0e5uq3wmzys3452dge62m99u0xz30u",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1h70xcjaq5a4p4r02qjwqgvvpe9k5l9aafnyelh"
   },
   {
     "id": "terra18em0a2s6ca7j00sa87h8ypdvxw6cyxvddt9a8p",
-    "lp_token_id": "terra12wg09c4azptm8yaw7cadhz8u2nvthj0xm99rva",
     "asset_ids": [
       "terra1hd4hgml43g4k50nlyhuntsaw8p7rvnrht0f9e0",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra12wg09c4azptm8yaw7cadhz8u2nvthj0xm99rva"
   },
   {
     "id": "terra18f063y03tq2tdj20gcm7w5t0an29m7yex0cvy0",
-    "lp_token_id": "terra1kr5twwkkdr38wa3t2477cmmrwwpjuggxl962y9",
     "asset_ids": [
       "terra1z454qecteghkd8m3shgd48cdc7j7vtnsgxh4z7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1kr5twwkkdr38wa3t2477cmmrwwpjuggxl962y9"
   },
   {
     "id": "terra18gdjzd5p76dwywsqn7kgxsadfllw6csghl37vv",
-    "lp_token_id": "terra1tnpd7tzz7nyd7a2uq2kcu0r9pue5fwmafph9qg",
     "asset_ids": [
       "terra1twcwynuvhs778m8x46n7e6gyvu7srtkjcaufxd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1tnpd7tzz7nyd7a2uq2kcu0r9pue5fwmafph9qg"
   },
   {
     "id": "terra18j6lacah32zsxfmx8uevzq93ryzx5qlt3r3jk5",
-    "lp_token_id": "terra19rc9ttpt80k7mgmy8e0t9e3r6q4m5mwvwyjwul",
     "asset_ids": [
       "uusd",
       "terra1ax3mp4cs78xkryavm733s2m4exsv72kd9c4c5g"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19rc9ttpt80k7mgmy8e0t9e3r6q4m5mwvwyjwul"
   },
   {
     "id": "terra18pykmlsv9llayy0j252h365vkh9h787jla9vg8",
-    "lp_token_id": "terra1lgr4y6xd92m53mdrtw2jk4zs87hahyw72k0kh6",
     "asset_ids": [
       "uusd",
       "terra19cmt6vzvhnnnfsmccaaxzy2uaj06zjktu6yzjx"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1lgr4y6xd92m53mdrtw2jk4zs87hahyw72k0kh6"
   },
   {
     "id": "terra18raj59xx32kuz66sfg82kqta6q0aslfs3m8s4r",
-    "lp_token_id": "terra17mau5a2q453vf4e33ffaa4cvtn0twle5vm0zuf",
     "asset_ids": [
       "terra1jx4lmmke2srcvpjeereetc9hgegp4g5j0p9r2q",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17mau5a2q453vf4e33ffaa4cvtn0twle5vm0zuf"
   },
   {
     "id": "terra18rwpsjq4pcyv2cj2555a74yykwkrn3yktktlrc",
-    "lp_token_id": "terra1erl67wndtyf2nngpy2lr0xj5z7yrustt3v2jew",
     "asset_ids": [
       "uusd",
       "terra1lj2t6zem4kk3cf400srvhaczpv2lg8kzpy5xr5"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1erl67wndtyf2nngpy2lr0xj5z7yrustt3v2jew"
   },
   {
     "id": "terra18sdrrnm8v283m57pwr2d8m5hlxmwj2tgajj7nl",
-    "lp_token_id": "terra1ter57huylshhqmkjr0m8kkl773tk7f5p3dgjqv",
     "asset_ids": [
       "terra1jzvh42e8auxk63dg5vdp4lh0fct8vw8pn2s34d",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ter57huylshhqmkjr0m8kkl773tk7f5p3dgjqv"
   },
   {
     "id": "terra18u4fdqhlsxraltxj9xq6rdf5h8ttp6quwtqhxa",
-    "lp_token_id": "terra1arxzxdelkjpz6fgh37vszpw23qpsncy4rfatsx",
     "asset_ids": [
       "terra1av86k92kuj9jem24pmrv3j6xkrltr2xluz4665",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1arxzxdelkjpz6fgh37vszpw23qpsncy4rfatsx"
   },
   {
     "id": "terra18xk94xj3qyrv4laxy25hhvwggr8d4g5z6ynl3p",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1s0fnj6cz44e2j45293320wmwmjp5pmdkuuv878"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra18z9fg8nd7dvccqnmyhy2p5t4pdak9c8j9qkr4y",
-    "lp_token_id": "terra17k56585u8yu084060vjlgf4jgmswxahguee47n",
     "asset_ids": [
       "terra12hesat74nzz6av5hw2c5qxxqkhafxsgjhgnd6y",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17k56585u8yu084060vjlgf4jgmswxahguee47n"
   },
   {
     "id": "terra19073h5d7rczrnu49r8aje5yly5llenv878eekm",
-    "lp_token_id": "terra1k67ut87c2up66tury4qc4n96d85t43u20v24sy",
     "asset_ids": [
       "terra12qxyx2l90c37kylw4jqe8t40ppnrnu8wqmx940",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1k67ut87c2up66tury4qc4n96d85t43u20v24sy"
   },
   {
     "id": "terra1935xkvhhrv8aeq7sl5hqez5uxlwvld3098mjmp",
-    "lp_token_id": "terra1l0yxvzzszzfcrfcle55wdf2xxmalc9eg5c28ej",
     "asset_ids": [
       "uusd",
       "terra1y0spkg2up7ddqd98f9d45wacfwjmdvpq702y72"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1l0yxvzzszzfcrfcle55wdf2xxmalc9eg5c28ej"
   },
   {
     "id": "terra194j4rhezku4dmfz2vsnpzqv0actlg3xepg7l3t",
-    "lp_token_id": "terra1efsarez7elxhvgeulu4zgmtg6g9rm3smasgglg",
     "asset_ids": [
       "uusd",
       "ibc/FA0006F056DB6719B8C16C551FC392B62F5729978FC0B125AC9A432DBB2AA1A5"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1efsarez7elxhvgeulu4zgmtg6g9rm3smasgglg"
   },
   {
     "id": "terra196s9l7x89eue0tw37zy3ghxh42lpyfn4v5qsk3",
-    "lp_token_id": "terra1zck3zn662n00tvfhmwaf4ujltr885qt5v2n4sn",
     "asset_ids": [
       "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1zck3zn662n00tvfhmwaf4ujltr885qt5v2n4sn"
   },
   {
     "id": "terra198q4sqvt4yczlxxs9cjtktqdy7tzthz8vhz6xq",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1aaqzva7adgwtzfkt9nmrmuvkg9s6lmsgtkg3jd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra199dwfkrv44n52nrtyf4fsj0tp9s60vl0xuaaaw",
-    "lp_token_id": "terra1y6frqkq3ghvypja2t9uqxkfulpaqeuhfzm69vp",
     "asset_ids": [
       "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1y6frqkq3ghvypja2t9uqxkfulpaqeuhfzm69vp"
   },
   {
     "id": "terra19crn3jxwjspu29kc8ftn27lw5vr3vzk42qar86",
-    "lp_token_id": "terra1cv5l73x70wjcs7tz94tz24y874wgu8xktn02t9",
     "asset_ids": [
       "terra1jju99w456sm6w2snkmatm00gve7cvvzda0j6pn",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1cv5l73x70wjcs7tz94tz24y874wgu8xktn02t9"
   },
   {
     "id": "terra19fjaurx28dq4wgnf9fv3qg0lwldcln3jqafzm6",
-    "lp_token_id": "terra1h69kvcmg8jnq7ph2r45k6md4afkl96ugg73amc",
     "asset_ids": [
       "terra13awdgcx40tz5uygkgm79dytez3x87rpg4uhnvu",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1h69kvcmg8jnq7ph2r45k6md4afkl96ugg73amc"
   },
   {
     "id": "terra19jjgf89q82d84fag9qqr5lyhcmctljjygt2yac",
-    "lp_token_id": "terra1uf5xpl99zm7c8jxtq4c3y32ygjufjk6x6ggrav",
     "asset_ids": [
       "uusd",
       "terra1l2stn9sszzg6qwfqd6ckfa5n58hs4x5wwjaehh"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1uf5xpl99zm7c8jxtq4c3y32ygjufjk6x6ggrav"
   },
   {
     "id": "terra19kagxwyn0hj9nyjwzex5w5w609zggp52a58d22",
-    "lp_token_id": "terra1w34xlv8euhjfffp3mu98qtc9umcwy79jw7pfxe",
     "asset_ids": [
       "terra1we9tgz73r6q3nqxwre5375l0nxh0s7ry47s6j8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1w34xlv8euhjfffp3mu98qtc9umcwy79jw7pfxe"
   },
   {
     "id": "terra19pg6d7rrndg4z4t0jhcd7z9nhl3p5ygqttxjll",
-    "lp_token_id": "terra1uwhf02zuaw7grj6gjs7pxt5vuwm79y87ct5p70",
     "asset_ids": [
       "terra13xujxcrc9dqft4p9a8ls0w3j0xnzm6y2uvve8n",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1uwhf02zuaw7grj6gjs7pxt5vuwm79y87ct5p70"
   },
   {
     "id": "terra19pkpq2hmmag2954jdwpd4wqrhqp64umrtw6tmc",
-    "lp_token_id": "terra1a6unyqwce532dq9z9uez3l5du2zqhqlek8cg2p",
     "asset_ids": [
       "terra1yfjk0jn42krryudpv04mg0c3ghuq4u3qtyztgq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1a6unyqwce532dq9z9uez3l5du2zqhqlek8cg2p"
   },
   {
     "id": "terra19pldqzpsglzusuj59tw750yp5um885c4u888cp",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18zg84fg56lthpjd8skj70l4zd3puyul5weqfer",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra19slzdkvt3kekyq4ydp3ky4pjuus5lmedafkkzs",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra19vrx0crmjpkahyhmmtlsgcnzgss32nwgnqudfq",
-    "lp_token_id": "terra1lfffm32qqz3lt4vt36tcslmdayuh2lyvm0yhdp",
     "asset_ids": [
       "terra16t8cdhps9sxk7sje2w77fay8lh4se3p4gqjeya",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1lfffm32qqz3lt4vt36tcslmdayuh2lyvm0yhdp"
   },
   {
     "id": "terra19wz5r5kq0qewqhghvgrceqhq6fj2aw43j68u92",
-    "lp_token_id": "terra1xtrwsa7dh7jz0whaa5fsy0pu9x83z93r7lhmy4",
     "asset_ids": [
       "uusd",
       "terra1drsjzvzej4h4qlehcfwclxg4w5l3h5tuvd3jd8"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1xtrwsa7dh7jz0whaa5fsy0pu9x83z93r7lhmy4"
   },
   {
     "id": "terra19z6n7l67rkg6y7vggwr3jh889t9vg6yn2jdl9n",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra19zmlnmj5pqpwvtzzgyzqurlul972myjzntsmn8",
-    "lp_token_id": "terra1aarnpmtzs2nrkpr7tylsh8zevewjgg8gjp3djr",
     "asset_ids": [
       "terra1lcs47eqhugywzrf83xhk65skmfqmxgvkqfq64g",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1aarnpmtzs2nrkpr7tylsh8zevewjgg8gjp3djr"
   },
   {
     "id": "terra1a2k9k9g5gyuats98z69ssk4aqjt38a9z943xd9",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1zvhvg09zeyl3txrc7v3crnqnnwc0d2nvgxvdhd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1a4cjrs86m97rk0g5yuds8yjd7f0en5drqnynwk",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vsl7etwe53vglc2xq2rdt7mujarcjy9j694hdk",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1a5cc08jt5knh0yx64pg6dtym4c4l8t63rhlag3",
-    "lp_token_id": "terra1veqh8yc55mhw0ttjr5h6g9a6r9nylmrc0nzhr7",
     "asset_ids": [
       "uusd",
       "terra1qqfx5jph0rsmkur2zgzyqnfucra45rtjae5vh6"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1veqh8yc55mhw0ttjr5h6g9a6r9nylmrc0nzhr7"
   },
   {
     "id": "terra1a6uk8kz25l59krr2m683ph8l6waky0nphm5l66",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1g0pm8xm5c2dq4qtv8j9a80hg4mhe5ndy8qad07",
       "uchf"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1a852hrcu4rsafrf9wftvqstl2vqn2argplnnmp",
-    "lp_token_id": "terra1kdx0f3un67ds5a0pnx38krgpvkfar98gl3myfu",
     "asset_ids": [
       "terra14q0a4tfmdkwrvzakv7nq9jg2d36w8uj9jkhgee",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1kdx0f3un67ds5a0pnx38krgpvkfar98gl3myfu"
   },
   {
     "id": "terra1a8gkw3a2kc05wrnqv2tmvl0h3ej2gwenlakakh",
-    "lp_token_id": "terra1dchs757cqkjarjyl3cwk37kcd9tkvhkuypfr2f",
     "asset_ids": [
       "terra1zvncquef39sne2adlvl3xpzcsge0fypakp00zx",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1dchs757cqkjarjyl3cwk37kcd9tkvhkuypfr2f"
   },
   {
     "id": "terra1ad4crwtu2vpc0qcmw4xmypcy3asp54w3kg95cv",
-    "lp_token_id": "terra1vv83fgkfng78attun85wqgkp9yue39euyz40k3",
     "asset_ids": [
       "terra1hj8de24c3yqvcsv9r8chr03fzwsak3hgd8gv3m",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1vv83fgkfng78attun85wqgkp9yue39euyz40k3"
   },
   {
     "id": "terra1aduehngz4gzd68k8v474yaejfh7thf7cx8ml93",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1u553zk43jd4rwzc53qrdrq4jc2p8rextyq09dj",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ae0jhhxlwx46xp9uf9cwlca6pm5wa79wf8ppgj",
-    "lp_token_id": "terra1nannmaymqrxt00ya03ytfkhr027zrrgckuq7fg",
     "asset_ids": [
       "terra122anargqcp9anz2cmuwc3u5m4nww6fpvyc39tz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1nannmaymqrxt00ya03ytfkhr027zrrgckuq7fg"
   },
   {
     "id": "terra1afdz4l9vsqddwmjqxmel99atu4rwscpfjm4yfp",
-    "lp_token_id": "terra1stfeev27wdf7er2uja34gsmrv58yv397dlxmyn",
     "asset_ids": [
       "uusd",
       "terra1w7zgkcyt7y4zpct9dw8mw362ywvdlydnum2awa"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1stfeev27wdf7er2uja34gsmrv58yv397dlxmyn"
   },
   {
     "id": "terra1afslx9uqz7gw348kae05drt39uu2nxnrhlgupu",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
       "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ag6fqvxz33nqg78830k5c27n32mmqlcrcgqejl",
-    "lp_token_id": "terra1tragr8vkyx52rzy9f8n42etl6la42zylhcfkwa",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1tragr8vkyx52rzy9f8n42etl6la42zylhcfkwa"
   },
   {
     "id": "terra1aghtgj6c4m83cuyzfdq7cagh3e4yvksyh0afjk",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ahzjyx9l523fs5s7xe6luqy9auc5tdwzgqz0k9",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra18yqdfzfhnguerz9du5mnvxsh5kxlknqhcxzjfr"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ajj4klvt3gpf5mmkmlsaz7t23paaanm68xn9dj",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1t5kcd9285mqczsyy2ztu96h8h8ecpy5sf6h0qu",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1alaaant5ykususyuv0x6k298sh8kl8qkpkuu8e",
-    "lp_token_id": "terra1668hdgce50nwxs8myp33f4ywvs6lanzxvvu9sx",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1668hdgce50nwxs8myp33f4ywvs6lanzxvvu9sx"
   },
   {
     "id": "terra1alrzkvqfe2dczdr33kf8et205eeclcqzyvpez8",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1amv303y8kzxuegvurh0gug2xe9wkgj65enq2ux",
-    "lp_token_id": "terra17gjf2zehfvnyjtdgua9p9ygquk6gukxe7ucgwh",
     "asset_ids": [
       "uusd",
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17gjf2zehfvnyjtdgua9p9ygquk6gukxe7ucgwh"
   },
   {
     "id": "terra1atzg5zp4p9sy7k9urun8q703upffm2maffm8tz",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19cxwwhtkpp4qvf4tvjmhh8lnh8lle7uw7ndqjw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1au85utmuaskgd0uhgmhus35hpaca2munlzuhrd",
-    "lp_token_id": "terra19lttrz4lxk8pxaz8w650t3rupzz2avzud9lm3s",
     "asset_ids": [
       "terra1q9ec5g6q0s3ncl9v068jkk5s2eae8ng3lxqtlf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19lttrz4lxk8pxaz8w650t3rupzz2avzud9lm3s"
   },
   {
     "id": "terra1avv7dftyck6smyxl8k4juw4qkg8pef5stc7kmx",
-    "lp_token_id": "terra1xj8v6a4wajsjdc4r74a0285zuvst2rmkau5txl",
     "asset_ids": [
       "terra10en35kwlud79z2nljssvhp85ep5kx9k0ezzz8s",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1xj8v6a4wajsjdc4r74a0285zuvst2rmkau5txl"
   },
   {
     "id": "terra1awhdnu3pug33yr86gfu8kmkw4kn4cn720gkc3d",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1v7vp6ywlymprx9mk7ngm4uf0xgrz2ektg5wd6z",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1axd3wejrvzx27sn54yjlxlhrrr49zphqw9fpn5",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pzjd5axw303jt40l4pmakfa88d0jpjf8rpmj8n",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ayqus392c2fzs4mgrsnlkzjaqfd5efla72el85",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1l670q2m9j3npltmsqe428mwu0msw336m8jtq00",
       "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1c0afrdc5253tkp5wt7rxhuj42xwyf2lcre0s7c",
-    "lp_token_id": "terra1jvewsf7922dm47wr872crumps7ktxd7srwcgte",
     "asset_ids": [
       "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1jvewsf7922dm47wr872crumps7ktxd7srwcgte"
   },
   {
     "id": "terra1c4ddm3ds2zwun37r7ldek908ypkxxpkvkcat5f",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra100yeqvww74h4yaejj6h733thgcafdaukjtw397",
       "ueur"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1c5swgtnuunpf75klq5uztynurazuwqf0mmmcyy",
-    "lp_token_id": "terra1l8jgxd9uv430rdt2u58h4h7kdfxsle4w6w2ecq",
     "asset_ids": [
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
       "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1l8jgxd9uv430rdt2u58h4h7kdfxsle4w6w2ecq"
   },
   {
     "id": "terra1c7uxt89gap5gcclvhtqvx3wpd0ee2dpjhf0ct6",
-    "lp_token_id": "terra19umy5s6eal7kekrddw792wmcftxvsktc2wxzpf",
     "asset_ids": [
       "terra1vtr50tw0pgqpes34zqu60n554p9x4950wk8f63",
       "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19umy5s6eal7kekrddw792wmcftxvsktc2wxzpf"
   },
   {
     "id": "terra1c9cu5ny2kc0j2njj4lydpetgwrjm9t3raqu4tt",
-    "lp_token_id": "terra13698ymrlv2xpy8l28r6qx5fx420w744zg24qzp",
     "asset_ids": [
       "terra1k7pvdmk0z4hxhcncanp4pxl6ev3hqzeekzu437",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra13698ymrlv2xpy8l28r6qx5fx420w744zg24qzp"
   },
   {
     "id": "terra1cc660x0c7w8ln0rvqftrjt09sjs0wg4xaxtx6s",
-    "lp_token_id": "terra1mr7mh33nyf86vzutwr6ypcv3ceeecfvfdwz0l6",
     "asset_ids": [
       "ibc/73A56F04D27FC4CCF6F75C7516A9698B7411E1CE763E240C8A29A50404F86B53",
       "ueur"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mr7mh33nyf86vzutwr6ypcv3ceeecfvfdwz0l6"
   },
   {
     "id": "terra1ce7rky5mjrjhyadp976r25r05jhslyn0q3rl86",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "terra1042wzrwg2uk6jqxjm34ysqquyr9esdgm5qyswz"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1cgsuvt2nyxxqc6gfg39q2h99s3877mhyhd29uf",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1qqfx5jph0rsmkur2zgzyqnfucra45rtjae5vh6"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1cmehvqwvglg08clmqn66zfuv5cuxgxwrt3jz2u",
-    "lp_token_id": "terra1z0vaks4wkehncztu2a3j2z4fj2gjsnyk2ng9xu",
     "asset_ids": [
       "terra1ustvnmngueq0p4jd7gfnutgvdc6ujpsjhsjd02",
       "terra1ln2z938phz0nc2wepxpzfkwp6ezn9yrz9zv9ep"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1z0vaks4wkehncztu2a3j2z4fj2gjsnyk2ng9xu"
   },
   {
     "id": "terra1cpnemrjze8904e4ggujp86y0vs737uapqqfmjz",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ctt2k8euhqny20vqynjpxqv32nlr0r95gr2eeq",
-    "lp_token_id": "terra16r76trzhj48rj8tmq82f8set2mm6v7qrje3rn3",
     "asset_ids": [
       "terra1ktrxxylv7796wsd8rm7u0dftqhrjfs75r72wnn",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra16r76trzhj48rj8tmq82f8set2mm6v7qrje3rn3"
   },
   {
     "id": "terra1cvur5qlnaqulwt987f2crk8ccttlvztuq9w66a",
-    "lp_token_id": "terra1wrwxmmea6nxktx09hf2f2m5m0473wnq9lxhn66",
     "asset_ids": [
       "terra1zey5xuv48yfjf9y0v6zkyfdtv2du5kau2kdrna",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1wrwxmmea6nxktx09hf2f2m5m0473wnq9lxhn66"
   },
   {
     "id": "terra1cyu32h09k6djqt3a0pgljgan2vass3etl6vcng",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lnrphdxwfre5w7rwazzfnp0k9d4glm63t7gg70",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1d3jylrg6w94akvu0dky0y6l62sktrfzd4zfkq8",
-    "lp_token_id": "terra1w3ffc33tpmwc3fa0ga8jlqne647k3jtjftrsfl",
     "asset_ids": [
       "terra1gtjr689cyaau20k8ezdxy8eup34tntun5xr9l2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1w3ffc33tpmwc3fa0ga8jlqne647k3jtjftrsfl"
   },
   {
     "id": "terra1d6h7dqr20lrtv4zhqntvxpxgwqw694cfvhh4st",
-    "lp_token_id": "terra1ym24m9vg93hgq8hmvc8njquls9sq2x0wqjssvw",
     "asset_ids": [
       "terra1677xekxjqc4f3jqut8yr6p29e8h5zfay37et58",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ym24m9vg93hgq8hmvc8njquls9sq2x0wqjssvw"
   },
   {
     "id": "terra1d6k2mnhpqttsqhae2hwu7rs78nrrwymeq8p40j",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vwz7t30q76s7xx6qgtxdqnu6vpr3ak3vw62ygk",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1d76u99glatdeep6qjkhg48u2a9fvuejcwnasut",
-    "lp_token_id": "terra10etw4xh7ymehx3ngpknfa0p9nq2w7c97vhjzw8",
     "asset_ids": [
       "terra14lmsae6e4d5lu74yt67pkfsdaut4csjtq32a7x",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra10etw4xh7ymehx3ngpknfa0p9nq2w7c97vhjzw8"
   },
   {
     "id": "terra1dcq5sd3y34q4fjwgcja7uhw26xn5ylq33tk3gn",
-    "lp_token_id": "terra1ade4g64fk6jx3udjxrxz0lppqne3y2turx7cc7",
     "asset_ids": [
       "terra1d633fx8wlpgqnns9j4xw66cq6ypdy4u8r0rr7j",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ade4g64fk6jx3udjxrxz0lppqne3y2turx7cc7"
   },
   {
     "id": "terra1dcs9ja40rmdax9g4ffc756w4cf6yvrf4auxye5",
-    "lp_token_id": "terra1wn8t6kcaqhxrhtexkctyfaftrtvczkkh4u4p5w",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1wn8t6kcaqhxrhtexkctyfaftrtvczkkh4u4p5w"
   },
   {
     "id": "terra1dd7g5js5xqqkl2fse28hee38sdes7sv6f79pfd",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10gpgrr85u4g42uu6c3hkkxkggg2nw5kt95yc7x",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1de8xa55xm83s3ke0s20fc5pxy7p3cpndmmm7zk",
-    "lp_token_id": "terra1cksuxx4ryfyhkk2c6lw3mpnn4hahkxlkml82rp",
     "asset_ids": [
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1cksuxx4ryfyhkk2c6lw3mpnn4hahkxlkml82rp"
   },
   {
     "id": "terra1dgqs3aa66l24natsgslvwwkj3henn4c9uesfz9",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1dh2kva6kd99fnq0xa0rn3yjp4dqaw7h806klyt",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1jsxp2vt60nqfsuru6s6ewgfld7vpwgkvv5qqgl",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1dhs8euwxt0hu2vj0cne7v8qnxycsmwef36cshd",
-    "lp_token_id": "terra1u9s0hj3sw840xkygjhemt4rxazv7gv2dgnu45c",
     "asset_ids": [
       "terra1n2rujfc5lscglry30zaptfgncfc0gq4n8my0gv",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1u9s0hj3sw840xkygjhemt4rxazv7gv2dgnu45c"
   },
   {
     "id": "terra1dkc8075nv34k2fu6xn6wcgrqlewup2qtkr4ymu",
-    "lp_token_id": "terra16j09nh806vaql0wujw8ktmvdj7ph8h09ltjs2r",
     "asset_ids": [
       "uusd",
       "terra1csk6tc7pdmpr782w527hwhez6gfv632tyf72cp"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra16j09nh806vaql0wujw8ktmvdj7ph8h09ltjs2r"
   },
   {
     "id": "terra1dl6h9np5xhtwe520ksjawy5q9lh4cznmhmzkw2",
-    "lp_token_id": "terra145423sy3utrl5fh403tj0gpka36aqwu0nvktun",
     "asset_ids": [
       "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
       "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra145423sy3utrl5fh403tj0gpka36aqwu0nvktun"
   },
   {
     "id": "terra1dnz5katpc8374kkuwl6c7pak604u50gfpj6zuv",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1afgfjpny09lvxl06llcy7hfu0m2epfddzn0f75",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1dnzskpmnl0s9la8g4jczfgpzfq62kh766cg3pg",
-    "lp_token_id": "terra1qsem5279xw6ry5ntcffwh0ypnexhhz474j4yhm",
     "asset_ids": [
       "terra1dy469h5zdej955zgn4dlewrqxw2nq2wdegq3y7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qsem5279xw6ry5ntcffwh0ypnexhhz474j4yhm"
   },
   {
     "id": "terra1dpp6zc305d4fux8j3sp2c2x3kaykha8enhl3ur",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13x03uqz06gkam3dq4dgx0tj89dpw3vs2nlftjq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1dqjt2jm908qaayw5hdl36w50sshmgem37suawr",
-    "lp_token_id": "terra1lzacmnuaceg2578lpxemnx5mts5es8fnf2d6u2",
     "asset_ids": [
       "terra1td743l5k5cmfy7tqq202g7vkmdvq35q48u2jfm",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1lzacmnuaceg2578lpxemnx5mts5es8fnf2d6u2"
   },
   {
     "id": "terra1dtsjzg6g5zkqsfwrw0uxlyl6e6u4kna0xzk0q7",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "ugbp"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1dv8tp8nustr58z0mlg8v4jpxjd62s2g2dflwhr",
-    "lp_token_id": "terra1yxlq4zezzvkha2e8wmck0nzx9e26xrjylk2dax",
     "asset_ids": [
       "terra1xktc8znx48tuypg3p47fcgfxrhc07hex0qgpex",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1yxlq4zezzvkha2e8wmck0nzx9e26xrjylk2dax"
   },
   {
     "id": "terra1dy4dpuxev7y4tqa0rhwjrc6e4yz3w9gqr6szz3",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1e3d9xx54vc4fhepvgqhrwt7m97zftaxet2zayz",
-    "lp_token_id": "terra1qchhau7xaa5dtl6mvfftk5qh32qytt9pk9u0c9",
     "asset_ids": [
       "terra1mt2ytlrxhvd5c4d4fshxxs3zcus3fkdmuv4mk2",
       "ueur"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qchhau7xaa5dtl6mvfftk5qh32qytt9pk9u0c9"
   },
   {
     "id": "terra1e4vke4x2tu4xuh6s9zz42rnvghgcuxqcm3t9qx",
-    "lp_token_id": "terra125gygqsnr8sv58w7y8nh2ewdcexxrfkae53pak",
     "asset_ids": [
       "terra1vpehfldr2u2m2gw38zaryp4tfw7fe2kw2lryjf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra125gygqsnr8sv58w7y8nh2ewdcexxrfkae53pak"
   },
   {
     "id": "terra1e59utusv5rspqsu8t37h5w887d9rdykljedxw0",
-    "lp_token_id": "terra17fysmcl52xjrs8ldswhz7n6mt37r9cmpcguack",
     "asset_ids": [
       "terra1dy9kmlm4anr92e42mrkjwzyvfqwz66un00rwr5",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17fysmcl52xjrs8ldswhz7n6mt37r9cmpcguack"
   },
   {
     "id": "terra1e8dxc7saepd8l7cru73eryaakmrk67fc4qgw5j",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1e9zck0ak5ufz94csu83p90xu37q22dhk22trh7",
-    "lp_token_id": "terra1qffrtdpnj9afjw30njnw84f5rfmkxv8c86246h",
     "asset_ids": [
       "terra105hjuy8z0j0w4m0frlaynrnu8smk8qrsk36mas",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qffrtdpnj9afjw30njnw84f5rfmkxv8c86246h"
   },
   {
     "id": "terra1ea9js3y4l7vy0h46k4e5r5ykkk08zc3fx7v4t8",
-    "lp_token_id": "terra1fc5a5gsxatjey9syq93c2n3xq90n06t60nkj6l",
     "asset_ids": [
       "uusd",
       "terra1cc3enj9qgchlrj34cnzhwuclc4vl2z3jl7tkqg"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fc5a5gsxatjey9syq93c2n3xq90n06t60nkj6l"
   },
   {
     "id": "terra1eazr5t02gql7prqus2a8p6cc78y8vks04xc4za",
-    "lp_token_id": "terra1fwwxakw6ue3jt398uneyf8agnwyf2pys8dcjcz",
     "asset_ids": [
       "terra10thstrfuexp5nf9rnazzs433p7zeu9yxr322r9",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fwwxakw6ue3jt398uneyf8agnwyf2pys8dcjcz"
   },
   {
     "id": "terra1efwf7jw3tgyy7uqx3u8j9p0kpl9ts39avgnzec",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ejyqwcemr5kda5pxwz27t2ja784j3d0nj0v6lh",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ek3g47rves5tmulz3h7twl04fawldwhdr7pyxf",
-    "lp_token_id": "terra1gj5azdr9y80d3reegwumpz48ww09sqqym68vrz",
     "asset_ids": [
       "terra1zf00lfqwe6ackx0lcl5ys6lzmdhmvmn6sz2rh8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1gj5azdr9y80d3reegwumpz48ww09sqqym68vrz"
   },
   {
     "id": "terra1elte83u4a6yrw90qmaeee58w94sy6yq7mrf8k0",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1d8h5yckrkgzneng72c8yskgdfd2s9870fuxnfy",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1enhh46s0ry3mnj6zx0rd2jjr0pyuspmueywaxl",
-    "lp_token_id": "terra1hwdhxcm974vmlva2u9cd272ck5aegna8uh9t7n",
     "asset_ids": [
       "terra1w45ywafn2srq3q6svsam067uh8l2smlu7ljzv4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1hwdhxcm974vmlva2u9cd272ck5aegna8uh9t7n"
   },
   {
     "id": "terra1enlwzps4sr4g84jwr3qnx3czcvf5ayjgfyfxuw",
-    "lp_token_id": "terra10dlmpyedw742sjg99kkh3sfyy4e0tqkjfd3qyh",
     "asset_ids": [
       "terra1x95tutcwe4tjxcdvtgrjg5jxkf24sm74xz3leq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra10dlmpyedw742sjg99kkh3sfyy4e0tqkjfd3qyh"
   },
   {
     "id": "terra1eqclhzm2d9r7kecf2v87lja6ghgc4s6fmh9prt",
-    "lp_token_id": "terra1kjk5nxkmz26nds873qml7mqtuv45yqcak60ekq",
     "asset_ids": [
       "uusd",
       "terra1227ppwxxj3jxz8cfgq00jgnxqcny7ryenvkwj6"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1kjk5nxkmz26nds873qml7mqtuv45yqcak60ekq"
   },
   {
     "id": "terra1erdxk0afwhq0hwpftndeayeqct9eluxyzt0v2e",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lrdzs5tgllwqgawtq2emuzn7snpxq87fzzl44y",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1erfdlgdtt9e05z0j92wkndwav4t75xzyapntkv",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "ukrw",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1esaxnyzts8256a8afsgqsghvm263ngzr32c9km",
-    "lp_token_id": "terra143v5xc8zll66xq8zljxulacqylsdhlzwaraz02",
     "asset_ids": [
       "terra1zf5jn0nsureuqaeqmj4pwkrtcm9m7rmlkdjxra",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra143v5xc8zll66xq8zljxulacqylsdhlzwaraz02"
   },
   {
     "id": "terra1et63aq9nclyehc6j05uv5j3nvm8sqfey99u9g2",
-    "lp_token_id": "terra1qn4mpmcjwky96v0cqk0ru8azrk36ghasn8raue",
     "asset_ids": [
       "terra1mgyht7c5usg40gqt57zmcd93cdwt49eehysm9p",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qn4mpmcjwky96v0cqk0ru8azrk36ghasn8raue"
   },
   {
     "id": "terra1et8gmg0khfmv04vznevg5fx9ngucauh6hg3dm3",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1etdkg9p0fkl8zal6ecp98kypd32q8k3ryced9d",
-    "lp_token_id": "terra1c9wr85y8p8989tr58flz5gjkqp8q2r6murwpm9",
     "asset_ids": [
       "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1c9wr85y8p8989tr58flz5gjkqp8q2r6murwpm9"
   },
   {
     "id": "terra1evjf2hq2w6y9t53d2fmxrfddauz8manutpykp4",
-    "lp_token_id": "terra15g2lqpqvv2zn3hz63q2m26vfle3vlgj6cqvny8",
     "asset_ids": [
       "terra1tzkc6jejskv5qnqfa866qrlltx4240n3hwpeay",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra15g2lqpqvv2zn3hz63q2m26vfle3vlgj6cqvny8"
   },
   {
     "id": "terra1ewyn79c2nnzp7g57a54vv6l99lxcjdcd4z770n",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1f9h22l730vxxj5jmrakuwh3neuhdynwy42ezvv",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1f22zcf6m4600eajay6wnzw03lmjdy0f8mjxphe",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra14xulq5g99rfmrm6qkgzmrrspvknupajdqyd92k"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1f2d4qd9wdwrwkksezst20u0dgk867vuf438pah",
-    "lp_token_id": "terra1g7a4hl64r0pmjmdrd3cwsy2cdg2st5x7xlc6m0",
     "asset_ids": [
       "terra1ddjp4wgu52cktzgzvahwkr4dcd95mxaqad2pmu",
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1g7a4hl64r0pmjmdrd3cwsy2cdg2st5x7xlc6m0"
   },
   {
     "id": "terra1f562s8g3y45cqxqn4qftvwcwxh2rc3v68ug2cx",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1u3cykdenv7z3hveg6vfc0w23gfhwkdktftka9a",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1f6d9mhrsl5t6yxqnr4rgfusjlt3gfwxdveeyuy",
-    "lp_token_id": "terra178cf7xf4r9d3z03tj3pftewmhx0x2p77s0k6yh",
     "asset_ids": [
       "uusd",
       "terra1kscs6uhrqwy6rx5kuw5lwpuqvm3t6j2d6uf2lp"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra178cf7xf4r9d3z03tj3pftewmhx0x2p77s0k6yh"
   },
   {
     "id": "terra1f9aln0c98j9w749szx958la7x25chdnz9hqx0v",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1sn208s2cmya87707w4r9hf36znv8ml8dcnhr2d",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1f9l20gvf6vd7wtkga89n2vu69jmpqg0qyzapa5",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ng9dsq2m5mw993s0uljj06scrj5g07sq36lq8t",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1faaael2u6jp9wscfvwqu0376djt8t4rnjmn9p6",
-    "lp_token_id": "terra1twkxlsys3e02tw5kx8x4uw8xvhhv40ym3tsaky",
     "asset_ids": [
       "terra102cjx95xvww7cl9l6usxltk75ww3mpxtyw4lpm",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1twkxlsys3e02tw5kx8x4uw8xvhhv40ym3tsaky"
   },
   {
     "id": "terra1farlsg7xvnj55ttp7y8t39t9e252fusuvqhm85",
-    "lp_token_id": "terra1hq2t2lgg6frwpr9sycwc5cyqqdlv7pam5qehe7",
     "asset_ids": [
       "terra1cxaky6tfw4j0xqx8ezxw60cukmkewpx70kr9du",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1hq2t2lgg6frwpr9sycwc5cyqqdlv7pam5qehe7"
   },
   {
     "id": "terra1fcr6s373mxsw000z5xv9zftmpz2uvc4u0x3dxk",
-    "lp_token_id": "terra166h9t9xrsy0wq8t7hpdjx52eecze4gcussgr44",
     "asset_ids": [
       "terra1ch852sflpmw500y9jzvkpspzw8ej2jf5934g2n",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra166h9t9xrsy0wq8t7hpdjx52eecze4gcussgr44"
   },
   {
     "id": "terra1fd9hxy2ajycyywzgvu72mj0m75myqy75dwuhtn",
-    "lp_token_id": "terra1u2ksckpcec73mmy3gl3l2uc473vl4vh864npt6",
     "asset_ids": [
       "terra1z09gnzufuflz6ckd9k0u456l9dnpgsynu0yyhe",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1u2ksckpcec73mmy3gl3l2uc473vl4vh864npt6"
   },
   {
     "id": "terra1fdwsevq7skhfq93zkg0xxr6zrv29aqupw2fura",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1zd6let0zg0xjn2sestagxv4ax24a4ml6j40qdr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1fehg72ukrnmt56evclq023rpefzjmrwre9k6vl",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1y8w753jk2x2j6f7a9ea30xc2qk5esharn89sk2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1fg8f9s8ltyw59crjde6vrv2chvcprndayk9gt4",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra16wggm67a34msdxasg2vergm2pt289y7930wv7d",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1fggg5s5eayyqm46p6m27xh3manl6c4pt8kfvn2",
-    "lp_token_id": "terra1jaw7xw5904fsarqgugk0h4tl32w385zv5zaax9",
     "asset_ids": [
       "terra15as2k330rp40z3yp8ufs2uqnmdurlzgl643fsp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1jaw7xw5904fsarqgugk0h4tl32w385zv5zaax9"
   },
   {
     "id": "terra1fh2j8kr484725ra3hwc9q3j52h2qdnnwargzhp",
-    "lp_token_id": "terra1a3n5ryr8ud3mw0cdu6gm8yqdcjjmelu5d79g7q",
     "asset_ids": [
       "terra1k8fakrhcg5h87zux06hlds3eswej8389l8fdlc",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1a3n5ryr8ud3mw0cdu6gm8yqdcjjmelu5d79g7q"
   },
   {
     "id": "terra1fl3x3plfat8y82c9wpu6uv97wkqap7lp04a4jr",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
       "terra1nagqpmyw55yjphea4rhntlfv87ugmeaj8ym756"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1fmv3g96s4xc9nrnlkdn87vxyaydd22xsxzel5r",
-    "lp_token_id": "terra1edum55hjxu0fts7wxq5j0umjzm359fenausrup",
     "asset_ids": [
       "terra1l0y8yg0s86x299nqw0p6fhh7ngex3r4phtjeuq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1edum55hjxu0fts7wxq5j0umjzm359fenausrup"
   },
   {
     "id": "terra1fpg2dkcnaca8su8chw6e0m3jlvw0fax8p6ls3a",
-    "lp_token_id": "terra1luejncg2je82xgts7sg3f3g4ytq2473ge5z3px",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1luejncg2je82xgts7sg3f3g4ytq2473ge5z3px"
   },
   {
     "id": "terra1fqf55gk7a2znglw3kh8j5gu0zgfj6sxv4q9ng4",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1lvmx8fsagy70tv0fhmfzdw9h6s3sy4prz38ugf"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1fqhyxfrvlhguw97nuhxm34uvzar8vfr63ft7km",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1fts4e488k0u9xc6etggjdqrcnxvmj48vmd23ly",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra14y5affaarufk3uscy2vr6pe6w6zqf2wpjzn5sh"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1fxn30f9j9a2slvlxxxk6gyjlqnznhprh0wu0mv",
-    "lp_token_id": "terra1wy2cweqqxf0w23g3c9t8e8n5wukcf24fujfhpt",
     "asset_ids": [
       "uusd",
       "terra1a7ye2splpfzyenu0yrdu8t83uzgusx2malkc7u"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1wy2cweqqxf0w23g3c9t8e8n5wukcf24fujfhpt"
   },
   {
     "id": "terra1fykaggpacrhy6rjh2u7vs3ec8p9u3l7ynf6gy8",
-    "lp_token_id": "terra12apekfpt3pzjrcwz7rqjswqr0nsrezjkvlzvzm",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra12apekfpt3pzjrcwz7rqjswqr0nsrezjkvlzvzm"
   },
   {
     "id": "terra1fzjflxpv8e0d8ue7hu7faap6mnd0ckamwje5zp",
-    "lp_token_id": "terra1fhvkxz23x2w5kgsag0dteecwmfu9zk9l0frurh",
     "asset_ids": [
       "terra1pwu44z0gwlfqecwxuxh6kwn46d8930x226drxw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fhvkxz23x2w5kgsag0dteecwmfu9zk9l0frurh"
   },
   {
     "id": "terra1fzlm4rzcctes3g230vfgcqwth94wupgsht96xn",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ng3nsd3u3emflmp4rv7ac70ug3g87pt930g6t5",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1g8kjs70d5r68j9507s3gwymzc30yaur5j2ccfr",
-    "lp_token_id": "terra1qf5xuhns225e6xr3mnjv3z8qwlpzyzf2c8we82",
     "asset_ids": [
       "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn",
       "terra188w26t95tf4dz77raftme8p75rggatxjxfeknw"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qf5xuhns225e6xr3mnjv3z8qwlpzyzf2c8we82"
   },
   {
     "id": "terra1g9rrgs63wm55ad7rv6rmj8hu8nauc0ru4yussv",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra188w26t95tf4dz77raftme8p75rggatxjxfeknw",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1gal8pckrn8w0mxk3q5lkwa0grw2qmdfpkwgex4",
-    "lp_token_id": "terra1fkkffszqrmskfynchj7pr3yrjq7ug27vsah26c",
     "asset_ids": [
       "terra1kvjscdgwuvwc6uzm4rqfjl6nlmuhj28tequlnc",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fkkffszqrmskfynchj7pr3yrjq7ug27vsah26c"
   },
   {
     "id": "terra1gc46an30tdv0n25ch5twgzcsw0wpk2h32gp4nq",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1gg00qrm9l7ghqs2c2ey55uwtc7cvu39c799lr9",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17ggkh9upvkmeyew240lz95zcdytpd2j9m55he5",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1gg0snqxxxhjcma4095nn7lduwtv3k5xw34lzks",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1gun7mcfjq965gm2jqmq2upxkeqd2lay4qrzfej"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ggqhles03a4zcxp470s0nwctm9n57ggae0vmfj",
-    "lp_token_id": "terra1hu7f7es3y2y20a55h7v3fe460nhc368wnptx35",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "ugbp"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1hu7f7es3y2y20a55h7v3fe460nhc368wnptx35"
   },
   {
     "id": "terra1ghjp8h6kn3rgtdw6kgkx4h4lnnwdtca90q4ymp",
-    "lp_token_id": "terra1zaj3vee3qrperz3djkmjzhvsdnt80vy2a9szgw",
     "asset_ids": [
       "terra1hpkk7ar777hx8ne5vgkkg5tvntm8j9m32w6zam",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1zaj3vee3qrperz3djkmjzhvsdnt80vy2a9szgw"
   },
   {
     "id": "terra1gkdudgg2a5wt70cneyx5rtehjls4dvhhcmlptv",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg",
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1gkx2ft0568avqalllpj0d29gxkfq6spk967vzu",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
       "ugbp"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1gm5p3ner9x9xpwugn9sp6gvhd0lwrtkyrecdn3",
-    "lp_token_id": "terra1gecs98vcuktyfkrve9czrpgtg0m3aq586x6gzm",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1gecs98vcuktyfkrve9czrpgtg0m3aq586x6gzm"
   },
   {
     "id": "terra1gpc8f9t9fhehjqlhxlq7aug4vgpw0rfrzsgwd0",
-    "lp_token_id": "terra1q3qrs5q54m0u8ws8vtluwyfppt9ummqp52wftn",
     "asset_ids": [
       "terra1mt2ytlrxhvd5c4d4fshxxs3zcus3fkdmuv4mk2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1q3qrs5q54m0u8ws8vtluwyfppt9ummqp52wftn"
   },
   {
     "id": "terra1gq080qp496gncf20z8vh4sl0jp504dywm3cw5n",
-    "lp_token_id": "terra10yk2ujugpd4ank5pvp2ewr9en4dnlrul0zqeur",
     "asset_ids": [
       "terra1n0pfp0ygz4sqpcjck8ntvlhw74l3tzhe4k9xd6",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra10yk2ujugpd4ank5pvp2ewr9en4dnlrul0zqeur"
   },
   {
     "id": "terra1gq7lq389w4dxqtkxj03wp0fvz0cemj0ek5wwmm",
-    "lp_token_id": "terra1jmauv302lfvpdfau5nhzy06q0j2f9te4hy2d07",
     "asset_ids": [
       "uusd",
       "terra1g4x2pzmkc9z3mseewxf758rllg08z3797xly0n"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1jmauv302lfvpdfau5nhzy06q0j2f9te4hy2d07"
   },
   {
     "id": "terra1gs8pm90pllcz5t7hsqs2fnxjv6pxzf47gg3eua",
-    "lp_token_id": "terra1hrrdpncsr6z978kekdamdaw9jrxjr5r5qtsdas",
     "asset_ids": [
       "uusd",
       "terra1f0us6p9axmzacwq2fn7sm5ke8k302tx7hg7s49"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1hrrdpncsr6z978kekdamdaw9jrxjr5r5qtsdas"
   },
   {
     "id": "terra1gv6t0xkxdr096gkad4kksxr0kjl4rxuf583rgr",
-    "lp_token_id": "terra13u54znnd3m8xx6cmujxk6z8mgmr8mzmcjvkc0a",
     "asset_ids": [
       "terra1wky9xanuqfjjy4kxt8xa2pcrf7x6lf0zlwenq0",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra13u54znnd3m8xx6cmujxk6z8mgmr8mzmcjvkc0a"
   },
   {
     "id": "terra1gxxu7stjnshv7c7l87upcs9pqv7n6k07qfr7wj",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1p5k0vl2g22zv0r07fxm627pf8u5frazevqgkw5",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1gxyn0lewraduax9lgcqekpcxf0yx2cqtl9pq99",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dssh7fk2gjjgf7yhcrd29repaz2gnxcs9yj9ay",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1h205tvn624npz49snyha3l4cv60d9kccvdr3cn",
-    "lp_token_id": "terra1klc5n2zy79ttxur0mdvhqldyzhkmcehaqm877w",
     "asset_ids": [
       "terra1xs3pv5rd2xu36w9vg05shkgxcrxkvz40fhnfsv",
       "umcp"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1klc5n2zy79ttxur0mdvhqldyzhkmcehaqm877w"
   },
   {
     "id": "terra1h2mpd99j8mcuyjcxh2wa5xsdkhwtrhyucsyrzr",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
       "ueur"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1h7t2yq00rxs8a78nyrnhlvp0ewu8vnfnx5efsl",
-    "lp_token_id": "terra1ktckr8v7judrr6wkwv476pwsv8mht0zqzw2t0h",
     "asset_ids": [
       "uusd",
       "terra18wayjpyq28gd970qzgjfmsjj7dmgdk039duhph"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ktckr8v7judrr6wkwv476pwsv8mht0zqzw2t0h"
   },
   {
     "id": "terra1h7zyvfmu3fqy6ew43c38t0f3p795c8lyyghhnf",
-    "lp_token_id": "terra126pa5vgw2ca80yd8gnk4fs08ef94g6j2f4kjcu",
     "asset_ids": [
       "terra1fj06x3hq2xum56htlrdeame70knzl765cq4txr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra126pa5vgw2ca80yd8gnk4fs08ef94g6j2f4kjcu"
   },
   {
     "id": "terra1haay9t8vvpvdrtd6t9c6pzl2cpr8m4xeadhykv",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1vwvpvamj60rtnzxzr00thgtv5hplhu55jx67d6"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1he8as5az55glkg7rye69ujsgl8f8gs3khjxwm2",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1cczv3ck2r909w64n9rdqs3gh5gsmwumh4utz49"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1hgzc444yxhgrdj4g9js9j87uarvsk3ze0uv4mn",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kntmj30tuu0fyu7vmgcrxuzax8gzt7mdmuppwv",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1hh5c3yuq9q2rnvndkdqp0nxr3yh7hwkfsnuwwl",
-    "lp_token_id": "terra1x9rpp68cesaf9mavgyy037pqpdpvp2mllt8yg3",
     "asset_ids": [
       "uusd",
       "terra17qkws34rpkzp5clc86xkyal8235lugj38dhk5v"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1x9rpp68cesaf9mavgyy037pqpdpvp2mllt8yg3"
   },
   {
     "id": "terra1hh8zw9ppkfrqg6h3lxft5qlz0svqhg2nwutmp3",
-    "lp_token_id": "terra1wjw2f93ntqtahv9unlwhx3jjzmmy0npnkjh6f2",
     "asset_ids": [
       "terra1tht79ct6uqe4ngg6wwjpxcu4ep3wdjhlttkthz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1wjw2f93ntqtahv9unlwhx3jjzmmy0npnkjh6f2"
   },
   {
     "id": "terra1hkp4hulmttwzagzphr6vczvjm46e6ryxv99nan",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy",
       "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1hl4624c6pkza6jyxnzpyxf07vyhuwt34c67ujf",
-    "lp_token_id": "terra1f2mpaw7jmm7jzhkgf2x7yg50vr9m4aplu7gkxg",
     "asset_ids": [
       "terra14eqahu3wavvesuyplmstsrnfu7uglxxy3m96dl",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1f2mpaw7jmm7jzhkgf2x7yg50vr9m4aplu7gkxg"
   },
   {
     "id": "terra1hm4gfvl5d65v03wzgvy5lh780dnwk6xtnaeurj",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra16xtp5rmhx4agcas4cyg3srp6m6gauqagh02v9z",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1hmcd4kwafyydd4mjv2rzhcuuwnfuqc2prkmlhj",
-    "lp_token_id": "terra1qq6g0kds9zn97lvrukf2qxf6w4sjt0k9jhcdty",
     "asset_ids": [
       "terra15k5r9r8dl8r7xlr29pry8a9w7sghehcnv5mgp6",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qq6g0kds9zn97lvrukf2qxf6w4sjt0k9jhcdty"
   },
   {
     "id": "terra1hngzkju6egu78eyzzw2fn8el9dnjk3rr704z2f",
-    "lp_token_id": "terra1t5tg7jrmsk6mj9xs3fk0ey092wfkqqlapuevwr",
     "asset_ids": [
       "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1t5tg7jrmsk6mj9xs3fk0ey092wfkqqlapuevwr"
   },
   {
     "id": "terra1hnpr3uukuryj72al4knes8a2eerpfjpf7phmd5",
-    "lp_token_id": "terra1gs3hkq6qylxukkklscswd98ar9lxqguzu8aed2",
     "asset_ids": [
       "terra1999psgmwex5f7fs0u9nnxrnu82c0c6s7qczhxy",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1gs3hkq6qylxukkklscswd98ar9lxqguzu8aed2"
   },
   {
     "id": "terra1hpslekgztdgykswwhgu7udnqkqudvjdqpns605",
-    "lp_token_id": "terra1j0j79nurur9fhqf5hrl8uav75pqmrt0t06a4ap",
     "asset_ids": [
       "terra1c0awzlg4ujlt0c2prwtukqeapg2m4qty5fdgs2",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1j0j79nurur9fhqf5hrl8uav75pqmrt0t06a4ap"
   },
   {
     "id": "terra1hqnk9expq3k4la2ruzdnyapgndntec4fztdyln",
-    "lp_token_id": "terra1kg9vmu4e43d3pz0dfsdg9vzwgnnuf6uf3z9jwj",
     "asset_ids": [
       "terra14vz4v8adanzph278xyeggll4tfww7teh0xtw2y",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1kg9vmu4e43d3pz0dfsdg9vzwgnnuf6uf3z9jwj"
   },
   {
     "id": "terra1hr3dnvgw5lp36gj5chc9k8te525sa6yr44zeps",
-    "lp_token_id": "terra146ndl4j5mrps92ksc39wm6uc9j2w2hq9ha928f",
     "asset_ids": [
       "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra146ndl4j5mrps92ksc39wm6uc9j2w2hq9ha928f"
   },
   {
     "id": "terra1hrffg85q6gph9rktyluglcwfpffh2t98jctu3c",
-    "lp_token_id": "terra1gm0vm4fpr9xe93tw3nc2vdp9ju3g9knwd75afn",
     "asset_ids": [
       "terra1j0te9qwyxggd9xq7vhscnnek7yg7cv5gpgurer",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1gm0vm4fpr9xe93tw3nc2vdp9ju3g9knwd75afn"
   },
   {
     "id": "terra1ht8f0pnym9tcnt5srxmlnyndsfl84nntphqfsl",
-    "lp_token_id": "terra1ku5mkpj7nr402ncduym4mgs8ggva67qcjw72hd",
     "asset_ids": [
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
       "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ku5mkpj7nr402ncduym4mgs8ggva67qcjw72hd"
   },
   {
     "id": "terra1hts7pmh590w6hd264pq6pm8ya0ck8qxsethpfp",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1htymlk5xlkzezmd6sy3rmucvhgdcglv5e8jzay",
-    "lp_token_id": "terra13k9lu3kcvee27lw66fw075t9jvza9xjyhyaz0z",
     "asset_ids": [
       "terra1clqsjgv98sa2ewwlmyt3pv4uuzz68u45w9pkyw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra13k9lu3kcvee27lw66fw075t9jvza9xjyhyaz0z"
   },
   {
     "id": "terra1hukf5q2k0pphwlmc752aay5qtq29mmd5nn2s7a",
-    "lp_token_id": "terra1kksfhstvdl9ht4pxzx900279s7fdaqp3un6l40",
     "asset_ids": [
       "terra18cs7aktav46v3pwxr8r2hfkl9pdfmrthcn58qf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1kksfhstvdl9ht4pxzx900279s7fdaqp3un6l40"
   },
   {
     "id": "terra1hwaaf5sj0039qf80q3e5cce37rw6kgdce44q0f",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1j0927vf9tuawu3k85q73jjrp58mn26psmmyw75",
-    "lp_token_id": "terra143h0kw3eyt8xjfl8pg77xpjd4alpkns4su3gls",
     "asset_ids": [
       "terra18n2k7nwwkgn20epntr4usy8nrs4l9ecu6wzqv6",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra143h0kw3eyt8xjfl8pg77xpjd4alpkns4su3gls"
   },
   {
     "id": "terra1j20n7e6klfkp2xjruh000u5lhpj2fgfng3an84",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a",
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1j3dc7eh7tus3jn476zwz9waf37w6hy5qgtjhc3",
-    "lp_token_id": "terra1k7er6xrdmyuqrsevhv9h25gxxpwl43hxmmtd82",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "terra1u553zk43jd4rwzc53qrdrq4jc2p8rextyq09dj"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1k7er6xrdmyuqrsevhv9h25gxxpwl43hxmmtd82"
   },
   {
     "id": "terra1j4nl03rhuf9ww53w0626jpng4tz40qm5uuqgnd",
-    "lp_token_id": "terra1susaylhx8sed45ljaww6wrdafqm7hccxhtwyyt",
     "asset_ids": [
       "terra155kdqp7le4fw8z8m7wk6c62d6dg5mgdug924nq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1susaylhx8sed45ljaww6wrdafqm7hccxhtwyyt"
   },
   {
     "id": "terra1j5l4c2n9x5hjrluk2k746jx60hpgycva4kg5g9",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ewvul5j47zpsr6dtyt0fup6q3tquqq3cvxpjhp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1j5rqw5vtxsx7el0mptyjqhtfaqnxgg6yu90ek7",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
       "terra130fhr9jz0nylzhdvuwcpp3hne2s5qlft6hfzgv"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1j6dx9d05sdpynkxexvp4jqdlgqv2adp7uls4we",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12qeh8p79q6jrnlmw09hvtytv9e99yl2077cmgz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1j8cg2ncvtkfm00lvhsaa80rckq7cerhlvs9r5s",
-    "lp_token_id": "terra1q6ktjyy3mpk4edjz5lq3wphu860sqp2rkhchkt",
     "asset_ids": [
       "terra1042wzrwg2uk6jqxjm34ysqquyr9esdgm5qyswz",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1q6ktjyy3mpk4edjz5lq3wphu860sqp2rkhchkt"
   },
   {
     "id": "terra1jdzll6cwkmeeqjjkm4vfljmjx7aats8fyqmvda",
-    "lp_token_id": "terra1ujttg4pcvkjj9z8xazhzemv8kpexn3vexq4vpp",
     "asset_ids": [
       "terra1jvg4ls8jz098g77t04u4hw2gg2c64w8t5g8jdz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ujttg4pcvkjj9z8xazhzemv8kpexn3vexq4vpp"
   },
   {
     "id": "terra1je2lsw0720h2w64ca0559zcav5ltsqcv3230ze",
-    "lp_token_id": "terra1lzqkq68yfgtuu5hkmd38f3tsnw9khgaj7362t6",
     "asset_ids": [
       "terra16p7wv0m0upx763r5aux6qatzyve44ezdyqpq5m",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1lzqkq68yfgtuu5hkmd38f3tsnw9khgaj7362t6"
   },
   {
     "id": "terra1jgvh68gc0zedgrs0fne2y8r0zvc2z7u4sdemwh",
-    "lp_token_id": "terra122pv8ln4s5kled99288gn8sfk4ep5pw05yynez",
     "asset_ids": [
       "terra15a9dr3a2a2lj5fclrw35xxg9yuxg0d908wpf2y",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra122pv8ln4s5kled99288gn8sfk4ep5pw05yynez"
   },
   {
     "id": "terra1jhvqagr7mqf0nn749et3qz9nc9rfehq6n8xgv2",
-    "lp_token_id": "terra1w4kqk5dxef3f6mlc6rcx35csyc4qk5axd0g827",
     "asset_ids": [
       "terra1cxvsl5qdvctc537a8q9ynv0seu4r5ceacptwx0",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1w4kqk5dxef3f6mlc6rcx35csyc4qk5axd0g827"
   },
   {
     "id": "terra1jpf8pnqqswwwnpygsk4eudsujr9fjkh9f4gjcv",
-    "lp_token_id": "terra12pltplchslx9wmsc2mey5hvramycnmnra974f2",
     "asset_ids": [
       "terra1gtjtyyhj2cu0ekzju4rj86vsvg7d2uu576rrl7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra12pltplchslx9wmsc2mey5hvramycnmnra974f2"
   },
   {
     "id": "terra1jvhqxjzezxvss9d0rfpttvz4hv6lp7urvwmx0j",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1tthplnk67e7tvga2dh49jk6l6cn4furuuffu9x"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1jxazgm67et0ce260kvrpfv50acuushpjsz2y0p",
-    "lp_token_id": "terra1nuy34nwnsh53ygpc4xprlj263cztw7vc99leh2",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1nuy34nwnsh53ygpc4xprlj263cztw7vc99leh2"
   },
   {
     "id": "terra1jxzxyjf2cvl7d88un4pp9dak8tljvxhfpgrqh7",
-    "lp_token_id": "terra1qjlakmnnswdzmssfzurpdg48ygu5cnw4lg9h80",
     "asset_ids": [
       "terra1wfau60yqgdtrqay0cdtcp5rre3l50khacyyhhz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qjlakmnnswdzmssfzurpdg48ygu5cnw4lg9h80"
   },
   {
     "id": "terra1jyqk0rg9wty4nvvxej9qhnsg3ef3agcc5nmkqp",
-    "lp_token_id": "terra1llqsh0fr47vxpgv2s8l0d3k8h2g2lqcg87zhts",
     "asset_ids": [
       "terra14pv5z9j9auwf7p4dg3ds0gch8sr8gnnf0psk8c",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1llqsh0fr47vxpgv2s8l0d3k8h2g2lqcg87zhts"
   },
   {
     "id": "terra1jz5jv3kwnr7mk5yfpp4f2n9yytlywrqpyh6zqr",
-    "lp_token_id": "terra123hvqls8hltc6t5llwfeegjfyp08rtysdvgk2r",
     "asset_ids": [
       "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra123hvqls8hltc6t5llwfeegjfyp08rtysdvgk2r"
   },
   {
     "id": "terra1jzkzn2hdvlq2d8lr8rj77r5lsqckxd0hj52mek",
-    "lp_token_id": "terra1e3fdfzrs0dw2tr9hkv8r3d649rydcwrx9zhum6",
     "asset_ids": [
       "terra12j5fqlxaurnvxr27dfsg2lku57rnmgqs6nm6ja",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1e3fdfzrs0dw2tr9hkv8r3d649rydcwrx9zhum6"
   },
   {
     "id": "terra1jzqlw8mfau9ewr7lufqkrpgfzk4legz9zx306p",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1r5506ckw5tfr3z52jwlek8vg9sn3yflrqrzfsc",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1k2ez4u7fnmwv30gysa2rhj4gs4pkngatnl6vxw",
-    "lp_token_id": "terra1ka9qplck0h0kj2jxmnagt8vh64c5qczwkwp0hx",
     "asset_ids": [
       "terra1cvdaetw5ljrtkxax8z0pgpdyhhhln3saxl8xsg",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ka9qplck0h0kj2jxmnagt8vh64c5qczwkwp0hx"
   },
   {
     "id": "terra1k30c303e059kqhz705a77kgdhr2ndldfdxjvsr",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1k3nh2pqgxm0clwm8c4d3stggytn824kejht7v8",
-    "lp_token_id": "terra1mxup2qhrk0d5pd57erhxa9h4uwl9ugh2yn32ef",
     "asset_ids": [
       "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mxup2qhrk0d5pd57erhxa9h4uwl9ugh2yn32ef"
   },
   {
     "id": "terra1k6na35qccghzvdcrmp8djyw9vxklrkxx3vd49p",
-    "lp_token_id": "terra1k0zuu3ljmwqmvaufz0d22d37evsrzju3cz4xru",
     "asset_ids": [
       "terra16pj0sful7hl87j8h5qwnv6j4vv76mxj6a6026v",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1k0zuu3ljmwqmvaufz0d22d37evsrzju3cz4xru"
   },
   {
     "id": "terra1k8dax754ampumzvrkq9770p7x40tnvamglg8kd",
-    "lp_token_id": "terra1njsea05lp96jt50f7nc0euc8sjmak6drz8ajdf",
     "asset_ids": [
       "terra1jusuf8pcuw56pmj0len5tcsdu9dm4xpqwqk48p",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1njsea05lp96jt50f7nc0euc8sjmak6drz8ajdf"
   },
   {
     "id": "terra1k9ndjyjxmyqe3kk7sq92p42kz8ptrtz9wuyq6n",
-    "lp_token_id": "terra10jmlz5uwz6w5hks8y9tretjjk4f8ad2me44lve",
     "asset_ids": [
       "terra1nzvqd5mr0jn58cvam9j06k9kry4myu0vp7a9ug",
       "ukrw"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra10jmlz5uwz6w5hks8y9tretjjk4f8ad2me44lve"
   },
   {
     "id": "terra1kaed40250kxfhy60sy2zf6g665l50m2ms3zjw4",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1kf6ctpmz72mta3h2y68jyg2mlnxktaudsjcxdm",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1kg3ngv5j7jmef9vkrtdgaglrkxs9csruur822y",
-    "lp_token_id": "terra19ur8rp69x37apddlqlnmty8uvckxlgy60r6gqa",
     "asset_ids": [
       "uusd",
       "terra165nd2qmrtszehcfrntlplzern7zl4ahtlhd5t2"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19ur8rp69x37apddlqlnmty8uvckxlgy60r6gqa"
   },
   {
     "id": "terra1kg52fgp0e45nt0wjlg8v25zn4v3gkmatz5xk3g",
-    "lp_token_id": "terra174gmmzaxtrxq6z0tamu2lcekjkjy4vwhvxn93y",
     "asset_ids": [
       "terra1cnsxjj0378qwu3p5vmrja6j9f84gepvt6r62rw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra174gmmzaxtrxq6z0tamu2lcekjkjy4vwhvxn93y"
   },
   {
     "id": "terra1kg6emvfc38xtvvlpxr6z8z89t3zwu3etugkzz6",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pkp0pkxp9mtlan7cg0qatu65hmkgyq2342g27g",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1kgcv6dq7ajlh98t34puyexhy08ltnnx2tycrtu",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1g77epr507pp572hnhaprjuz9fp6yn3e4mgyxar"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1kh2g4fnhvqtnwwpqa84eywn72ve9vdkp5chhlx",
-    "lp_token_id": "terra1c5khguw3ensqawepuxh7vdzfpxa9ulwauhm0r5",
     "asset_ids": [
       "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1c5khguw3ensqawepuxh7vdzfpxa9ulwauhm0r5"
   },
   {
     "id": "terra1khjnf8qwlun4k4c2pvn92qw8e77e6ctkpq9n2e",
-    "lp_token_id": "terra1z7ura0m4gg6zcp53fw5vx9cjhjsndvvpdy92ge",
     "asset_ids": [
       "uusd",
       "terra1vxtwu4ehgzz77mnfwrntyrmgl64qjs75mpwqaz"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1z7ura0m4gg6zcp53fw5vx9cjhjsndvvpdy92ge"
   },
   {
     "id": "terra1khyj5x39ryfn26thsv2l499pz0upgkye277ljf",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1jsxngqasf2zynj5kyh0tgq9mj3zksa5gk35j4k"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1kj8zfkf3nsc2wcad7gkjjza45qnd5lgslpz4pr",
-    "lp_token_id": "terra1lsx5sjly4yc8szw6w04cwhp7tzmlrssh2g7trr",
     "asset_ids": [
       "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55",
       "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1lsx5sjly4yc8szw6w04cwhp7tzmlrssh2g7trr"
   },
   {
     "id": "terra1kluzznl8srzx3ssxqw5las5ym9rwqtnrgcl5wu",
-    "lp_token_id": "terra1u7v3aqt6uv2y60kwur5zk3sxpcjn609s4xyzx6",
     "asset_ids": [
       "terra1cyaj8agnyzqtw2k5095ysxxgjpgqptyam283dj",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1u7v3aqt6uv2y60kwur5zk3sxpcjn609s4xyzx6"
   },
   {
     "id": "terra1krny2jc0tpkzeqfmswm7ss8smtddxqm3mxxsjm",
-    "lp_token_id": "terra1ekd58y58vq4gmxlzpc27dwuhw7wmms928ftuep",
     "asset_ids": [
       "uusd",
       "terra19cmt6vzvhnnnfsmccaaxzy2uaj06zjktu6yzjx"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ekd58y58vq4gmxlzpc27dwuhw7wmms928ftuep"
   },
   {
     "id": "terra1ks267e2cr5r3rxsvh728ghg5emz5e7d5kxxks3",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vsyyg4rs483uzd7jzw5fqqlm2q5n2yd37yylfc",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ktsswe96kkjwvcx8md8dt4k8szt2wkr5fh7px7",
-    "lp_token_id": "terra1npak6kyfz07etkg7hk027yge7h83pp2h5u0t26",
     "asset_ids": [
       "terra1f3gyvkfwy6lvst5c63gx7alp6547clceaamyyp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1npak6kyfz07etkg7hk027yge7h83pp2h5u0t26"
   },
   {
     "id": "terra1kxvdprmwjxpfl4e87vazwmzdu3pphxgkmt7j2v",
-    "lp_token_id": "terra1v5e88rv3easl8630pf8g2ylzlg73nv5hx0km4k",
     "asset_ids": [
       "terra14pwhc79alqnxdhtzm0rrxt64uh4s568u8mluhu",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1v5e88rv3easl8630pf8g2ylzlg73nv5hx0km4k"
   },
   {
     "id": "terra1kytqskj07g0d5qwk3jr3l3z8fdvzjytyntda9v",
-    "lp_token_id": "terra15mewh6pgu8lvwjvyp692ez0yfu386mtydw3vp7",
     "asset_ids": [
       "uluna",
       "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra15mewh6pgu8lvwjvyp692ez0yfu386mtydw3vp7"
   },
   {
     "id": "terra1l3gn79zdchj977p5cg9etzv97cnmcp2yze4ulz",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kqf8ua7al5tdnkz95ue4zkuv4gcu52pt63ya54",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1l5lxw4uucaserz6f9g7av9ejyfyac5jpw94fh3",
-    "lp_token_id": "terra1c6p2vl3xcc2ggufa0a9mkn2wjh9qy0v8y9zxha",
     "asset_ids": [
       "terra1zppj8uz7w6xz3ktg6nj2r4ntzzypgpcy07t5qa",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1c6p2vl3xcc2ggufa0a9mkn2wjh9qy0v8y9zxha"
   },
   {
     "id": "terra1l5xws6n5wyhjr46cxhvnmfdqqck2xd9tyq0ze4",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1l774jntnhr80wsj758fr9hlj49t8j5qf0dxhsg",
-    "lp_token_id": "terra1knrlem7cg0ywg5hldmghlj8eqh0f8lw2fhc599",
     "asset_ids": [
       "terra153qrdszuq65avs9flpeve43e46ypvt4clj6p4p",
       "ukrw"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1knrlem7cg0ywg5hldmghlj8eqh0f8lw2fhc599"
   },
   {
     "id": "terra1l7urxwu5txjsy56xcuaxac4et42ll3jnjnjrsk",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1g2dz304juraseqdqq6ufnktqgeqen67sct3p7d",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1l7vy20x940je7lskm6x9s839vjsmekz9k9mv7g",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ldpgn35p9m2ksumh8dksp3edvv4nz9tdj2pwv2",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1enj2np0785hw3vt2gn2yga9y75306g6e9lq799"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1le9jy02n73ghxkus40dldgrpeez24pa0t0yl65",
-    "lp_token_id": "terra1u4474h3hqesjwkrtkxekjw065fduc92wke4clq",
     "asset_ids": [
       "terra15kqr498g9r2j5mnddy27qgppcp8a759lcegsz0",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1u4474h3hqesjwkrtkxekjw065fduc92wke4clq"
   },
   {
     "id": "terra1lj3z3hfc2hms3r2yc3q4r5w83m2zwktpkuvmmq",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rdqy74e080e96qhk5gntnr882awm4pfc7t6dn4",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1llf5gsmqnql3rvztx6zv0ej3fdes7nqmhrwvfw",
-    "lp_token_id": "terra1ed7rjhvld0rum7uk6pdkwp7jwawsystzdkttc4",
     "asset_ids": [
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ed7rjhvld0rum7uk6pdkwp7jwawsystzdkttc4"
   },
   {
     "id": "terra1llhpkqd5enjfflt27u3jx0jcp5pdn6s9lfadx3",
-    "lp_token_id": "terra1ah6vn794y3fjvn5jvcv0pzrzky7gar3tp8zuyu",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ah6vn794y3fjvn5jvcv0pzrzky7gar3tp8zuyu"
   },
   {
     "id": "terra1lp6exls2fpz3lv9yc7mtmc6r070zy4lg3lse6u",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra102cjx95xvww7cl9l6usxltk75ww3mpxtyw4lpm",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1lr6rglgd50xxzqe6l5axaqp9d5ae3xf69z3qna",
-    "lp_token_id": "terra1s0dgcsdy9kgunnf3gnwl40uwy9rxtmc39mhy2m",
     "asset_ids": [
       "uusd",
       "terra18yqdfzfhnguerz9du5mnvxsh5kxlknqhcxzjfr"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1s0dgcsdy9kgunnf3gnwl40uwy9rxtmc39mhy2m"
   },
   {
     "id": "terra1ltjtvt27ra3vrhyfmv4x4wymez7kwal5tzx3mq",
-    "lp_token_id": "terra10g77x9yzy2tchs8d02tjrr3dtmt5qcq97mteqa",
     "asset_ids": [
       "terra1vchw83qt25j89zqwdpmdzj722sqxthnckqzxxp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra10g77x9yzy2tchs8d02tjrr3dtmt5qcq97mteqa"
   },
   {
     "id": "terra1lullqskr4jqh6fweuh9ret8k4f9ppy9nf9awtx",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "ueur"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1lvkkwhzgchq9n9xafag9u4q96q057vge0q87zd",
-    "lp_token_id": "terra1snem5zhmzj3q4wzm59tf98f0czsf6hcfpf703z",
     "asset_ids": [
       "uusd",
       "terra1246zy658dfgtausf0c4a6ly8sc2e285q4kxqga"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1snem5zhmzj3q4wzm59tf98f0czsf6hcfpf703z"
   },
   {
     "id": "terra1lxug53rtdtv5c8k7alxum9pfnayzhq5mu4y880",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1l6nqyv78m3kj8v4wa7r5fr3vhp0qzrauwkx5av",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1m68xcezywdvdwr7tfe9lauygx99h7wyx64ss7m",
-    "lp_token_id": "terra15kezlnepzjk40sx4d0e3q46shkwwv4j63hwt7x",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra15kezlnepzjk40sx4d0e3q46shkwwv4j63hwt7x"
   },
   {
     "id": "terra1m6kxrr0uvyy7as6fu2p65p4kgzg9rww9j9yhj9",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17n223dxpkypc5c48la7aqjvverczg82ga3cr93",
       "uchf"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1m70c962mz88gesrp2ascej5pr2027vs324vynh",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vsyyg4rs483uzd7jzw5fqqlm2q5n2yd37yylfc",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1m97h5kfh9gf8d42vuvhsq7es4t8y6s6dte8kz5",
-    "lp_token_id": "terra1un3hm3atn9kw5eavtsp84awhhjgjn4crr639y9",
     "asset_ids": [
       "terra100yeqvww74h4yaejj6h733thgcafdaukjtw397",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1un3hm3atn9kw5eavtsp84awhhjgjn4crr639y9"
   },
   {
     "id": "terra1m9hm6cxlf0907yy7lsssyfpzswlu54r99k9dxf",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vwz7t30q76s7xx6qgtxdqnu6vpr3ak3vw62ygk",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1m9wn7rpc570tsgfuk973m4c8u52k8gmks4f3ej",
-    "lp_token_id": "terra12mh2afj5mpsncshgm2pnwwp3svaqwattvzjaza",
     "asset_ids": [
       "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra12mh2afj5mpsncshgm2pnwwp3svaqwattvzjaza"
   },
   {
     "id": "terra1mgun8jhvfd4zcqzl73rc04447vn3kuhfjasnpt",
-    "lp_token_id": "terra1q5mgsnqdnlca3zlffy8mc2fu5y4xmm9hd9w3gf",
     "asset_ids": [
       "terra1vtr50tw0pgqpes34zqu60n554p9x4950wk8f63",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1q5mgsnqdnlca3zlffy8mc2fu5y4xmm9hd9w3gf"
   },
   {
     "id": "terra1mhtsdde76nulexf5p5fawnlnq2trs65zrd98zp",
-    "lp_token_id": "terra1jyy5a49r77le4l566m4wfun3pkpm0ed7n0luk8",
     "asset_ids": [
       "terra1yv2fdec6ej4g8pv9sru5ezcz75a2zrczllxn86",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1jyy5a49r77le4l566m4wfun3pkpm0ed7n0luk8"
   },
   {
     "id": "terra1mlz0yv4j8rw6saz5v7fq35m0qtacag8qj4hr83",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lladdxhn49jz0hrvwgalu4a548txh94mcec595",
       "uchf"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1mp40g7sneygtnxdm2ncxmjq45pgut2hryxck3a",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1u9hgxjw5k0aje9xjf0ejfu6uwmamc2k8ylzd7l",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1mp8mm0m43s926dqmwv3mgfaagvtpx8e4w84ur6",
-    "lp_token_id": "terra1kg0wdgxsqgy4trqmjmag5qd00hlygh2df8th8m",
     "asset_ids": [
       "terra15dcd0j3tqtefj96nhqryt59qyr820tyxq3l0dr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1kg0wdgxsqgy4trqmjmag5qd00hlygh2df8th8m"
   },
   {
     "id": "terra1mqcremxfr90hu5a7nvyrn7zkx3zu26ndl4zeua",
-    "lp_token_id": "terra1dugqpn2r79rqlyudz7xtfd0nqlt53ek628a0vk",
     "asset_ids": [
       "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a",
       "uchf"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1dugqpn2r79rqlyudz7xtfd0nqlt53ek628a0vk"
   },
   {
     "id": "terra1mspf3g3fx3j0u9p6y7nxaf23wetn54hgm3z753",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1mv3tksqwfextmnejw8s7ada9qu3pwav098qfxu",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1mveechnw84gnylqjs7v5wrk9ky9jyly6lsfmfr",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra193c42lfwmlkasvcw22l9qqzc5q2dx208tkd7wl",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1mvjm8g5zmwutqmqsjaq6q4rtv96c825v3lpep3",
-    "lp_token_id": "terra13dvh4d653c6tyu7f30hwcpjnrz8xhx87yduphr",
     "asset_ids": [
       "uusd",
       "terra1xhqxa9c3z223lt67lt86r2lsvtmuguddc9g55m"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra13dvh4d653c6tyu7f30hwcpjnrz8xhx87yduphr"
   },
   {
     "id": "terra1myn9wsgv02jny8jwhnxdf8lrfy6gvdnv2c3wk3",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra137qvfdvlkj9vfhrctz4rlkk7lmgql7xalqlwpw"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1mz0p4wzz5tmethu7rca2jjrw077hv2ypj7h06z",
-    "lp_token_id": "terra1mxpq2xc6k7zasj4wmlz07x4wh9la8dqn3nrxja",
     "asset_ids": [
       "terra1hnezwjqlhzawcrfysczcxs6xqxu2jawn729kkf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mxpq2xc6k7zasj4wmlz07x4wh9la8dqn3nrxja"
   },
   {
     "id": "terra1n0v5y6t5qakqsl504q6x5f2qvstqujaavxcapd",
-    "lp_token_id": "terra1vcecxknz3rc8ktpc9pgrxg578fsxlkksnuwx72",
     "asset_ids": [
       "terra18tc5vrxzvxwlcchq83d4nxy635cu87v8g0030y",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1vcecxknz3rc8ktpc9pgrxg578fsxlkksnuwx72"
   },
   {
     "id": "terra1n3khk8w48y8jf5cgjjhccg5dg9qua0xdkt98we",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra176eej9z5upauemz7wg2q6n86472xyy836v6smx"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1n4cqpg6yrgrjy3znfyx0pka5gyh6hysv5vqudj",
-    "lp_token_id": "terra1dp54cd4mq449w0x6gnxlw6v0yg9dtpjpm4urv3",
     "asset_ids": [
       "terra144w7e54fwkpz2aavq33p6d2upyc0u006udf32g",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1dp54cd4mq449w0x6gnxlw6v0yg9dtpjpm4urv3"
   },
   {
     "id": "terra1n66fcrg3hh2q36jrk8j900jx6xf72zw0thf3h7",
-    "lp_token_id": "terra1vwts232nu2r9nhaacmsnfs6fmfr6tf49yhd7s4",
     "asset_ids": [
       "terra1l95pyqf2ahqy7c53pejt8v7nnlg060fghs2499",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1vwts232nu2r9nhaacmsnfs6fmfr6tf49yhd7s4"
   },
   {
     "id": "terra1n6snwmgzpfs73juuxurwxmt2md49s2l5ggf5f2",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xt9fgu7965kgvunnjts9zkprd8986kcc444q86",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1n9dgrp7e8fxds75ffflaqfk9f7edeswnd7x2pc",
-    "lp_token_id": "terra19ynuzuwg9eymlyk745vw8suna2r2f20fu8uc8a",
     "asset_ids": [
       "uusd",
       "terra1csk6tc7pdmpr782w527hwhez6gfv632tyf72cp"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19ynuzuwg9eymlyk745vw8suna2r2f20fu8uc8a"
   },
   {
     "id": "terra1naeq3qjrd0mzw2amr0yr42mmkpmq5nrsxvnyqp",
-    "lp_token_id": "terra1hv0xq2uyav58w57dckcvcg3fu39gvrjca737sg",
     "asset_ids": [
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1hv0xq2uyav58w57dckcvcg3fu39gvrjca737sg"
   },
   {
     "id": "terra1ndvg44ygupqwq8xqzvtyqjq7agl50wwfpm0jfq",
-    "lp_token_id": "terra1fepqumj8lea8w0au7mqluuthv0jly22tx0rcls",
     "asset_ids": [
       "terra1nl9dx4pkat90gzw2j99n338n984e4cw7nxq65w",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fepqumj8lea8w0au7mqluuthv0jly22tx0rcls"
   },
   {
     "id": "terra1nfe80fnw2d0wax64ag7j95evqglqelhkh78l6t",
-    "lp_token_id": "terra105j7u0yn7gjx6sdnahd35a6n6f2hm6y6saqz07",
     "asset_ids": [
       "ueur",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra105j7u0yn7gjx6sdnahd35a6n6f2hm6y6saqz07"
   },
   {
     "id": "terra1njhvhtgvteu08dpgnhve9gpa0wmcrzyf80s76t",
-    "lp_token_id": "terra1mlkgz49lqndlgjfe3m5m4et7kz258fx89re28p",
     "asset_ids": [
       "terra17yjdhu7pk865t0jeswtpecukg0uw8xelzvfmdq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mlkgz49lqndlgjfe3m5m4et7kz258fx89re28p"
   },
   {
     "id": "terra1nlk3qg58gu88kfm2j34qydaxaxu9rw3yf2scvf",
-    "lp_token_id": "terra16w4f3frfyqkkd8gvc2r04ynyvykc558ssw93jw",
     "asset_ids": [
       "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra16w4f3frfyqkkd8gvc2r04ynyvykc558ssw93jw"
   },
   {
     "id": "terra1nlrtp53mpvlged7pp537avj8uf59j3s0qlwrga",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1cwretz2zmeqe2uhq4fuk2mrp4ptuvsct890c6f"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1nr2hvucfvtnzxm39022jal53wker54thdkll4r",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "ueur"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1nsmppls52m3fmphznag3f7lue5wp6ffrp9e4s5",
-    "lp_token_id": "terra1dmuw5wyluxe6hf85x7waepwuqjgs2460fmj8qn",
     "asset_ids": [
       "uusd",
       "terra1h4hvry62zk4zh0udecqmatfg02phnyu6hq74xd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1dmuw5wyluxe6hf85x7waepwuqjgs2460fmj8qn"
   },
   {
     "id": "terra1nszsz38jnmfs6xl9tsq093sc23stm7xz33dqqx",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19xk3rsesaupv72se69y8v6y6m04fl8yj6vnmtv",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ntdceldg23ymqljh94wcp78dl6qmzndq8u2hwa",
-    "lp_token_id": "terra1swpfg0q9uz0ct4tqfdunrumnxx8zxxzdlnlfkw",
     "asset_ids": [
       "terra14mvkydkwm2pzz62cgrkpeusphm4trrqrzd88ju",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1swpfg0q9uz0ct4tqfdunrumnxx8zxxzdlnlfkw"
   },
   {
     "id": "terra1nx3rggxrpv0yekes85kg3fa7v73qgphst6v5gj",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1aydw57mpa6jg5n3xnrau9g7mftd3ch6fh7qzal",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1nytaqyhspr05thllfkl9lgnvmfwxdxmcy42k3s",
-    "lp_token_id": "terra14fy4yzl893m0wqh89mv6c00lnutmgrml08ndrm",
     "asset_ids": [
       "terra19u8cgzsmgg27mnevcc22293yl3j82f26l8nvtz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14fy4yzl893m0wqh89mv6c00lnutmgrml08ndrm"
   },
   {
     "id": "terra1nzepxu4scprmc6ly4amam0f2teufy69uu02wzw",
-    "lp_token_id": "terra1v6s4drn5hyp4jhyn797ddn8w3zjxl50c647y3v",
     "asset_ids": [
       "terra14v9wrjs55qsn9lkvylsqela3w2ytwxzkycqzcr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1v6s4drn5hyp4jhyn797ddn8w3zjxl50c647y3v"
   },
   {
     "id": "terra1p0sjx8kg9zeuefzwu0ac9ftemrr0usdyypsnty",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1c00vskhyzdv0z63z2tyetzx2qma67n2z3vzyn0",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1p2462m98je6pk3n03fwrnmngkm05mcr9pn6cmt",
-    "lp_token_id": "terra198pmh4mhd42ltqlcntja99fzg4psw7en4w3z7l",
     "asset_ids": [
       "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv",
       "ueur"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra198pmh4mhd42ltqlcntja99fzg4psw7en4w3z7l"
   },
   {
     "id": "terra1p44kn7l233p7gcj0v3mzury8k7cwf4zt6gsxs5",
-    "lp_token_id": "terra1khm4az2cjlzl76885x2n7re48l9ygckjuye0mt",
     "asset_ids": [
       "terra13zx49nk8wjavedjzu8xkk95r3t0ta43c9ptul7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1khm4az2cjlzl76885x2n7re48l9ygckjuye0mt"
   },
   {
     "id": "terra1p4jvensmff8knpp76ej35ugaj2l75yrk5aufux",
-    "lp_token_id": "terra1k0q9wnqs4c8kuy2gudva5dl3cucf8xqxfjwsek",
     "asset_ids": [
       "terra1g53pyke8jtmt4lwvk4yl0xaqc4u0qlsl8dz3ex",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1k0q9wnqs4c8kuy2gudva5dl3cucf8xqxfjwsek"
   },
   {
     "id": "terra1p5a83hq638z7l5eqr0ll8tnayy3gecakzftc8m",
-    "lp_token_id": "terra126evm399rxsvzw06qe9kxcmv3ly5lwarycq5nw",
     "asset_ids": [
       "terra190tqwgqx7s8qrknz6kckct7v607cu068gfujpk",
       "terra1c00vskhyzdv0z63z2tyetzx2qma67n2z3vzyn0"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra126evm399rxsvzw06qe9kxcmv3ly5lwarycq5nw"
   },
   {
     "id": "terra1pc0r79hmaznqh7tnsmzmh9zsl5y87t02zz2fmr",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1uhwhrypcnucvcc2ayt92mlky2xtatslrn7tte4"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1pc7pufyc4z5lcwm0fhrsveu3fxly97htyh2hnu",
-    "lp_token_id": "terra1ea6srqjggq3j8spanguqfekcklwnqwren6km9t",
     "asset_ids": [
       "terra19953ttzk3mxghgwpdt85gua3gzzcj9a6wjwek6",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ea6srqjggq3j8spanguqfekcklwnqwren6km9t"
   },
   {
     "id": "terra1pcgx4257v8lskc9dul37searsf8uh8zyrj077x",
-    "lp_token_id": "terra12jcvk4ltvdygacp2k56vnre42cjwr60jmv77py",
     "asset_ids": [
       "terra1mt2ytlrxhvd5c4d4fshxxs3zcus3fkdmuv4mk2",
       "uchf"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra12jcvk4ltvdygacp2k56vnre42cjwr60jmv77py"
   },
   {
     "id": "terra1pd3sdj23u85w3vlrtmrpadud4qmxhppyy6dsyq",
-    "lp_token_id": "terra1rdjzzqdcqasnu4kgk796e3rr9nvrhx5y9xdg7e",
     "asset_ids": [
       "terra1mqug8fps3zqsywzrukz5m6shcnj4j4rqna3kzf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1rdjzzqdcqasnu4kgk796e3rr9nvrhx5y9xdg7e"
   },
   {
     "id": "terra1pdxyk2gkykaraynmrgjfq2uu7r9pf5v8x7k4xk",
-    "lp_token_id": "terra1ygazp9w7tx64rkx5wmevszu38y5cpg6h3fk86e",
     "asset_ids": [
       "uusd",
       "terra14y5affaarufk3uscy2vr6pe6w6zqf2wpjzn5sh"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ygazp9w7tx64rkx5wmevszu38y5cpg6h3fk86e"
   },
   {
     "id": "terra1pdytx5xzs57t6qqdrnf9vn4ejxclpdn7eqs6kt",
-    "lp_token_id": "terra1wegnql6drjz35m68xjnfrz4w9tp35fhn5e40y4",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1wegnql6drjz35m68xjnfrz4w9tp35fhn5e40y4"
   },
   {
     "id": "terra1peyurud64sjajna3s9g2s9er4uv3tftyj9avwf",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1pgf2ntzk2gh2lar6zh0yjwchmrtym8zfzp296y",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1uc4fwlh2wn59qqk8y7ld0vxc9hvsufaa5gv5z8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1pgla9506h2ed9p93y6ryvxgj5admukssrcedwx",
-    "lp_token_id": "terra108gn88qjjm0zmd0sjg39dwnksq6j2ehmp6pf27",
     "asset_ids": [
       "terra1akwn8y34upderjyw07hgepunte8mza00vafzfd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra108gn88qjjm0zmd0sjg39dwnksq6j2ehmp6pf27"
   },
   {
     "id": "terra1phjmfqsajhrzdq056nawr55kqqerylpthpvlat",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra10h7ry7apm55h4ez502dqdv9gr53juu85nkd4aq"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1pk77hewqerplsemc7wu9h78zwxs7cktfejdq5s",
-    "lp_token_id": "terra1ukk0exsl5cejgnsn4jrdju83wrpdcwg0thfzpm",
     "asset_ids": [
       "terra1wwpxtgrrfn0jxq8f0hlrzngx8m28r8kd5umaq8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ukk0exsl5cejgnsn4jrdju83wrpdcwg0thfzpm"
   },
   {
     "id": "terra1plf355sg3tntq72wa35qlrv99tduhhjax0vxjr",
-    "lp_token_id": "terra1ufumstplfqt5c9qs6zjzr5vp3dew7s29u7e7jd",
     "asset_ids": [
       "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw",
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ufumstplfqt5c9qs6zjzr5vp3dew7s29u7e7jd"
   },
   {
     "id": "terra1pn20mcwnmeyxf68vpt3cyel3n57qm9mp289jta",
-    "lp_token_id": "terra1t4xype7nzjxrzttuwuyh9sglwaaeszr8l78u6e",
     "asset_ids": [
       "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1t4xype7nzjxrzttuwuyh9sglwaaeszr8l78u6e"
   },
   {
     "id": "terra1prfcyujt9nsn5kfj5n925sfd737r2n8tk5lmpv",
-    "lp_token_id": "terra1d34edutzwcz6jgecgk26mpyynqh74j3emdsnq5",
     "asset_ids": [
       "uusd",
       "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1d34edutzwcz6jgecgk26mpyynqh74j3emdsnq5"
   },
   {
     "id": "terra1ps8wcwxt783qq07gfza0f67xf3kuaguq0r0e4y",
-    "lp_token_id": "terra15qmh9jl388v2hr2yn75v8psdj0q9ghfwwxzckg",
     "asset_ids": [
       "terra1x5t6zkvhc6dg2jjug34tfreme3hcufpuy77da2",
       "ukrw"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra15qmh9jl388v2hr2yn75v8psdj0q9ghfwwxzckg"
   },
   {
     "id": "terra1pufczag48fwqhsmekfullmyu02f93flvfc9a25",
-    "lp_token_id": "terra1xwyhu8geetx2mv8429a3z5dyzr0ajqnmmn4rtr",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1xwyhu8geetx2mv8429a3z5dyzr0ajqnmmn4rtr"
   },
   {
     "id": "terra1pyc4z680nrvd00xnqh24dtvap2840w0a44x7ns",
-    "lp_token_id": "terra1udkgg8n4ynny7njj7fra88lkmjw8f3ggy0crdu",
     "asset_ids": [
       "terra1m09t5cs473tvl7lsregj024d3dwg65su6ufpfh",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1udkgg8n4ynny7njj7fra88lkmjw8f3ggy0crdu"
   },
   {
     "id": "terra1pyx0xvdeqmn8r7ljakjwx6z852zg25kxpesyn0",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1g4x2pzmkc9z3mseewxf758rllg08z3797xly0n"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1pzhcs3l028l8dzvj9hvxgt93ez4uq203askad3",
-    "lp_token_id": "terra18jwvd3w34eudhvz97gtut5qtas57al7ez0kg4c",
     "asset_ids": [
       "terra1kqsgl8p84szmmv0npvsv0u5qlq5fng3zk8c4w0",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra18jwvd3w34eudhvz97gtut5qtas57al7ez0kg4c"
   },
   {
     "id": "terra1q00r9whldewsktqne5sux6gtaxn2vlfvu5geej",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1q2cg4sauyedt8syvarc8hcajw6u94ah40yp342",
-    "lp_token_id": "terra1jl4vkz3fllvj6fchnj2trrm9argtqxq6335ews",
     "asset_ids": [
       "uusd",
       "terra15hp9pr8y4qsvqvxf3m4xeptlk7l8h60634gqec"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1jl4vkz3fllvj6fchnj2trrm9argtqxq6335ews"
   },
   {
     "id": "terra1q3pem26pyxq7qggmxkh5egd4km0a7l0gxe84wk",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1q4xywudqrgsuvdc0n9w0mhmrpzqj9lrl5wcf6j",
-    "lp_token_id": "terra15pclv9fqytszqlmjymshyk9cfytaaqrs4h87sf",
     "asset_ids": [
       "terra145627szryw7lxr58cvclx9aj468qupld4vnf88",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra15pclv9fqytszqlmjymshyk9cfytaaqrs4h87sf"
   },
   {
     "id": "terra1q5uy25egxd95tt6j7kxu26xtnn50pl7w6grq0z",
-    "lp_token_id": "terra13wgcwjzgcphqgcay6k06th604rdggjf2plcyjz",
     "asset_ids": [
       "terra18lx7nzwlp8sr83y2wymhj37fnrlehm7rj6lhlf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra13wgcwjzgcphqgcay6k06th604rdggjf2plcyjz"
   },
   {
     "id": "terra1q772ps7jxy57kgfhhpmg8gxsgn9fr7npwsn4kw",
-    "lp_token_id": "terra1jm8tx0aump43epcd8u0fspqp47agykvmmfrzh6",
     "asset_ids": [
       "uusd",
       "terra15z4tj56cdpdk5jxf28nep3ep0myu0frhlh6f3u"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1jm8tx0aump43epcd8u0fspqp47agykvmmfrzh6"
   },
   {
     "id": "terra1q9lnctytu3c4p5ekv3xpmyxnegxe83adeufemv",
-    "lp_token_id": "terra128pdzd65aju0q94vwj98j9lphnklgvkdpz7q83",
     "asset_ids": [
       "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
       "terra1nagqpmyw55yjphea4rhntlfv87ugmeaj8ym756"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra128pdzd65aju0q94vwj98j9lphnklgvkdpz7q83"
   },
   {
     "id": "terra1q9lvy34kjnwr9552yd3thv39nmrwg7ej46cvy7",
-    "lp_token_id": "terra1f0l9d3dedr3au4frre8uc7w7s2chs73a9xqwjp",
     "asset_ids": [
       "terra128vws7v3ruqpysj0wwy95nl8a7an7nnyctmvle",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1f0l9d3dedr3au4frre8uc7w7s2chs73a9xqwjp"
   },
   {
     "id": "terra1q9mgca3xh5ka3jtsunjsdy5vjjwaykkynx00ld",
-    "lp_token_id": "terra1qs8frq6vn59u4hv6l7k0rvf8m5xd4n46n0vzwa",
     "asset_ids": [
       "terra1czqey2sj9h2w625ez5kefp6j7d5s08e7lj2yhd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qs8frq6vn59u4hv6l7k0rvf8m5xd4n46n0vzwa"
   },
   {
     "id": "terra1qdvgzumzmfjzyjkvr647n8el7pq05jm958f6ml",
-    "lp_token_id": "terra15rsfe8x9w3p7hl9n4ptawzw40x29t4w4h0hhnq",
     "asset_ids": [
       "terra1lchkxy5ednukxepwxejak8xevqlmz89ukjh6hl",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra15rsfe8x9w3p7hl9n4ptawzw40x29t4w4h0hhnq"
   },
   {
     "id": "terra1qhnylhd7vdu87sdyjs908ndxc4ck0pgzpr7ky0",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1948uvsah8aw40dhsa9mhl3htq8lraj0smlh77g",
       "uchf"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1qjus04wsfvxgg0k5k4hjdr20ttlcxewq2lu7vk",
-    "lp_token_id": "terra183pmt26qpwy4xnpunzmckjydsnyw43hejgaucf",
     "asset_ids": [
       "terra1ckvmptla24qm80yrwkxluhptee4y8h3gemwkw7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra183pmt26qpwy4xnpunzmckjydsnyw43hejgaucf"
   },
   {
     "id": "terra1qkf2kffhu3f6x4d34tu67eu2u8nkrqrn6w3a2n",
-    "lp_token_id": "terra1mspnuehp4h68f03t35lr0dzz8ajhzdq9jazjk8",
     "asset_ids": [
       "terra13sg4qarsjual8ew8sr4nwtkv6ut4dd3378820r",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mspnuehp4h68f03t35lr0dzz8ajhzdq9jazjk8"
   },
   {
     "id": "terra1qll0dwhllspv30xnekl2csr6k3ykygtqdzuxl8",
-    "lp_token_id": "terra1fgc9vy7hhzjgv90chemxgs0p5j5dfhkzsfexlt",
     "asset_ids": [
       "terra10famrcyze8z9c84x5726aplefwuf4k2zqf3rxr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fgc9vy7hhzjgv90chemxgs0p5j5dfhkzsfexlt"
   },
   {
     "id": "terra1qp6jp2sfsv8gmdh2tu33w904qqym394fzkxnxd",
-    "lp_token_id": "terra13ek9x87hp9t3gf5ltchzhl3xuhhakm26jyj4vz",
     "asset_ids": [
       "terra1ukk89gn25p7xseqc4s4d45yarjlwychrwx7umv",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra13ek9x87hp9t3gf5ltchzhl3xuhhakm26jyj4vz"
   },
   {
     "id": "terra1qpd9n7afwf45rkjlpujrrdfh83pldec8rpujgn",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1qr3jrdwrkqhntnkpvx39efrmayx45ysuhpg9qk",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1g0pm8xm5c2dq4qtv8j9a80hg4mhe5ndy8qad07",
       "terra1mjhrlgwv8dnvc7mp0cynfxna947hxnm5m4tp6u"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1qs0zjzd6j0kwrwwf2qj5kmqqhav5ygq3q7p8s7",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1qthlsaqccp8mxr2z4vvkhf5ynqjl86ccxg0pqn",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1zjhsuvuy5z7ucvx56facefmlrrgluhun27chlf",
       "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1quf8yfhqkt38fa2j3zhgfv93ra6tvj9t0q6sgn",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1quz6cfd40l6qsfjyrmu0xe5xsnufg6g4rr00a4",
-    "lp_token_id": "terra1fd34ray6t095g3rnj9yskjum0kglrym44qnmra",
     "asset_ids": [
       "terra1pr2swnalac9ny993tgvtcfyhe4h9cuqm3rdmnf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fd34ray6t095g3rnj9yskjum0kglrym44qnmra"
   },
   {
     "id": "terra1qwk53cmt2j50ge2vkmt5sgcnmua5va5gx2s6yr",
-    "lp_token_id": "terra1nazd47xg74dg4a2eld2qxaynarv67d2l24z3y4",
     "asset_ids": [
       "terra14zeffuryjlzw566k7cfrnzf9dy94qeat2xvcda",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1nazd47xg74dg4a2eld2qxaynarv67d2l24z3y4"
   },
   {
     "id": "terra1qyynd88qccpjrdn4yghhf8n9dm9msayrtqwwva",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1r0288hx3mjgx0zrpmpc8rulm6ca8jheqtwhwq5",
-    "lp_token_id": "terra1nafrz6yep84lvphmj03gryht3exa624ttgkf06",
     "asset_ids": [
       "terra13xujxcrc9dqft4p9a8ls0w3j0xnzm6y2uvve8n",
       "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1nafrz6yep84lvphmj03gryht3exa624ttgkf06"
   },
   {
     "id": "terra1r2hhqmwh68uslcw0np3gwkrdd36thfagq6hzj6",
-    "lp_token_id": "terra1j33rxfgdpuv3dpxaexhsuc64n6ltlascr5te2j",
     "asset_ids": [
       "uusd",
       "terra1kscs6uhrqwy6rx5kuw5lwpuqvm3t6j2d6uf2lp"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1j33rxfgdpuv3dpxaexhsuc64n6ltlascr5te2j"
   },
   {
     "id": "terra1r3djf4znn0vknjhdmlyg89hd8955v3vhr7jj5h",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1r6pp7pp0pgvp06nh80qmu697qfjsegddqnsg8t",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra194a6jn3cyydhrfpdnz5r5zkj6wx3t3cr673z4r",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1r786pmp9z6edc0qufxgxxaheh5ag735avkfm30",
-    "lp_token_id": "terra1tsg6xz8n86lz538psktzfca7fe35gp84pn487v",
     "asset_ids": [
       "terra1e47v67sld3p2pre5skqh05ddld22rwhu30fnwm",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1tsg6xz8n86lz538psktzfca7fe35gp84pn487v"
   },
   {
     "id": "terra1r8k9pea8wmt93l703azhs82kpjva0cpq8tq5at",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1r9e7efml7zk8fd5x5atk39e8jua9kdt7n7lp5r",
-    "lp_token_id": "terra14dgkwkplgmw9tkdf4rc72ppk6q5p2mu0uhfl09",
     "asset_ids": [
       "terra1gmpn6gy7tdm39tc97te2f5prjdpgml760pke8k",
       "ukrw"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14dgkwkplgmw9tkdf4rc72ppk6q5p2mu0uhfl09"
   },
   {
     "id": "terra1r9n03pheztcxrfcykwazvxzd0rnvzrdrdwpsf5",
-    "lp_token_id": "terra1gvakrl38c6ygrvzv2srnp738z43xy5prpmy78v",
     "asset_ids": [
       "terra1mpq5zkkm39nmjrjg9raknpfrfmcfwv0nh0whvn",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1gvakrl38c6ygrvzv2srnp738z43xy5prpmy78v"
   },
   {
     "id": "terra1rds4mfy90pxtn64px8dq9d68d2vwkcplpt6sl5",
-    "lp_token_id": "terra19uca4zxqr8e9t9l6lcz3rztzaygnawwlex8g8l",
     "asset_ids": [
       "terra1xjxegty6mmdr5jwqwde9rqhz758sy8c73vxzea",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19uca4zxqr8e9t9l6lcz3rztzaygnawwlex8g8l"
   },
   {
     "id": "terra1rh6rwrekv3r7ep89lmkysxugsvuaqljmmepx5s",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra16qsk2zwv5fsqd944p28f2dkddr7eq9uzuxeh8h",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1rhsh5xxl52xkuj7qq9240hwmcyzq2gpyj9hl0x",
-    "lp_token_id": "terra1s6e449z6xz0vm0tx2h5p6drxwz9r2jvrcvcc62",
     "asset_ids": [
       "terra1skjr69exm6v8zellgjpaa2emhwutrk5a6dz7dd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1s6e449z6xz0vm0tx2h5p6drxwz9r2jvrcvcc62"
   },
   {
     "id": "terra1rnc5cp7r9nxrskhup9uqs9v0e43hmm6u9xydec",
-    "lp_token_id": "terra13p6glny4ltdtrlptq2g9gs3e8m35t55uwgs9ea",
     "asset_ids": [
       "uusd",
       "terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra13p6glny4ltdtrlptq2g9gs3e8m35t55uwgs9ea"
   },
   {
     "id": "terra1rq55zs9w6s24wmlmd540j2q2p6whanurfj26eh",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
       "ugbp"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1rre03e5p2w39uuvgxpxygnmtalj7cu7sp540zk",
-    "lp_token_id": "terra10n748ua6aktwge5387w5gez45nvava0dzn2r9e",
     "asset_ids": [
       "terra1ghnll5fz4n6c0vt47jdnnyrjgfg4fgnqnchwys",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra10n748ua6aktwge5387w5gez45nvava0dzn2r9e"
   },
   {
     "id": "terra1rrek47kf0t968g2jcg5ww8fw58n93jkclkk4v5",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lkjq6f2sqlqjk0crs2a7fv6m5pquhl8nuesp3j",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1rsuhf9cfvrfcj5h2h28ad72hhqgxxqyg2pf74y",
-    "lp_token_id": "terra1ce5l6em2gc58lu0ltxq5xsn4d9u3nj49qdntjv",
     "asset_ids": [
       "terra1mt2ytlrxhvd5c4d4fshxxs3zcus3fkdmuv4mk2",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ce5l6em2gc58lu0ltxq5xsn4d9u3nj49qdntjv"
   },
   {
     "id": "terra1rtyprjhqks470dgggn6nvx06ny388np6uy53vr",
-    "lp_token_id": "terra1zc86cnlsmgz50swt9nluhpmn45k2fc0w9du3ys",
     "asset_ids": [
       "uusd",
       "terra1ptdxmj3xmmljzx02nr4auwfuelmj0cnkh8egs2"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1zc86cnlsmgz50swt9nluhpmn45k2fc0w9du3ys"
   },
   {
     "id": "terra1runncker37zx0wlp43xchzep33udsn6yje3rt3",
-    "lp_token_id": "terra1zn5ycnftj4lplwwtjrt6jtvqtqwc2xl0ypyegs",
     "asset_ids": [
       "terra1cetg5wruw2wsdjp7j46rj44xdel00z006e9yg8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1zn5ycnftj4lplwwtjrt6jtvqtqwc2xl0ypyegs"
   },
   {
     "id": "terra1rvnzun0xww86xnhu88prga8qt2n2trkjm72s4m",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15k5r9r8dl8r7xlr29pry8a9w7sghehcnv5mgp6",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1rxn03zjqscvv770h0ede4v4649y62zlr0lxlx8",
-    "lp_token_id": "terra1etsh6y54ew6jcud4yhuu8awfdcz4j6jev6ej3u",
     "asset_ids": [
       "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1etsh6y54ew6jcud4yhuu8awfdcz4j6jev6ej3u"
   },
   {
     "id": "terra1rxzs4rs28rx89dt57nnph6xz8zmycf5js2d4ey",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1srp2u95kxps35nvan88gn96nfqhukqya2d0ffc",
       "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ryajnmy7npuzq3de9yt9c7x8ac2awdtf8ekaw8",
-    "lp_token_id": "terra149zg8aesny2xasfkc4wd6z8agewjfq5uve3pfe",
     "asset_ids": [
       "terra1djd0hmv2hq8s0g9hs53s7gmc2phgg33kqq4uul",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra149zg8aesny2xasfkc4wd6z8agewjfq5uve3pfe"
   },
   {
     "id": "terra1s47rsyk3q7h8ketsuw2swdtgqr4lqfvt9jfdx3",
-    "lp_token_id": "terra140a886v0e6nl8s8gpzkrunk443pr0venvvt32e",
     "asset_ids": [
       "terra1gecs98vcuktyfkrve9czrpgtg0m3aq586x6gzm",
       "terra1nuy34nwnsh53ygpc4xprlj263cztw7vc99leh2"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra140a886v0e6nl8s8gpzkrunk443pr0venvvt32e"
   },
   {
     "id": "terra1s5w4yymch3y85n54pma0qkuyqek0s5a9kys39k",
-    "lp_token_id": "terra1svwqdq0gcuw2q2vzmy76qjvl2pnwaz65d4xvs0",
     "asset_ids": [
       "terra1tgfw423t34rwaezm4u4vwy5d80tfgzuyx2s6x0",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1svwqdq0gcuw2q2vzmy76qjvl2pnwaz65d4xvs0"
   },
   {
     "id": "terra1sa70wy0857fzu2gjcrg4mm7n5767k7lhj3yrct",
-    "lp_token_id": "terra1juspa927c7kdr0jf7wc0lxg6wfjz2cersm9r82",
     "asset_ids": [
       "terra183x8jduwtdgcqkwtqxdzjlq2mq0rlnj6hm22j7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1juspa927c7kdr0jf7wc0lxg6wfjz2cersm9r82"
   },
   {
     "id": "terra1sc02s2q53678ase0uh5e02x95dv6knkkgf6xwx",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10ynpvp8trmlkf6n69qx0kp9qjs54d8wsh2pddc",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1sdmk3k5ajmnk5zdfujmr8q3yfvlp067h8syq5l",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1sdu63qdzkndpavvl5ephzwl7jj2slvcy89qu9s",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra158y6aypem94yj34ycvgdm3py23afhnu2dj24ak",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1seh55ualnngk9jau3qsw7xrl4q7vqhc8y64w5q",
-    "lp_token_id": "terra1jnn5xpmeythug88hu66pwl3x9fz2s0ms034aw6",
     "asset_ids": [
       "terra1yjlqptvn3al5402jp600l7n3l5yl8man8d4kex",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1jnn5xpmeythug88hu66pwl3x9fz2s0ms034aw6"
   },
   {
     "id": "terra1sg6tzmqegqhacd6nkrkrxn6hy4lx59ex7tt6mv",
-    "lp_token_id": "terra19w95ffdpqeweglhzadwcaa0amu0g7m490kx5ch",
     "asset_ids": [
       "terra1t0csdwp5u9592522n35ededwt2e46sur5u4mkg",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19w95ffdpqeweglhzadwcaa0amu0g7m490kx5ch"
   },
   {
     "id": "terra1sgpvnwxmd9gmhhxzw03t7qftu00x35994denrm",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra130fhr9jz0nylzhdvuwcpp3hne2s5qlft6hfzgv",
       "uchf"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1smwa4uj94ecy8qtenezzew0z8mur9vy443pqc5",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1sndgzq62wp23mv20ndr4sxg6k8xcsudsy87uph",
-    "lp_token_id": "terra1xqeym28j9xgv0p93pwwt6qcxf9tdvf9ztfxf0w",
     "asset_ids": [
       "umnt",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1xqeym28j9xgv0p93pwwt6qcxf9tdvf9ztfxf0w"
   },
   {
     "id": "terra1sprg4sv9dwnk78ahxdw78asslj8upyv9lerjhm",
-    "lp_token_id": "terra19ryu7a586s75ncw3ddc8julkszjht4ahwd7zja",
     "asset_ids": [
       "terra1f62tqesptvmhtzr8sudru00gsdtdz24srgm7wp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19ryu7a586s75ncw3ddc8julkszjht4ahwd7zja"
   },
   {
     "id": "terra1squzmwcpr5486f0zp759d5zyt0q3yykaf6e4zx",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1st3tr5ppd3cs8zfl7ygqtc50y5thn5h6chdpmr",
-    "lp_token_id": "terra1qqecag8xppl7faec4rrxp5v0vheex0s9dtvhte",
     "asset_ids": [
       "terra1zn26hzdegq2c9qa0etqcthk2kjcr6cqeaud7q9",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qqecag8xppl7faec4rrxp5v0vheex0s9dtvhte"
   },
   {
     "id": "terra1stdzf28wlq7llzfecse366r657rtdh6wtrdfk2",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra140k6k2pmh2lmy4q4wyz5znqmtgwvs3gkgfeevq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1su90khngc8fe80dwu0xgwt49262ytaye6zsv4l",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1swdaspvv9w0wtf9sylmkdmfnzjx7eu5734n64q",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra190tqwgqx7s8qrknz6kckct7v607cu068gfujpk",
       "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1syp7rzmgtp9r6m4qlhu9x6luh4ltqyglkd22u3",
-    "lp_token_id": "terra1mgz7rsnqzvdfem9zg55afdzxvzfhymeed42uw7",
     "asset_ids": [
       "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mgz7rsnqzvdfem9zg55afdzxvzfhymeed42uw7"
   },
   {
     "id": "terra1szj7qd0azfzf4sarhxr2wfzf0k8js3vng545cv",
-    "lp_token_id": "terra1p3urvqahfp6pup8xw6lp3zcruw8kv3xrkjwk4l",
     "asset_ids": [
       "terra10f2mt82kjnkxqj2gepgwl637u2w4ue2z5nhz5j",
       "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1p3urvqahfp6pup8xw6lp3zcruw8kv3xrkjwk4l"
   },
   {
     "id": "terra1t0pd5uqsqp85cgly5cvggm698asez55ked2ftu",
-    "lp_token_id": "terra1768vz98dnfxlvwjnx25r520pfevk7djfc3ymhx",
     "asset_ids": [
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
       "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1768vz98dnfxlvwjnx25r520pfevk7djfc3ymhx"
   },
   {
     "id": "terra1t228agv0gpw0uryk7j2lcqhcwgylwkgumf2eej",
-    "lp_token_id": "terra14j965wgdyyrkryjem570jh7y7lzgyrs0jp6xud",
     "asset_ids": [
       "terra16pektynpxqrs66gk6cgqpwr7rjsudyfzustm6s",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14j965wgdyyrkryjem570jh7y7lzgyrs0jp6xud"
   },
   {
     "id": "terra1t33pflkepsmky9smma25ne05ghre3zk5wgz9u6",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1t4z4tdtn8ka6q5g7x3mx4h5w8ufh07c3s6eca4",
-    "lp_token_id": "terra1n8fwsrf3qruwx99eg87dmw7x4pjc8n0a35vlef",
     "asset_ids": [
       "uusd",
       "terra1td527f09l7lgf55fqtr0zvtx5ek0yl0fdrx574"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1n8fwsrf3qruwx99eg87dmw7x4pjc8n0a35vlef"
   },
   {
     "id": "terra1t5kr723pn2nv9rz576lxtqhjlaevhhfw30g7z3",
-    "lp_token_id": "terra19fg28zjmr6fukx0jfm5q472yn8jq83mhlwphrc",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19fg28zjmr6fukx0jfm5q472yn8jq83mhlwphrc"
   },
   {
     "id": "terra1t5prq6e8pygcyv7zwd4zs2nkxn7808fnqf5lz8",
-    "lp_token_id": "terra1y3k4vj8qhgultc388wwmx6m4mdlt2098fyj2h8",
     "asset_ids": [
       "terra1ye68rx8etwj7xylwc4nd4vp58zz236mlhk0cpx",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1y3k4vj8qhgultc388wwmx6m4mdlt2098fyj2h8"
   },
   {
     "id": "terra1t7zq9ujczprlqss0dec7akfmnc2wumvsl8dr2v",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1hqgzrrtsft73pjnlf7w946u3m70a99cxjjm879"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1t82m784qavjuawu2n6m47u6gch9wvfne38pftf",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18ejpjp9eyx9t8j07jd7kzah9p0rvkzdfeeva6n",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1ta3lth8wu992m20qjeucg59rlxeez6qeygsxtm",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1j7ft2ze4phmcj4x2mnr7cfcns5x5hqjnnt8myj",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1tcrpkhxurjj2qcl5sksxs4cqc8mgz8dp0kfvhm",
-    "lp_token_id": "terra1v0qd7s259lr83t7qp8aknmn6jeq679u4xnnhpz",
     "asset_ids": [
       "terra1p3z96mc9gr66yruc3c0v73u0e574kjpgeledm3",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1v0qd7s259lr83t7qp8aknmn6jeq679u4xnnhpz"
   },
   {
     "id": "terra1tn8ejzw8kpuc87nu42f6qeyen4c7qy35tl8t20",
-    "lp_token_id": "terra1y9kxxm97vu4ex3uy0rgdr5h2vt7aze5sqx7jyl",
     "asset_ids": [
       "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1y9kxxm97vu4ex3uy0rgdr5h2vt7aze5sqx7jyl"
   },
   {
     "id": "terra1tndcaqxkpc5ce9qee5ggqf430mr2z3pefe5wj6",
-    "lp_token_id": "terra17dkr9rnmtmu7x4azrpupukvur2crnptyfvsrvr",
     "asset_ids": [
       "uusd",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17dkr9rnmtmu7x4azrpupukvur2crnptyfvsrvr"
   },
   {
     "id": "terra1tnt6qdre3htcd6wwf2asj40ch4fys5x5wzz35v",
-    "lp_token_id": "terra1ldlsayhau0qdj92j9r5nzy4mfr2gunqv6qukdj",
     "asset_ids": [
       "terra146fhkmq8d7ae3e6jemufy4h5eq9zerftm8wzmt",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ldlsayhau0qdj92j9r5nzy4mfr2gunqv6qukdj"
   },
   {
     "id": "terra1tpk0tu4qstvzd5px7yc39urweeqj3yvm9wlauc",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1246zy658dfgtausf0c4a6ly8sc2e285q4kxqga"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1tq4mammgkqrxrmcfhwdz59mwvwf4qgy6rdrt46",
-    "lp_token_id": "terra1t6chem282fju8jhgnkrpcm5ltc3frxq93qsped",
     "asset_ids": [
       "uusd",
       "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1t6chem282fju8jhgnkrpcm5ltc3frxq93qsped"
   },
   {
     "id": "terra1tqk8w5zzkv0affe375m7pldgwvx8m496lrhcsx",
-    "lp_token_id": "terra17y23mq28m6df9gghnf0d4tzedrsga2v4k36k56",
     "asset_ids": [
       "terra160hntqlsd7wzyydhzw653lw8puftnwaj327xyd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17y23mq28m6df9gghnf0d4tzedrsga2v4k36k56"
   },
   {
     "id": "terra1trsmqwdgej32welv329ranjf60edtl0q4qrm7w",
-    "lp_token_id": "terra147kcqfp5kw9m5axds4ulz0h9z4wcc9uga7yfsh",
     "asset_ids": [
       "terra1ckkyhfxnqkumqrvmpl6rnrjzvklephzvsse57z",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra147kcqfp5kw9m5axds4ulz0h9z4wcc9uga7yfsh"
   },
   {
     "id": "terra1tu9a790fj5mv2qlxmsqaxejysutmtnqyf86tlf",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1dj2cj02zak0nvwy3uj9r9dhhxhdwxnw6psse6p"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1twvmq2yfahhdpelavz94d9xhcmrfyazrn08lrz",
-    "lp_token_id": "terra1wdjsxymg424mw4sv6zmw4luqajwxa5e7qfvfxw",
     "asset_ids": [
       "terra1ltfq7n4x383t8wjmp8ujjzrvyskk6eu4y2p3qh",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1wdjsxymg424mw4sv6zmw4luqajwxa5e7qfvfxw"
   },
   {
     "id": "terra1tz76786rwwnfra68jx3rhfnst3p6d3dscvuduj",
-    "lp_token_id": "terra120zjj4dze8wll9c0xtxsmds7zv26n0cam852kp",
     "asset_ids": [
       "terra1dkhqqfc4gkrcs35xjndvea7fl3mur0uptzmaxr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra120zjj4dze8wll9c0xtxsmds7zv26n0cam852kp"
   },
   {
     "id": "terra1tzfcwlfyf8608y6m6xhelhckd97hquqpu3rp7j",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1cdg2m5swqzatvzuvseef9xcxpwqylx2h983hm4",
       "uchf"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1u3pknaazmmudfwxsclcfg3zy74s3zd3anc5m52",
-    "lp_token_id": "terra1mv3pgkzs4krcennqj442jscg6jv84cejrs50n2",
     "asset_ids": [
       "uusd",
       "terra1u43zu5amjlsgty5j64445fr9yglhm53m576ugh"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mv3pgkzs4krcennqj442jscg6jv84cejrs50n2"
   },
   {
     "id": "terra1u475wh425cs3wmgjqn4fqxyqpv7qmsnw7qs0sd",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1yrch507vhsmd9rue6q3v8pz4pe445jl09nrvz6"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1u4je05rr7galjya4pn2c6s4gutg4evmt9qlxl5",
-    "lp_token_id": "terra1wfms03rc04cdc0xvs7rh8z3s498ns2zgqctq7y",
     "asset_ids": [
       "terra1ghtspakevqnazc3jtceag7uc3tnjujs94edlkf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1wfms03rc04cdc0xvs7rh8z3s498ns2zgqctq7y"
   },
   {
     "id": "terra1u4uuvku6lupcwn2w8h3d4xmfedf6fz5x6xup8r",
-    "lp_token_id": "terra1423vexq03kadycrhzu4phqrwal8nrls6yzzv45",
     "asset_ids": [
       "terra1qt0j6rzqrc0rxpxxlyrvljmjkxrss2frsef5n0",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1423vexq03kadycrhzu4phqrwal8nrls6yzzv45"
   },
   {
     "id": "terra1u522uyxu6t9lku7gawf6k8evmrlqkjazgj4yk8",
-    "lp_token_id": "terra1wg3dhzz6m5q3dm738u6sxzxhld60l0chgvpele",
     "asset_ids": [
       "terra1c2mghp27ysrmmw0na4cvvsmn5s4n27hq4hhfqd",
       "ukrw"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1wg3dhzz6m5q3dm738u6sxzxhld60l0chgvpele"
   },
   {
     "id": "terra1u56eamzkwzpm696hae4kl92jm6xxztar9uhkea",
-    "lp_token_id": "terra1falkl6jy4087h4z567y2l59defm9acmwcs70ts",
     "asset_ids": [
       "uusd",
       "terra1h8arz2k547uvmpxctuwush3jzc8fun4s96qgwt"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1falkl6jy4087h4z567y2l59defm9acmwcs70ts"
   },
   {
     "id": "terra1u6dhkawjqxn0za9w8kvr7588ng9y73l0vj62fa",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra169edevav3pdrtjcx35j6pvzuv54aevewar4nlh",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1u79vnslyaxprhmeqla6lj7dkcecg800ssclhu6",
-    "lp_token_id": "terra13sjghs2r7seamgr4g9c4p2eeacknggetsrhcar",
     "asset_ids": [
       "uusd",
       "terra149755r3y0rve30e209awkhn5cxgkn5c8ju9pm5"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra13sjghs2r7seamgr4g9c4p2eeacknggetsrhcar"
   },
   {
     "id": "terra1u993cu7zuzsgt4el5f6qu235xw2shezrde393r",
-    "lp_token_id": "terra143szxpzsamn9x6z2uwjm58369n9dmzt2rr77sk",
     "asset_ids": [
       "terra1v60qvtprpwt65w5tfamt4l4wpp3jk5mfeh64rt",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra143szxpzsamn9x6z2uwjm58369n9dmzt2rr77sk"
   },
   {
     "id": "terra1u9jgz9t8huvxcfc3u4w78u3fdxftcmzv297nc2",
-    "lp_token_id": "terra19zkcq8cq3w8vl58w7nkz07n6y9ujc47ftcakgh",
     "asset_ids": [
       "terra190tqwgqx7s8qrknz6kckct7v607cu068gfujpk",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19zkcq8cq3w8vl58w7nkz07n6y9ujc47ftcakgh"
   },
   {
     "id": "terra1uahrcwj3k2vjngvmr646226zg2fe2q3dguhlc5",
-    "lp_token_id": "terra172unvcgg9tys53l8m5hxedw7uey4cya39e5agc",
     "asset_ids": [
       "terra1laqzmwrpyrd5tumpx5hs638tzhle4nc42k9jak",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra172unvcgg9tys53l8m5hxedw7uey4cya39e5agc"
   },
   {
     "id": "terra1uenpalqlmfaf4efgtqsvzpa3gh898d9h2a232g",
-    "lp_token_id": "terra1mtvslkm2tgsmh908dsfksnqu7r7lulh24a6knv",
     "asset_ids": [
       "uusd",
       "terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mtvslkm2tgsmh908dsfksnqu7r7lulh24a6knv"
   },
   {
     "id": "terra1ufl3mnqqkucdgp68zrqxwmth9yy3ja5hnjv2c0",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kp8vne240370hn722ec5sacsdluyt2j0gc5nph",
       "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1upmgq76cn9fcyftawd5a03nm88y8c82gnwhkhp",
-    "lp_token_id": "terra14lvlk5z3kcdpm0026w4a7wfv5cvvegdyrpwjnh",
     "asset_ids": [
       "uusd",
       "terra17ana8hvzea0q7w367dm0dw48sxwql39qekpt7g"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14lvlk5z3kcdpm0026w4a7wfv5cvvegdyrpwjnh"
   },
   {
     "id": "terra1upuslwv5twc8l7hrwlka4wju9z97q8ju63a6jt",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ustvnmngueq0p4jd7gfnutgvdc6ujpsjhsjd02",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1urmuf440vzkj48uh7x89vgmsp3w4tyzs0dln02",
-    "lp_token_id": "terra1uc59nf6kzep09k4fruxh2kzfq5kztlqwrnezk5",
     "asset_ids": [
       "terra15pr9sk7qkr46ys4gaxmsyl825m4fgl7fdjwqaj",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1uc59nf6kzep09k4fruxh2kzfq5kztlqwrnezk5"
   },
   {
     "id": "terra1urnd4esuqwq89ylqrrh6lktp3rdaew9hqm8txc",
-    "lp_token_id": "terra19zju3mkymrhfefd9lv7mq0u9ke0xmveemuu33g",
     "asset_ids": [
       "terra174muj5m4c83mvtr49dm4gvf5h2zp24nzphwvmc",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19zju3mkymrhfefd9lv7mq0u9ke0xmveemuu33g"
   },
   {
     "id": "terra1urt608par6rkcancsjzm76472phptfwq397gpm",
-    "lp_token_id": "terra1pc6fvx7vzk220uj840kmkrnyjhjwxcrneuffnk",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "terra1042wzrwg2uk6jqxjm34ysqquyr9esdgm5qyswz"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1pc6fvx7vzk220uj840kmkrnyjhjwxcrneuffnk"
   },
   {
     "id": "terra1ut8zf8q03vcutkqgfhd8vep4xzkstt4jhap4cc",
-    "lp_token_id": "terra14y8396cv7trzufwknxy0jd545jdagx5d0n82ce",
     "asset_ids": [
       "uusd",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14y8396cv7trzufwknxy0jd545jdagx5d0n82ce"
   },
   {
     "id": "terra1uvchkwq4kv0vhy23c78hyy72zks2hqtpctklh2",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kvjscdgwuvwc6uzm4rqfjl6nlmuhj28tequlnc",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1uxduyw72vlrh8t0hvmrwn270l7z650ykeevx03",
-    "lp_token_id": "terra1qajzf4lefy6wcvpc0dk7fvundp8arcukz7jwp4",
     "asset_ids": [
       "terra18ykszsm06k0suqjvz0q040lm36u7pn9eeq4uc4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qajzf4lefy6wcvpc0dk7fvundp8arcukz7jwp4"
   },
   {
     "id": "terra1uxf47plxtc9tj4lnfwrlah0xp04hhhquye0wcf",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vte2xv7dr8sfnrnwdf9arcyprqgr0hty5ads28",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1uytrvr6hqkptkkyesmf78qgwz9rhhcsxul9zsf",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rxfw0y02hfhnase727dqpn8kn2uu49qwrwul8t",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1uyvksaz9xpgxpqnq8vz9vzg59up8mlhx3463tf",
-    "lp_token_id": "terra1wlssklspcq2arkl0vqgha5rg2sz8jfufvmjj82",
     "asset_ids": [
       "terra1u2k0nkenw0p25ljsr4ksh7rxm65y466vkdewwj",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1wlssklspcq2arkl0vqgha5rg2sz8jfufvmjj82"
   },
   {
     "id": "terra1uz8dm5nfyrqxq0qutlx3xsgqq0ca4v7jr75zuz",
-    "lp_token_id": "terra1fvy3m6z2rsdzg5qkuuwptusw96k2ayp4fw42a5",
     "asset_ids": [
       "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
       "terra1lladdxhn49jz0hrvwgalu4a548txh94mcec595"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fvy3m6z2rsdzg5qkuuwptusw96k2ayp4fw42a5"
   },
   {
     "id": "terra1uz8hhjwg3472744kgkz69jfqf3d2uwl5aw66mw",
-    "lp_token_id": "terra1svt83amwsvghu9elhme382em26vupp0uprur9p",
     "asset_ids": [
       "terra14f7u8z4eqpxcrp4xr6knhgfp5n4h68nwy3yzg5",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1svt83amwsvghu9elhme382em26vupp0uprur9p"
   },
   {
     "id": "terra1v0lwlpagxy4mpyd4j9xg37tq3nz4wrrgz98e5q",
-    "lp_token_id": "terra1hdnfxxn7j84t4jwjxsegd9qmcksfa8zjldc37l",
     "asset_ids": [
       "terra1dyptd3795l57lencr2eltut973kum8wgu36f7p",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1hdnfxxn7j84t4jwjxsegd9qmcksfa8zjldc37l"
   },
   {
     "id": "terra1v25n4wuld4zyuglmurx32tru56qtk5hxqe4vu3",
-    "lp_token_id": "terra1sr3r222uaw80q0rnu04atj2hxtak3kwcgkvlj0",
     "asset_ids": [
       "uchf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1sr3r222uaw80q0rnu04atj2hxtak3kwcgkvlj0"
   },
   {
     "id": "terra1v2yed2jlgunnh4u2xejd7c30ys7r33fheea7n4",
-    "lp_token_id": "terra1jv3g5g7sew53wzgu3ngn4e3ljdzcgsuzmhjsg9",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1jv3g5g7sew53wzgu3ngn4e3ljdzcgsuzmhjsg9"
   },
   {
     "id": "terra1v42wjhpntmq8nxjuqm6tttkx4q8zfrdd7ps3z7",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13jkds0xx2hy2xrqwggzkt4navhremx2cjyl7aw",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1v4kpj65uq63m4x0mqzntzm27ecpactt42nyp5c",
-    "lp_token_id": "terra17pqpurglgfqnvkhypask28c3llnf69cstaquke",
     "asset_ids": [
       "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17pqpurglgfqnvkhypask28c3llnf69cstaquke"
   },
   {
     "id": "terra1v62azzxe9np653n09q5v0p4v0xrrzausukwq45",
-    "lp_token_id": "terra1s89gf74pdhen0lgugethgf2jv3y2kc44xtyake",
     "asset_ids": [
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1s89gf74pdhen0lgugethgf2jv3y2kc44xtyake"
   },
   {
     "id": "terra1v846hwep6tr3wfwe2phu3z5ht9ufm9kwqzn7w3",
-    "lp_token_id": "terra1hz2xxt4saxl79k4p3c9pqutldyqcugwuh8fzpl",
     "asset_ids": [
       "terra16hwgds2089kktskluq8dh5ntw7eu5e4q4z6ud4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1hz2xxt4saxl79k4p3c9pqutldyqcugwuh8fzpl"
   },
   {
     "id": "terra1v97030v5lhr3f65qen0pc5k0723qhs5uplxnxp",
-    "lp_token_id": "terra166y3h6l4k42lrrj83y4lp9cdyqyxhv4cnkrjs7",
     "asset_ids": [
       "terra14s3g6jmytjjg2jcxmmaj6k837vcr6h98muxc07",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra166y3h6l4k42lrrj83y4lp9cdyqyxhv4cnkrjs7"
   },
   {
     "id": "terra1vau3jl4x6206qx9acy6pya4vk8utv5gex0sm9l",
-    "lp_token_id": "terra1xsfjx985rvkchme4wws0fjt79x3wylmjyhvvv2",
     "asset_ids": [
       "terra1p8yhtrp8ttcrrl90kqez0602yl2sx2gvrw4h23",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1xsfjx985rvkchme4wws0fjt79x3wylmjyhvvv2"
   },
   {
     "id": "terra1vayuttjw6z4hk5r734z9qatgs8vp6r5a2t043p",
-    "lp_token_id": "terra1p4pfnpsv8ly4mgzsmegz52kgjq8gp64almryky",
     "asset_ids": [
       "terra1m3tdguf59xq3pa2twk5fjte5g6szj5y9x5npy7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1p4pfnpsv8ly4mgzsmegz52kgjq8gp64almryky"
   },
   {
     "id": "terra1vfk7qfdchgjadv2l2rgmkfnswe5n277kwcjafk",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra12lvpnlphqh3q0cxp8y47e5km8k2ad5ydw5asu4"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1vjn47wdahfwxe0qm68e6k2c9uhcy4mltjdjup7",
-    "lp_token_id": "terra1ucfttyyfm48fepyrstxlkjpp0qa9ygvln6jez0",
     "asset_ids": [
       "terra18yqdfzfhnguerz9du5mnvxsh5kxlknqhcxzjfr",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ucfttyyfm48fepyrstxlkjpp0qa9ygvln6jez0"
   },
   {
     "id": "terra1vkvmvnmex90wanque26mjvay2mdtf0rz57fm6d",
-    "lp_token_id": "terra1q7m2qsj3nzlz5ng25z5q5w5qcqldclfe3ljup9",
     "asset_ids": [
       "uusd",
       "terra165nd2qmrtszehcfrntlplzern7zl4ahtlhd5t2"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1q7m2qsj3nzlz5ng25z5q5w5qcqldclfe3ljup9"
   },
   {
     "id": "terra1vmvsdr04xdhh7mure2v9lgwy7l6js6s3689qyg",
-    "lp_token_id": "terra1a05a50wz2n8mlr5nzwlsftzrdf9gvy5sypxdg9",
     "asset_ids": [
       "terra1yuvwz0wzd49mjlvh24g23jst89dllua0nc3knt",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1a05a50wz2n8mlr5nzwlsftzrdf9gvy5sypxdg9"
   },
   {
     "id": "terra1vnpmtslwxr76ar3wmjy8jlp6c5y0sckvh96esl",
-    "lp_token_id": "terra1hmuhs99qw938edq07c4sguhnpmwaulxjmufm9u",
     "asset_ids": [
       "terra1p9wk5tns7jagwch6cdasgd753nzfj544v75qxr",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1hmuhs99qw938edq07c4sguhnpmwaulxjmufm9u"
   },
   {
     "id": "terra1vq8ygvc47qn277pke8k3jvuyslh3ljtqkxka3m",
-    "lp_token_id": "terra1mc4tyswf0msvm2358x7eyrlswn54n6x973v60a",
     "asset_ids": [
       "terra1aft2zjfhmetslqvy0jg6d0ywhf9r5zf5zqratc",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mc4tyswf0msvm2358x7eyrlswn54n6x973v60a"
   },
   {
     "id": "terra1vs2vuks65rq7xj78mwtvn7vvnm2gn7adjlr002",
-    "lp_token_id": "terra1mljg7dvzknqh3gc62emagf7hwxxg8efemennp8",
     "asset_ids": [
       "usdr",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mljg7dvzknqh3gc62emagf7hwxxg8efemennp8"
   },
   {
     "id": "terra1vwk0dhr5lha56ssddl58ntxlcunfru36d0jfuf",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra18xyl0ees6ueyhkhn0mjdtrm82e393ult2dazl3"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1w3uwnguslkntkm3wsq86zan0a6jgtgwk0wr8z8",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1w8symfluw393l0f83wv7rv64jklhegcjk2yv0p",
-    "lp_token_id": "terra1p9hy2wvdgzdngexhtqfhllme89gvjpsj4uqe9w",
     "asset_ids": [
       "uusd",
       "terra1qsnj5gvq8rgs7yws8x5u02gwd5wvtu4tks0hjm"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1p9hy2wvdgzdngexhtqfhllme89gvjpsj4uqe9w"
   },
   {
     "id": "terra1wcpqg4pr62dku9cry6r6xp7pagarvtzjtpql3n",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14vw4sfqwe7jw8ppcc7u44vq7hy9qa2nlstnxmu",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1wl3ravhhyqmtslfrwvpap0xda2pwq4epxd0adu",
-    "lp_token_id": "terra12ma0hyjetxx2w2vz0vagd4huyuf54v4uf69uc0",
     "asset_ids": [
       "terra1hc9zu9jx0vy5gt8yl7evu0wk6xvjl0ylnsg75x",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra12ma0hyjetxx2w2vz0vagd4huyuf54v4uf69uc0"
   },
   {
     "id": "terra1wm0ht8upyxy6lkn236hmzp657m58wlwsahkgn9",
-    "lp_token_id": "terra1fa6hue6yjt90ytjuxqv6mlsmrm2agc7w6vjhd4",
     "asset_ids": [
       "terra129796y06jrejsk9hjmvhkhat92mxt76k6qpyfw",
       "ukrw"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1fa6hue6yjt90ytjuxqv6mlsmrm2agc7w6vjhd4"
   },
   {
     "id": "terra1wmz6qgayzam40lzplz55mmss8xadcqm7mx6f93",
-    "lp_token_id": "terra16x0yfryw50tr8a4mhkh2jv2fccdtm8nyavcfxe",
     "asset_ids": [
       "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra16x0yfryw50tr8a4mhkh2jv2fccdtm8nyavcfxe"
   },
   {
     "id": "terra1wqvhrrzkcn7dv2rkd5gdq2prawm64g7lnasy47",
-    "lp_token_id": "terra14ppflprywpsgwds6wn6ffrlruyqv4sl3m90mjq",
     "asset_ids": [
       "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14ppflprywpsgwds6wn6ffrlruyqv4sl3m90mjq"
   },
   {
     "id": "terra1wrcvvmwcy5kfqlmdfv4jsekv4uxjxhyl3s8hk4",
-    "lp_token_id": "terra13p06gkedafgwg57fdhvsrxra88q6ydx97l55nl",
     "asset_ids": [
       "terra1t4hgtl3uqukaas9lzswl9hr7d55mn3tq3tt3rd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra13p06gkedafgwg57fdhvsrxra88q6ydx97l55nl"
   },
   {
     "id": "terra1wrwf3um5vm30vpwnlpvjzgwpf5fjknt68nah05",
-    "lp_token_id": "terra1qxlp0q3z20llu0gz9c7urzw7rmlnchm23yk8xc",
     "asset_ids": [
       "terra1nuy34nwnsh53ygpc4xprlj263cztw7vc99leh2",
       "terra17dkr9rnmtmu7x4azrpupukvur2crnptyfvsrvr"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1qxlp0q3z20llu0gz9c7urzw7rmlnchm23yk8xc"
   },
   {
     "id": "terra1ws34kqg6kek40jy8amdz7j4tyzqx8cenz40rem",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw",
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1wwtdsvlakd9dxstp85vyawrh5t6ftjuuqern0n",
-    "lp_token_id": "terra1kucdkxvceeue4lknqdjc49jazkuw3hmx6jqr2l",
     "asset_ids": [
       "terra1t9m52s6gey6mcy9upq5ucujl5n6ewwqk80hp8t",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1kucdkxvceeue4lknqdjc49jazkuw3hmx6jqr2l"
   },
   {
     "id": "terra1wwyh5grgm8h7y2k0jy0n6h8em3su0cverprwgm",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "ueur"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1wye679e2zq7pu55yzs9g9ptq054waaang0frfn",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1f62tqesptvmhtzr8sudru00gsdtdz24srgm7wp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1x2jjzqv55f3gvrh8ytejkt998p8vnhn0gcg26w",
-    "lp_token_id": "terra1vxplg3wdnz4xtqu8srfvsgh2ws7nt63qx77np9",
     "asset_ids": [
       "terra1a8an0aqzjghcukqrdgnkt3ygzhmaaqza03mc3h",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1vxplg3wdnz4xtqu8srfvsgh2ws7nt63qx77np9"
   },
   {
     "id": "terra1x5m76lyeklv2hl50kqlmw5893qawq22k30yw45",
-    "lp_token_id": "terra1gq6ulqmrxnzx8uyrmjmqu4kguqxyy8xwky5mh4",
     "asset_ids": [
       "terra1em52fj74ezgeqp5s6mp96y494s2gkjmtqy46sq",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1gq6ulqmrxnzx8uyrmjmqu4kguqxyy8xwky5mh4"
   },
   {
     "id": "terra1x5zatqdvtxkc6fz96h4zslfj4zueqr8rmdvfje",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1v8wg6yr69cu842w053f8qk909f4swp4cn2waqp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1x6umr9xk86l37gxsayt4fz26cku4dya7qr2gtn",
-    "lp_token_id": "terra1t46rhfcgqpz9xkx33qpzk55yudp7wdaygj7yfw",
     "asset_ids": [
       "terra1r98ydsd3jdjpnq8hhcdd5rnptf2l0r7zvaxu48",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1t46rhfcgqpz9xkx33qpzk55yudp7wdaygj7yfw"
   },
   {
     "id": "terra1x8h5gan6vey5cz2xfyst74mtqsj7746fqj2hze",
-    "lp_token_id": "terra1spagsh9rgcpdgl5pj6lfyftmhtz9elugurfl92",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1spagsh9rgcpdgl5pj6lfyftmhtz9elugurfl92"
   },
   {
     "id": "terra1x9jv7vjcpy46k7eadp9ldx0jkkx3f8n2yvwtxe",
-    "lp_token_id": "terra1tctqptkl50uxqt3wgpt02cmk8vxye3a3fvcm7f",
     "asset_ids": [
       "terra1xk0a738cxushekjtvf6f9qtr7uz36yxc3egne4",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1tctqptkl50uxqt3wgpt02cmk8vxye3a3fvcm7f"
   },
   {
     "id": "terra1xf3u2ka5tvtq23wqy9dk94zx3kyaqvttzfetvv",
-    "lp_token_id": "terra17a995wgrz7ch4qvk3s748tzs9u89a274yk8qh0",
     "asset_ids": [
       "terra1d6vy3aueuucu3sf5qkrccnq7v58uwegh9m9x74",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra17a995wgrz7ch4qvk3s748tzs9u89a274yk8qh0"
   },
   {
     "id": "terra1xg660nndl83z5n7j4jd0cnrygs5dndcj30sazn",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ehcjwxwf96c278n2ks84zes3ece5fqy78fa749",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1xj2w7w8mx6m2nueczgsxy2gnmujwejjeu2xf78",
-    "lp_token_id": "terra1n3gt4k3vth0uppk0urche6m3geu9eqcyujt88q",
     "asset_ids": [
       "terra100yeqvww74h4yaejj6h733thgcafdaukjtw397",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1n3gt4k3vth0uppk0urche6m3geu9eqcyujt88q"
   },
   {
     "id": "terra1xk2tjgs43pv3pkfv4cmwauvnjd09wxsaedshg4",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1h8arz2k547uvmpxctuwush3jzc8fun4s96qgwt"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1xk72vswca7jkjg8cpl9dz0qvfadam3ms365lp7",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1jxypgnfa07j6w92wazzyskhreq2ey2a5crgt6z",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1xljkuseertrcrguycjwvqhht22u75epe6hdcxr",
-    "lp_token_id": "terra1s4jnf3gaw27ju6x9jll7sar06e6m2hj5hklmsj",
     "asset_ids": [
       "terra12l53n0hg4kh9y8jlafd7lyakj3lrejedpryj7s",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1s4jnf3gaw27ju6x9jll7sar06e6m2hj5hklmsj"
   },
   {
     "id": "terra1xly8628q4w7ytfq2dtxt7c39knnhqnaj83zzsx",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1xqsumj7ydu0dwnsf66hf4aye8l0gyaawz87rrk",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1qsnj5gvq8rgs7yws8x5u02gwd5wvtu4tks0hjm",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1xskmucgxkzf3quwry3dazerw74q4aqplu0vgg4",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1xtm4yzrd3a7k6pzqjnk0kag0gea7w0rkkzmqg3",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1xw6yl2vhnlusw5gnj7l2mk0em80c2mw03n9ny0",
-    "lp_token_id": "terra1muk54uc0pqjwe6w26tpwun0x55ncttnadxrr6l",
     "asset_ids": [
       "terra1gcfdqwp2ztyn22mu845n7axlua6nwt38s4nkdl",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1muk54uc0pqjwe6w26tpwun0x55ncttnadxrr6l"
   },
   {
     "id": "terra1y0z6ulatz6puwdrjk3lnyltc2vg9rvgwyztrg3",
-    "lp_token_id": "terra1dwr0kh0gpv0xmk0u57m8j7clg3s0zq9d27aawt",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "ugbp"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1dwr0kh0gpv0xmk0u57m8j7clg3s0zq9d27aawt"
   },
   {
     "id": "terra1y24vfnpcr0f037tww6t87cwuxq3dul74rstkl0",
-    "lp_token_id": "terra1ll78pl5a256d7lgqk49mc0r4cj9fnn544pwr0e",
     "asset_ids": [
       "terra15823sstx9pl2fqacnpaxsj9jsku2rjrk4aj34z",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ll78pl5a256d7lgqk49mc0r4cj9fnn544pwr0e"
   },
   {
     "id": "terra1y7vdguewgus669kcxjlwughyxtdt3kheys05q0",
-    "lp_token_id": "terra10t6a287n4flvjpvdwuhre79ws9plufaagdj4r4",
     "asset_ids": [
       "uusd",
       "terra1qsnj5gvq8rgs7yws8x5u02gwd5wvtu4tks0hjm"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra10t6a287n4flvjpvdwuhre79ws9plufaagdj4r4"
   },
   {
     "id": "terra1y8mwewf406ayd8uquekh5a7yljpfdcjekkle9c",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1y8uendv07j259m26dmw0mtcy4mvc5wc2qhptyr",
-    "lp_token_id": "terra1kmf20rwahh3e22af9u6vq2h5s7kh89fhd9g5ds",
     "asset_ids": [
       "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a",
       "terra1cdg2m5swqzatvzuvseef9xcxpwqylx2h983hm4"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1kmf20rwahh3e22af9u6vq2h5s7kh89fhd9g5ds"
   },
   {
     "id": "terra1ycp5lnn0qu4sq4wq7k63zax9f05852xt9nu3yc",
-    "lp_token_id": "terra1l0wqwge0vtfmukx028pluxsr7ee2vk8gl5mlxr",
     "asset_ids": [
       "terra1cl7whtrqmz5ldr553q69qahck8xvk80fm33qjx",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1l0wqwge0vtfmukx028pluxsr7ee2vk8gl5mlxr"
   },
   {
     "id": "terra1yecrrjs5alr5vakfrvvh0yrufvfla50fpcvefk",
-    "lp_token_id": "terra1rfrwm60zydsdsr9hy4smp7sckuq57nt56s3tp9",
     "asset_ids": [
       "terra1xy2gf523j92khfn8nx0uurkmkguul2u95cwv8v",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1rfrwm60zydsdsr9hy4smp7sckuq57nt56s3tp9"
   },
   {
     "id": "terra1yfpksrlypf5c3xc9ktsup9mtxw24r6sshck3g0",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1a07n2cp4wd49ezxdgm9xgtfrnpmxfcdp4yrdnv",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1yg74xslj94r7cjweu8gg6s5c497vs2sdd6zwgy",
-    "lp_token_id": "terra1z36hglaqjgv867xr7e4jsz32pr7mcstjg2xm6u",
     "asset_ids": [
       "terra1rp3mdhrwxhdlx923t2q50f0n6z6660z9yqghpv",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1z36hglaqjgv867xr7e4jsz32pr7mcstjg2xm6u"
   },
   {
     "id": "terra1ykfz4hrq8en2f098j8a4ppaq8u8hangpw9tnqu",
-    "lp_token_id": "terra1vwx88jskew3sdf2wpzj6e03mtw2t0c0rajg72u",
     "asset_ids": [
       "terra193c42lfwmlkasvcw22l9qqzc5q2dx208tkd7wl",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1vwx88jskew3sdf2wpzj6e03mtw2t0c0rajg72u"
   },
   {
     "id": "terra1yl2atgxw422qxahm02p364wtgu7gmeya237pcs",
-    "lp_token_id": "terra1jh2dh4g65hptsrwjv53nhsnkwlw8jdrxaxrca0",
     "asset_ids": [
       "uusd",
       "terra1mqsjugsugfprn3cvgxsrr8akkvdxv2pzc74us7"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1jh2dh4g65hptsrwjv53nhsnkwlw8jdrxaxrca0"
   },
   {
     "id": "terra1yl9lv57fq5txrfzwevjdh5v28z9tt0cn3rsyx6",
-    "lp_token_id": "terra1m386g65qjvcf6nrz6p0ael59y37l5suf6ys6sm",
     "asset_ids": [
       "terra1hw6q5ecr0gp09v668szzx3qz86w08jru9rqyq7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1m386g65qjvcf6nrz6p0ael59y37l5suf6ys6sm"
   },
   {
     "id": "terra1ylw3fvy4h5ll9tyaeuxrqngwnlqp3jtaegtjfq",
-    "lp_token_id": "terra15lnt74xvhhrz528gkhtz9xe23r77w00chktddr",
     "asset_ids": [
       "terra17raumdxxxlm8smtx2pcxmqpz7qq9am4zfxzl8d",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra15lnt74xvhhrz528gkhtz9xe23r77w00chktddr"
   },
   {
     "id": "terra1ylwwchhdvck0n07sks7703xzke7vk2yudu3s7d",
-    "lp_token_id": "terra1et5tavdywdx5ug6ywph9uhnwnkc70zg8e26x0l",
     "asset_ids": [
       "terra1cuku0vggplpgfxegdrenp302km26symjk4xxaf",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1et5tavdywdx5ug6ywph9uhnwnkc70zg8e26x0l"
   },
   {
     "id": "terra1yn9quy0xsvjenh3l96lc2ff7l0s3r7yk43qn9f",
-    "lp_token_id": "terra1ttul46957r00dkxuduqcadn5yuhqrspdk7hvga",
     "asset_ids": [
       "uusd",
       "terra18wayjpyq28gd970qzgjfmsjj7dmgdk039duhph"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1ttul46957r00dkxuduqcadn5yuhqrspdk7hvga"
   },
   {
     "id": "terra1yngadscckdtd68nzw5r5va36jccjmmasm7klpp",
-    "lp_token_id": "terra1cmrl4txa7cwd7cygpp4yzu7xu8g7c772els2y8",
     "asset_ids": [
       "uusd",
       "terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1cmrl4txa7cwd7cygpp4yzu7xu8g7c772els2y8"
   },
   {
     "id": "terra1yphapr9zkd7eq60n2nux0xfldzs58z9ncs7s6f",
-    "lp_token_id": "terra146dmpuj9zyzk6a47qdfn0djup3kddey5vdpk0c",
     "asset_ids": [
       "uusd",
       "terra17ana8hvzea0q7w367dm0dw48sxwql39qekpt7g"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra146dmpuj9zyzk6a47qdfn0djup3kddey5vdpk0c"
   },
   {
     "id": "terra1yppvuda72pvmxd727knemvzsuergtslj486rdq",
-    "lp_token_id": "terra1mwu3cqzvhygqg7vrsa6kfstgg9d6yzkgs6yy3t",
     "asset_ids": [
       "uusd",
       "terra1jsxngqasf2zynj5kyh0tgq9mj3zksa5gk35j4k"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1mwu3cqzvhygqg7vrsa6kfstgg9d6yzkgs6yy3t"
   },
   {
     "id": "terra1ysac4wfu87qgu0qkkz8yrh57wwgx2upytva3fx",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "ueur"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1yusz6qz86wuhd7vlkkc89e0y6j8au6w93f24fm",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1yvfnqxcksy6007sp6rfu776chtugm2u7qfhved",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1yx5487aewxagnrg8s0s5aar7kzzjyhtr52gtyr",
-    "lp_token_id": "terra1epnyjjcg6thvxrm0mzffrcx7wyludl9t7z3ja5",
     "asset_ids": [
       "terra1n2rujfc5lscglry30zaptfgncfc0gq4n8my0gv",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1epnyjjcg6thvxrm0mzffrcx7wyludl9t7z3ja5"
   },
   {
     "id": "terra1yxfvmmy6ftelwk9ke2y7kmyxh7pkd0ev6d47e6",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1353an33z0u5dd0yajwjazfnyt4585q5085c5mg",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1yypalnanxp26u5uypunlj7mwx0mrkrfw3juqtf",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1f77l2dprlhg2h47uvhzp2zhkdrkcy8fse90xkk",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1yz9qsxe70p6j4vdhrmsg45gs858lhqzxq3dgh7",
-    "lp_token_id": "terra1peprsfuh0kt3xz8zgjmy9rfgx40jpf36cp24sa",
     "asset_ids": [
       "terra1gazefv0j5m0hhalp0qea5smypej2r0matncl88",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1peprsfuh0kt3xz8zgjmy9rfgx40jpf36cp24sa"
   },
   {
     "id": "terra1z4pwt3nqrwkvw26vl5tr0pm595t5qf7a2s20kk",
-    "lp_token_id": "terra1y7rnxw089cv0a5t5jlaa6wuh5uaa78rnm5k7n6",
     "asset_ids": [
       "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
       "usek"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1y7rnxw089cv0a5t5jlaa6wuh5uaa78rnm5k7n6"
   },
   {
     "id": "terra1z50zu7j39s2dls8k9xqyxc89305up0w7f7ec3n",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1z6tp0ruxvynsx5r9mmcc2wcezz9ey9pmrw5r8g",
-    "lp_token_id": "terra14ffp0waxcck733a9jfd58d86h9rac2chf5xhev",
     "asset_ids": [
       "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra14ffp0waxcck733a9jfd58d86h9rac2chf5xhev"
   },
   {
     "id": "terra1z8masgnagfxvjwdqc43mltrzpa3t4x5u873vz6",
-    "lp_token_id": "terra1yxaczswtwnlqqyn9x9ccsa495lm2tlrte5aa9g",
     "asset_ids": [
       "terra1drsjzvzej4h4qlehcfwclxg4w5l3h5tuvd3jd8",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1yxaczswtwnlqqyn9x9ccsa495lm2tlrte5aa9g"
   },
   {
     "id": "terra1ze5f2lm5clq2cdd9y2ve3lglfrq6ap8cqncld8",
-    "lp_token_id": "terra1pjgzke6h5v4nz978z3a92gqajwhn8yyh5kv4zv",
     "asset_ids": [
       "uusd",
       "terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1pjgzke6h5v4nz978z3a92gqajwhn8yyh5kv4zv"
   },
   {
     "id": "terra1zey9knmvs2frfrjnf4cfv4prc4ts3mrsefstrj",
-    "lp_token_id": "terra1utf3tm35qk6fkft7ltcnscwml737vfz7xghwn5",
     "asset_ids": [
       "uusd",
       "terra1lvmx8fsagy70tv0fhmfzdw9h6s3sy4prz38ugf"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1utf3tm35qk6fkft7ltcnscwml737vfz7xghwn5"
   },
   {
     "id": "terra1zgrz3dc3cpgk9qet8r7767yvpdpsuvlc6ymvee",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
       "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1zh33l9e6pj385jpum6uyngwhhe62p9gfaph2gl",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13awdgcx40tz5uygkgm79dytez3x87rpg4uhnvu",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1zhffgf949uvq8sxgynmxa3n477sgvd4gf64w49",
-    "lp_token_id": "terra1jlme2556ygty3va4sw2k2p8j7lz5felpclvq0q",
     "asset_ids": [
       "terra19cnnyaah7c32hhcdt5m83pvdxa7ts64caarcm8",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1jlme2556ygty3va4sw2k2p8j7lz5felpclvq0q"
   },
   {
     "id": "terra1zjn2vpgstwl75qk0v7ae48yx3yd5layuy2s9vs",
-    "lp_token_id": "terra1nknmv45l04ft6t38zvw3xg0kqnwgqtqrewf2dh",
     "asset_ids": [
       "terra1q2k77qmnujgk0w89wx55rsnqxecz5wd86y2p2q",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1nknmv45l04ft6t38zvw3xg0kqnwgqtqrewf2dh"
   },
   {
     "id": "terra1zkyrfyq7x9v5vqnnrznn3kvj35az4f6jxftrl2",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1zpets4h5zyvhln3muemyvk7cwvmwmam4tp8c5w",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra18ej5nsuu867fkx4tuy2aglpvqjrkcrjjslap3z"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1zpu7lgsfw3l4q782wdjskn8t6nn6rwlpq3d6j6",
-    "lp_token_id": "terra1f3wqhqe7sad8f8vjvsjjv0na3w2xcc639njxjm",
     "asset_ids": [
       "terra1asq6hza8spaeghqt4k7fnj4m7nfaag07ljdqz7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1f3wqhqe7sad8f8vjvsjjv0na3w2xcc639njxjm"
   },
   {
     "id": "terra1zr24fxhh5hf8k9vqv0xp63rhyy2g373m83scps",
-    "lp_token_id": "terra19ekpmkxnysep0tuxza66z475vfd79xput6dw9l",
     "asset_ids": [
       "uusd",
       "terra1k637r8ucfp585tv57gsnqzfdmsw6mnm9zn59zy"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra19ekpmkxnysep0tuxza66z475vfd79xput6dw9l"
   },
   {
     "id": "terra1zrl9mugl97mrhtkacvws70w95sjemyxmq5ydwk",
-    "lp_token_id": "terra178lvrr8aa3fl70ar3kp9rgvny2qrnmgepa2ctw",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "terra1c00vskhyzdv0z63z2tyetzx2qma67n2z3vzyn0"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra178lvrr8aa3fl70ar3kp9rgvny2qrnmgepa2ctw"
   },
   {
     "id": "terra1zrsuu42fnz2zaj0hgl8s9fzz78wgzau3464luh",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "ueur"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1zrx57z4qhsejk3r0ug6pt3xvz2efpee39rle5n",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra182740uw8nh6tk3yjfcf7gu5phg3kqryhtuxp0p",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1zrzy688j8g6446jzd88vzjzqtywh6xavww92hy",
-    "lp_token_id": "terra1halhfnaul7c0u9t5aywj430jnlu2hgauftdvdq",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1halhfnaul7c0u9t5aywj430jnlu2hgauftdvdq"
   },
   {
     "id": "terra1zv2q88u7pslnj00w6u7ketjq77tu6lupc2twav",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1y77avpcwxc49ezmex8nsupklgc0qt7le44z4qd",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1zvn8z6y8u2ndwvsjhtpsjsghk6pa6ugwzxp6vx",
-    "lp_token_id": "terra1tuw46dwfvahpcwf3ulempzsn9a0vhazut87zec",
     "asset_ids": [
       "terra10f2mt82kjnkxqj2gepgwl637u2w4ue2z5nhz5j",
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1tuw46dwfvahpcwf3ulempzsn9a0vhazut87zec"
   },
   {
     "id": "terra1zw0kfxrxgrs5l087mjm79hcmj3y8z6tljuhpmc",
-    "lp_token_id": "terra12dnl585uxzddjw9hw4ca694f054shgpg93cg90",
     "asset_ids": [
       "ukrw",
       "uluna"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra12dnl585uxzddjw9hw4ca694f054shgpg93cg90"
   },
   {
     "id": "terra1zxcmcjurg5jrml8kv2vhupdlfqn4n6euasuc5q",
-    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
       "uchf"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "TODO LP TOKEN ID"
   },
   {
     "id": "terra1zz39wfyyqt4tjz7dz6p7s9c8pwmcw2xzde3xl8",
-    "lp_token_id": "terra1k5kumxd24cyvhf52r5u4ywlr3ztktj657wnf7a",
     "asset_ids": [
       "terra17jnhankdfl8vyzj6vejt7ag8uz0cjc9crkl2h7",
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "xyk"
+    "type": "xyk",
+    "lp_token_id": "terra1k5kumxd24cyvhf52r5u4ywlr3ztktj657wnf7a"
   }
 ]

--- a/terraclassic/pool.json
+++ b/terraclassic/pool.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "terra102t6psqa45ahfd7wjskk3gcnfev32wdngkcjzd",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
       "uluna"
@@ -21,7 +21,7 @@
   },
   {
     "id": "terra14q0cgunptuym048a4y2awt8a7fl9acudmfzk5e",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rl4zyexjphwgx6v3ytyljkkc4mrje2pyznaclv",
       "uluna"
@@ -41,7 +41,7 @@
   },
   {
     "id": "terra18fl6aywx2c8xlfp5epl40dygqnrvqp9a678a9c",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "uusd"
@@ -71,7 +71,7 @@
   },
   {
     "id": "terra1cevdyd0gvta3h79uh5t47kk235rvn42gzf0450",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kkyyh7vganlpkj0gkc2rfmhy858ma4rtwywe3x",
       "uusd"
@@ -91,7 +91,7 @@
   },
   {
     "id": "terra1gxjjrer8mywt4020xdl5e5x7n6ncn6w38gjzae",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
       "uluna"
@@ -101,7 +101,7 @@
   },
   {
     "id": "terra1h2g2mldq2fskq0sqdhupnzpfj396d03ds2yfkd",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kkyyh7vganlpkj0gkc2rfmhy858ma4rtwywe3x",
       "terra1pepwcav40nvj3kh60qqgrk8k07ydmc00xyat06"
@@ -121,7 +121,7 @@
   },
   {
     "id": "terra1n5jzjvqlylw4kz9cfed2djqvz5qsjlz4kvmkmz",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf",
       "uusd"
@@ -131,7 +131,7 @@
   },
   {
     "id": "terra1pxexyejamkg856vmspyttcy4sva84qgyaq445z",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hj8de24c3yqvcsv9r8chr03fzwsak3hgd8gv3m",
       "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58"
@@ -151,7 +151,7 @@
   },
   {
     "id": "terra1qswfc7hmmsnwf7f2nyyx843sug60urnqgz75zu",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "uluna"
@@ -191,7 +191,7 @@
   },
   {
     "id": "terra10cw43kz2ujn4ur938u2qsrr9duhsqydkrxl07p",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hqr3l4je2yvn3l790ly0y6r0vgfs7yukwwj0ak",
       "uusd"
@@ -201,7 +201,7 @@
   },
   {
     "id": "terra10k05ec24u8nrd3889c6zydr8tlv73cyhaufs4t",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14ec8v4c5dnwu2pq9plfquaffutu59tq9hld77e",
       "uusd"
@@ -221,7 +221,7 @@
   },
   {
     "id": "terra12sf5en42qlfc3qle4m4pew6n4vjc6lrpwvhh2h",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1cl7whtrqmz5ldr553q69qahck8xvk80fm33qjx",
       "terra1jn0w9ttjavzqeqmp79jzx3da6dx3p6jwmm6tk2"
@@ -241,7 +241,7 @@
   },
   {
     "id": "terra130w5j5yu7rc29wuc49qdcm2su72pljl77jlmk6",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra16x6mn6ulxzg4pgg7gpachkkgrkuac59vl7xgyl",
       "uusd"
@@ -251,7 +251,7 @@
   },
   {
     "id": "terra1366x8d5h0mexk83c8hjkqafk72a4rcwwwdk62h",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xmd43yrfxm4xy3lnptc7kr4rr93pzh5u0z0wgt",
       "uusd"
@@ -271,7 +271,7 @@
   },
   {
     "id": "terra152655kx8ff6fa393h642uu075mmu9dz8xlfqvv",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rwph273axfefh8gh57scw3jfm7kn4s7t5hlu03",
       "uusd"
@@ -281,7 +281,7 @@
   },
   {
     "id": "terra152wlyd53nfcltuwcje9ale8qv3hpyna4sv9mvg",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1mpq5zkkm39nmjrjg9raknpfrfmcfwv0nh0whvn",
       "uusd"
@@ -301,7 +301,7 @@
   },
   {
     "id": "terra15pehlkssvyu8e7x6s9gz0j9x8q2qthvcf6hdqh",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pc253zfn4zns6awk7eks779uk3m7dna7y4cmlf",
       "uusd"
@@ -311,7 +311,7 @@
   },
   {
     "id": "terra167lmzjrfvrqm59ycxvr4f937vgap4uytnkyrat",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1mely4fttd94g5kgjmz05dmclgdahq45xnv5n22",
       "uusd"
@@ -341,7 +341,7 @@
   },
   {
     "id": "terra17ds7t9z2pu3cyqtlnklhfpruc0nnahddzr49wn",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vfhh44f57a72vaqdk69k2y9pllwlrhkv32n6nr",
       "uusd"
@@ -351,7 +351,7 @@
   },
   {
     "id": "terra17umn0xctu4qj8w6psqfjfp20nx454csspuvdur",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1e6mq63y64zcxz8xyu5van4tgkhemj3r86yvgu4",
       "terra1pepwcav40nvj3kh60qqgrk8k07ydmc00xyat06"
@@ -361,7 +361,7 @@
   },
   {
     "id": "terra17w79y5ptp63dlr79tup9rkh6294qe448phup3f",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17ktj9hq69ae9mj49dwqfzmj05t6eqlkyywukf8",
       "uusd"
@@ -371,7 +371,7 @@
   },
   {
     "id": "terra1awy55useu780l3hsprulg0s26maxgtx2pjkev0",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1zce4mxwwdyk04txa2f3aqepzsq8jy7ca50gn8w",
       "uusd"
@@ -391,7 +391,7 @@
   },
   {
     "id": "terra1cylvlytxzjywy0wpf5mrtua3q37esduhqfk9w9",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vyusa796w86yh99l67dpd5g3hfva759vyuhn5z",
       "uusd"
@@ -451,7 +451,7 @@
   },
   {
     "id": "terra1equ0rx0hhk4q22v2rlg779war57rhgt7d8vwls",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12qgpr0fw773gc8lrkys3knnw6nkgdlc8ggaty9",
       "uusd"
@@ -491,7 +491,7 @@
   },
   {
     "id": "terra1fqqtkhx8c3jxfl94jzzldvjmu4u9jeuyful6ma",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1jp4r38w4j2qkxavjs9ypqv6mv833wdar3tywe2",
       "uusd"
@@ -501,7 +501,7 @@
   },
   {
     "id": "terra1gpel5uny2f2hw3e7kln4y3mluwtdlcpukaeukk",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ypgjelmtp0mv5akzwmnj5xhukhd3fy9gd28wpj",
       "uusd"
@@ -541,7 +541,7 @@
   },
   {
     "id": "terra1mxd85ljdjcm7ddfh8qvnxx8tyggnh3zsahy7aa",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17n223dxpkypc5c48la7aqjvverczg82ga3cr93",
       "uusd"
@@ -551,7 +551,7 @@
   },
   {
     "id": "terra1nq6ty6lppp7kz58nkshhmyfe8tv4p85ueh50mp",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1tf6ukhukcqwfasm6e3ae2406c87vc8zhrh5ex7",
       "uusd"
@@ -591,7 +591,7 @@
   },
   {
     "id": "terra1qv0j5udg2lcnqkuy5rqt2n6n2z9m2zps6zfx2v",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "terra18ky9ln4g6x3n9f9s8a5ttshynv6lgzfppmrmyg"
@@ -601,7 +601,7 @@
   },
   {
     "id": "terra1r49ew9xrpauml4chelxd6mt32xwpywlmcnt853",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1gjuhc34ccr6ajq7dm5266xyedu96sgkv4qnley",
       "uusd"
@@ -631,7 +631,7 @@
   },
   {
     "id": "terra1shgwa4xwdegsxvtr0qaergjq689sakzvn87fvy",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1l385362dg276797k7lzsfktskfssg22n7hn4at",
       "uusd"
@@ -671,7 +671,7 @@
   },
   {
     "id": "terra1uqsny2clznnhrmq2rvlhv72l78lmlss32uzuyh",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18ejpjp9eyx9t8j07jd7kzah9p0rvkzdfeeva6n",
       "uusd"
@@ -701,7 +701,7 @@
   },
   {
     "id": "terra1v7hcllx3l7namvvffg3jfl7vc3ksy089yr3ewu",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1mh7nlhzvvesgc4whcx7dg2nhj3p0dhl9fwrexu",
       "uusd"
@@ -721,7 +721,7 @@
   },
   {
     "id": "terra1wau74j4ykmx5nfjad4wjra8m02x9vg5h8g7ym2",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13kr45ssru9cqhp2kaaan88wfaa7f2h3jfvuldp",
       "uusd"
@@ -731,7 +731,7 @@
   },
   {
     "id": "terra1x2l3qhtcp2jlgn3duwrt7f6pqaz3tq3qydmkp4",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra153u8c40h2mm8nvs0daqxsnwgvpw43muxj3c28h",
       "uusd"
@@ -741,7 +741,7 @@
   },
   {
     "id": "terra1xckx7r8ay8hr6qneqlftcejzaqme4jw0k35e0l",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1fhsljj6qc8f7cnu62e8uxqt82czflztge05dwk",
       "uusd"
@@ -751,7 +751,7 @@
   },
   {
     "id": "terra1xhewlp3h0kh82t2n33x2cc200t3zcxmhmrsyqk",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1z4pfv9rrm53tg72cwkcv6ddvd4x6wcce43nua2",
       "uusd"
@@ -761,7 +761,7 @@
   },
   {
     "id": "terra1y6e5xmqxcq9zm9mdncf4nwneyp27d98awgqjv7",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vm507q46f2sm8jltjcvp3dtncttquwld0tfkdl",
       "uusd"
@@ -781,7 +781,7 @@
   },
   {
     "id": "terra1092tamrn3w8j7qp0uu2ltml7sjts7z9hkj2wga",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1unewn6sa7hg3z0pvhrc9u9rmph7z975h4nrfvq",
       "uusd"
@@ -801,7 +801,7 @@
   },
   {
     "id": "terra10nfk6fcz5nc5uru964qmpels9ctg6j0vczjgl7",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "uusd"
@@ -811,7 +811,7 @@
   },
   {
     "id": "terra10xczfpmpryl3m434jjvvv0rre70yyscw98pueu",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17n223dxpkypc5c48la7aqjvverczg82ga3cr93",
       "uusd"
@@ -841,7 +841,7 @@
   },
   {
     "id": "terra12k8d0uzrgcqn4ge4k8ntr4aaycpwunz7pu2umj",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09",
       "uusd"
@@ -851,7 +851,7 @@
   },
   {
     "id": "terra12qna5j5nehx7wamqelxg7pup877wd3jwd0dnpz",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uluna",
       "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09"
@@ -891,7 +891,7 @@
   },
   {
     "id": "terra13uwsn7sp0559lgpppyjkvf63kzdyuaqe2dc50d",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1atagmw0ssv6wlgmrjjdaa22p7h4wmsy33eljgw",
       "uusd"
@@ -901,7 +901,7 @@
   },
   {
     "id": "terra13xz77zwk9jvulch92uwzuk3astcp0uvymh7f2p",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a",
       "uusd"
@@ -931,7 +931,7 @@
   },
   {
     "id": "terra143az0w2e504n56q7k43qyh2fu69fh3rhup32n3",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vwz7t30q76s7xx6qgtxdqnu6vpr3ak3vw62ygk",
       "uusd"
@@ -951,7 +951,7 @@
   },
   {
     "id": "terra144p2hh09v4y9ytj7x3r97jl5etrrg9lrgyf8yn",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1fyxs23jdlj5qgfp4hv2qqv4d3csmvqxsva573m",
       "uluna"
@@ -961,7 +961,7 @@
   },
   {
     "id": "terra1476fucrvu5tuga2nx28r3fctd34xhksc2gckgf",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra169edevav3pdrtjcx35j6pvzuv54aevewar4nlh",
       "uusd"
@@ -991,7 +991,7 @@
   },
   {
     "id": "terra14rnschsdlllt00yk8fxvxmcqgzhme3cx06t2x4",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "ibc/18ABA66B791918D51D33415DA173632735D830E2E77E63C91C11D3008CFD5262",
       "uusd"
@@ -1001,7 +1001,7 @@
   },
   {
     "id": "terra14sal7lg7ny207yz0ue4dc02mdqs03zytegsn2r",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1yeyr6taynkwdl85ppaggr3zr8txhf66cny2ang"
@@ -1021,7 +1021,7 @@
   },
   {
     "id": "terra15env0fa3z9jsc65cun7m37dhjypzwejqpy80vp",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp"
@@ -1031,7 +1031,7 @@
   },
   {
     "id": "terra15s2wgdeqhuc4gfg7sfjyaep5cch38mwtzmwqrx",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dy9kmlm4anr92e42mrkjwzyvfqwz66un00rwr5",
       "uusd"
@@ -1111,7 +1111,7 @@
   },
   {
     "id": "terra17sswfv8mvvdx75j9q33l83j3cnahnta3wqqpa3",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kqf8ua7al5tdnkz95ue4zkuv4gcu52pt63ya54",
       "uluna"
@@ -1141,7 +1141,7 @@
   },
   {
     "id": "terra18e20cuvqex2h662talchnura7v48rz0ey7xc4v",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rdqy74e080e96qhk5gntnr882awm4pfc7t6dn4",
       "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf"
@@ -1171,7 +1171,7 @@
   },
   {
     "id": "terra190jp9g28h5ntm2ekfecyfgwlf2y7qj4809gys7",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kqf8ua7al5tdnkz95ue4zkuv4gcu52pt63ya54",
       "terra1rdqy74e080e96qhk5gntnr882awm4pfc7t6dn4"
@@ -1181,7 +1181,7 @@
   },
   {
     "id": "terra19rcpzd2w35trvtwkjt4lrckqeqdstlplnqz2ny",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1a8an0aqzjghcukqrdgnkt3ygzhmaaqza03mc3h",
       "uusd"
@@ -1201,7 +1201,7 @@
   },
   {
     "id": "terra1a75f02tqk6pf6xzkjgyxcpkpm9l5dzmqud5ely",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr",
       "uluna"
@@ -1251,7 +1251,7 @@
   },
   {
     "id": "terra1ctvlz7cqc6h7davlj46j9dne8ewc4hp2sqkmts",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1n2rujfc5lscglry30zaptfgncfc0gq4n8my0gv",
       "uusd"
@@ -1291,7 +1291,7 @@
   },
   {
     "id": "terra1daxuedmyeu8cak0ds43u6emj7srkgjeka0twe4",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm",
       "uusd"
@@ -1301,7 +1301,7 @@
   },
   {
     "id": "terra1e76nq6ll0vzy4apprphh0k5wqzzsndjakwd6x0",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rz964297kvt86rteajhtp4hsffhcum0ye8eljh",
       "uusd"
@@ -1311,7 +1311,7 @@
   },
   {
     "id": "terra1eck465e7u33y95flte0sld8ndrhk2yssnkea37",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
       "uusd"
@@ -1321,7 +1321,7 @@
   },
   {
     "id": "terra1edurrzv6hhd8u48engmydwhvz8qzmhhuakhwj3",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
       "uusd"
@@ -1341,7 +1341,7 @@
   },
   {
     "id": "terra1esm0pztzdq6hqgtj72w9dsnlfwtm343c7axvxu",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
       "uluna"
@@ -1371,7 +1371,7 @@
   },
   {
     "id": "terra1fx2w5w8yfvncc7newqg5l08png5wln6s5k7qwy",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rz964297kvt86rteajhtp4hsffhcum0ye8eljh",
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
@@ -1381,7 +1381,7 @@
   },
   {
     "id": "terra1gfvp0tynfdeux2rlfryqjrurcjyqfadw7sl502",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7"
@@ -1401,7 +1401,7 @@
   },
   {
     "id": "terra1gs2zrwxz0szra07ks8xze04g4clwjsj6jjaq90",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vchw83qt25j89zqwdpmdzj722sqxthnckqzxxp",
       "uluna"
@@ -1411,7 +1411,7 @@
   },
   {
     "id": "terra1gxluuw67zmflr7qun7vxgk04lqam8mt42m4945",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "uusd"
@@ -1431,7 +1431,7 @@
   },
   {
     "id": "terra1hasy32pvxmgu485x5tujylemqxynsv72lsu7ve",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn",
       "uusd"
@@ -1471,7 +1471,7 @@
   },
   {
     "id": "terra1jfuq655fmqp7uhkkqanmljqj26r9acs68drn2s",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1cdc6nlsx0l6jmt3nnx7gxjggf902wge3n2z76k",
       "uusd"
@@ -1481,7 +1481,7 @@
   },
   {
     "id": "terra1jkjpcgn4wywcytpnq0y7wq9jsythz6azmyw5ec",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vsyyg4rs483uzd7jzw5fqqlm2q5n2yd37yylfc",
       "uusd"
@@ -1501,7 +1501,7 @@
   },
   {
     "id": "terra1jusmcruce9q3xu9y9mkxspm9rawvaa67w7fsd5",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7"
@@ -1521,7 +1521,7 @@
   },
   {
     "id": "terra1k4wvysv90yndgl98udr0eq4nmdp92u4zrpr46m",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1rck0zefy4juahqjjk5q0wz2ykp7028hjwvzcaj"
@@ -1531,7 +1531,7 @@
   },
   {
     "id": "terra1k8lvj3w7dxzd6zlyptcj086gfwms422xkqjmzx",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14v9wrjs55qsn9lkvylsqela3w2ytwxzkycqzcr",
       "uusd"
@@ -1551,7 +1551,7 @@
   },
   {
     "id": "terra1lk3tj2xyhr0ju9nhsarw79j3wpnntnzcxzvsdw",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1n2rujfc5lscglry30zaptfgncfc0gq4n8my0gv",
       "uluna"
@@ -1561,7 +1561,7 @@
   },
   {
     "id": "terra1ls8hsss7tp3cna6nd95reevtmstm4uc644akxx",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pkp0pkxp9mtlan7cg0qatu65hmkgyq2342g27g",
       "uluna"
@@ -1571,7 +1571,7 @@
   },
   {
     "id": "terra1ltf9ss5syeeu5schnw6ah3t4arfqmj53kgtc3k",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1mpq5zkkm39nmjrjg9raknpfrfmcfwv0nh0whvn",
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3"
@@ -1581,7 +1581,7 @@
   },
   {
     "id": "terra1m32zs8725j9jzvva7zmytzasj392wpss63j2v0",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
       "uluna"
@@ -1621,7 +1621,7 @@
   },
   {
     "id": "terra1mm772kftkt7yhx68t2edm736rnel83c8eqf6ee",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
       "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr"
@@ -1651,7 +1651,7 @@
   },
   {
     "id": "terra1myl709y74vrdcyuxy6g9wv5l2sgah4e9lstnwe",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
       "uusd"
@@ -1711,7 +1711,7 @@
   },
   {
     "id": "terra1ng6rcmjcdcpde8jy3k37wm8kzgr7zgpqx72lud",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra133r6snp000sw0qhuspkua39fjc4c6pux82cnxh",
       "uusd"
@@ -1721,7 +1721,7 @@
   },
   {
     "id": "terra1ngs0xlmxan6ktqwtcj8c2l2ddp3z00wpxt43vr",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B",
       "uusd"
@@ -1751,7 +1751,7 @@
   },
   {
     "id": "terra1p99huvu9wskfuum8grftx5pmcunl4ruv8v0wvv",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
@@ -1761,7 +1761,7 @@
   },
   {
     "id": "terra1pzemhnxtmtp7z7hlecafjqpnrt29czhmyhyd2z",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg"
@@ -1771,7 +1771,7 @@
   },
   {
     "id": "terra1q0eh3pct8da820t0san35pcg0sqqtmz4k532xh",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
@@ -1781,7 +1781,7 @@
   },
   {
     "id": "terra1q843tspwkcec87n5xrwdx8ygnmjjk7kj0lc7p3",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "terra1hnezwjqlhzawcrfysczcxs6xqxu2jawn729kkf"
@@ -1801,7 +1801,7 @@
   },
   {
     "id": "terra1qvq38uhmtdqh5tu3ratganwapnjefs2elxduy4",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yy0w2w8rkrfn5ul967rhpjrj4a0hpjy6m7end7",
       "uluna"
@@ -1811,7 +1811,7 @@
   },
   {
     "id": "terra1qzqzvsr3hvgsfkvcl4jgv0l4lsdhap8skawqt4",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "ibc/18ABA66B791918D51D33415DA173632735D830E2E77E63C91C11D3008CFD5262",
       "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf"
@@ -1821,7 +1821,7 @@
   },
   {
     "id": "terra1r0u977a90c5l8dxq8hu00eydm4ahl0mqwms9a8",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1l4uygw365sgdgvasmckkd7lcawyemzn9k83lrh",
       "uusd"
@@ -1841,7 +1841,7 @@
   },
   {
     "id": "terra1r6fchdsr8k65082u3cyrdn6x2n8hrpyrp72je0",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
       "uluna"
@@ -1861,7 +1861,7 @@
   },
   {
     "id": "terra1rhk92dvz3tjayymy8pl08gpkmamnud7ttzc03h",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1f0us6p9axmzacwq2fn7sm5ke8k302tx7hg7s49",
       "uusd"
@@ -1871,7 +1871,7 @@
   },
   {
     "id": "terra1rjql89achu0aq3e69nxz78qnj7xfdjewndsk2v",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uluna",
       "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03"
@@ -1881,7 +1881,7 @@
   },
   {
     "id": "terra1ruu2gxsuplha5r2uzh0fnxqyd4svx23njwy74k",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uluna",
       "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf"
@@ -1891,7 +1891,7 @@
   },
   {
     "id": "terra1t0qdxv523fxkuyhk9yv6hgal33cwnwh9hmzq55",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup"
@@ -1901,7 +1901,7 @@
   },
   {
     "id": "terra1tehmd65kyleuwuf3a362mhnupkpza29vd86sml",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1cetg5wruw2wsdjp7j46rj44xdel00z006e9yg8",
       "uluna"
@@ -1911,7 +1911,7 @@
   },
   {
     "id": "terra1tkcnky57lthm2w7xce9cj5jeu9hjtq427tpwxr",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
       "uusd"
@@ -1921,7 +1921,7 @@
   },
   {
     "id": "terra1tlmqtwj5lq27knn7x932mqwmwdlnppesvwt5pa",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yy0w2w8rkrfn5ul967rhpjrj4a0hpjy6m7end7",
       "uusd"
@@ -1931,7 +1931,7 @@
   },
   {
     "id": "terra1tteawchaue7myplvgm46ghszymh2wd4ghhcjq3",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55"
@@ -1971,7 +1971,7 @@
   },
   {
     "id": "terra1wdwg06ksy3dfvkys32yt4yqh9gm6a9f7qmsh37",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "uusd"
@@ -2001,7 +2001,7 @@
   },
   {
     "id": "terra1xg60dmxqzt0c8hxuzgnlmpzqnnmux97xjrdzwf",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uluna",
       "terra14v9wrjs55qsn9lkvylsqela3w2ytwxzkycqzcr"
@@ -2021,7 +2021,7 @@
   },
   {
     "id": "terra1xrj6cy0jewpw0gt7zfcfpk9j54w30ycz869lcy",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
       "uluna"
@@ -2051,7 +2051,7 @@
   },
   {
     "id": "terra1zh8m6yu8nrvryu2g9gyyzqenrv6h034puqss49",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf"
@@ -2061,7 +2061,7 @@
   },
   {
     "id": "terra1zjj37anlqt99tv5hwhsew0x7e007hcg3fsm8sx",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1cf9ey4pm9ugeeehat50gadlze9s0mvluxws2c2",
       "uusd"
@@ -2071,7 +2071,7 @@
   },
   {
     "id": "terra1zpnhtf9h5s7ze2ewlqyer83sr4043qcq64zfc4",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra100yeqvww74h4yaejj6h733thgcafdaukjtw397",
       "uusd"
@@ -2081,7 +2081,7 @@
   },
   {
     "id": "terra106a00unep7pvwvcck4wylt4fffjhgkf9a0u6eu",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
       "uusd"
@@ -2101,7 +2101,7 @@
   },
   {
     "id": "terra10s94a5gesvayqlekgn570r3nsnmr8q7lf5zkjp",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15a9dr3a2a2lj5fclrw35xxg9yuxg0d908wpf2y",
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4"
@@ -2121,7 +2121,7 @@
   },
   {
     "id": "terra12aazc56hv7aj2fcvmhuxve0l4pmayhpn794m0p",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
       "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq"
@@ -2181,7 +2181,7 @@
   },
   {
     "id": "terra154jt8ppucvvakvqa5fyfjdflsu6v83j4ckjfq3",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1jx4lmmke2srcvpjeereetc9hgegp4g5j0p9r2q",
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4"
@@ -2241,7 +2241,7 @@
   },
   {
     "id": "terra17kmgn775v2y9m35gunn3pnw8s2ggv6h95wvkxr",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
       "uusd"
@@ -2261,7 +2261,7 @@
   },
   {
     "id": "terra18zh29lwx36uxh4a4ff5at9ysm6n0da4puz7z62",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
       "terra17wkadg0tah554r35x6wvff0y5s7ve8npcjfuhz"
@@ -2291,7 +2291,7 @@
   },
   {
     "id": "terra1cpzkckgzz90pq8fkumdjc58ee5llrxt2yka9fp",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
       "uusd"
@@ -2301,7 +2301,7 @@
   },
   {
     "id": "terra1dttfsvgwvpz0zy9x52zyxnc4pa5lcx7l7pzguc",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1jxypgnfa07j6w92wazzyskhreq2ey2a5crgt6z",
       "uusd"
@@ -2311,7 +2311,7 @@
   },
   {
     "id": "terra1dw5j23l6nwge69z0enemutfmyc93c36aqnzjj5",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1jx4lmmke2srcvpjeereetc9hgegp4g5j0p9r2q",
       "uusd"
@@ -2351,7 +2351,7 @@
   },
   {
     "id": "terra1fgc8tmys2kxzyl39k3gtgw9dlxxuhlqux7k38e",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55",
       "uluna"
@@ -2391,7 +2391,7 @@
   },
   {
     "id": "terra1jkr0ef9fpghdru38ht70ds6jfldprgttw6xlek",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr",
       "uusd"
@@ -2411,7 +2411,7 @@
   },
   {
     "id": "terra1kw95x0l3qw5y7jw3j0h3fy83y56rj68wd8w7rc",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
       "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr"
@@ -2451,7 +2451,7 @@
   },
   {
     "id": "terra1n6rn6cn8a3rqad8v2mth3u3qwgq9styt84wv4u",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
       "uusd"
@@ -2461,7 +2461,7 @@
   },
   {
     "id": "terra1np5jr05v08vjk5f665qu5xjxak8dyxnswtujn6",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "uusd"
@@ -2481,7 +2481,7 @@
   },
   {
     "id": "terra1p4lz9qcs8wp4pxpgd5uugvfvcrxdjtyhs9wuw7",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
@@ -2541,7 +2541,7 @@
   },
   {
     "id": "terra1um8zappwu8csxv6c7zmadjvnf5rs7xgnc573fx",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
       "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2"
@@ -2551,7 +2551,7 @@
   },
   {
     "id": "terra1ur6yyha884t5rhpf6was9xlr7xpcq40aw2r5jx",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
       "uluna"
@@ -2671,7 +2671,7 @@
   },
   {
     "id": "terra19d2alknajcngdezrdhq40h6362k92kz23sz62u",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "uusd"
@@ -2691,7 +2691,7 @@
   },
   {
     "id": "terra1kqc65n5060rtvcgcktsxycdt2a4r67q2zlvhce",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "terra17wkadg0tah554r35x6wvff0y5s7ve8npcjfuhz"
@@ -2701,7 +2701,7 @@
   },
   {
     "id": "terra1persuahr6f8fm6nyup0xjc7aveaur89nwgs5vs",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2"
@@ -2711,7 +2711,7 @@
   },
   {
     "id": "terra1r38qlqt69lez4nja5h56qwf4drzjpnu8gz04jd",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "uluna"
@@ -2721,7 +2721,7 @@
   },
   {
     "id": "terra1yxgq5y6mw30xy9mmvz9mllneddy9jaxndrphvk",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau"
@@ -2731,7 +2731,7 @@
   },
   {
     "id": "terra10whh69k8p9df2ccchvq03ddqqdpxlsxhte99j7",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pmf2x6gp8u979q672lkkkruuhe9zarxyu5w7t2",
       "uusd"
@@ -2781,7 +2781,7 @@
   },
   {
     "id": "terra1hkh0mr4y0y0gjf8t9c55arnvy0m79s80297d9z",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1z2u9p4x9cnp7c44rnntxzhgqlnepv8elmde43d",
       "uusd"
@@ -2791,7 +2791,7 @@
   },
   {
     "id": "terra1k8pflcvj3mhrmthrgux2pk9a9ytthsr5trnq7z",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yzj58vsvryarrasx6rkf9deyn5h60zlm7lzv8r",
       "uusd"
@@ -2811,7 +2811,7 @@
   },
   {
     "id": "terra1rjwzkud2xtltyqamkq0md0esdk3qkhjwey5xzk",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vte2xv7dr8sfnrnwdf9arcyprqgr0hty5ads28",
       "uusd"
@@ -2821,7 +2821,7 @@
   },
   {
     "id": "terra1t9ffaw69tfensrn2s0hx79tm68g7hps30unys8",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1u2k0nkenw0p25ljsr4ksh7rxm65y466vkdewwj",
       "uusd"
@@ -2901,7 +2901,7 @@
   },
   {
     "id": "terra1x3fcujqgk8uvn8vssw52jtwtanlu3shgj3ftlk",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra18xyl0ees6ueyhkhn0mjdtrm82e393ult2dazl3"
@@ -2931,7 +2931,7 @@
   },
   {
     "id": "terra105cnw8azykz23ec9gtm06prssq9aqxg8pchjq4",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10jyyy0ylv34lafqv2mldcuxhk4qpdmnckgfls2",
       "uusd"
@@ -2941,7 +2941,7 @@
   },
   {
     "id": "terra105lwyhfuw0p0q39tghg2hxnjdarg6uy6n9s24n",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xc5ll57yu269x8ysxvdpjmvxmac3js7pst5ddr",
       "uusd"
@@ -3021,7 +3021,7 @@
   },
   {
     "id": "terra10qeuxxj46luwqk8huh4gcp2r0ve7w5vh3hrtev",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ft9qff9fgumdca5qluxu3e8fh8xc7d4hfek8s2",
       "uusd"
@@ -3091,7 +3091,7 @@
   },
   {
     "id": "terra1238lf7cayjp4f4fxle5v87eat6vekqn2zfh9w2",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17qy9f5h35504jxexwprsf6gtj009d3gjcml5pp",
       "uusd"
@@ -3201,7 +3201,7 @@
   },
   {
     "id": "terra132hq2uqczg2d7l4czhtcdwwlgl6cga6rs3nv6p",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18zqpuua4d8u9q9d6zsn8fqtjj5k8hk845prz9v",
       "uusd"
@@ -3211,7 +3211,7 @@
   },
   {
     "id": "terra134jare8j7annsu6fgtkpu6zp8gmfau88jrsnaz",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19fd35n93667mg020fj5lupws9rhkw59cw459wm",
       "uusd"
@@ -3251,7 +3251,7 @@
   },
   {
     "id": "terra13ha9p29fpj4cckj6jr3m743d9h9v9nv3xcmded",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1atagmw0ssv6wlgmrjjdaa22p7h4wmsy33eljgw",
       "uusd"
@@ -3271,7 +3271,7 @@
   },
   {
     "id": "terra13l4d3vq7kurmyah9fxcjv8zdqdpndm9n0zs954",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1nywvm8avu8medrj84x9dxdc4gfdqd2zg8gv049",
       "uusd"
@@ -3301,7 +3301,7 @@
   },
   {
     "id": "terra13lnw7ytlt0cjtjtakgewfzydq3nmx7n9q60gs8",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1extnklxgx3sylp25zplvxsfarmvh3r4k6grskj",
       "uusd"
@@ -3381,7 +3381,7 @@
   },
   {
     "id": "terra14572czl65ta5gqhpjfehk47yytdxerpntw2h5w",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1efu7hut9pywcgwj74klay9mlzswp542s6fa0zq",
       "uusd"
@@ -3431,7 +3431,7 @@
   },
   {
     "id": "terra14j82htz2rhn47jasltna6tnqy4gy2097zf2pat",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra153u8c40h2mm8nvs0daqxsnwgvpw43muxj3c28h",
       "uusd"
@@ -3461,7 +3461,7 @@
   },
   {
     "id": "terra14pq5tphkfpd2wphq47g7mrwmvt7x63nskmkkrc",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1m2ar36pnymh6h4n0p7l2w4uxswc70e9auyvxh6",
       "uusd"
@@ -3571,7 +3571,7 @@
   },
   {
     "id": "terra156wnmhqelwxwcmkfcn0j5fehj59ktjv6w4xca8",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra109vclyh90fkj77ruk299pkk460sjm54vs9x6et",
       "uusd"
@@ -3611,7 +3611,7 @@
   },
   {
     "id": "terra15p4lwjtk9jkkvkz33pf5xelnrnqahac5ksj8cj",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10jgqgc3vt34w79t4puharnzjxxv7s3fq8tmnkp",
       "uusd"
@@ -3651,7 +3651,7 @@
   },
   {
     "id": "terra15z794we063zfzxtvlxzetnq9cv7ftymglqh0g6",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10722f40cxl8tkxjk7f88uj0ehkcw6lu2j504f0",
       "uusd"
@@ -3661,7 +3661,7 @@
   },
   {
     "id": "terra15zfs6kf7c0f8u4layzwnwkzpqnkj8lrm86q8un",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1gjuhc34ccr6ajq7dm5266xyedu96sgkv4qnley",
       "uusd"
@@ -3671,7 +3671,7 @@
   },
   {
     "id": "terra160vz23qwte45w6dcgkkae05fqpap8l4s4alaax",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12jhul3zlafuvl4fd54pvaax4ls872z8p06p8qv",
       "uusd"
@@ -3691,7 +3691,7 @@
   },
   {
     "id": "terra162cf20c6hrag6fhy9aqwaq9cvrp5lq5ffpvuez",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1qup6c3w83xjrfdtzujqkh5j8pcar96up8f0pdy",
       "uusd"
@@ -3721,7 +3721,7 @@
   },
   {
     "id": "terra166j8s9pehm35egpmdfkrvlqj9a4248wqcg5s08",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yx2z4j3wr55k7jns06qhn2hsw6agskvcke6zu6",
       "uusd"
@@ -3781,7 +3781,7 @@
   },
   {
     "id": "terra16g8fsnjsmys6dl25s7wvl4r7y68drvfjc7pszl",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18vl2cypy8pdys2qdqlg7pzmcmpqmur8lmrnk2c",
       "uusd"
@@ -3791,7 +3791,7 @@
   },
   {
     "id": "terra16k9sv0425t8prauxk680sj8aecgh4t948v8ktf",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1534wdj9s0c3c64pmgqk8544usm0jvfysn9zq2k",
       "uusd"
@@ -3841,7 +3841,7 @@
   },
   {
     "id": "terra16s7w70jm98htj2v6mkhcx8uy03l7d4w5mjfnf7",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vjgnhlv9h0nlta2v7s5hts75h2mc065c6ap3j5",
       "uusd"
@@ -3871,7 +3871,7 @@
   },
   {
     "id": "terra16yrzqhe84x86jzgaav5hszfsu4mhxjk0aqlk2g",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19m0xqgdaltwkesdt6m383jkqh3m9xyxwtp0f6f",
       "uusd"
@@ -4001,7 +4001,7 @@
   },
   {
     "id": "terra17lvnk2k34us38zflqz4zze6zkn7vrktpeuszcy",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10aey3n8rwxup6l2x68fa7fwdurxnu9hwxf0k7f",
       "uusd"
@@ -4011,7 +4011,7 @@
   },
   {
     "id": "terra17nht56uc42wj73z8u0gs5n2x9d74ur7z76vmz6",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1je4ll79zmy03zpl4wdhgmadvznqr08tzrncpqw",
       "uusd"
@@ -4031,7 +4031,7 @@
   },
   {
     "id": "terra17rduyemsyel8jl5pvyh7j33ee78606zqzkzh8l",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
       "usek"
@@ -4061,7 +4061,7 @@
   },
   {
     "id": "terra17supgps4aqq7nfkcqt97y0jxzh5u6mrzqlg936",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hn8mghxm4qm2g654m3h4rmqccgs2wcdsvsex82",
       "uusd"
@@ -4081,7 +4081,7 @@
   },
   {
     "id": "terra17y80pnvqu3kd3g5jwn5kpkfp6hh2stzxmvazjw",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18we4g8y6u55x7atttzu5xgx46zzss0tpmktf9s",
       "uusd"
@@ -4111,7 +4111,7 @@
   },
   {
     "id": "terra1854dxe6nw9pktdd5j5ulesv74k3ztqgdx6mcxe",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17etsw9uywcmw79st5yp4saar97z22l3np0m3zz",
       "uusd"
@@ -4211,7 +4211,7 @@
   },
   {
     "id": "terra18kwhhu4fxcc2x7lwtct8jatwv9843n6de33g6r",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rkn2d2yc0946a0gx0w0hwf3l2j32ve39egsjkd",
       "uusd"
@@ -4221,7 +4221,7 @@
   },
   {
     "id": "terra18nz2gztwduce3u40wuuafl8xj8e4s63nty75ym",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zs7w76g0u4qgagcen6vq92wxuvgfucr3dy4tm",
       "uusd"
@@ -4331,7 +4331,7 @@
   },
   {
     "id": "terra19mzvauzmythgn8d8vl944vczh5egrlnqfqygke",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ruz2e26humerfnd9uhurc9766a4at8x8e3m2e4",
       "uusd"
@@ -4391,7 +4391,7 @@
   },
   {
     "id": "terra1a5s9cgdzw4pz4nf8rxyqp77q0wuegahs78tpfd",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12qgpr0fw773gc8lrkys3knnw6nkgdlc8ggaty9",
       "uusd"
@@ -4401,7 +4401,7 @@
   },
   {
     "id": "terra1a8t3w4ts39fu5su3dg60p9akhr8uf85fzccuxq",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra19hnegq0ed5w0gds64765uakh5huw7jepvjakh5"
@@ -4411,7 +4411,7 @@
   },
   {
     "id": "terra1afgh029jj9nxglezr3jxmr0heujj55pgspvx4m",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1cq4lkf7dlygdp23yql8a4daunnxr4xd5tymszl"
@@ -4431,7 +4431,7 @@
   },
   {
     "id": "terra1ak3u2e0303wvnfsese2z382pn4sxl9etz9rrkj",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
       "luna"
@@ -4461,7 +4461,7 @@
   },
   {
     "id": "terra1c0hc7ncedxaps2hxl0qazxlh79g4zdre5geq4m",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pmmdfnmhrjnywsgkd6xplgp8nx03fxm6ygma09",
       "uusd"
@@ -4511,7 +4511,7 @@
   },
   {
     "id": "terra1c59fgnldauz68wpxzawxy7w650r0yvhq34g6ng",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra158ut7lycly6ep0v334rpjtcjs8hlvwjzf5tfrk",
       "uusd"
@@ -4561,7 +4561,7 @@
   },
   {
     "id": "terra1c9t0gzff3z4mh62ky9cj9hkunlj8zqz58kqa87",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15q3lzrnfstr3rqgh55cqmp95z4xr3we5tfyqm9",
       "uusd"
@@ -4591,7 +4591,7 @@
   },
   {
     "id": "terra1cds3ru8n9s6cpuqszd6kupxjghj8r8rqk8jvmq",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1fpfn2kkr8mv390wx4dtpfk3vkjx9ch3thvykl3",
       "uusd"
@@ -4601,7 +4601,7 @@
   },
   {
     "id": "terra1cf38v8qumxruarhxfsgnylkymz6935c6qhcrkv",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra16pem7c3h7renxuxa4jvw8efv4nhrdc3leguzyn",
       "uusd"
@@ -4711,7 +4711,7 @@
   },
   {
     "id": "terra1cvg3jjepvcxzkv5elvr3x5khk83wllvg4qygfc",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lxpjyl6k60rsyp0x7fa40s8jsl5l0d27ycmwfh",
       "uusd"
@@ -4761,7 +4761,7 @@
   },
   {
     "id": "terra1ddu6j495ephpxm8at7jzg55n6u0zc2yadvuz26",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1v6p9v6dqaql0600hmdl78h592ax5rxmheefgd2",
       "uusd"
@@ -4781,7 +4781,7 @@
   },
   {
     "id": "terra1dj35t0w5w5knw7cq6dj3s68ry724nctq069w5s",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xmd43yrfxm4xy3lnptc7kr4rr93pzh5u0z0wgt",
       "uusd"
@@ -4821,7 +4821,7 @@
   },
   {
     "id": "terra1dqz4zx0uecwjqafzyej7pzyhhqse2agq767al2",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17qfuwapug8scgw5satxs4n95u3taw6fe8hdgty",
       "uusd"
@@ -4831,7 +4831,7 @@
   },
   {
     "id": "terra1ds7gy9gyf9e7rl8zmmtfjt2e2dm4d6p9szu8tq",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ss460ny4hl5zew0tlvywnw38rsy2ql3n420lv2",
       "uusd"
@@ -4871,7 +4871,7 @@
   },
   {
     "id": "terra1dvwewun965qpex2k8hrpfpzt8t7qtq3ptwu6j3",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra133j6tpq7gcrjjgvgj4r3fjwda0hegmmrazmwt0",
       "uusd"
@@ -4931,7 +4931,7 @@
   },
   {
     "id": "terra1ek0rr6pj76mtrukw9l90wd8xwcuknw8aqp48sj",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1247nlrmskhfu9qpg66zt5w6f8cw250878enl9g",
       "uusd"
@@ -4991,7 +4991,7 @@
   },
   {
     "id": "terra1et3se39fd2nmnuygcvls2amujzmv4v6k4xwv69",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1mz858mn7jeglmzj0ay8z5zy6v78fvv7em9tljz",
       "uusd"
@@ -5021,7 +5021,7 @@
   },
   {
     "id": "terra1ex4tn8m3g2c8xv3q9q5mlm0d8aa6684g40y3cx",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12mvfnsk4r2chx7n032aztme7zcypyla5pllhzm",
       "uusd"
@@ -5051,7 +5051,7 @@
   },
   {
     "id": "terra1f3tdduzpsdrg33x6w8cqmzmyytnmhzcvwnharl",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1y8q4jk5xwag3sschctduxa43eesupjkk6kr452",
       "uusd"
@@ -5061,7 +5061,7 @@
   },
   {
     "id": "terra1fcgvdqe2dcgr7x2a9w3nfc0nhjh07zggzdlnfm",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1paulfn369vuz6s6ty65y56wj8gnamzpdzwk9x3",
       "uusd"
@@ -5091,7 +5091,7 @@
   },
   {
     "id": "terra1fgwk7tjfzcul8mc8xwdkf3ejswgcxkh7d087ku",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yanmc0xxg9dl387qkudnysjkymgytj3cdhgeek",
       "uusd"
@@ -5121,7 +5121,7 @@
   },
   {
     "id": "terra1fjrjynsdxvgqsahquuun46w440d59020vxva9d",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1fcq75y4ezhsws0vudna3cddk20d3k0eg9nznyh",
       "uusd"
@@ -5131,7 +5131,7 @@
   },
   {
     "id": "terra1fmp455y0fgee5dv68fxwfnylnpux6fv3th4m2f",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10vwyclaux26l47hj2dgnjw2pcsrt4y0ukfgp9u",
       "uusd"
@@ -5171,7 +5171,7 @@
   },
   {
     "id": "terra1fx82cs3ttpcnd9wg32a70ajkfturmedrgup2vv",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1cxusd4uhgpgk2sp99rexrcknpn08anak3v9tz7",
       "uusd"
@@ -5231,7 +5231,7 @@
   },
   {
     "id": "terra1gk2nnql0vllx34dev6l9grl425leuehckwpx3d",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14ec8v4c5dnwu2pq9plfquaffutu59tq9hld77e",
       "uusd"
@@ -5331,7 +5331,7 @@
   },
   {
     "id": "terra1h9zcqxdcl89hwvgxh2v6l3e3lfyguawxcvtasw",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pc253zfn4zns6awk7eks779uk3m7dna7y4cmlf",
       "uusd"
@@ -5341,7 +5341,7 @@
   },
   {
     "id": "terra1haarsvn3uxmul3rt5vr8x0856pjj45js6fwkhz",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15fvz44vh89rj4ykamk2tadw0f7wdnccn5qp0ua",
       "uusd"
@@ -5501,7 +5501,7 @@
   },
   {
     "id": "terra1jq6ud6xdljsrpgnmuhwc8e9sxjut5el6t5z9gr",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1qn4v9nnc2a0mdnkzl73rh60264gvhu6pxusz0r",
       "uusd"
@@ -5541,7 +5541,7 @@
   },
   {
     "id": "terra1jx3m7swaseumanezk3z6r73cptucc9dqg6hprk",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pmcr4gjjsu62t2d9e33q6d75sydrhnpt37nayz",
       "uusd"
@@ -5561,7 +5561,7 @@
   },
   {
     "id": "terra1k2sgkcw0z5drjcy4nl09v40xt6hgf0kpcm4rpc",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1gl3ywddjkukupa3qv86r8xy434frncmxna630k"
@@ -5611,7 +5611,7 @@
   },
   {
     "id": "terra1k8fkje4xawkgtg0czxkp98qd2gu8uz4xgnuzsv",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra157n30a667ethsknneaavga2txtze58eajyfv45",
       "uusd"
@@ -5691,7 +5691,7 @@
   },
   {
     "id": "terra1kjlt8zsdvmxaw63u38krl658zunaj9hzxwknqs",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1zqyfp259xhhct6q2alp88pke90qrxgr5u2zc7s"
@@ -5731,7 +5731,7 @@
   },
   {
     "id": "terra1kneyp2t00kehpwkaxml9w7dg5p7nl703dv65vr",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1gs2pykgl27l04e6lprgqs6uwlr7rm2vjcnya8g",
       "uusd"
@@ -5901,7 +5901,7 @@
   },
   {
     "id": "terra1lskrhzzyxtm235j69ty3y4fk7mswczq5f93ntq",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10l407saphqe2tc35ejhzg7xyulqkeqccvvc6uw",
       "uusd"
@@ -5951,7 +5951,7 @@
   },
   {
     "id": "terra1m8dlx0g0j00xlxvavh972sk0gja2xn5gxjvtu3",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra16ygrvq7q2zxw7jj3f96racur50w0g7r0mj6e2y",
       "uusd"
@@ -6061,7 +6061,7 @@
   },
   {
     "id": "terra1n8jq50xnupyassyc3z4apwc33av3499v45tllv",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lxh32h38lf8xdk6lv7k5w0ewy7gu6psy4gfmnm",
       "uusd"
@@ -6091,7 +6091,7 @@
   },
   {
     "id": "terra1nf6wl37jxthskggvesngsp7y50s0jchmur57v3",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dw6yapjv8k8anef2kg43hewg3g73wle22ncaje",
       "uusd"
@@ -6201,7 +6201,7 @@
   },
   {
     "id": "terra1p39xsp5j3e6e9703gguen049pkf4p52rmwf2vm",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lrdzs5tgllwqgawtq2emuzn7snpxq87fzzl44y",
       "uchf"
@@ -6231,7 +6231,7 @@
   },
   {
     "id": "terra1p7npd4c5f8vsr47ncvkm50qfkvddanwy4er5ls",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13kr45ssru9cqhp2kaaan88wfaa7f2h3jfvuldp",
       "uusd"
@@ -6351,7 +6351,7 @@
   },
   {
     "id": "terra1pr6tmhnve5cawzauzyzw5uscz558gzmd3d6wps",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1s8gu8mx2qcxpx9y90fxvdetpwq9mpyrapphw2u",
       "uusd"
@@ -6361,7 +6361,7 @@
   },
   {
     "id": "terra1ps2j3kp3gwjx56fsahnnkmzv2y9e597gqkulfn",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1u02kfjra4q9272p0ckq8yjtfc5qq6584amvrnm",
       "uusd"
@@ -6391,7 +6391,7 @@
   },
   {
     "id": "terra1pxlm7mjmqc4h4ht494jvmmwq840zn77eyex8yd",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14dtgwushpvu2c8d8rtc58z9r2t4p67ug8wl4d7",
       "uusd"
@@ -6431,7 +6431,7 @@
   },
   {
     "id": "terra1q6h4sgkulkxl6tq8tafadl899sc88zp4dj6yd3",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1p2enl6vfmhdfj7ud32p3fkgns22sg62ls9mh2e",
       "uusd"
@@ -6581,7 +6581,7 @@
   },
   {
     "id": "terra1qxvf6f92f38wznvpyjqcd8ncppffuva79rvdeu",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kafnpwanfluj6ne5t8ayg8ykarx060a50l72sw",
       "uusd"
@@ -6591,7 +6591,7 @@
   },
   {
     "id": "terra1qyag7j7s5z0d02em5g09ltgcztxpdguz3pkxjk",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18y93cy77qrxx65vdz959g2ngms55v3s3yythys",
       "uusd"
@@ -6611,7 +6611,7 @@
   },
   {
     "id": "terra1qzrqt3phmawkrrzm8x8hwngz26nrpdgpkw5pmd",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1p0w9hh9aea5mg26mjnx7tl695ldwxfksvw4yn4",
       "uusd"
@@ -6621,7 +6621,7 @@
   },
   {
     "id": "terra1r3cjla7hlktc4vfa0dmzz8489e88k67yxjndpd",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap",
       "usek"
@@ -6641,7 +6641,7 @@
   },
   {
     "id": "terra1r6dcz9whd2dxunau0vtp3g06n0yus9gfaq76pz",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17ckx25kqhwzf3fudprs78kqgp3lhpr2w74yf7t",
       "uusd"
@@ -6741,7 +6741,7 @@
   },
   {
     "id": "terra1rpcz0746qj4f6nwcpap8z5knjpf4fj6wmalupy",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kx4y3y4pn32jssqr90cj0rw89ds98dc0t5eqfp",
       "uusd"
@@ -6841,7 +6841,7 @@
   },
   {
     "id": "terra1s9gquy9js5z64eehsf22w2zq7dwr9a7lavuxk7",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hja2d2790m6hynju77t56nhmmyl0w09s5acqhc",
       "uusd"
@@ -6851,7 +6851,7 @@
   },
   {
     "id": "terra1sez4t0zhe9d7lxlup0j8u4cnkz0qvzr7dj2lf0",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1qrq5r95txaregxpa2c7mhf549u5jkm28rzmvt5",
       "uusd"
@@ -6881,7 +6881,7 @@
   },
   {
     "id": "terra1sqaw3rsp5w84r5hwvcvcgweqcxlrhxl3e5a9na",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17azgr4x2gz20uquy7vdacfdgjjkgd0h9lm377v",
       "uusd"
@@ -6911,7 +6911,7 @@
   },
   {
     "id": "terra1svqq5rsjpvsrt6g365wrrxz3xje0jnjljax42r",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra138zs0y4arp48v0vpzqa7r4ehxcy7sk3dpv606e",
       "uusd"
@@ -6931,7 +6931,7 @@
   },
   {
     "id": "terra1sxxn4rxuqgxn3um6ly5lf9wsjuewrr7j8tvjg0",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lnav098k7vd006lz7d73mychha503pmw35la7l",
       "uusd"
@@ -6981,7 +6981,7 @@
   },
   {
     "id": "terra1twxv2kaeuyf3uxc6uzpgh3twe4mtagzpmn6sj4",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ghkclqug2jhanmjsx46x0vymcglchcesg98057",
       "uusd"
@@ -7051,7 +7051,7 @@
   },
   {
     "id": "terra1umst8uwnuvd42aecxzf26jyy9eutghxk4xvlkn",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rwskqpnk03hrh8z8rrprzdluxhzc5udycdn5g4",
       "uusd"
@@ -7081,7 +7081,7 @@
   },
   {
     "id": "terra1usq239ur4z4utc8s4ecdrk09hd062nrdcdc7yd",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19pz3ehx9f2thr9t9jk5y89aalxmhzuq9j8ak99",
       "uusd"
@@ -7101,7 +7101,7 @@
   },
   {
     "id": "terra1uxwgfuyn57xqek4jgxajhd3270khgyusncarnv",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10t5spcvn5m52fs4j5tnjerm6wzsn9vuqdsheje",
       "uusd"
@@ -7291,7 +7291,7 @@
   },
   {
     "id": "terra1vzhsu5x9f9sglyq3acm5vq7hv0deemvdneqqw7",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ex5age9gqd5em86wg8hu0ak5wrqez9yufvlrat",
       "uusd"
@@ -7351,7 +7351,7 @@
   },
   {
     "id": "terra1wgyq7kdeqeq70uzv04effzrgndtmtmevv4p9xr",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19y395vzlylv3s3nasr7cu4yey7s22ghqd35ps8",
       "uusd"
@@ -7371,7 +7371,7 @@
   },
   {
     "id": "terra1wn34gxq3jyg9qtjxjfzlj42jzjeegvgymdld2c",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1re7as700g3gels30zak6ctnjtsjhhc6vjr93ms",
       "uusd"
@@ -7441,7 +7441,7 @@
   },
   {
     "id": "terra1wysjqge8zc40e5g67vlaw0n2qu865pxxxv9sn3",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13k03g6n38f4m90pchn5h3nmk55xrnzt5ksvsml",
       "uusd"
@@ -7481,7 +7481,7 @@
   },
   {
     "id": "terra1x6sxgww5nrclca4thc6f7m35fyk5mgepe63pxh",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1a95wwge5ut59aet6wx9m5ukq0alnxj0waf4sgl",
       "uusd"
@@ -7501,7 +7501,7 @@
   },
   {
     "id": "terra1x8rmne82kuy2gx26r3ecxrjns97ef8ckf9exvv",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ldrmvk4n0le7tdaxj7r8gk5kny95r6mxw3ask7",
       "uusd"
@@ -7581,7 +7581,7 @@
   },
   {
     "id": "terra1xvvrm52lglquyp62kgpcww8489v4wqy9us6skq",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1r2p90ur2zy8javfhnf7ejdvzac60ax3wcvkvxz",
       "uusd"
@@ -7601,7 +7601,7 @@
   },
   {
     "id": "terra1xzk9vcd53j2eql8zfnds9xfxy6z9c6ran3ld7p",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1e3s670y5lns7vlq3gxdcn9rv8mdpydhd89jdwz",
       "uusd"
@@ -7731,7 +7731,7 @@
   },
   {
     "id": "terra1z3u6mw3s20kt67ts9txrg2mjkzcwt7tgasp7gw",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12flsr4mk5sxmu8yk7m8zc5f44tfx00yjvzj7v4",
       "uusd"
@@ -7741,7 +7741,7 @@
   },
   {
     "id": "terra1z50d83kx5dke2fw2wtrs4kj6ae8ga2pe5vhwl8",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pfynaj6mslxnlekjx7f6rxgfastl46c4hg3kg7",
       "uusd"
@@ -7921,7 +7921,7 @@
   },
   {
     "id": "terra10jyd2dy3ul5z2qqh9gej2zd3d46kv9dtk7c3a0",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
@@ -7951,7 +7951,7 @@
   },
   {
     "id": "terra10u8rwg2wjj4x2wyyhddjkpkkp8v40thyyg0gwj",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1mqsjugsugfprn3cvgxsrr8akkvdxv2pzc74us7"
@@ -7961,7 +7961,7 @@
   },
   {
     "id": "terra10vatx9jkv4lcksugsrkajstw2duh834j5psxzs",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1r7qpupdxkkh58vw9u8y9n9wjp6d9lr08u39j0z",
       "uusd"
@@ -7981,7 +7981,7 @@
   },
   {
     "id": "terra10xafj6lu07e7at9nccfwgjyrqqjfnsp8wp0f9q",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
@@ -7991,7 +7991,7 @@
   },
   {
     "id": "terra10xf7yakydjc5q4uye6zuuux8d3hxet2wpfk4se",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1mjhrlgwv8dnvc7mp0cynfxna947hxnm5m4tp6u",
       "uchf"
@@ -8031,7 +8031,7 @@
   },
   {
     "id": "terra10z6670zcw0787a6p5ydxtct5ff37g3tnz2dfaa",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1u43zu5amjlsgty5j64445fr9yglhm53m576ugh"
@@ -8041,7 +8041,7 @@
   },
   {
     "id": "terra10zaw5l7aa8hcgfml5eugkmg3dgvrxhnxnsrtdr",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1afgfjpny09lvxl06llcy7hfu0m2epfddzn0f75",
       "uusd"
@@ -8051,7 +8051,7 @@
   },
   {
     "id": "terra10zcf3z97m34kks7ly78ydshrcqf57fttc5sdrt",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1jl0egxpdfw0eqkzsgedzzet9zgwmhet2rd3s6u",
       "uusd"
@@ -8061,7 +8061,7 @@
   },
   {
     "id": "terra1228ck5ztqu455fye2yg8jwm9nr7w7yzdjqzj8n",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kf3ez7z2kzvvv7z7kte4en35gxm8keurgl09nj",
       "uusd"
@@ -8101,7 +8101,7 @@
   },
   {
     "id": "terra124vedvwx3nrwepzc2kmdhuhqn7j6zxq0jq2p2h",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1uxqd9gmtxz45yq53t2m9vrs74twwfrjmrqmdjd",
       "uusd"
@@ -8111,7 +8111,7 @@
   },
   {
     "id": "terra126fv7f8e3qgpc0g74vnp0gzks57r8z2ec2jh6j",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
@@ -8191,7 +8191,7 @@
   },
   {
     "id": "terra12j29ct74f4wx0vrz54c96sl4gvz5a3k7mynzrq",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra178v546c407pdnx5rer3hu8s2c0fc924k74ymnn",
       "uusd"
@@ -8261,7 +8261,7 @@
   },
   {
     "id": "terra12tuqcyr3aw6fuky8l2xfp0uyje5kmdf7yr6spa",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "ueur"
@@ -8291,7 +8291,7 @@
   },
   {
     "id": "terra12zwtkdu6qhs4f8jw9zvdgrwl24mwag5kuh7gus",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1ay3729yle6u6wxj3wcm8racn50a2yq5r8vxvkx"
@@ -8301,7 +8301,7 @@
   },
   {
     "id": "terra1305xtjl5qtlpdlp8gg0k8u4yl05hj7qvyffvd4",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm",
       "uusd"
@@ -8311,7 +8311,7 @@
   },
   {
     "id": "terra132qjgv0evru0em6v2rcwakgxzafjhwfz7fc7hh",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1drsjzvzej4h4qlehcfwclxg4w5l3h5tuvd3jd8"
@@ -8321,7 +8321,7 @@
   },
   {
     "id": "terra133308rh6p96pxw0cztmfln8av2jkxnjlfvfcyq",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n",
       "ueur"
@@ -8381,7 +8381,7 @@
   },
   {
     "id": "terra13eyn98smadfflnm0jgt04q5dqzs3dtjg6kjjrj",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hfyxtste6842zulmjv9n92srv803q6rhn7t8d4",
       "uusd"
@@ -8391,7 +8391,7 @@
   },
   {
     "id": "terra13h83g8cv50e98kk450pkpk76fmjeryd32zvef6",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1w7zgkcyt7y4zpct9dw8mw362ywvdlydnum2awa"
@@ -8411,7 +8411,7 @@
   },
   {
     "id": "terra13hprd7adym4cf2hgjmnjdv48akxj8fplelp6pz",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1xzn8e3h9k4qk7082z330sn8ptz99lnghyua9xy"
@@ -8421,7 +8421,7 @@
   },
   {
     "id": "terra13htj4202asg8fdmyq002zm53j7h4my8q4kdddt",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
       "usek"
@@ -8431,7 +8431,7 @@
   },
   {
     "id": "terra13kvcwhxa0ym2tpgcchk0rn0zrrl7r7w0mgv74q",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lkszqh6duver9s9h0qfr2dcktj605km3hzfzjd",
       "uusd"
@@ -8441,7 +8441,7 @@
   },
   {
     "id": "terra13nerldmwsc5gal4jtjr2t04vng02q5d7nthqtj",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv",
       "uusd"
@@ -8451,7 +8451,7 @@
   },
   {
     "id": "terra13nwgt8kxyat5pt70faxnm8dje0c67hwsp53d5x",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
       "ueur"
@@ -8491,7 +8491,7 @@
   },
   {
     "id": "terra13xh4kjkx2xd0nn5tzwnqpmzwrc9mhrfdvl4axp",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf",
       "uluna"
@@ -8541,7 +8541,7 @@
   },
   {
     "id": "terra14c8m8anc8u9llaf2tq0d80986vmeprehkrwpnq",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra16gqgpuy7z64chzz3su2xugjgrhuj3h89wx2z59",
       "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
@@ -8551,7 +8551,7 @@
   },
   {
     "id": "terra14czsfcd6j4z8ffyekkgsr4zkpw8tdnec0v9jz5",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "uchf"
@@ -8571,7 +8571,7 @@
   },
   {
     "id": "terra14eey9rfl9we6hurlf9q44nfffrm2cd8xjkdqmz",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
       "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm"
@@ -8611,7 +8611,7 @@
   },
   {
     "id": "terra14hpees7gp0addrkgavwpylsr9tnzg57c0vdxav",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1jkkt5638cd5pur0u5jnr2juw0v6hz5d6z8xu8m",
       "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
@@ -8621,7 +8621,7 @@
   },
   {
     "id": "terra14lg4pfn3s5p4zcmujnppvpr09n5a7583cz4czd",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
       "uchf"
@@ -8661,7 +8661,7 @@
   },
   {
     "id": "terra14q2h9nce4spj8n74g6kppj3yf86qx8hsrqngfh",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7"
@@ -8671,7 +8671,7 @@
   },
   {
     "id": "terra14rmvvzfs88axcrk0farsdswylj55umpj6kqh79",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra16ea8pnh3hu69kzqqps5gqw0zdd94hgul9tfnzw",
       "uusd"
@@ -8681,7 +8681,7 @@
   },
   {
     "id": "terra14t6yzxt5vhx4dyjknzj78tge6j8385awnczxpg",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1ucme9gd7wr7lx0sysnydhdhaqtrg4403nrqm0l"
@@ -8701,7 +8701,7 @@
   },
   {
     "id": "terra14wt2rhghhtuyl07h4ls78hjuh5gk4nxj66u2tp",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vlqeghv5mt5udh96kt5zxlh2wkh8q4kewkr0dd",
       "uusd"
@@ -8771,7 +8771,7 @@
   },
   {
     "id": "terra155rgjn955ppq9vz5gapcfgwaf6vg9294xp2kcj",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra15hp9pr8y4qsvqvxf3m4xeptlk7l8h60634gqec"
@@ -8791,7 +8791,7 @@
   },
   {
     "id": "terra1583mexe3t5gwfjf97paz3r8m23dxw9gjqa2ap6",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1cjf3m2zsx4lu6c0edhfcvp0v4hps6gfr79hyc4",
       "uusd"
@@ -8831,7 +8831,7 @@
   },
   {
     "id": "terra15n30h56p9zva8gfp7ejd0smw2zf5xlxwelgg95",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1tt9jmf58nvaj8l0lckwfekfl43verjdpywcdwa",
       "uusd"
@@ -8861,7 +8861,7 @@
   },
   {
     "id": "terra15qa20t4hrq27ugcyut363mum72hdlgcqnannm2",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "uusd"
@@ -8871,7 +8871,7 @@
   },
   {
     "id": "terra15rl2agmgqjwlx3qqqe9rfjcvs3lxl2e3srzwda",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1a59ns8fnk04sj982ymkvx9ygscmf4jjtm4sltg",
       "uusd"
@@ -8881,7 +8881,7 @@
   },
   {
     "id": "terra15sut89ms4lts4dd5yrcuwcpctlep3hdgeu729f",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n",
       "uusd"
@@ -8911,7 +8911,7 @@
   },
   {
     "id": "terra163pkeeuwxzr0yhndf8xd2jprm9hrtk59xf7nqf",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
       "uusd"
@@ -8941,7 +8941,7 @@
   },
   {
     "id": "terra167gwjhv4mrs0fqj0q5tejyl6cz6qc2cl95z530",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1zsaswh926ey8qa5x4vj93kzzlfnef0pstuca0y",
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608"
@@ -8951,7 +8951,7 @@
   },
   {
     "id": "terra169l808rtk42ukexh3wqyx2cgxp4gvn5fqmn5zq",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
       "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm"
@@ -9001,7 +9001,7 @@
   },
   {
     "id": "terra16pwrn7frj4d8r4dfc3l8y3xkt5uk2505ad7nvm",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "umnt",
       "uluna"
@@ -9021,7 +9021,7 @@
   },
   {
     "id": "terra16rzrqaa3srgffadx3al0cjf9s6au0dy6ertxtk",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
       "terra1nagqpmyw55yjphea4rhntlfv87ugmeaj8ym756"
@@ -9041,7 +9041,7 @@
   },
   {
     "id": "terra16wwzrfv28lhqzv7l9m9qnpzyae600dsratzqg7",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yeyr6taynkwdl85ppaggr3zr8txhf66cny2ang",
       "uchf"
@@ -9051,7 +9051,7 @@
   },
   {
     "id": "terra16x00f2haetp736xgj8v0t2p3ju6tgnc4f8pzd8",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1skjr69exm6v8zellgjpaa2emhwutrk5a6dz7dd",
       "uluna"
@@ -9091,7 +9091,7 @@
   },
   {
     "id": "terra17dh7ekvz3qeghj50rqphx9es33qr5z5c5dhgdz",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
       "usek"
@@ -9111,7 +9111,7 @@
   },
   {
     "id": "terra17ef74ttzva3fg7kc29w8na3nut8ugcdmxyycw2",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "uchf"
@@ -9181,7 +9181,7 @@
   },
   {
     "id": "terra17rmhzak7ymvwlwr275neppvxkrr3xl6vj0dczr",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1e6lfxnuyqg3wxvczuz0zkmvr40ldvqx26eqk5g",
       "uusd"
@@ -9201,7 +9201,7 @@
   },
   {
     "id": "terra17vk5j4mhxnpl74xmndmyjfma3ynpef6kj7jhuj",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1zawrkv57eh7rne45zjta7s876jqc59slrev9xy",
       "uusd"
@@ -9221,7 +9221,7 @@
   },
   {
     "id": "terra17zp4dqu3d2sj9kq8uqnsvwy4ll66g7380uh03s",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dwyd6vds479kv54f7kucevny97lge20c3s9w2k",
       "uusd"
@@ -9231,7 +9231,7 @@
   },
   {
     "id": "terra180jp452au9sfwq4kuxtsd9q2wzjfu6v9ghrkax",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1dj2cj02zak0nvwy3uj9r9dhhxhdwxnw6psse6p"
@@ -9241,7 +9241,7 @@
   },
   {
     "id": "terra1830q85e520kyhh5e0a254gvt88z8ngxa05tj6q",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1h8hmr0em0avkz4kzuwgakyxrdvxqwg5d3cg4sd",
       "uusd"
@@ -9251,7 +9251,7 @@
   },
   {
     "id": "terra187406r5f8nl09xskt0p6zeq54hs86m6j04q35f",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx"
@@ -9411,7 +9411,7 @@
   },
   {
     "id": "terra18xk94xj3qyrv4laxy25hhvwggr8d4g5z6ynl3p",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1s0fnj6cz44e2j45293320wmwmjp5pmdkuuv878"
@@ -9471,7 +9471,7 @@
   },
   {
     "id": "terra198q4sqvt4yczlxxs9cjtktqdy7tzthz8vhz6xq",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1aaqzva7adgwtzfkt9nmrmuvkg9s6lmsgtkg3jd",
       "uusd"
@@ -9551,7 +9551,7 @@
   },
   {
     "id": "terra19pldqzpsglzusuj59tw750yp5um885c4u888cp",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18zg84fg56lthpjd8skj70l4zd3puyul5weqfer",
       "uusd"
@@ -9561,7 +9561,7 @@
   },
   {
     "id": "terra19slzdkvt3kekyq4ydp3ky4pjuus5lmedafkkzs",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
       "uusd"
@@ -9591,7 +9591,7 @@
   },
   {
     "id": "terra19z6n7l67rkg6y7vggwr3jh889t9vg6yn2jdl9n",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "uusd"
@@ -9611,7 +9611,7 @@
   },
   {
     "id": "terra1a2k9k9g5gyuats98z69ssk4aqjt38a9z943xd9",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1zvhvg09zeyl3txrc7v3crnqnnwc0d2nvgxvdhd",
       "uusd"
@@ -9621,7 +9621,7 @@
   },
   {
     "id": "terra1a4cjrs86m97rk0g5yuds8yjd7f0en5drqnynwk",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vsl7etwe53vglc2xq2rdt7mujarcjy9j694hdk",
       "uusd"
@@ -9641,7 +9641,7 @@
   },
   {
     "id": "terra1a6uk8kz25l59krr2m683ph8l6waky0nphm5l66",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1g0pm8xm5c2dq4qtv8j9a80hg4mhe5ndy8qad07",
       "uchf"
@@ -9681,7 +9681,7 @@
   },
   {
     "id": "terra1aduehngz4gzd68k8v474yaejfh7thf7cx8ml93",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1u553zk43jd4rwzc53qrdrq4jc2p8rextyq09dj",
       "uluna"
@@ -9711,7 +9711,7 @@
   },
   {
     "id": "terra1afslx9uqz7gw348kae05drt39uu2nxnrhlgupu",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
       "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur"
@@ -9731,7 +9731,7 @@
   },
   {
     "id": "terra1aghtgj6c4m83cuyzfdq7cagh3e4yvksyh0afjk",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
@@ -9741,7 +9741,7 @@
   },
   {
     "id": "terra1ahzjyx9l523fs5s7xe6luqy9auc5tdwzgqz0k9",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra18yqdfzfhnguerz9du5mnvxsh5kxlknqhcxzjfr"
@@ -9751,7 +9751,7 @@
   },
   {
     "id": "terra1ajj4klvt3gpf5mmkmlsaz7t23paaanm68xn9dj",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1t5kcd9285mqczsyy2ztu96h8h8ecpy5sf6h0qu",
       "uusd"
@@ -9771,7 +9771,7 @@
   },
   {
     "id": "terra1alrzkvqfe2dczdr33kf8et205eeclcqzyvpez8",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
@@ -9791,7 +9791,7 @@
   },
   {
     "id": "terra1atzg5zp4p9sy7k9urun8q703upffm2maffm8tz",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19cxwwhtkpp4qvf4tvjmhh8lnh8lle7uw7ndqjw",
       "uusd"
@@ -9821,7 +9821,7 @@
   },
   {
     "id": "terra1awhdnu3pug33yr86gfu8kmkw4kn4cn720gkc3d",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1v7vp6ywlymprx9mk7ngm4uf0xgrz2ektg5wd6z",
       "uusd"
@@ -9831,7 +9831,7 @@
   },
   {
     "id": "terra1axd3wejrvzx27sn54yjlxlhrrr49zphqw9fpn5",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pzjd5axw303jt40l4pmakfa88d0jpjf8rpmj8n",
       "uusd"
@@ -9841,7 +9841,7 @@
   },
   {
     "id": "terra1ayqus392c2fzs4mgrsnlkzjaqfd5efla72el85",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1l670q2m9j3npltmsqe428mwu0msw336m8jtq00",
       "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
@@ -9861,7 +9861,7 @@
   },
   {
     "id": "terra1c4ddm3ds2zwun37r7ldek908ypkxxpkvkcat5f",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra100yeqvww74h4yaejj6h733thgcafdaukjtw397",
       "ueur"
@@ -9911,7 +9911,7 @@
   },
   {
     "id": "terra1ce7rky5mjrjhyadp976r25r05jhslyn0q3rl86",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "terra1042wzrwg2uk6jqxjm34ysqquyr9esdgm5qyswz"
@@ -9921,7 +9921,7 @@
   },
   {
     "id": "terra1cgsuvt2nyxxqc6gfg39q2h99s3877mhyhd29uf",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1qqfx5jph0rsmkur2zgzyqnfucra45rtjae5vh6"
@@ -9941,7 +9941,7 @@
   },
   {
     "id": "terra1cpnemrjze8904e4ggujp86y0vs737uapqqfmjz",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "uusd"
@@ -9971,7 +9971,7 @@
   },
   {
     "id": "terra1cyu32h09k6djqt3a0pgljgan2vass3etl6vcng",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lnrphdxwfre5w7rwazzfnp0k9d4glm63t7gg70",
       "uusd"
@@ -10001,7 +10001,7 @@
   },
   {
     "id": "terra1d6k2mnhpqttsqhae2hwu7rs78nrrwymeq8p40j",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vwz7t30q76s7xx6qgtxdqnu6vpr3ak3vw62ygk",
       "usek"
@@ -10041,7 +10041,7 @@
   },
   {
     "id": "terra1dd7g5js5xqqkl2fse28hee38sdes7sv6f79pfd",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10gpgrr85u4g42uu6c3hkkxkggg2nw5kt95yc7x",
       "uusd"
@@ -10061,7 +10061,7 @@
   },
   {
     "id": "terra1dgqs3aa66l24natsgslvwwkj3henn4c9uesfz9",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq",
       "uusd"
@@ -10071,7 +10071,7 @@
   },
   {
     "id": "terra1dh2kva6kd99fnq0xa0rn3yjp4dqaw7h806klyt",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1jsxp2vt60nqfsuru6s6ewgfld7vpwgkvv5qqgl",
       "uusd"
@@ -10111,7 +10111,7 @@
   },
   {
     "id": "terra1dnz5katpc8374kkuwl6c7pak604u50gfpj6zuv",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1afgfjpny09lvxl06llcy7hfu0m2epfddzn0f75",
       "uusd"
@@ -10131,7 +10131,7 @@
   },
   {
     "id": "terra1dpp6zc305d4fux8j3sp2c2x3kaykha8enhl3ur",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13x03uqz06gkam3dq4dgx0tj89dpw3vs2nlftjq",
       "uusd"
@@ -10151,7 +10151,7 @@
   },
   {
     "id": "terra1dtsjzg6g5zkqsfwrw0uxlyl6e6u4kna0xzk0q7",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "ugbp"
@@ -10171,7 +10171,7 @@
   },
   {
     "id": "terra1dy4dpuxev7y4tqa0rhwjrc6e4yz3w9gqr6szz3",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a",
       "uusd"
@@ -10211,7 +10211,7 @@
   },
   {
     "id": "terra1e8dxc7saepd8l7cru73eryaakmrk67fc4qgw5j",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45"
@@ -10251,7 +10251,7 @@
   },
   {
     "id": "terra1efwf7jw3tgyy7uqx3u8j9p0kpl9ts39avgnzec",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
@@ -10261,7 +10261,7 @@
   },
   {
     "id": "terra1ejyqwcemr5kda5pxwz27t2ja784j3d0nj0v6lh",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
       "uluna"
@@ -10281,7 +10281,7 @@
   },
   {
     "id": "terra1elte83u4a6yrw90qmaeee58w94sy6yq7mrf8k0",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1d8h5yckrkgzneng72c8yskgdfd2s9870fuxnfy",
       "uusd"
@@ -10321,7 +10321,7 @@
   },
   {
     "id": "terra1erdxk0afwhq0hwpftndeayeqct9eluxyzt0v2e",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lrdzs5tgllwqgawtq2emuzn7snpxq87fzzl44y",
       "uusd"
@@ -10331,7 +10331,7 @@
   },
   {
     "id": "terra1erfdlgdtt9e05z0j92wkndwav4t75xzyapntkv",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "ukrw",
       "uluna"
@@ -10361,7 +10361,7 @@
   },
   {
     "id": "terra1et8gmg0khfmv04vznevg5fx9ngucauh6hg3dm3",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr",
       "usek"
@@ -10391,7 +10391,7 @@
   },
   {
     "id": "terra1ewyn79c2nnzp7g57a54vv6l99lxcjdcd4z770n",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1f9h22l730vxxj5jmrakuwh3neuhdynwy42ezvv",
       "uusd"
@@ -10401,7 +10401,7 @@
   },
   {
     "id": "terra1f22zcf6m4600eajay6wnzw03lmjdy0f8mjxphe",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra14xulq5g99rfmrm6qkgzmrrspvknupajdqyd92k"
@@ -10421,7 +10421,7 @@
   },
   {
     "id": "terra1f562s8g3y45cqxqn4qftvwcwxh2rc3v68ug2cx",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1u3cykdenv7z3hveg6vfc0w23gfhwkdktftka9a",
       "uusd"
@@ -10441,7 +10441,7 @@
   },
   {
     "id": "terra1f9aln0c98j9w749szx958la7x25chdnz9hqx0v",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1sn208s2cmya87707w4r9hf36znv8ml8dcnhr2d",
       "uusd"
@@ -10451,7 +10451,7 @@
   },
   {
     "id": "terra1f9l20gvf6vd7wtkga89n2vu69jmpqg0qyzapa5",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ng9dsq2m5mw993s0uljj06scrj5g07sq36lq8t",
       "uusd"
@@ -10501,7 +10501,7 @@
   },
   {
     "id": "terra1fdwsevq7skhfq93zkg0xxr6zrv29aqupw2fura",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1zd6let0zg0xjn2sestagxv4ax24a4ml6j40qdr",
       "uusd"
@@ -10511,7 +10511,7 @@
   },
   {
     "id": "terra1fehg72ukrnmt56evclq023rpefzjmrwre9k6vl",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1y8w753jk2x2j6f7a9ea30xc2qk5esharn89sk2",
       "uusd"
@@ -10521,7 +10521,7 @@
   },
   {
     "id": "terra1fg8f9s8ltyw59crjde6vrv2chvcprndayk9gt4",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra16wggm67a34msdxasg2vergm2pt289y7930wv7d",
       "uusd"
@@ -10551,7 +10551,7 @@
   },
   {
     "id": "terra1fl3x3plfat8y82c9wpu6uv97wkqap7lp04a4jr",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
       "terra1nagqpmyw55yjphea4rhntlfv87ugmeaj8ym756"
@@ -10581,7 +10581,7 @@
   },
   {
     "id": "terra1fqf55gk7a2znglw3kh8j5gu0zgfj6sxv4q9ng4",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1lvmx8fsagy70tv0fhmfzdw9h6s3sy4prz38ugf"
@@ -10591,7 +10591,7 @@
   },
   {
     "id": "terra1fqhyxfrvlhguw97nuhxm34uvzar8vfr63ft7km",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
       "uusd"
@@ -10601,7 +10601,7 @@
   },
   {
     "id": "terra1fts4e488k0u9xc6etggjdqrcnxvmj48vmd23ly",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra14y5affaarufk3uscy2vr6pe6w6zqf2wpjzn5sh"
@@ -10641,7 +10641,7 @@
   },
   {
     "id": "terra1fzlm4rzcctes3g230vfgcqwth94wupgsht96xn",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ng3nsd3u3emflmp4rv7ac70ug3g87pt930g6t5",
       "uusd"
@@ -10661,7 +10661,7 @@
   },
   {
     "id": "terra1g9rrgs63wm55ad7rv6rmj8hu8nauc0ru4yussv",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra188w26t95tf4dz77raftme8p75rggatxjxfeknw",
       "usek"
@@ -10681,7 +10681,7 @@
   },
   {
     "id": "terra1gc46an30tdv0n25ch5twgzcsw0wpk2h32gp4nq",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7",
       "uusd"
@@ -10691,7 +10691,7 @@
   },
   {
     "id": "terra1gg00qrm9l7ghqs2c2ey55uwtc7cvu39c799lr9",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17ggkh9upvkmeyew240lz95zcdytpd2j9m55he5",
       "uusd"
@@ -10701,7 +10701,7 @@
   },
   {
     "id": "terra1gg0snqxxxhjcma4095nn7lduwtv3k5xw34lzks",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1gun7mcfjq965gm2jqmq2upxkeqd2lay4qrzfej"
@@ -10731,7 +10731,7 @@
   },
   {
     "id": "terra1gkdudgg2a5wt70cneyx5rtehjls4dvhhcmlptv",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg",
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
@@ -10741,7 +10741,7 @@
   },
   {
     "id": "terra1gkx2ft0568avqalllpj0d29gxkfq6spk967vzu",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
       "ugbp"
@@ -10811,7 +10811,7 @@
   },
   {
     "id": "terra1gxxu7stjnshv7c7l87upcs9pqv7n6k07qfr7wj",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1p5k0vl2g22zv0r07fxm627pf8u5frazevqgkw5",
       "uusd"
@@ -10821,7 +10821,7 @@
   },
   {
     "id": "terra1gxyn0lewraduax9lgcqekpcxf0yx2cqtl9pq99",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dssh7fk2gjjgf7yhcrd29repaz2gnxcs9yj9ay",
       "uusd"
@@ -10841,7 +10841,7 @@
   },
   {
     "id": "terra1h2mpd99j8mcuyjcxh2wa5xsdkhwtrhyucsyrzr",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
       "ueur"
@@ -10871,7 +10871,7 @@
   },
   {
     "id": "terra1haay9t8vvpvdrtd6t9c6pzl2cpr8m4xeadhykv",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1vwvpvamj60rtnzxzr00thgtv5hplhu55jx67d6"
@@ -10881,7 +10881,7 @@
   },
   {
     "id": "terra1he8as5az55glkg7rye69ujsgl8f8gs3khjxwm2",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1cczv3ck2r909w64n9rdqs3gh5gsmwumh4utz49"
@@ -10891,7 +10891,7 @@
   },
   {
     "id": "terra1hgzc444yxhgrdj4g9js9j87uarvsk3ze0uv4mn",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kntmj30tuu0fyu7vmgcrxuzax8gzt7mdmuppwv",
       "uusd"
@@ -10921,7 +10921,7 @@
   },
   {
     "id": "terra1hkp4hulmttwzagzphr6vczvjm46e6ryxv99nan",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy",
       "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
@@ -10941,7 +10941,7 @@
   },
   {
     "id": "terra1hm4gfvl5d65v03wzgvy5lh780dnwk6xtnaeurj",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra16xtp5rmhx4agcas4cyg3srp6m6gauqagh02v9z",
       "uusd"
@@ -11031,7 +11031,7 @@
   },
   {
     "id": "terra1hts7pmh590w6hd264pq6pm8ya0ck8qxsethpfp",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
@@ -11061,7 +11061,7 @@
   },
   {
     "id": "terra1hwaaf5sj0039qf80q3e5cce37rw6kgdce44q0f",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
       "usek"
@@ -11081,7 +11081,7 @@
   },
   {
     "id": "terra1j20n7e6klfkp2xjruh000u5lhpj2fgfng3an84",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a",
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
@@ -11111,7 +11111,7 @@
   },
   {
     "id": "terra1j5l4c2n9x5hjrluk2k746jx60hpgycva4kg5g9",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ewvul5j47zpsr6dtyt0fup6q3tquqq3cvxpjhp",
       "uusd"
@@ -11121,7 +11121,7 @@
   },
   {
     "id": "terra1j5rqw5vtxsx7el0mptyjqhtfaqnxgg6yu90ek7",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
       "terra130fhr9jz0nylzhdvuwcpp3hne2s5qlft6hfzgv"
@@ -11131,7 +11131,7 @@
   },
   {
     "id": "terra1j6dx9d05sdpynkxexvp4jqdlgqv2adp7uls4we",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra12qeh8p79q6jrnlmw09hvtytv9e99yl2077cmgz",
       "uusd"
@@ -11201,7 +11201,7 @@
   },
   {
     "id": "terra1jvhqxjzezxvss9d0rfpttvz4hv6lp7urvwmx0j",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1tthplnk67e7tvga2dh49jk6l6cn4furuuffu9x"
@@ -11261,7 +11261,7 @@
   },
   {
     "id": "terra1jzqlw8mfau9ewr7lufqkrpgfzk4legz9zx306p",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1r5506ckw5tfr3z52jwlek8vg9sn3yflrqrzfsc",
       "uusd"
@@ -11281,7 +11281,7 @@
   },
   {
     "id": "terra1k30c303e059kqhz705a77kgdhr2ndldfdxjvsr",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap"
@@ -11331,7 +11331,7 @@
   },
   {
     "id": "terra1kaed40250kxfhy60sy2zf6g665l50m2ms3zjw4",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
       "uluna"
@@ -11341,7 +11341,7 @@
   },
   {
     "id": "terra1kf6ctpmz72mta3h2y68jyg2mlnxktaudsjcxdm",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
       "uluna"
@@ -11371,7 +11371,7 @@
   },
   {
     "id": "terra1kg6emvfc38xtvvlpxr6z8z89t3zwu3etugkzz6",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1pkp0pkxp9mtlan7cg0qatu65hmkgyq2342g27g",
       "uluna"
@@ -11381,7 +11381,7 @@
   },
   {
     "id": "terra1kgcv6dq7ajlh98t34puyexhy08ltnnx2tycrtu",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1g77epr507pp572hnhaprjuz9fp6yn3e4mgyxar"
@@ -11411,7 +11411,7 @@
   },
   {
     "id": "terra1khyj5x39ryfn26thsv2l499pz0upgkye277ljf",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1jsxngqasf2zynj5kyh0tgq9mj3zksa5gk35j4k"
@@ -11451,7 +11451,7 @@
   },
   {
     "id": "terra1ks267e2cr5r3rxsvh728ghg5emz5e7d5kxxks3",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vsyyg4rs483uzd7jzw5fqqlm2q5n2yd37yylfc",
       "uusd"
@@ -11491,7 +11491,7 @@
   },
   {
     "id": "terra1l3gn79zdchj977p5cg9etzv97cnmcp2yze4ulz",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kqf8ua7al5tdnkz95ue4zkuv4gcu52pt63ya54",
       "uluna"
@@ -11511,7 +11511,7 @@
   },
   {
     "id": "terra1l5xws6n5wyhjr46cxhvnmfdqqck2xd9tyq0ze4",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls"
@@ -11531,7 +11531,7 @@
   },
   {
     "id": "terra1l7urxwu5txjsy56xcuaxac4et42ll3jnjnjrsk",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1g2dz304juraseqdqq6ufnktqgeqen67sct3p7d",
       "uusd"
@@ -11541,7 +11541,7 @@
   },
   {
     "id": "terra1l7vy20x940je7lskm6x9s839vjsmekz9k9mv7g",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "uluna"
@@ -11551,7 +11551,7 @@
   },
   {
     "id": "terra1ldpgn35p9m2ksumh8dksp3edvv4nz9tdj2pwv2",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1enj2np0785hw3vt2gn2yga9y75306g6e9lq799"
@@ -11571,7 +11571,7 @@
   },
   {
     "id": "terra1lj3z3hfc2hms3r2yc3q4r5w83m2zwktpkuvmmq",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rdqy74e080e96qhk5gntnr882awm4pfc7t6dn4",
       "uluna"
@@ -11601,7 +11601,7 @@
   },
   {
     "id": "terra1lp6exls2fpz3lv9yc7mtmc6r070zy4lg3lse6u",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra102cjx95xvww7cl9l6usxltk75ww3mpxtyw4lpm",
       "uluna"
@@ -11631,7 +11631,7 @@
   },
   {
     "id": "terra1lullqskr4jqh6fweuh9ret8k4f9ppy9nf9awtx",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "ueur"
@@ -11651,7 +11651,7 @@
   },
   {
     "id": "terra1lxug53rtdtv5c8k7alxum9pfnayzhq5mu4y880",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1l6nqyv78m3kj8v4wa7r5fr3vhp0qzrauwkx5av",
       "uusd"
@@ -11671,7 +11671,7 @@
   },
   {
     "id": "terra1m6kxrr0uvyy7as6fu2p65p4kgzg9rww9j9yhj9",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17n223dxpkypc5c48la7aqjvverczg82ga3cr93",
       "uchf"
@@ -11681,7 +11681,7 @@
   },
   {
     "id": "terra1m70c962mz88gesrp2ascej5pr2027vs324vynh",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vsyyg4rs483uzd7jzw5fqqlm2q5n2yd37yylfc",
       "uluna"
@@ -11701,7 +11701,7 @@
   },
   {
     "id": "terra1m9hm6cxlf0907yy7lsssyfpzswlu54r99k9dxf",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vwz7t30q76s7xx6qgtxdqnu6vpr3ak3vw62ygk",
       "uusd"
@@ -11741,7 +11741,7 @@
   },
   {
     "id": "terra1mlz0yv4j8rw6saz5v7fq35m0qtacag8qj4hr83",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lladdxhn49jz0hrvwgalu4a548txh94mcec595",
       "uchf"
@@ -11751,7 +11751,7 @@
   },
   {
     "id": "terra1mp40g7sneygtnxdm2ncxmjq45pgut2hryxck3a",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1u9hgxjw5k0aje9xjf0ejfu6uwmamc2k8ylzd7l",
       "uusd"
@@ -11781,7 +11781,7 @@
   },
   {
     "id": "terra1mspf3g3fx3j0u9p6y7nxaf23wetn54hgm3z753",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
@@ -11791,7 +11791,7 @@
   },
   {
     "id": "terra1mv3tksqwfextmnejw8s7ada9qu3pwav098qfxu",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur"
@@ -11801,7 +11801,7 @@
   },
   {
     "id": "terra1mveechnw84gnylqjs7v5wrk9ky9jyly6lsfmfr",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra193c42lfwmlkasvcw22l9qqzc5q2dx208tkd7wl",
       "usek"
@@ -11821,7 +11821,7 @@
   },
   {
     "id": "terra1myn9wsgv02jny8jwhnxdf8lrfy6gvdnv2c3wk3",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra137qvfdvlkj9vfhrctz4rlkk7lmgql7xalqlwpw"
@@ -11851,7 +11851,7 @@
   },
   {
     "id": "terra1n3khk8w48y8jf5cgjjhccg5dg9qua0xdkt98we",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra176eej9z5upauemz7wg2q6n86472xyy836v6smx"
@@ -11881,7 +11881,7 @@
   },
   {
     "id": "terra1n6snwmgzpfs73juuxurwxmt2md49s2l5ggf5f2",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xt9fgu7965kgvunnjts9zkprd8986kcc444q86",
       "uusd"
@@ -11951,7 +11951,7 @@
   },
   {
     "id": "terra1nlrtp53mpvlged7pp537avj8uf59j3s0qlwrga",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1cwretz2zmeqe2uhq4fuk2mrp4ptuvsct890c6f"
@@ -11961,7 +11961,7 @@
   },
   {
     "id": "terra1nr2hvucfvtnzxm39022jal53wker54thdkll4r",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "ueur"
@@ -11981,7 +11981,7 @@
   },
   {
     "id": "terra1nszsz38jnmfs6xl9tsq093sc23stm7xz33dqqx",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra19xk3rsesaupv72se69y8v6y6m04fl8yj6vnmtv",
       "uusd"
@@ -12001,7 +12001,7 @@
   },
   {
     "id": "terra1nx3rggxrpv0yekes85kg3fa7v73qgphst6v5gj",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1aydw57mpa6jg5n3xnrau9g7mftd3ch6fh7qzal",
       "uusd"
@@ -12031,7 +12031,7 @@
   },
   {
     "id": "terra1p0sjx8kg9zeuefzwu0ac9ftemrr0usdyypsnty",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1c00vskhyzdv0z63z2tyetzx2qma67n2z3vzyn0",
       "uusd"
@@ -12081,7 +12081,7 @@
   },
   {
     "id": "terra1pc0r79hmaznqh7tnsmzmh9zsl5y87t02zz2fmr",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1uhwhrypcnucvcc2ayt92mlky2xtatslrn7tte4"
@@ -12141,7 +12141,7 @@
   },
   {
     "id": "terra1peyurud64sjajna3s9g2s9er4uv3tftyj9avwf",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
       "uusd"
@@ -12151,7 +12151,7 @@
   },
   {
     "id": "terra1pgf2ntzk2gh2lar6zh0yjwchmrtym8zfzp296y",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1uc4fwlh2wn59qqk8y7ld0vxc9hvsufaa5gv5z8",
       "uusd"
@@ -12171,7 +12171,7 @@
   },
   {
     "id": "terra1phjmfqsajhrzdq056nawr55kqqerylpthpvlat",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra10h7ry7apm55h4ez502dqdv9gr53juu85nkd4aq"
@@ -12251,7 +12251,7 @@
   },
   {
     "id": "terra1pyx0xvdeqmn8r7ljakjwx6z852zg25kxpesyn0",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1g4x2pzmkc9z3mseewxf758rllg08z3797xly0n"
@@ -12271,7 +12271,7 @@
   },
   {
     "id": "terra1q00r9whldewsktqne5sux6gtaxn2vlfvu5geej",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
@@ -12291,7 +12291,7 @@
   },
   {
     "id": "terra1q3pem26pyxq7qggmxkh5egd4km0a7l0gxe84wk",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm",
       "uusd"
@@ -12371,7 +12371,7 @@
   },
   {
     "id": "terra1qhnylhd7vdu87sdyjs908ndxc4ck0pgzpr7ky0",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1948uvsah8aw40dhsa9mhl3htq8lraj0smlh77g",
       "uchf"
@@ -12421,7 +12421,7 @@
   },
   {
     "id": "terra1qpd9n7afwf45rkjlpujrrdfh83pldec8rpujgn",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "uusd"
@@ -12431,7 +12431,7 @@
   },
   {
     "id": "terra1qr3jrdwrkqhntnkpvx39efrmayx45ysuhpg9qk",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1g0pm8xm5c2dq4qtv8j9a80hg4mhe5ndy8qad07",
       "terra1mjhrlgwv8dnvc7mp0cynfxna947hxnm5m4tp6u"
@@ -12441,7 +12441,7 @@
   },
   {
     "id": "terra1qs0zjzd6j0kwrwwf2qj5kmqqhav5ygq3q7p8s7",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "uluna"
@@ -12451,7 +12451,7 @@
   },
   {
     "id": "terra1qthlsaqccp8mxr2z4vvkhf5ynqjl86ccxg0pqn",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1zjhsuvuy5z7ucvx56facefmlrrgluhun27chlf",
       "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
@@ -12461,7 +12461,7 @@
   },
   {
     "id": "terra1quf8yfhqkt38fa2j3zhgfv93ra6tvj9t0q6sgn",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz",
       "uusd"
@@ -12491,7 +12491,7 @@
   },
   {
     "id": "terra1qyynd88qccpjrdn4yghhf8n9dm9msayrtqwwva",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc"
@@ -12521,7 +12521,7 @@
   },
   {
     "id": "terra1r3djf4znn0vknjhdmlyg89hd8955v3vhr7jj5h",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
       "usek"
@@ -12531,7 +12531,7 @@
   },
   {
     "id": "terra1r6pp7pp0pgvp06nh80qmu697qfjsegddqnsg8t",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra194a6jn3cyydhrfpdnz5r5zkj6wx3t3cr673z4r",
       "uusd"
@@ -12551,7 +12551,7 @@
   },
   {
     "id": "terra1r8k9pea8wmt93l703azhs82kpjva0cpq8tq5at",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm",
       "uluna"
@@ -12591,7 +12591,7 @@
   },
   {
     "id": "terra1rh6rwrekv3r7ep89lmkysxugsvuaqljmmepx5s",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra16qsk2zwv5fsqd944p28f2dkddr7eq9uzuxeh8h",
       "uusd"
@@ -12621,7 +12621,7 @@
   },
   {
     "id": "terra1rq55zs9w6s24wmlmd540j2q2p6whanurfj26eh",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
       "ugbp"
@@ -12641,7 +12641,7 @@
   },
   {
     "id": "terra1rrek47kf0t968g2jcg5ww8fw58n93jkclkk4v5",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1lkjq6f2sqlqjk0crs2a7fv6m5pquhl8nuesp3j",
       "uusd"
@@ -12681,7 +12681,7 @@
   },
   {
     "id": "terra1rvnzun0xww86xnhu88prga8qt2n2trkjm72s4m",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15k5r9r8dl8r7xlr29pry8a9w7sghehcnv5mgp6",
       "usek"
@@ -12701,7 +12701,7 @@
   },
   {
     "id": "terra1rxzs4rs28rx89dt57nnph6xz8zmycf5js2d4ey",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1srp2u95kxps35nvan88gn96nfqhukqya2d0ffc",
       "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
@@ -12751,7 +12751,7 @@
   },
   {
     "id": "terra1sc02s2q53678ase0uh5e02x95dv6knkkgf6xwx",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra10ynpvp8trmlkf6n69qx0kp9qjs54d8wsh2pddc",
       "uusd"
@@ -12761,7 +12761,7 @@
   },
   {
     "id": "terra1sdmk3k5ajmnk5zdfujmr8q3yfvlp067h8syq5l",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "usek"
@@ -12771,7 +12771,7 @@
   },
   {
     "id": "terra1sdu63qdzkndpavvl5ephzwl7jj2slvcy89qu9s",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra158y6aypem94yj34ycvgdm3py23afhnu2dj24ak",
       "uusd"
@@ -12801,7 +12801,7 @@
   },
   {
     "id": "terra1sgpvnwxmd9gmhhxzw03t7qftu00x35994denrm",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra130fhr9jz0nylzhdvuwcpp3hne2s5qlft6hfzgv",
       "uchf"
@@ -12811,7 +12811,7 @@
   },
   {
     "id": "terra1smwa4uj94ecy8qtenezzew0z8mur9vy443pqc5",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy"
@@ -12841,7 +12841,7 @@
   },
   {
     "id": "terra1squzmwcpr5486f0zp759d5zyt0q3yykaf6e4zx",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
@@ -12861,7 +12861,7 @@
   },
   {
     "id": "terra1stdzf28wlq7llzfecse366r657rtdh6wtrdfk2",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra140k6k2pmh2lmy4q4wyz5znqmtgwvs3gkgfeevq",
       "uusd"
@@ -12871,7 +12871,7 @@
   },
   {
     "id": "terra1su90khngc8fe80dwu0xgwt49262ytaye6zsv4l",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "uusd"
@@ -12881,7 +12881,7 @@
   },
   {
     "id": "terra1swdaspvv9w0wtf9sylmkdmfnzjx7eu5734n64q",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra190tqwgqx7s8qrknz6kckct7v607cu068gfujpk",
       "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap"
@@ -12931,7 +12931,7 @@
   },
   {
     "id": "terra1t33pflkepsmky9smma25ne05ghre3zk5wgz9u6",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
@@ -12971,7 +12971,7 @@
   },
   {
     "id": "terra1t7zq9ujczprlqss0dec7akfmnc2wumvsl8dr2v",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1hqgzrrtsft73pjnlf7w946u3m70a99cxjjm879"
@@ -12981,7 +12981,7 @@
   },
   {
     "id": "terra1t82m784qavjuawu2n6m47u6gch9wvfne38pftf",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra18ejpjp9eyx9t8j07jd7kzah9p0rvkzdfeeva6n",
       "uusd"
@@ -12991,7 +12991,7 @@
   },
   {
     "id": "terra1ta3lth8wu992m20qjeucg59rlxeez6qeygsxtm",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1j7ft2ze4phmcj4x2mnr7cfcns5x5hqjnnt8myj",
       "uusd"
@@ -13041,7 +13041,7 @@
   },
   {
     "id": "terra1tpk0tu4qstvzd5px7yc39urweeqj3yvm9wlauc",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1246zy658dfgtausf0c4a6ly8sc2e285q4kxqga"
@@ -13081,7 +13081,7 @@
   },
   {
     "id": "terra1tu9a790fj5mv2qlxmsqaxejysutmtnqyf86tlf",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1dj2cj02zak0nvwy3uj9r9dhhxhdwxnw6psse6p"
@@ -13111,7 +13111,7 @@
   },
   {
     "id": "terra1tzfcwlfyf8608y6m6xhelhckd97hquqpu3rp7j",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1cdg2m5swqzatvzuvseef9xcxpwqylx2h983hm4",
       "uchf"
@@ -13131,7 +13131,7 @@
   },
   {
     "id": "terra1u475wh425cs3wmgjqn4fqxyqpv7qmsnw7qs0sd",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1yrch507vhsmd9rue6q3v8pz4pe445jl09nrvz6"
@@ -13181,7 +13181,7 @@
   },
   {
     "id": "terra1u6dhkawjqxn0za9w8kvr7588ng9y73l0vj62fa",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra169edevav3pdrtjcx35j6pvzuv54aevewar4nlh",
       "uusd"
@@ -13241,7 +13241,7 @@
   },
   {
     "id": "terra1ufl3mnqqkucdgp68zrqxwmth9yy3ja5hnjv2c0",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kp8vne240370hn722ec5sacsdluyt2j0gc5nph",
       "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy"
@@ -13261,7 +13261,7 @@
   },
   {
     "id": "terra1upuslwv5twc8l7hrwlka4wju9z97q8ju63a6jt",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ustvnmngueq0p4jd7gfnutgvdc6ujpsjhsjd02",
       "uusd"
@@ -13311,7 +13311,7 @@
   },
   {
     "id": "terra1uvchkwq4kv0vhy23c78hyy72zks2hqtpctklh2",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kvjscdgwuvwc6uzm4rqfjl6nlmuhj28tequlnc",
       "uusd"
@@ -13331,7 +13331,7 @@
   },
   {
     "id": "terra1uxf47plxtc9tj4lnfwrlah0xp04hhhquye0wcf",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1vte2xv7dr8sfnrnwdf9arcyprqgr0hty5ads28",
       "uusd"
@@ -13341,7 +13341,7 @@
   },
   {
     "id": "terra1uytrvr6hqkptkkyesmf78qgwz9rhhcsxul9zsf",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rxfw0y02hfhnase727dqpn8kn2uu49qwrwul8t",
       "uusd"
@@ -13411,7 +13411,7 @@
   },
   {
     "id": "terra1v42wjhpntmq8nxjuqm6tttkx4q8zfrdd7ps3z7",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13jkds0xx2hy2xrqwggzkt4navhremx2cjyl7aw",
       "uusd"
@@ -13481,7 +13481,7 @@
   },
   {
     "id": "terra1vfk7qfdchgjadv2l2rgmkfnswe5n277kwcjafk",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra12lvpnlphqh3q0cxp8y47e5km8k2ad5ydw5asu4"
@@ -13551,7 +13551,7 @@
   },
   {
     "id": "terra1vwk0dhr5lha56ssddl58ntxlcunfru36d0jfuf",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra18xyl0ees6ueyhkhn0mjdtrm82e393ult2dazl3"
@@ -13561,7 +13561,7 @@
   },
   {
     "id": "terra1w3uwnguslkntkm3wsq86zan0a6jgtgwk0wr8z8",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
@@ -13581,7 +13581,7 @@
   },
   {
     "id": "terra1wcpqg4pr62dku9cry6r6xp7pagarvtzjtpql3n",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14vw4sfqwe7jw8ppcc7u44vq7hy9qa2nlstnxmu",
       "uusd"
@@ -13651,7 +13651,7 @@
   },
   {
     "id": "terra1ws34kqg6kek40jy8amdz7j4tyzqx8cenz40rem",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw",
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
@@ -13671,7 +13671,7 @@
   },
   {
     "id": "terra1wwyh5grgm8h7y2k0jy0n6h8em3su0cverprwgm",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "ueur"
@@ -13681,7 +13681,7 @@
   },
   {
     "id": "terra1wye679e2zq7pu55yzs9g9ptq054waaang0frfn",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1f62tqesptvmhtzr8sudru00gsdtdz24srgm7wp",
       "uusd"
@@ -13711,7 +13711,7 @@
   },
   {
     "id": "terra1x5zatqdvtxkc6fz96h4zslfj4zueqr8rmdvfje",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1v8wg6yr69cu842w053f8qk909f4swp4cn2waqp",
       "uusd"
@@ -13761,7 +13761,7 @@
   },
   {
     "id": "terra1xg660nndl83z5n7j4jd0cnrygs5dndcj30sazn",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1ehcjwxwf96c278n2ks84zes3ece5fqy78fa749",
       "uusd"
@@ -13781,7 +13781,7 @@
   },
   {
     "id": "terra1xk2tjgs43pv3pkfv4cmwauvnjd09wxsaedshg4",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1h8arz2k547uvmpxctuwush3jzc8fun4s96qgwt"
@@ -13791,7 +13791,7 @@
   },
   {
     "id": "terra1xk72vswca7jkjg8cpl9dz0qvfadam3ms365lp7",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1jxypgnfa07j6w92wazzyskhreq2ey2a5crgt6z",
       "uusd"
@@ -13811,7 +13811,7 @@
   },
   {
     "id": "terra1xly8628q4w7ytfq2dtxt7c39knnhqnaj83zzsx",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
@@ -13821,7 +13821,7 @@
   },
   {
     "id": "terra1xqsumj7ydu0dwnsf66hf4aye8l0gyaawz87rrk",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1qsnj5gvq8rgs7yws8x5u02gwd5wvtu4tks0hjm",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
@@ -13831,7 +13831,7 @@
   },
   {
     "id": "terra1xskmucgxkzf3quwry3dazerw74q4aqplu0vgg4",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx"
@@ -13841,7 +13841,7 @@
   },
   {
     "id": "terra1xtm4yzrd3a7k6pzqjnk0kag0gea7w0rkkzmqg3",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55",
       "uluna"
@@ -13891,7 +13891,7 @@
   },
   {
     "id": "terra1y8mwewf406ayd8uquekh5a7yljpfdcjekkle9c",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55",
       "uusd"
@@ -13931,7 +13931,7 @@
   },
   {
     "id": "terra1yfpksrlypf5c3xc9ktsup9mtxw24r6sshck3g0",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1a07n2cp4wd49ezxdgm9xgtfrnpmxfcdp4yrdnv",
       "uusd"
@@ -14041,7 +14041,7 @@
   },
   {
     "id": "terra1ysac4wfu87qgu0qkkz8yrh57wwgx2upytva3fx",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
       "ueur"
@@ -14051,7 +14051,7 @@
   },
   {
     "id": "terra1yusz6qz86wuhd7vlkkc89e0y6j8au6w93f24fm",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw",
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
@@ -14061,7 +14061,7 @@
   },
   {
     "id": "terra1yvfnqxcksy6007sp6rfu776chtugm2u7qfhved",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
       "uusd"
@@ -14081,7 +14081,7 @@
   },
   {
     "id": "terra1yxfvmmy6ftelwk9ke2y7kmyxh7pkd0ev6d47e6",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1353an33z0u5dd0yajwjazfnyt4585q5085c5mg",
       "uusd"
@@ -14091,7 +14091,7 @@
   },
   {
     "id": "terra1yypalnanxp26u5uypunlj7mwx0mrkrfw3juqtf",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1f77l2dprlhg2h47uvhzp2zhkdrkcy8fse90xkk",
       "uusd"
@@ -14121,7 +14121,7 @@
   },
   {
     "id": "terra1z50zu7j39s2dls8k9xqyxc89305up0w7f7ec3n",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
       "uusd"
@@ -14171,7 +14171,7 @@
   },
   {
     "id": "terra1zgrz3dc3cpgk9qet8r7767yvpdpsuvlc6ymvee",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
       "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r"
@@ -14181,7 +14181,7 @@
   },
   {
     "id": "terra1zh33l9e6pj385jpum6uyngwhhe62p9gfaph2gl",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra13awdgcx40tz5uygkgm79dytez3x87rpg4uhnvu",
       "uusd"
@@ -14211,7 +14211,7 @@
   },
   {
     "id": "terra1zkyrfyq7x9v5vqnnrznn3kvj35az4f6jxftrl2",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn",
       "uusd"
@@ -14221,7 +14221,7 @@
   },
   {
     "id": "terra1zpets4h5zyvhln3muemyvk7cwvmwmam4tp8c5w",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "uusd",
       "terra18ej5nsuu867fkx4tuy2aglpvqjrkcrjjslap3z"
@@ -14261,7 +14261,7 @@
   },
   {
     "id": "terra1zrsuu42fnz2zaj0hgl8s9fzz78wgzau3464luh",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
       "ueur"
@@ -14271,7 +14271,7 @@
   },
   {
     "id": "terra1zrx57z4qhsejk3r0ug6pt3xvz2efpee39rle5n",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra182740uw8nh6tk3yjfcf7gu5phg3kqryhtuxp0p",
       "uusd"
@@ -14291,7 +14291,7 @@
   },
   {
     "id": "terra1zv2q88u7pslnj00w6u7ketjq77tu6lupc2twav",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1y77avpcwxc49ezmex8nsupklgc0qt7le44z4qd",
       "uusd"
@@ -14321,7 +14321,7 @@
   },
   {
     "id": "terra1zxcmcjurg5jrml8kv2vhupdlfqn4n6euasuc5q",
-    "lp_token_id": "-1",
+    "lp_token_id": "TODO LP TOKEN ID",
     "asset_ids": [
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
       "uchf"

--- a/terraclassic/pool.json
+++ b/terraclassic/pool.json
@@ -1,0 +1,14342 @@
+[
+  {
+    "id": "terra102t6psqa45ahfd7wjskk3gcnfev32wdngkcjzd",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra10y0jqynfchuadr7cycl3qqaugl2jd6s76660w7",
+    "lp_token_id": "terra1vchyrrx3nwgary8aq36rc2uxt3y56ex5x3qkhd",
+    "asset_ids": [
+      "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra14q0cgunptuym048a4y2awt8a7fl9acudmfzk5e",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1rl4zyexjphwgx6v3ytyljkkc4mrje2pyznaclv",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra15rx5ghq4nxrv62fqvdvm78kuasfkl95c6mcmqs",
+    "lp_token_id": "terra16aurvlp5xctv0ftcelaseypyc89ylf4y0s5q0y",
+    "asset_ids": [
+      "terra1g53pyke8jtmt4lwvk4yl0xaqc4u0qlsl8dz3ex",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra18fl6aywx2c8xlfp5epl40dygqnrvqp9a678a9c",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra1c868juk7lk9vuvetf0644qgxscsu4xwag6yaxs",
+    "lp_token_id": "terra198en0xuzldzyark7pqz409p3u2d2g3y3k8u3py",
+    "asset_ids": [
+      "terra1042wzrwg2uk6jqxjm34ysqquyr9esdgm5qyswz",
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra1cc6kqk0yl25hdpr5llxmx62mlyfdl7n0rwl3hq",
+    "lp_token_id": "terra1yf9hh2zrpydwqnqaw4p5hqfzzhgv49jj24prew",
+    "asset_ids": [
+      "terra1e6mq63y64zcxz8xyu5van4tgkhemj3r86yvgu4",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra1cevdyd0gvta3h79uh5t47kk235rvn42gzf0450",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kkyyh7vganlpkj0gkc2rfmhy858ma4rtwywe3x",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra1dawj5mr2qt2nlurge30lfgjg6ly4ls99yeyd25",
+    "lp_token_id": "terra1cxmdyn5srv8uwvhgz5ckqf28zf8c7uwyz08f2j",
+    "asset_ids": [
+      "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n",
+      "terra1a04v570f9cxp49mk06vjsm8axsswndpwwt67k4"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra1gxjjrer8mywt4020xdl5e5x7n6ncn6w38gjzae",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra1h2g2mldq2fskq0sqdhupnzpfj396d03ds2yfkd",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kkyyh7vganlpkj0gkc2rfmhy858ma4rtwywe3x",
+      "terra1pepwcav40nvj3kh60qqgrk8k07ydmc00xyat06"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra1j66jatn3k50hjtg2xemnjm8s7y8dws9xqa5y8w",
+    "lp_token_id": "terra1htw7hm40ch0hacm8qpgd24sus4h0tq3hsseatl",
+    "asset_ids": [
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra1n5jzjvqlylw4kz9cfed2djqvz5qsjlz4kvmkmz",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra1pxexyejamkg856vmspyttcy4sva84qgyaq445z",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1hj8de24c3yqvcsv9r8chr03fzwsak3hgd8gv3m",
+      "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra1qmxkqcgcgq8ch72k6kwu3ztz6fh8tx2xd76ws7",
+    "lp_token_id": "terra1hkm7w33fpmnruxka9tykfsntl4s692kwr8hj27",
+    "asset_ids": [
+      "terra1pvel56a2hs93yd429pzv9zp5aptcjg5ulhkz7w",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra1qswfc7hmmsnwf7f2nyyx843sug60urnqgz75zu",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra1szt6cq52akhmzcqw5jhkw3tvdjtl4kvyk3zkhx",
+    "lp_token_id": "terra186cxwpreuzqm9nhmaltycxfyqxz379aef752qw",
+    "asset_ids": [
+      "terra1skjr69exm6v8zellgjpaa2emhwutrk5a6dz7dd",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra1wgdjvp388mlvhad8u7ly5d34ga4zyyfvf3e5j8",
+    "lp_token_id": "terra19tmtkl0w6kfgvxj6tt3dg0vepzrzugh0x9yfpk",
+    "asset_ids": [
+      "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
+      "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra1x0ulpvp6m46c5j7t40nj24mjp900954ys2jsnu",
+    "lp_token_id": "terra1lapdj4fcg936fpgdwewx55h7n79p4p9tzrg4lw",
+    "asset_ids": [
+      "terra1pepwcav40nvj3kh60qqgrk8k07ydmc00xyat06",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "stable"
+  },
+  {
+    "id": "terra10cw43kz2ujn4ur938u2qsrr9duhsqydkrxl07p",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1hqr3l4je2yvn3l790ly0y6r0vgfs7yukwwj0ak",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra10k05ec24u8nrd3889c6zydr8tlv73cyhaufs4t",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra14ec8v4c5dnwu2pq9plfquaffutu59tq9hld77e",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra124yter7w9e5mf6m843erql48xy5szsxd75zjxw",
+    "lp_token_id": "terra1p7l5qx277ql2rql6lxz3wsgusc53lfv097ckyq",
+    "asset_ids": [
+      "terra17e6sxcxxxp6j2xf6rzhcwnafk6sggrrl5wdvw3",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra12sf5en42qlfc3qle4m4pew6n4vjc6lrpwvhh2h",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1cl7whtrqmz5ldr553q69qahck8xvk80fm33qjx",
+      "terra1jn0w9ttjavzqeqmp79jzx3da6dx3p6jwmm6tk2"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra12z67dhctkvsw8u8pr95rlefr5zcs2d2dwa0pth",
+    "lp_token_id": "terra1vwdjaak7rtqc7wc0zf9car40rt0qv79dppyxyt",
+    "asset_ids": [
+      "terra1p0w9hh9aea5mg26mjnx7tl695ldwxfksvw4yn4",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra130w5j5yu7rc29wuc49qdcm2su72pljl77jlmk6",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra16x6mn6ulxzg4pgg7gpachkkgrkuac59vl7xgyl",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1366x8d5h0mexk83c8hjkqafk72a4rcwwwdk62h",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1xmd43yrfxm4xy3lnptc7kr4rr93pzh5u0z0wgt",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra14m6dv3w66u8nk6nmrmvh4lxyd7fnw98tfm8qh9",
+    "lp_token_id": "terra1jd99306zw03cp937l7cugennqcscqz920vqftx",
+    "asset_ids": [
+      "terra1779kwh0aux9mesns3l7laxtu7njjpzqd7k7m3r",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra152655kx8ff6fa393h642uu075mmu9dz8xlfqvv",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1rwph273axfefh8gh57scw3jfm7kn4s7t5hlu03",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra152wlyd53nfcltuwcje9ale8qv3hpyna4sv9mvg",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1mpq5zkkm39nmjrjg9raknpfrfmcfwv0nh0whvn",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra15av79vdec34egtwt9dhyuy73pdhfztazacs2tw",
+    "lp_token_id": "terra1pctrnkng8ev6swvjmg5vfu5uwv6zcznutcjpct",
+    "asset_ids": [
+      "terra1w724lm9qt5q8rz9n0kqlfglkulz7z98yjvxzn8",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra15pehlkssvyu8e7x6s9gz0j9x8q2qthvcf6hdqh",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1pc253zfn4zns6awk7eks779uk3m7dna7y4cmlf",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra167lmzjrfvrqm59ycxvr4f937vgap4uytnkyrat",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1mely4fttd94g5kgjmz05dmclgdahq45xnv5n22",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra16af3ksetslvny2ypwe0nync0lahs87t9csvyz7",
+    "lp_token_id": "terra1xer502ejxn9g3elanqgrh4cl7zzk9dzxkwmy9q",
+    "asset_ids": [
+      "terra1n6eltvex47mta0me66ygqw0fgvjx2ul7qm9fjp",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra16lle05y09g2eazntxdx89m6u8d4y68t2tglmk3",
+    "lp_token_id": "terra10fwytprs0lnnwtdkvst0dpy9v5ql6ydwq278l7",
+    "asset_ids": [
+      "terra103ws85fnvy3j9vr3ss9va2zr26vepemqx2n88u",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17ds7t9z2pu3cyqtlnklhfpruc0nnahddzr49wn",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1vfhh44f57a72vaqdk69k2y9pllwlrhkv32n6nr",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17umn0xctu4qj8w6psqfjfp20nx454csspuvdur",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1e6mq63y64zcxz8xyu5van4tgkhemj3r86yvgu4",
+      "terra1pepwcav40nvj3kh60qqgrk8k07ydmc00xyat06"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17w79y5ptp63dlr79tup9rkh6294qe448phup3f",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra17ktj9hq69ae9mj49dwqfzmj05t6eqlkyywukf8",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1awy55useu780l3hsprulg0s26maxgtx2pjkev0",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1zce4mxwwdyk04txa2f3aqepzsq8jy7ca50gn8w",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ccwy34ygpj9qav05y2d5akzeeflvz6lzvsz9l9",
+    "lp_token_id": "terra1rm36n8c5zacf83aljwzzxtq8ctge7wlym689we",
+    "asset_ids": [
+      "terra1a07n2cp4wd49ezxdgm9xgtfrnpmxfcdp4yrdnv",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1cylvlytxzjywy0wpf5mrtua3q37esduhqfk9w9",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1vyusa796w86yh99l67dpd5g3hfva759vyuhn5z",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1d5uhps2w38fqnx2zzfrkhk96sw4j4twjpr5s46",
+    "lp_token_id": "terra1ztj6x5exa33w7dsvjxmdxam8w7j7t2phglmpea",
+    "asset_ids": [
+      "terra15k5r9r8dl8r7xlr29pry8a9w7sghehcnv5mgp6",
+      "terra18vl2cypy8pdys2qdqlg7pzmcmpqmur8lmrnk2c"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1dleq0ve3wlkcqsj93d63u4t7c8h8d65uztnfl0",
+    "lp_token_id": "terra192nxzlpw8kgtppmrr9uqzn27cphpyaqauxd6qw",
+    "asset_ids": [
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+      "terra1kujvztl5p8a45k56u42fq39jxldxcvuejtpfq5"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1e46tre2rxhuxq58ygxsxm2m8djup7f3gasen6w",
+    "lp_token_id": "terra1r0wdunh0nrn65863hrs0p72us2502x525m62sg",
+    "asset_ids": [
+      "terra157n30a667ethsknneaavga2txtze58eajyfv45",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1egk8w9eeta7dehmhsf4v3fjkrxucc6ygamj5sz",
+    "lp_token_id": "terra1jy6r3knmz2a62k5vpy6f65smm6nrgsaqreqj0d",
+    "asset_ids": [
+      "terra1h0jk42weh0urhgdtjql93rrvgdccspnp7vyf49",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1eguektu6mgqqc8rxprsk5nadpxpr7v5k7ttpqx",
+    "lp_token_id": "terra175jguvthv6m7xj20eqc609ftcnddk9mhxkhmkc",
+    "asset_ids": [
+      "terra1hauj2lpsnye4jsxxww8kpze4mzyq76e5cjr2wp",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1equ0rx0hhk4q22v2rlg779war57rhgt7d8vwls",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra12qgpr0fw773gc8lrkys3knnw6nkgdlc8ggaty9",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1eqv7ldavhp8lvgesk0083g6jwqktgwp7cm6hq6",
+    "lp_token_id": "terra1ntcs04cq40vqyj5qjr8w43yrhqx5zcwx0nm2kd",
+    "asset_ids": [
+      "terra1ew3yvrg0ejpgvswyw70gcqqp3g2j45d24se5xq",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1f37ftdeeke582crsdc9exf8n6m05awzpjjm60c",
+    "lp_token_id": "terra1tr6l7vugxjtzm2jtmm53rguxh6j7qdu46jnatu",
+    "asset_ids": [
+      "terra1mfek3m9s0sazd40kjraw5qv3963t5n3gwk408u",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1f87y5r6xmt37sf09nl0fw3mgnk0xsnnyeecgnn",
+    "lp_token_id": "terra1ylug28lxeykpag00rl59ethqy8tq2n65stld3d",
+    "asset_ids": [
+      "terra1teh62le6cndl2ch9yw5vkjk30h2fd4mhkrt5wc",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1fqqtkhx8c3jxfl94jzzldvjmu4u9jeuyful6ma",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1jp4r38w4j2qkxavjs9ypqv6mv833wdar3tywe2",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1gpel5uny2f2hw3e7kln4y3mluwtdlcpukaeukk",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1ypgjelmtp0mv5akzwmnj5xhukhd3fy9gd28wpj",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1hhpgcp2stvzx952zfxtxg4dhgf60yfzchesj3e",
+    "lp_token_id": "terra1kt26adtzwu4yefw37snr73n393vsu8w0hmazxc",
+    "asset_ids": [
+      "uusd",
+      "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1j3se2lhn7kwzu0zpa9zgc2sk9r20gmrrxz0n88",
+    "lp_token_id": "terra1tzlc5g00ny7vh78mc8fnw2qqe4wmy7mmjgv497",
+    "asset_ids": [
+      "terra1krg7amkeenvqwkaarp4r4grmrnldd83lmkl26u",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1lnr6aacxfng34m69076s2mdfjzt8nev2p6z5q0",
+    "lp_token_id": "terra1rx4xd94l74jupghnrn27r8ymauap9fy7tr3js7",
+    "asset_ids": [
+      "terra1dw6yapjv8k8anef2kg43hewg3g73wle22ncaje",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1mxd85ljdjcm7ddfh8qvnxx8tyggnh3zsahy7aa",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra17n223dxpkypc5c48la7aqjvverczg82ga3cr93",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1nq6ty6lppp7kz58nkshhmyfe8tv4p85ueh50mp",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1tf6ukhukcqwfasm6e3ae2406c87vc8zhrh5ex7",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1nvzgfu8yyzcsm7a3je2hnn597ndz74g9a22zzl",
+    "lp_token_id": "terra14jqrnf75jaqwyz5q6j4fk4503qyvfult6juytl",
+    "asset_ids": [
+      "terra16ygrvq7q2zxw7jj3f96racur50w0g7r0mj6e2y",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qkzw4cfr74d0n5s9mf865vcpuchv0ssygkmvuy",
+    "lp_token_id": "terra1vhustrxwexul87cj7yk5wr993rk68p8mkwuvkw",
+    "asset_ids": [
+      "terra1nq9epqtswmj7uaymsw59w9n5h5e78k9rwduets",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qpu9ve7lle9wl7npkqq745j8fwekw5ghfnttkj",
+    "lp_token_id": "terra1zejyjpwf6fpeg7fpa42vu0d5fjwejv7tx4ts3z",
+    "asset_ids": [
+      "terra17ckx25kqhwzf3fudprs78kqgp3lhpr2w74yf7t",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qv0j5udg2lcnqkuy5rqt2n6n2z9m2zps6zfx2v",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+      "terra18ky9ln4g6x3n9f9s8a5ttshynv6lgzfppmrmyg"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1r49ew9xrpauml4chelxd6mt32xwpywlmcnt853",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1gjuhc34ccr6ajq7dm5266xyedu96sgkv4qnley",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1r5m5h9nvnw0hhzwn4gzz9p2wzg78q2jsq0alvp",
+    "lp_token_id": "terra1l6jgxephuj6uggg4hvdvcg8ys0twkm7t68j0kz",
+    "asset_ids": [
+      "terra1e6mq63y64zcxz8xyu5van4tgkhemj3r86yvgu4",
+      "terra1kkyyh7vganlpkj0gkc2rfmhy858ma4rtwywe3x"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1r5xu0edlqgjd9t7smsaww0tr7jvqh0805x8nd4",
+    "lp_token_id": "terra1t4fsj0eu0jg9h9um8wmj9c9r05mjj2pvcevyp5",
+    "asset_ids": [
+      "terra1fx6ffswrmgyuf5nsxruce5gertr8vgsm7krrp7",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1shgwa4xwdegsxvtr0qaergjq689sakzvn87fvy",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1l385362dg276797k7lzsfktskfssg22n7hn4at",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1suwlj0tlfqngq67gy2pjyqjwx3rfry2klvtxe5",
+    "lp_token_id": "terra1pth0gsyh8j0x08zv2fqq930xq6assges0zg82u",
+    "asset_ids": [
+      "terra1cvsfc32dkdvmla6urrscrtfceztecj0u5tvlvz",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1sz988qp6vma3j0xj5w7fsskqcuc8kjn0mmtcqc",
+    "lp_token_id": "terra152e9whmpjlgenfhjj6rm4lcffcpdfgqc0u5qx2",
+    "asset_ids": [
+      "uusd",
+      "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1t59ywlkkmvy7rmkdmdpy0z7wdqez5tne9mrd0r",
+    "lp_token_id": "terra1jxhmcjh3ymd32v7e8f5uar92pg3e05yts8z6lf",
+    "asset_ids": [
+      "terra1pepwcav40nvj3kh60qqgrk8k07ydmc00xyat06",
+      "terra10f2mt82kjnkxqj2gepgwl637u2w4ue2z5nhz5j"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1uqsny2clznnhrmq2rvlhv72l78lmlss32uzuyh",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra18ejpjp9eyx9t8j07jd7kzah9p0rvkzdfeeva6n",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1v67ycjhzup787j9efpygr4fcky7rpxgkfkf89d",
+    "lp_token_id": "terra1nxgs0pfu89wyx6wfg3yssmeykg3nuh5mae4uyx",
+    "asset_ids": [
+      "terra17nekftv2yp8n4lsex85008sphchs4t3rnfcqzf",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1v6vmpgpq3lky0w9jhmqn8ccr0sgetkgus70e62",
+    "lp_token_id": "terra1zadxq9h0aw40tna7ytrnn57ymc57chwluxkhyc",
+    "asset_ids": [
+      "terra1kggysvv0q3tq2r58f5nt03hqa8pqj87c2m8k09",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1v7hcllx3l7namvvffg3jfl7vc3ksy089yr3ewu",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1mh7nlhzvvesgc4whcx7dg2nhj3p0dhl9fwrexu",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1vfxjj237nsyxu8034syv46d4gzmrajksrdnvdc",
+    "lp_token_id": "terra1xlrclrh3zu8vpjmnlnkjealnw6ggtf287ms3ly",
+    "asset_ids": [
+      "terra1lyppcm0cjc5nrge6hmwdkkeqeh4m9cat8nyf3e",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1wau74j4ykmx5nfjad4wjra8m02x9vg5h8g7ym2",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra13kr45ssru9cqhp2kaaan88wfaa7f2h3jfvuldp",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1x2l3qhtcp2jlgn3duwrt7f6pqaz3tq3qydmkp4",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra153u8c40h2mm8nvs0daqxsnwgvpw43muxj3c28h",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1xckx7r8ay8hr6qneqlftcejzaqme4jw0k35e0l",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1fhsljj6qc8f7cnu62e8uxqt82czflztge05dwk",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1xhewlp3h0kh82t2n33x2cc200t3zcxmhmrsyqk",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1z4pfv9rrm53tg72cwkcv6ddvd4x6wcce43nua2",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1y6e5xmqxcq9zm9mdncf4nwneyp27d98awgqjv7",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1vm507q46f2sm8jltjcvp3dtncttquwld0tfkdl",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ymh8xk3uv522vs2g7m8j6v059s7cmcxyr5vqtc",
+    "lp_token_id": "terra13fwa5e5m95tye2jtnkxjmwe3632hp2pampxjk7",
+    "asset_ids": [
+      "terra1ult8nl3u83p7vdjdehtjfn9ylkm6u606nmdry3",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1092tamrn3w8j7qp0uu2ltml7sjts7z9hkj2wga",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1unewn6sa7hg3z0pvhrc9u9rmph7z975h4nrfvq",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10lv5wz84kpwxys7jeqkfxx299drs3vnw0lj8mz",
+    "lp_token_id": "terra1t53c8p0zwvj5xx7sxh3qtse0fq5765dltjrg33",
+    "asset_ids": [
+      "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
+      "terra10f2mt82kjnkxqj2gepgwl637u2w4ue2z5nhz5j"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10nfk6fcz5nc5uru964qmpels9ctg6j0vczjgl7",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10xczfpmpryl3m434jjvvv0rre70yyscw98pueu",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra17n223dxpkypc5c48la7aqjvverczg82ga3cr93",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra126j4psud93ee83n6uyxq5m9zd40yzlmjvmsf94",
+    "lp_token_id": "terra1q5pw834sfnxw6htcng58pgugl3cm6g3506yf0w",
+    "asset_ids": [
+      "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1296jw27cq8svlg4ywm8t84u448p3zs7mcqg9ra",
+    "lp_token_id": "terra1c7upd2p5p294dtdj7xx0dd9yu5cm2ak4lgz2h0",
+    "asset_ids": [
+      "terra1vchw83qt25j89zqwdpmdzj722sqxthnckqzxxp",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12k8d0uzrgcqn4ge4k8ntr4aaycpwunz7pu2umj",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12qna5j5nehx7wamqelxg7pup877wd3jwd0dnpz",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uluna",
+      "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra132qwlqxffksjfg6ntzp4m5786lrlmgrufzx5c6",
+    "lp_token_id": "terra1x869hqq8483tc3qc6pdhnmcqnfkccftvwqvp8d",
+    "asset_ids": [
+      "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra134m8n2epp0n40qr08qsvvrzycn2zq4zcpmue48",
+    "lp_token_id": "terra16unvjel8vvtanxjpw49ehvga5qjlstn8c826qe",
+    "asset_ids": [
+      "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13krvk2ujpkfx8zk8sqsjq6nmzul287jfwy9e26",
+    "lp_token_id": "terra129dd20k60vaw9wu4lhesj9hwaumcczpggqg5nr",
+    "asset_ids": [
+      "terra1z3fvf7tae0586jjn5ve580thc3pyj9vwandw4n",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13uwsn7sp0559lgpppyjkvf63kzdyuaqe2dc50d",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1atagmw0ssv6wlgmrjjdaa22p7h4wmsy33eljgw",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13xz77zwk9jvulch92uwzuk3astcp0uvymh7f2p",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13yftwgefkggq3u627gphq98s6ufwh9u85h5kmg",
+    "lp_token_id": "terra16zy9g2eym8rghxx95ny60c3dyrwqsfx0ypmu5y",
+    "asset_ids": [
+      "terra1hnezwjqlhzawcrfysczcxs6xqxu2jawn729kkf",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13zduyt3rzuhlkzcax0a8djpvfdvtnw59e8st3f",
+    "lp_token_id": "terra1dkryxdrs2a5jjx97c4u5t37c4h6kfwv736rv74",
+    "asset_ids": [
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra143az0w2e504n56q7k43qyh2fu69fh3rhup32n3",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1vwz7t30q76s7xx6qgtxdqnu6vpr3ak3vw62ygk",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra143xxfw5xf62d5m32k3t4eu9s82ccw80lcprzl9",
+    "lp_token_id": "terra17trxzqjetl0q6xxep0s2w743dhw2cay0x47puc",
+    "asset_ids": [
+      "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra144p2hh09v4y9ytj7x3r97jl5etrrg9lrgyf8yn",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1fyxs23jdlj5qgfp4hv2qqv4d3csmvqxsva573m",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1476fucrvu5tuga2nx28r3fctd34xhksc2gckgf",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra169edevav3pdrtjcx35j6pvzuv54aevewar4nlh",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14glht7py7e3zp09wex9awej5cu4jql90yygdw0",
+    "lp_token_id": "terra1tr7w28vzsx6pl7z8wvps6t57k3uw29fc735rnc",
+    "asset_ids": [
+      "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14pds7y2xdal7l96heq03mhfsadt6ezes8wyvn6",
+    "lp_token_id": "terra17msxjffsm37etkna34n7yltzdmzf9akz26w6lj",
+    "asset_ids": [
+      "terra1yy0w2w8rkrfn5ul967rhpjrj4a0hpjy6m7end7",
+      "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14rnschsdlllt00yk8fxvxmcqgzhme3cx06t2x4",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/18ABA66B791918D51D33415DA173632735D830E2E77E63C91C11D3008CFD5262",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14sal7lg7ny207yz0ue4dc02mdqs03zytegsn2r",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1yeyr6taynkwdl85ppaggr3zr8txhf66cny2ang"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14xxxh8mq4rkxr6uy0q78chn5nu2jkj2uk09fwd",
+    "lp_token_id": "terra1geh0qnt0u8e8jqug08cnfmkwnjyrpv3t65ur64",
+    "asset_ids": [
+      "terra17rwgygp5y7tx83xyclwuxu654vjt2whpwxx688",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra15env0fa3z9jsc65cun7m37dhjypzwejqpy80vp",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra15s2wgdeqhuc4gfg7sfjyaep5cch38mwtzmwqrx",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dy9kmlm4anr92e42mrkjwzyvfqwz66un00rwr5",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1605aqnlpve2tes8vzqajg0ntzm5vx470vgrhta",
+    "lp_token_id": "terra1yej0l2y3sqy4alzcvymcxx7vmq5nvc7qswq4es",
+    "asset_ids": [
+      "terra1m3tdguf59xq3pa2twk5fjte5g6szj5y9x5npy7",
+      "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra162emskmgmfyc73ryxx43y98gcvcavmprqkhepv",
+    "lp_token_id": "terra1h087pv7lh2pulshddjm3wyem0jcs7cpm0pera9",
+    "asset_ids": [
+      "terra1rdqy74e080e96qhk5gntnr882awm4pfc7t6dn4",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra16e5tgdxre44gvmjuu3ulsa64kc6eku4972yjp3",
+    "lp_token_id": "terra1x6jws8lh505gw7dl67a7qq077g9mn3cjj3v22r",
+    "asset_ids": [
+      "terra190tqwgqx7s8qrknz6kckct7v607cu068gfujpk",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra16gz5fc8d3truesv3ssndgezxfn3p2879tfpwg9",
+    "lp_token_id": "terra1ey4hy3ar4n448pl4dq4yf2ncd6086ec0gajef3",
+    "asset_ids": [
+      "terra1l0rnt55mf8q87q2nqfn9un3lxnmxkhqrl939x5",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra16jaryra6dgfvkd3gqr5tcpy3p2s37stpa9sk7s",
+    "lp_token_id": "terra1pme6xgsr0f6sdcq5gm2qs8dsc2v0h6gqzs8js5",
+    "asset_ids": [
+      "terra1hj8de24c3yqvcsv9r8chr03fzwsak3hgd8gv3m",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra170x0m3vmc7s5pdvpt5lh9n6wfmsz6wcykcr0vg",
+    "lp_token_id": "terra1mzslpzys2j67c2pzmde8kvj27vvkup978ujgcg",
+    "asset_ids": [
+      "terra1mt2ytlrxhvd5c4d4fshxxs3zcus3fkdmuv4mk2",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra174q0k4ynjuz6tewjjep2yhzzw55aw6gq82q4c6",
+    "lp_token_id": "terra170qpzy04ad3dnahw53ng43grcervgr7caglvyz",
+    "asset_ids": [
+      "terra1epz3d7rmltreyt6chgnuv28cy8e0d3yad75xh8",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra17sswfv8mvvdx75j9q33l83j3cnahnta3wqqpa3",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kqf8ua7al5tdnkz95ue4zkuv4gcu52pt63ya54",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1820d2zqjqu3jkkdatsf4lktrkjkxslr4t4qf76",
+    "lp_token_id": "terra1aqndpg3rhqkc0qwyef5luh04s2anutsa08fr8g",
+    "asset_ids": [
+      "uusd",
+      "terra143gyjf53a8ksn6r4nulaa69ld0dp6yety5gkmx"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18dq84qfpz267xuu0k47066svuaez9hr4xvwlex",
+    "lp_token_id": "terra1cgvlpz6vltqa49jlj3yr2ddnwy22xw62k4433t",
+    "asset_ids": [
+      "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18e20cuvqex2h662talchnura7v48rz0ey7xc4v",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1rdqy74e080e96qhk5gntnr882awm4pfc7t6dn4",
+      "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18hjdxnnkv8ewqlaqj3zpn0vsfpzdt3d0y2ufdz",
+    "lp_token_id": "terra1pjfqacx7k6dg63v2h5q96zjg7w5q25093wnkjc",
+    "asset_ids": [
+      "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
+      "terra178v546c407pdnx5rer3hu8s2c0fc924k74ymnn"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18hq940rwpc94692tw90vyuxucp465e9gdd2ewm",
+    "lp_token_id": "terra19x53slg4ax56mvxuqtk369vrhef23zrsw6zckh",
+    "asset_ids": [
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra190jp9g28h5ntm2ekfecyfgwlf2y7qj4809gys7",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kqf8ua7al5tdnkz95ue4zkuv4gcu52pt63ya54",
+      "terra1rdqy74e080e96qhk5gntnr882awm4pfc7t6dn4"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra19rcpzd2w35trvtwkjt4lrckqeqdstlplnqz2ny",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1a8an0aqzjghcukqrdgnkt3ygzhmaaqza03mc3h",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra19wauh79y42u5vt62c5adt2g5h4exgh26t3rpds",
+    "lp_token_id": "terra1ww6sqvfgmktp0afcmvg78st6z89x5zr3tmvpss",
+    "asset_ids": [
+      "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1a75f02tqk6pf6xzkjgyxcpkpm9l5dzmqud5ely",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1aa68js6yxavg9zzzle2zaynem9cstvmaj3xyu3",
+    "lp_token_id": "terra12kf0s56pz2xhus9cqs4wva2xgz8wdkuqmh396s",
+    "asset_ids": [
+      "terra17wkadg0tah554r35x6wvff0y5s7ve8npcjfuhz",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1arqxm8dp00z8sy36q30ve7rmw2wl2wfavwkk7g",
+    "lp_token_id": "terra153p2zvds95vavrenmtcrv8xqxy2sm8xhrl3784",
+    "asset_ids": [
+      "uusd",
+      "terra1545laqy9s6jcej2pgts32rhqy6dzq62umk8g9q"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1c9yy9ftxpdg3drk9upg60hykyw2ardrgus00ew",
+    "lp_token_id": "terra1j495mkdh6tjxexkatae9xq4300dw0jga3p4xzs",
+    "asset_ids": [
+      "terra19qad83kr29qg89fpl4qh8m02wapmlwzpw5hvc4",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1crat7ql0q4z0wc3uhqvnckenlgjvjcduecdegg",
+    "lp_token_id": "terra1cdddc8u5l4ytscuz7m9wxvk3hx53rqcs2vgh30",
+    "asset_ids": [
+      "terra1qlan324u6rsdevvc6ye3m02ump7dtp3z67uhqy",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ctvlz7cqc6h7davlj46j9dne8ewc4hp2sqkmts",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1n2rujfc5lscglry30zaptfgncfc0gq4n8my0gv",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1d3t80j3d4raeg8m94erljaqehutve52yelw7r3",
+    "lp_token_id": "terra1jr7ca9vpxkhxwe8uk2649640t0gx5xcy4xknxg",
+    "asset_ids": [
+      "terra1zdpymdwpyg5gj5ye4uvr0mqmxw8c88k5vqegfr",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1d4xrsa5rsyjy689mjf7c7hr8vg74d6q6gk3p6m",
+    "lp_token_id": "terra16n47ledvk4ye47r7z4hwmdz0fpphavamslv0ej",
+    "asset_ids": [
+      "uusd",
+      "terra149tus2mxyak6ec9tm0fqs6eumeryga2ps9w7ku"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1d7028vhd9u26fqyreee38cj39fwqvcyjps8sjk",
+    "lp_token_id": "terra1l40w4g5fea0qhlh304uzsyv03hanhpnsmrv0a9",
+    "asset_ids": [
+      "terra1mpq5zkkm39nmjrjg9raknpfrfmcfwv0nh0whvn",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1daxuedmyeu8cak0ds43u6emj7srkgjeka0twe4",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1e76nq6ll0vzy4apprphh0k5wqzzsndjakwd6x0",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1rz964297kvt86rteajhtp4hsffhcum0ye8eljh",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1eck465e7u33y95flte0sld8ndrhk2yssnkea37",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1edurrzv6hhd8u48engmydwhvz8qzmhhuakhwj3",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1egwcnkeqsf28y4k8wg399ptz5zcsek52qypgzp",
+    "lp_token_id": "terra1v30r6lju6hs2kxrj2z0wdt2q38uwflh6mydx6k",
+    "asset_ids": [
+      "uluna",
+      "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1esm0pztzdq6hqgtj72w9dsnlfwtm343c7axvxu",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1f57qu9cavwv9522gkr4pcpe78t8rmwxq7w5weg",
+    "lp_token_id": "terra140eypk8cxgkrpvx4lfldqrtfwdakxgng3uwzc0",
+    "asset_ids": [
+      "uusd",
+      "terra102cjx95xvww7cl9l6usxltk75ww3mpxtyw4lpm"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ffjjxeu5l9f027qtkwseulgz6ddx5f04czyf0w",
+    "lp_token_id": "terra1u45sf0k8xr2dn5fl2hpll7tjrv0pn3l30c4jnt",
+    "asset_ids": [
+      "terra1u2k0nkenw0p25ljsr4ksh7rxm65y466vkdewwj",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fx2w5w8yfvncc7newqg5l08png5wln6s5k7qwy",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1rz964297kvt86rteajhtp4hsffhcum0ye8eljh",
+      "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gfvp0tynfdeux2rlfryqjrurcjyqfadw7sl502",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
+      "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gj2l0vrna4g73e0500hexzyy444g46vre3eaa3",
+    "lp_token_id": "terra1waafz57kdr2y6y8wcqq0rx72cjwkj0pg5f64au",
+    "asset_ids": [
+      "terra1ustvnmngueq0p4jd7gfnutgvdc6ujpsjhsjd02",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gs2zrwxz0szra07ks8xze04g4clwjsj6jjaq90",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1vchw83qt25j89zqwdpmdzj722sqxthnckqzxxp",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gxluuw67zmflr7qun7vxgk04lqam8mt42m4945",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1h574pqdsnj42scyyc66ec54757mlpsnn6gefjv",
+    "lp_token_id": "terra1rljlrtce6acd6m58audxsxmjxqnga5ltrzwmg5",
+    "asset_ids": [
+      "terra1n8awtfqa0wphx90pd2zc9v8vccc65f0gvv6rq5",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hasy32pvxmgu485x5tujylemqxynsv72lsu7ve",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hlq6ye6km5sq2pcnmrvlf784gs9zygt0akwvsu",
+    "lp_token_id": "terra1kp4n4tms5w4tvvypya7589zswssqqahtjxy6da",
+    "asset_ids": [
+      "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn",
+      "terra188w26t95tf4dz77raftme8p75rggatxjxfeknw"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hn8d8ldzu2v2td5uj335pz32phanm90a4kjfal",
+    "lp_token_id": "terra1cmvmemsas2rrmytq6wtvt7jf0nrg7dpc804jws",
+    "asset_ids": [
+      "terra1hj8de24c3yqvcsv9r8chr03fzwsak3hgd8gv3m",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hpgsgua62a9r2lsc9esfpxypw080ts93k8zxkg",
+    "lp_token_id": "terra1478nzcqhdpzmg6ztjkdjfkycdwrmeegn5r0yku",
+    "asset_ids": [
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
+      "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jfuq655fmqp7uhkkqanmljqj26r9acs68drn2s",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1cdc6nlsx0l6jmt3nnx7gxjggf902wge3n2z76k",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jkjpcgn4wywcytpnq0y7wq9jsythz6azmyw5ec",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1vsyyg4rs483uzd7jzw5fqqlm2q5n2yd37yylfc",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jlvyyp6hhy60g0um3cx4wq989rtcxqars5jyy7",
+    "lp_token_id": "terra1c65pnllhe0ac89ha255kslnhu58ypgvw3efj8l",
+    "asset_ids": [
+      "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jusmcruce9q3xu9y9mkxspm9rawvaa67w7fsd5",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
+      "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jvvc4gh5ksydjqgryrdph2msa2aj0qgxj4pzhq",
+    "lp_token_id": "terra15vacdmpxgpmcrrmlwqz2vl95rky0v855nykatw",
+    "asset_ids": [
+      "terra1vsyyg4rs483uzd7jzw5fqqlm2q5n2yd37yylfc",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1k4wvysv90yndgl98udr0eq4nmdp92u4zrpr46m",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1rck0zefy4juahqjjk5q0wz2ykp7028hjwvzcaj"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1k8lvj3w7dxzd6zlyptcj086gfwms422xkqjmzx",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra14v9wrjs55qsn9lkvylsqela3w2ytwxzkycqzcr",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1l7xu2rl3c7qmtx3r5sd2tz25glf6jh8ul7aag7",
+    "lp_token_id": "terra17n5sunn88hpy965mzvt3079fqx3rttnplg779g",
+    "asset_ids": [
+      "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1lk3tj2xyhr0ju9nhsarw79j3wpnntnzcxzvsdw",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1n2rujfc5lscglry30zaptfgncfc0gq4n8my0gv",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ls8hsss7tp3cna6nd95reevtmstm4uc644akxx",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1pkp0pkxp9mtlan7cg0qatu65hmkgyq2342g27g",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ltf9ss5syeeu5schnw6ah3t4arfqmj53kgtc3k",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1mpq5zkkm39nmjrjg9raknpfrfmcfwv0nh0whvn",
+      "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1m32zs8725j9jzvva7zmytzasj392wpss63j2v0",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1m6ywlgn6wrjuagcmmezzz2a029gtldhey5k552",
+    "lp_token_id": "terra1m24f7k4g66gnh9f7uncp32p722v0kyt3q4l3u5",
+    "asset_ids": [
+      "uusd",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1m95udvvdame93kl6j2mk8d03kc982wqgr75jsr",
+    "lp_token_id": "terra14p4srhzd5zng8vghly5artly0s53dmryvg3qc6",
+    "asset_ids": [
+      "terra13xujxcrc9dqft4p9a8ls0w3j0xnzm6y2uvve8n",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1mcvdrnnv7zxmnr4vnm9rwu8gr56wvfnx7hg0c5",
+    "lp_token_id": "terra13xujwys2afj6uzryv8g4cq6pvh6s50w7ueuhu7",
+    "asset_ids": [
+      "terra1kx73zld4tmv24r66h7jp8gaz2rrl4asxlzq2g4",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1mm772kftkt7yhx68t2edm736rnel83c8eqf6ee",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
+      "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1mv04l9m4xc6fntxnty265rsqpnn0nk8aq0c9ge",
+    "lp_token_id": "terra160jxnp3qfxrrjrfhul3xens4ggw6le7p4m4e6g",
+    "asset_ids": [
+      "terra1fpfn2kkr8mv390wx4dtpfk3vkjx9ch3thvykl3",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1mxyp5z27xxgmv70xpqjk7jvfq54as9dfzug74m",
+    "lp_token_id": "terra1w80npmymwhdtvcmrg44xmqqdnufu3gyfaytr9z",
+    "asset_ids": [
+      "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1myl709y74vrdcyuxy6g9wv5l2sgah4e9lstnwe",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1mzw4s868sagj2hgh5kfc4e722pug95wea3f87w",
+    "lp_token_id": "terra1waun82g7fzqxee75dwqsmwds8zauz6mhhlylaf",
+    "asset_ids": [
+      "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1n2n5gumwuf3d3j2yxje6pczdykwx47y090vr5u",
+    "lp_token_id": "terra17npwjcgl3g4pv3xjv8xmmw67y49xeqhyw2n63q",
+    "asset_ids": [
+      "terra1tmar57largkrtts55q8szey2q78zc9em43ej5n",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1namdguuyt2tngpwfyxsnjwaym2kts0svlvgdc6",
+    "lp_token_id": "terra1fvvfypp5v8r2nu30rducnuqn6rsp7tnwhxdnja",
+    "asset_ids": [
+      "terra1wctr29t5gul8qq6qvk6lue2lucymuptvcn9avl",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1netea00ej9gplmk063dwgd96qpmdy08lvd4ds0",
+    "lp_token_id": "terra1haar7vwrpwtgrzzrvntdrvm0gyxtlsus46zr37",
+    "asset_ids": [
+      "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ng5xg5p63c3qvjpwqsmry2dz8mr9n39v8eztv9",
+    "lp_token_id": "terra1whaysztdqq27q6smnf7uknpfh0uus4suv3y0wa",
+    "asset_ids": [
+      "terra1gpwkclxwwuzd5wyjw2qn3km0r5ge4t4f4mnf0x",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ng6rcmjcdcpde8jy3k37wm8kzgr7zgpqx72lud",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra133r6snp000sw0qhuspkua39fjc4c6pux82cnxh",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ngs0xlmxan6ktqwtcj8c2l2ddp3z00wpxt43vr",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1nujm9zqa4hpaz9s8wrhrp86h3m9xwprjt9kmf9",
+    "lp_token_id": "terra1ryxkslm6p04q0nl046quwz8ctdd5llkjnaccpa",
+    "asset_ids": [
+      "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1p2fxxmkxsct97spt3f82acytxw2vpvm2f4f7t3",
+    "lp_token_id": "terra1jp2v2h82nd3rghm0hwgtegjg0hhe0xnnshcwqg",
+    "asset_ids": [
+      "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
+      "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1p99huvu9wskfuum8grftx5pmcunl4ruv8v0wvv",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1pzemhnxtmtp7z7hlecafjqpnrt29czhmyhyd2z",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+      "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1q0eh3pct8da820t0san35pcg0sqqtmz4k532xh",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+      "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1q843tspwkcec87n5xrwdx8ygnmjjk7kj0lc7p3",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
+      "terra1hnezwjqlhzawcrfysczcxs6xqxu2jawn729kkf"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1qr2k6yjjd5p2kaewqvg93ag74k6gyjr7re37fs",
+    "lp_token_id": "terra1wmaty65yt7mjw6fjfymkd9zsm6atsq82d9arcd",
+    "asset_ids": [
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1qvq38uhmtdqh5tu3ratganwapnjefs2elxduy4",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1yy0w2w8rkrfn5ul967rhpjrj4a0hpjy6m7end7",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1qzqzvsr3hvgsfkvcl4jgv0l4lsdhap8skawqt4",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ibc/18ABA66B791918D51D33415DA173632735D830E2E77E63C91C11D3008CFD5262",
+      "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1r0u977a90c5l8dxq8hu00eydm4ahl0mqwms9a8",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1l4uygw365sgdgvasmckkd7lcawyemzn9k83lrh",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1r2xwh4fd0gyrr3403v72j89354qtryvrg0rjc9",
+    "lp_token_id": "terra1pmn4f2fcrhgtuetqr0wt3nldgr7zlufu688pfd",
+    "asset_ids": [
+      "terra1jxypgnfa07j6w92wazzyskhreq2ey2a5crgt6z",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1r6fchdsr8k65082u3cyrdn6x2n8hrpyrp72je0",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1repcset8dt8z9wm5s6x77n3sjg8hduem9tntd6",
+    "lp_token_id": "terra1yfwpk58tlvgzxx7zfrutlskgcp0cdqxtngpp6y",
+    "asset_ids": [
+      "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
+      "terra1jxypgnfa07j6w92wazzyskhreq2ey2a5crgt6z"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1rhk92dvz3tjayymy8pl08gpkmamnud7ttzc03h",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1f0us6p9axmzacwq2fn7sm5ke8k302tx7hg7s49",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1rjql89achu0aq3e69nxz78qnj7xfdjewndsk2v",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uluna",
+      "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ruu2gxsuplha5r2uzh0fnxqyd4svx23njwy74k",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uluna",
+      "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1t0qdxv523fxkuyhk9yv6hgal33cwnwh9hmzq55",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+      "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1tehmd65kyleuwuf3a362mhnupkpza29vd86sml",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1cetg5wruw2wsdjp7j46rj44xdel00z006e9yg8",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1tkcnky57lthm2w7xce9cj5jeu9hjtq427tpwxr",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1tlmqtwj5lq27knn7x932mqwmwdlnppesvwt5pa",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1yy0w2w8rkrfn5ul967rhpjrj4a0hpjy6m7end7",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1tteawchaue7myplvgm46ghszymh2wd4ghhcjq3",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1uf36lmgl3jut9xfg50cel2fh67ja6e5gqd98kj",
+    "lp_token_id": "terra1lt284v0t2psk9m9pj3ext0srtrzar6jsg70g8t",
+    "asset_ids": [
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1v5ct2tuhfqd0tf8z0wwengh4fg77kaczgf6gtx",
+    "lp_token_id": "terra1cspx9menzglmn7xt3tcn8v8lg6gu9r50d7lnve",
+    "asset_ids": [
+      "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1vfpfncl2wcxjhatl08mt0j8ppx5vzr6eek0wj2",
+    "lp_token_id": "terra1ggz8vxgngjc8atv8z70kdfhmlg534gg0zevfcf",
+    "asset_ids": [
+      "terra12flsr4mk5sxmu8yk7m8zc5f44tfx00yjvzj7v4",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1wdwg06ksy3dfvkys32yt4yqh9gm6a9f7qmsh37",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1wr07qcmfqz2vxhcfr6k8xv8eh5es7u9mv2z07x",
+    "lp_token_id": "terra1n32fdqslpyug72zrcv8gwq37vjj0mxhy9p4g7z",
+    "asset_ids": [
+      "terra1dtqlfecglk47yplfrtwjzyagkgcqqngd5lgjp8",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1xf44m98wgzn8gx9a3et0k52wnrrlh2gs0m05jq",
+    "lp_token_id": "terra106wpdmc228c5yd2w59lfzm5mfc2pyfuma2xk6c",
+    "asset_ids": [
+      "terra1vjgnhlv9h0nlta2v7s5hts75h2mc065c6ap3j5",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1xg60dmxqzt0c8hxuzgnlmpzqnnmux97xjrdzwf",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uluna",
+      "terra14v9wrjs55qsn9lkvylsqela3w2ytwxzkycqzcr"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1xpzusa4cqukutgra7fysjfyh4pkds5euepfe3q",
+    "lp_token_id": "terra16g6tt59pwqqmdknckmapy3k09qpqy6ky7hw3rm",
+    "asset_ids": [
+      "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1xrj6cy0jewpw0gt7zfcfpk9j54w30ycz869lcy",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
+      "uluna"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1yh5pcqpedv3uz6zuas2e9s944z3whhlh3lfq0j",
+    "lp_token_id": "terra12hjjangazdveuxr6l839dd67kprzfkwkmc7fj2",
+    "asset_ids": [
+      "terra1q96cf9rkt5aa4eqhun35d0u8pqwwyuqzlzjxps",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1z7634s8kyyvjjuv7lcgkfy49hamxssxq9f9xw6",
+    "lp_token_id": "terra1sw3kfuzd84t89krrshqusylqqvqw6amavp7rsu",
+    "asset_ids": [
+      "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zh8m6yu8nrvryu2g9gyyzqenrv6h034puqss49",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
+      "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zjj37anlqt99tv5hwhsew0x7e007hcg3fsm8sx",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1cf9ey4pm9ugeeehat50gadlze9s0mvluxws2c2",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zpnhtf9h5s7ze2ewlqyer83sr4043qcq64zfc4",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra100yeqvww74h4yaejj6h733thgcafdaukjtw397",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk"
+  },
+  {
+    "id": "terra106a00unep7pvwvcck4wylt4fffjhgkf9a0u6eu",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10jzrptpsx9y6uam6vfrxpmppyelevdkm39yxay",
+    "lp_token_id": "terra1newvwvd9w7hs3zl9pmweegrkqxzaedh045cyku",
+    "asset_ids": [
+      "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10s94a5gesvayqlekgn570r3nsnmr8q7lf5zkjp",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra15a9dr3a2a2lj5fclrw35xxg9yuxg0d908wpf2y",
+      "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra123neekasfmvcs4wa70cgw3j3uvwzqacdz2we03",
+    "lp_token_id": "terra19rvwt8gjqjpgwhg6h0hpvrrrxe3ljll8savt6t",
+    "asset_ids": [
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12aazc56hv7aj2fcvmhuxve0l4pmayhpn794m0p",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
+      "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13ay3hftcft25uazl76q8gmdk993y9nyv9avu2h",
+    "lp_token_id": "terra1v5zv0wupmweke89hsamyk3426rdr4uzmkg3hza",
+    "asset_ids": [
+      "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
+      "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13eggta6zqfg03mxgqg9p5paqka7tgaaxnkhuuu",
+    "lp_token_id": "terra1jf6s2xm7q6eh77r2lykvfrzlue6m8x9zxrg3zk",
+    "asset_ids": [
+      "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13f87x4c87ct5545t3j4mqw4k6jmgds5609z92c",
+    "lp_token_id": "terra1ddtvrwcv3s5z3w6j6vpxg95p7nxjzmprpmk6jf",
+    "asset_ids": [
+      "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
+      "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13qkgx03lu38p49yefnw7sr7xyy0k0ngamr8p2u",
+    "lp_token_id": "terra14gwvrtqc5rwjwyxd4ux30ulykz83dfvzq7nqqu",
+    "asset_ids": [
+      "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13tm0yrhn4wqptuhdc6fu4vh7gnqgtg2vw6c4uc",
+    "lp_token_id": "terra1rsc8l6xxn6f843cwzwctc2fm4x2xzqe0v5hjhu",
+    "asset_ids": [
+      "ibc/18ABA66B791918D51D33415DA173632735D830E2E77E63C91C11D3008CFD5262",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra154jt8ppucvvakvqa5fyfjdflsu6v83j4ckjfq3",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1jx4lmmke2srcvpjeereetc9hgegp4g5j0p9r2q",
+      "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra15568nqrqcawm263yqcuuuvj5mh763tp8jyscq3",
+    "lp_token_id": "terra1r566wqak92thyz2ka72p33fcup4uz35kdm64v0",
+    "asset_ids": [
+      "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra15xxfkxldxse9atz8ce7ne2a047pp09dy428njm",
+    "lp_token_id": "terra148gu0mqheqlx8t3kz0ldq0e0a5d84vkqnuj8wm",
+    "asset_ids": [
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra16j5f4lp4z8dddm3rhyw8stwrktyhcsc8ll6xtt",
+    "lp_token_id": "terra1mynsfcksuhe5nmum6wsz8gxemsutlqs0q3eywr",
+    "asset_ids": [
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+      "uluna"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra178yhudw6cwtnrn4fq593z87y385m0xe9n6x423",
+    "lp_token_id": "terra1d6a90q0stwcp4pvqeasqnl8l8kkjt0mgjt9pk9",
+    "asset_ids": [
+      "terra17jnhankdfl8vyzj6vejt7ag8uz0cjc9crkl2h7",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra17e0aslpj3rrt62gwh7utj3fayas4h8dl3y8ju3",
+    "lp_token_id": "terra1429u2vanflm8u0vtl4ejftadcgdunkzknhw72a",
+    "asset_ids": [
+      "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra17kmgn775v2y9m35gunn3pnw8s2ggv6h95wvkxr",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18r6rdnkgrg74zew3d8l9nhk0m4xanpeukw3e20",
+    "lp_token_id": "terra1de9dy3wnh0aq87knh8chejaxvkpxq3sjxx23ug",
+    "asset_ids": [
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18zh29lwx36uxh4a4ff5at9ysm6n0da4puz7z62",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
+      "terra17wkadg0tah554r35x6wvff0y5s7ve8npcjfuhz"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1a26j00ywq0llvms707hqycwlkl9erwhacr6jve",
+    "lp_token_id": "terra1qrwmv46n0dxw6ejyyc8ffalnlzth5mulznkrpw",
+    "asset_ids": [
+      "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
+      "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1a3x69h7gj72l2vt35psv64kerpsu2fuafrxhrl",
+    "lp_token_id": "terra1a52wc4q9y5fcz00d3j9plsp37jl7ncjrjylrkj",
+    "asset_ids": [
+      "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1cpzkckgzz90pq8fkumdjc58ee5llrxt2yka9fp",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1dttfsvgwvpz0zy9x52zyxnc4pa5lcx7l7pzguc",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1jxypgnfa07j6w92wazzyskhreq2ey2a5crgt6z",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1dw5j23l6nwge69z0enemutfmyc93c36aqnzjj5",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1jx4lmmke2srcvpjeereetc9hgegp4g5j0p9r2q",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1efvhm927dehrka0cgpcptt5gvjfdgqm07smawu",
+    "lp_token_id": "terra18m6fzarqv4klla35a4npad0nw7ytzda4s29jn2",
+    "asset_ids": [
+      "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1f6d3pggq7h2y7jrgwxp3xh08yhvj8znalql87h",
+    "lp_token_id": "terra1a3scsw0gr4wjvhnrg94g3yteg5cwxu92dr8rgz",
+    "asset_ids": [
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fdalk97tmgxlku6cepfs333frj9rt46pnvuyuv",
+    "lp_token_id": "terra1tqj36ektc8y3dcpx7g2edt6f6sp65643avt9hx",
+    "asset_ids": [
+      "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B",
+      "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fgc8tmys2kxzyl39k3gtgw9dlxxuhlqux7k38e",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55",
+      "uluna"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ga8dcmurj8a3hd4vvdtqykjq9etnw5sjglw4rg",
+    "lp_token_id": "terra1fsp4mrxtae6ay8lps5qpq3aq9hrv48h30cnyje",
+    "asset_ids": [
+      "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
+      "uluna"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jcewm66crare2lsv9fmdkxenf6gqamp2wxz5n5",
+    "lp_token_id": "terra1c4gjx7tgrajsk8vekjg6ppcs6l7f05xh8dtkml",
+    "asset_ids": [
+      "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09",
+      "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jfp5ew4tsru98wthajsqegtzaxt49ty4z2qws0",
+    "lp_token_id": "terra1waxv8terfksh59mx6yrpqjvgr4t4z5mad2ukfd",
+    "asset_ids": [
+      "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jkr0ef9fpghdru38ht70ds6jfldprgttw6xlek",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1k4aud54tprawf9l2uleh4ndjuf940m283yxvzt",
+    "lp_token_id": "terra18rppdamu2e8afe05pyllvdclslnsrlqp7mc599",
+    "asset_ids": [
+      "ibc/18ABA66B791918D51D33415DA173632735D830E2E77E63C91C11D3008CFD5262",
+      "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1kw95x0l3qw5y7jw3j0h3fy83y56rj68wd8w7rc",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
+      "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1l60336rkawujnwk7lgfq5u0s684r99p3y8hx65",
+    "lp_token_id": "terra1mc9zszumqwscqwa5aak0fjezl3tx79u6jpzut5",
+    "asset_ids": [
+      "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn",
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1lgazu0ltsxm3ayellqa2mhnhlvgx3hevkqeqy2",
+    "lp_token_id": "terra16j3v7gkczclh46p6uwymrtufnq5ca4psdl04sj",
+    "asset_ids": [
+      "terra13xujxcrc9dqft4p9a8ls0w3j0xnzm6y2uvve8n",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1me6a35xuzf9ycjaaqyj7798g5tewunp6dzg27e",
+    "lp_token_id": "terra1mvfyxwdxrs8ntvfkuau44dry0uzt2pspe8r0tr",
+    "asset_ids": [
+      "terra15a9dr3a2a2lj5fclrw35xxg9yuxg0d908wpf2y",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1n6rn6cn8a3rqad8v2mth3u3qwgq9styt84wv4u",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1np5jr05v08vjk5f665qu5xjxak8dyxnswtujn6",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1p0ne6gzy3mamyepm5c0r0wvwyac2cexrmvkz0p",
+    "lp_token_id": "terra1k6y57qfvq20mlf020s6v98gghaypy34v0q4rqh",
+    "asset_ids": [
+      "terra1g0pm8xm5c2dq4qtv8j9a80hg4mhe5ndy8qad07",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1p4lz9qcs8wp4pxpgd5uugvfvcrxdjtyhs9wuw7",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1pmmfz205es7axymwpl4jj2ruxnevufu3462f02",
+    "lp_token_id": "terra1azzqn88w3cc6x8jwl2mapuspjzdkzpz26qe2lk",
+    "asset_ids": [
+      "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
+      "uluna"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1sgu6yca6yjk0a34l86u6ju4apjcd6refwuhgzv",
+    "lp_token_id": "terra1t599xaj0lyyyjza86uskcqdy9aqy2txzdezyln",
+    "asset_ids": [
+      "uluna",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1tadgrmh5al0dy4wtjj8ks5jsa8chhjzjcch95w",
+    "lp_token_id": "terra1chestqf8qj0jgvl0aa3ke2jutk940htytrmy0n",
+    "asset_ids": [
+      "terra15k5r9r8dl8r7xlr29pry8a9w7sghehcnv5mgp6",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1tksv8cn7j95mecxjhj3dgcz3xtylcw5xkarre7",
+    "lp_token_id": "terra1z0qvh70fnt0yu99tjmkhcet7u4ml9mny3t0p2r",
+    "asset_ids": [
+      "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
+      "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1tus5ec9qsdht8dapq9ldfnsf8eehnfmwvsut83",
+    "lp_token_id": "terra1eas9qze4j0lhasc6g0hjykvcyksakvsun4ndyv",
+    "asset_ids": [
+      "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
+      "uluna"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1um8zappwu8csxv6c7zmadjvnf5rs7xgnc573fx",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
+      "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ur6yyha884t5rhpf6was9xlr7xpcq40aw2r5jx",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
+      "uluna"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1utds4jwyg2x0ajpuvxu358ry3v5zx98e345cat",
+    "lp_token_id": "terra1g2vxl25yg5vs5gc7zg8vtw3ase6qqmc524wqlf",
+    "asset_ids": [
+      "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
+      "uluna"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1v93ll6kqp33unukuwls3pslquehnazudu653au",
+    "lp_token_id": "terra1yy46j5xy7fykt6q58aa4u4y39h4fxc7jke2spd",
+    "asset_ids": [
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+      "uluna"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1vdc7mxx549pqpelcdkwydp2px3e4vvlrcvdjz9",
+    "lp_token_id": "terra1cmzuu60x2e47etp8rldxr447xxw03jytqq3a7k",
+    "asset_ids": [
+      "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1w7hny2catfwsv6dq8gfm4zgazx3hmpl3xwzxya",
+    "lp_token_id": "terra1e7625lctv0dpalqah9jzqgw7m3cmvfeky5nvp7",
+    "asset_ids": [
+      "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1wh2jqjkagzyd3yl4sddlapy45ry808xe80fchh",
+    "lp_token_id": "terra13nvzpqauc5u84yv5qd5jaqvsumhfnfxywa5m8t",
+    "asset_ids": [
+      "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1whns5nyc8sw328uw3qqnyafxd5yfqsytkdkgqz",
+    "lp_token_id": "terra1u32ccknva07y3er2npf05tk0euu7qjvhpv2csp",
+    "asset_ids": [
+      "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1wseaux4kpjle6andsvfzj4jv0a8tgmzeteapll",
+    "lp_token_id": "terra1xudur2f8x9vedlfu2s6gygjcyvnqehk7rxh6q6",
+    "asset_ids": [
+      "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1wznq6n5rw2jlyh274l0pmkq6chqfx5qqaduwwn",
+    "lp_token_id": "terra1jnqkemcayxupynwx7ul95yjcsgzntk6qh3302e",
+    "asset_ids": [
+      "terra17wkadg0tah554r35x6wvff0y5s7ve8npcjfuhz",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1x4msd26x8ncqcng3dapx8306rmgwuwtlg30a2j",
+    "lp_token_id": "terra1yyu8g58ks4q688j7paz8kehky94dx29dw7fmal",
+    "asset_ids": [
+      "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4",
+      "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1xew5epfvlzqc9zz8urhupnql5k2wls0p5dd0rg",
+    "lp_token_id": "terra14krnra4ysnyx7c32plectj6cac5h0vwwjtzmp9",
+    "asset_ids": [
+      "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1yjg0tuhc6kzwz9jl8yqgxnf2ctwlfumnvscupp",
+    "lp_token_id": "terra17pzt8t2hmx6587zn6yh5ensylm3s9mm4m72v2n",
+    "asset_ids": [
+      "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq",
+      "uusd"
+    ],
+    "dex": "Loop",
+    "type": "xyk"
+  },
+  {
+    "id": "terra19d2alknajcngdezrdhq40h6362k92kz23sz62u",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+      "uusd"
+    ],
+    "dex": "PRISM Swap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1czynvm64nslq2xxavzyrrhau09smvana003nrf",
+    "lp_token_id": "terra1zuv05w52xvtn3td2lpfl3q9jj807533ew54f0x",
+    "asset_ids": [
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+      "terra1042wzrwg2uk6jqxjm34ysqquyr9esdgm5qyswz"
+    ],
+    "dex": "PRISM Swap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1kqc65n5060rtvcgcktsxycdt2a4r67q2zlvhce",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+      "terra17wkadg0tah554r35x6wvff0y5s7ve8npcjfuhz"
+    ],
+    "dex": "PRISM Swap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1persuahr6f8fm6nyup0xjc7aveaur89nwgs5vs",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+      "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2"
+    ],
+    "dex": "PRISM Swap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1r38qlqt69lez4nja5h56qwf4drzjpnu8gz04jd",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+      "uluna"
+    ],
+    "dex": "PRISM Swap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1yxgq5y6mw30xy9mmvz9mllneddy9jaxndrphvk",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+      "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau"
+    ],
+    "dex": "PRISM Swap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra10whh69k8p9df2ccchvq03ddqqdpxlsxhte99j7",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1pmf2x6gp8u979q672lkkkruuhe9zarxyu5w7t2",
+      "uusd"
+    ],
+    "dex": "TerraFloki",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra13wgvm70z5py4gee5r03statmxp4hjtc6we80jq",
+    "lp_token_id": "terra1e9s5wklrlw44xl76p5e4gxvj7symsk0c3s8273",
+    "asset_ids": [
+      "terra15uc875u7uu8xyqf833nxwh5x4dm2kmu29u04vl",
+      "uusd"
+    ],
+    "dex": "TerraFloki",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra18lvan2ywhr40ql7tt6t40ck6vx4hlh0xamtqpm",
+    "lp_token_id": "terra1lsrjcwupdpzayeg3suc3kmtrr3yq405pppja0s",
+    "asset_ids": [
+      "terra1l0y8yg0s86x299nqw0p6fhh7ngex3r4phtjeuq",
+      "uusd"
+    ],
+    "dex": "TerraFloki",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra19l0hnypxzdrp76jdyc2tjd3yexwmhz3es4uwvz",
+    "lp_token_id": "terra1hr08ry5nmm65m74cyp3jq3c2vr89rm958s4rpz",
+    "asset_ids": [
+      "terra1a8k3jyv3wf6k3zngza5h6srrxcckdf7zv90p6u",
+      "uusd"
+    ],
+    "dex": "TerraFloki",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1a5lj0yacwz2gdmsk8acwmc6hlkv23dzykmksjv",
+    "lp_token_id": "terra1yf8aduaysgfde4d4g4qrg5z3qxutk4cdwyfz28",
+    "asset_ids": [
+      "terra1xt9fgu7965kgvunnjts9zkprd8986kcc444q86",
+      "uusd"
+    ],
+    "dex": "TerraFloki",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1hkh0mr4y0y0gjf8t9c55arnvy0m79s80297d9z",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1z2u9p4x9cnp7c44rnntxzhgqlnepv8elmde43d",
+      "uusd"
+    ],
+    "dex": "TerraFloki",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1k8pflcvj3mhrmthrgux2pk9a9ytthsr5trnq7z",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1yzj58vsvryarrasx6rkf9deyn5h60zlm7lzv8r",
+      "uusd"
+    ],
+    "dex": "TerraFloki",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1lq94l6w3eft9c95kj3rcex9h702ssp35qyaha3",
+    "lp_token_id": "terra1gtaly35ppahnheejtpcav38gd43ck8kmjmvepq",
+    "asset_ids": [
+      "terra1mzxr59qj8qr5plgd8kmqx9vn937qr5vzjd055w",
+      "uusd"
+    ],
+    "dex": "TerraFloki",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1rjwzkud2xtltyqamkq0md0esdk3qkhjwey5xzk",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1vte2xv7dr8sfnrnwdf9arcyprqgr0hty5ads28",
+      "uusd"
+    ],
+    "dex": "TerraFloki",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1t9ffaw69tfensrn2s0hx79tm68g7hps30unys8",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1u2k0nkenw0p25ljsr4ksh7rxm65y466vkdewwj",
+      "uusd"
+    ],
+    "dex": "TerraFloki",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1wez50a5t3658m6zyydaeyprtwwt8gtt0dcswlw",
+    "lp_token_id": "terra1jer5s9ykl64cm7xxp6zea9myjgru6vp38h9yzf",
+    "asset_ids": [
+      "terra16wggm67a34msdxasg2vergm2pt289y7930wv7d",
+      "uusd"
+    ],
+    "dex": "TerraFloki",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1yjmpu9c3dzknf8axtp6k74nvkwrd457u7p2sdr",
+    "lp_token_id": "terra1auxjy8f8al78g9ecmv85agaynj8wkjp5kjce2p",
+    "asset_ids": [
+      "terra1u2k0nkenw0p25ljsr4ksh7rxm65y466vkdewwj",
+      "uusd"
+    ],
+    "dex": "TerraFloki",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ar2lwxegfnap7umqx9ljp0wytt3t76yyc8ys2z",
+    "lp_token_id": "terra1633wdygwlds5dj3e97vyp3x8lhsnrwa8msc5tw",
+    "asset_ids": [
+      "uusd",
+      "terra1efjugpjc50d8sha7lr8s48cr7wmsthz94eevcl"
+    ],
+    "dex": "Terraformer",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1nmheu06jz6mxsg5n8nnmyn6fxgnvxzk28femx2",
+    "lp_token_id": "terra1g9esdhg0kjlzvmm7pwznwux0h7vpcclgjdx4wf",
+    "asset_ids": [
+      "uusd",
+      "terra193c42lfwmlkasvcw22l9qqzc5q2dx208tkd7wl"
+    ],
+    "dex": "Terraformer",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1rvvz9r8ys755wy9hat39es03d6h25rtz2u329l",
+    "lp_token_id": "terra1ktwelwele8sfyqksk2863wslg68mrn2e9d4tgp",
+    "asset_ids": [
+      "uusd",
+      "terra1948uvsah8aw40dhsa9mhl3htq8lraj0smlh77g"
+    ],
+    "dex": "Terraformer",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1uccez5grl2sr8xd4rswtgtc7ewf8ugfvcfutv5",
+    "lp_token_id": "terra1rttu7tzn7mnus9kw40j05nlzr0ef469lw43yfg",
+    "asset_ids": [
+      "uusd",
+      "terra1lrdzs5tgllwqgawtq2emuzn7snpxq87fzzl44y"
+    ],
+    "dex": "Terraformer",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1vsd2sgk47tm262q7l3eq74u9rrek4ucn2w2jm5",
+    "lp_token_id": "terra1x604xhmxr5lfwze3s4fsxl50vy5gps47k9e6q3",
+    "asset_ids": [
+      "uusd",
+      "terra1vpws4hmpmpsqwnz3gljn8zj42rv7rkpc5atgt4"
+    ],
+    "dex": "Terraformer",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1x3fcujqgk8uvn8vssw52jtwtanlu3shgj3ftlk",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra18xyl0ees6ueyhkhn0mjdtrm82e393ult2dazl3"
+    ],
+    "dex": "Terraformer",
+    "type": "xyk"
+  },
+  {
+    "id": "terra100k5zacnuzl0ksxrn6lclmdl0u7w6l8qalcn6e",
+    "lp_token_id": "terra1yg09m7lcj739wvr3ns6d67znhyp4jexvpx2vkg",
+    "asset_ids": [
+      "terra1amehwqrzcdrwmwdz9apz9mmctckez66ns67k5s",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra103kw7gde0cu8v7xm5fwm54dp7uyq8d58svtf8t",
+    "lp_token_id": "terra1q88d7swxfd36kcfeqhgdncjrht9rsh7c0a9vm3",
+    "asset_ids": [
+      "uusd",
+      "terra1q93ws00plywc5prwv7mf2gdf7alhuqgk5w68lq"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra105cnw8azykz23ec9gtm06prssq9aqxg8pchjq4",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra10jyyy0ylv34lafqv2mldcuxhk4qpdmnckgfls2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra105lwyhfuw0p0q39tghg2hxnjdarg6uy6n9s24n",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1xc5ll57yu269x8ysxvdpjmvxmac3js7pst5ddr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra108hz9wugglvu2rjty2xaddvwtr09ukd7kwm78n",
+    "lp_token_id": "terra1nzlw9mny82p598ue0d4skguwlffhl5vdszjr86",
+    "asset_ids": [
+      "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra10a9jdeled7uev64ugtmc8kzjlg9xv6eeey88xh",
+    "lp_token_id": "terra16qlxlx3h5ty2t2fmdwrh8a35yqngg6hlmv0w56",
+    "asset_ids": [
+      "terra1ewesd6y7dswxd8qdfff7vxl8g2p0dfwpanf5fv",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra10apggvnqewuu3zg03l8nzqemuwtnfhnsp7pup4",
+    "lp_token_id": "terra1y02yk8gwl7efuv76le3lrct9fn3uzs5a7nq4xh",
+    "asset_ids": [
+      "terra1gukawnd63qd9ptuqe0ejm0vvweql45084lx4pq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra10dua387cxqwuulwwpcvk6atwe5alkh6qky7xhu",
+    "lp_token_id": "terra1kdqt7wfvem3nmdsrr5pwqlnhzl6w8xklqey35v",
+    "asset_ids": [
+      "terra18ys4xv4yjy6c7984mv4sz08p3rpl8cdtxxhuhw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra10f9t46rjhxjdm3324kkadhsm6adqhzva3y2g4j",
+    "lp_token_id": "terra1tdhcdlugvx4wwx9metx92nqpumahw9mzn7mhrs",
+    "asset_ids": [
+      "terra1nxwnngqr0ks3j842jlr6pnrmd79kztjqyycer2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra10jnrtfv5vle4gdknnu55d2p8trd6lxzwc5shp5",
+    "lp_token_id": "terra1v7wyvflxcxchx2zxu2n7e858wlx9u72pkku3hv",
+    "asset_ids": [
+      "terra1f3nc4md37vcy9l89qte2p5tej42pr8rzch8mfe",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra10mwe766az3rz5u84h53z6u0hxq9jp6jx54z3jh",
+    "lp_token_id": "terra1tnj6gg7ntn9wht35uqxz5dpe6nw4fd92ukmhyl",
+    "asset_ids": [
+      "terra1j9zvn74s7v2kylvv2xcg4p0s69pvejrw5qzv7j",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra10qeuxxj46luwqk8huh4gcp2r0ve7w5vh3hrtev",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1ft9qff9fgumdca5qluxu3e8fh8xc7d4hfek8s2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra10qnu9yudvcnm7we04xj8lu3mjrgx5lc247h0y2",
+    "lp_token_id": "terra1xra8v827ml3m6zfylvzfv5g72mj4qhdk7snchy",
+    "asset_ids": [
+      "terra17ktj9hq69ae9mj49dwqfzmj05t6eqlkyywukf8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra10rqw6xrzq2y3whp2r9q44zxyu5f8cdk0f4qa63",
+    "lp_token_id": "terra139kpcz9239c35dulyqkkyqsdhnx99vhfk6q4fe",
+    "asset_ids": [
+      "terra120v2mhzge3mxat8nsz8ctqgy6f0cnnfjymsgum",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra10ups2qsazavszk2ml0ed52rqdstuwr2qtuxdjd",
+    "lp_token_id": "terra170c9286vqw9vddvfg4pemue5nxx6vdswxyccmx",
+    "asset_ids": [
+      "terra17pc8eq0u35yslg7zulkqzc2mvxryfj3hw7nmsr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra10v3f4lprsjx7wsxnmmah99vx0xw8q5zeq8zhvc",
+    "lp_token_id": "terra1v0wxjtv45n0emx87mlx8y8qy5e449wcj3t3gt2",
+    "asset_ids": [
+      "terra1n4g9jamjrxhe5yssczrlq55syhxvwqkx7jpkjl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra10yg2w6s5c38shu0l6mx0gn8u8ctdp8lr9xdplp",
+    "lp_token_id": "terra163fswxeuysgmnflm2hl75elytulp9qnxu4muqk",
+    "asset_ids": [
+      "terra1j3w0tswl56yxduhen4gnela7m4we86w9xkwaee",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra10zgqdcpxhj0rgvm98w2slu9z09t8rk4fs5r8da",
+    "lp_token_id": "terra1ces0z6rlujzjw2f6axxjxaqav8v8kh8tqmhpqk",
+    "asset_ids": [
+      "terra1r5c53q49wu2vqerecdvua2zpvy9k8vlw7cnx25",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1238lf7cayjp4f4fxle5v87eat6vekqn2zfh9w2",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra17qy9f5h35504jxexwprsf6gtj009d3gjcml5pp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra127zvfgggng7zx3taaj8myslx28rrq28ffycqxp",
+    "lp_token_id": "terra14un4rp20aqq7h07zpgzxrz2fcwsplj8jp0jham",
+    "asset_ids": [
+      "terra1ttm7w640scqrarn0qxqz26798d84u94sg7gshw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra128s8lplqeqepy8vh55cr0rzdhe66v9h3n52qk3",
+    "lp_token_id": "terra1ekfxyvagzayn32m6jcqylzefdtjnhkcnwjvwre",
+    "asset_ids": [
+      "terra1lnucwh7feutx0y8dgh3lu759a6netxx4wjzm4w",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra12guk0mlt4jknln7mu8y7kjdaglqehu2r2kk6d3",
+    "lp_token_id": "terra1jcu9exrj6ejq8a4u67xf9htmrn2dup8gg9kwts",
+    "asset_ids": [
+      "terra1fc38stp3xzjh5q8u0nrlk4n0gagxrnen35rsq8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra12lvqty3v0ncnxn3s4agekcp94akp95n7qgv289",
+    "lp_token_id": "terra1va79wsdl4zrs2f9z2eef3c76p7akhuk3n654gc",
+    "asset_ids": [
+      "terra1kdkcxnsldqmj50ll77gmq5x26u69z8m69hdas6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra12qgav8q2qa5x8me759ajhf3j64525qumznc8h7",
+    "lp_token_id": "terra1u3m39v7vs066wazhl3manl8ztmyxpafw7ysdr2",
+    "asset_ids": [
+      "terra1572yxtl5yxa9mjyzg44gj6knemudreekplelxh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra12uem5pwjtllme9dnw8ccw39ewvgyetrhnlnhtx",
+    "lp_token_id": "terra1vv7cqzr6ppgkueq4qgykfjfjsdlufvpljcxf8x",
+    "asset_ids": [
+      "terra19245ct3nfz95j3peem0zxy0e8e0w2uq4n4ssr3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra12vqe3zqn9t7j7k7r3u22mpr3pjq9w3gnmx6pd6",
+    "lp_token_id": "terra1y097nnhjger6l3ds9r96xfdpq7vcdp5yh70n6x",
+    "asset_ids": [
+      "terra1e05lrpp2tl6sfm8p095mgn8hqu9c42f9sn0eh5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra12xwh5s8nxl2tr9lvshtv5ny02g349sdhgca4zs",
+    "lp_token_id": "terra1hqz4rpdymf0vdmmg54r8fzr95uwtq7m7stsqzs",
+    "asset_ids": [
+      "terra16mvysduudq3ys8vn08c5ts8yx08g5vahjaylq4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra12y07m3ra6x6qgl4jl5jt5t0qvk7smft3ye4l3h",
+    "lp_token_id": "terra1jv5v6cskf8atvn0hlnmuhp3vpqypk76qjw9xxn",
+    "asset_ids": [
+      "terra1nccuq0ujp4hc84kjmfwjc3002z2q7xzmdu6crm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1323sdyuhfl05jkhlk47ypmhtyx2chzv92tnsn6",
+    "lp_token_id": "terra1phcujfuv584t5mrmmxtag00pn36kscspec80gy",
+    "asset_ids": [
+      "terra1tmar57largkrtts55q8szey2q78zc9em43ej5n",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra132hq2uqczg2d7l4czhtcdwwlgl6cga6rs3nv6p",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra18zqpuua4d8u9q9d6zsn8fqtjj5k8hk845prz9v",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra134jare8j7annsu6fgtkpu6zp8gmfau88jrsnaz",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra19fd35n93667mg020fj5lupws9rhkw59cw459wm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1390zekgvzfwdvjfghh9fxmaxq4tzfzux59slpp",
+    "lp_token_id": "terra14uuhfjnxewphya674fgf7t0g3cn32uryrgkm5k",
+    "asset_ids": [
+      "uusd",
+      "terra1t8wkdq7kth8ngxgrpltwam0gv0h88ajh0get5c"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra139j7k5lfre6kwy6lh2d37tkvyj07h7aafke3qj",
+    "lp_token_id": "terra1rcdp0wd0qww62h69kex8f9c99549902dp7huf6",
+    "asset_ids": [
+      "terra1z3ejshh0vwkdr35wt9eyxetsqm6mnraya8myxs",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra13eclwgxxns9v0m6nxveug7m54v49fsfx9fn88d",
+    "lp_token_id": "terra1jmzlups5p4upfx995j824vyngnahsx5tjpk3m7",
+    "asset_ids": [
+      "terra1wdz268njqhhpy30qcd6zxmvtu5y0xr06cnkdqq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra13ha9p29fpj4cckj6jr3m743d9h9v9nv3xcmded",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1atagmw0ssv6wlgmrjjdaa22p7h4wmsy33eljgw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra13kqma6mk7ylcvg8u4qmfcwyw3wfytdgwwszmqc",
+    "lp_token_id": "terra1p9gjvxkdefm98aghrv98nj5g3j8vp2qq22kg6m",
+    "asset_ids": [
+      "terra1uf95uwdtg7rp734pmadujg2ukmuc88fph2925c",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra13l4d3vq7kurmyah9fxcjv8zdqdpndm9n0zs954",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1nywvm8avu8medrj84x9dxdc4gfdqd2zg8gv049",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra13l96rf63hd9ysruu9ma0vpjwwnjuk4e05tj7xy",
+    "lp_token_id": "terra1f6jappjsusascekd2uk8djncfwsh6ygp07h7mq",
+    "asset_ids": [
+      "terra1fd2f52tmq59mc093nrawdaey5mzgjnwyu7hwqz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra13le0pfhey5ltg42z8e2cq2yt8jxu4ry3tdmwu0",
+    "lp_token_id": "terra1klgaa9lyrcgdwudd9mvu0ys2spdsxd8mk55ure",
+    "asset_ids": [
+      "terra1vnkmt0cwd5k870ny0e2crt2yrkmj0cfd3sylvc",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra13lnw7ytlt0cjtjtakgewfzydq3nmx7n9q60gs8",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1extnklxgx3sylp25zplvxsfarmvh3r4k6grskj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra13r4plx4hme32jmzlmsyah9ulewyrq56krxh84j",
+    "lp_token_id": "terra1qje7t49vxtulwq8lw5re455hnj3r266uc7lquh",
+    "asset_ids": [
+      "terra1g36mr60pqf8x4hr3ulpsptrg84w088m0eunsw0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra13tngwuhz27g97gue2wg36nsc73agv9axnjrmd2",
+    "lp_token_id": "terra12zfj4sczu849y7q3kzdlxxd9x7y3wjx5xtjmau",
+    "asset_ids": [
+      "terra19k974ngjsml8dtmk56cdhuy6pplr94rxqdt95p",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra13vj9z3cjvtg0v7uu00m4pwd7qw5faznuvr6mhf",
+    "lp_token_id": "terra120vlcdqz23ssmpvdeysq75a47pjy5shlxya4zv",
+    "asset_ids": [
+      "terra158gqaxafjche7vtew0f4zk9g80224qr07kwfsk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra13vkjx8agphchqzlntq7qn3et86ev4nga6uz9dh",
+    "lp_token_id": "terra12ms0jp4kt9r3s4g2w5dphu8vqf027x6u0t9z25",
+    "asset_ids": [
+      "terra1pjnfhsvg7g52hfkdegr4apz7ax9x9xn0n2eayj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra13zhrlgpz2zmw6c9vd8lgc60qfysdn97sgf2hej",
+    "lp_token_id": "terra10j58rxwrw5fqurt3yludmp9j7xxgxtn9k2thk2",
+    "asset_ids": [
+      "terra1h067erdar0vs6466jafpjsd7nahzwghtemn6y0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra140dcz7t06l4llh38u62wh8rcm0gus9dd93envl",
+    "lp_token_id": "terra13ynn6xnvm6pj9hgaw0ywkewr0nv33qgc0pt8dp",
+    "asset_ids": [
+      "uluna",
+      "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1452cjwwujuejcyy2jujmw54aae96dsyg063ycl",
+    "lp_token_id": "terra1gzu6j09js98082arj8a0nxlz47enzp4m0sp588",
+    "asset_ids": [
+      "uusd",
+      "terra1y5ffh484f3jcy62zuslx3qlv0n6c4zsffjapm8"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra14572czl65ta5gqhpjfehk47yytdxerpntw2h5w",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1efu7hut9pywcgwj74klay9mlzswp542s6fa0zq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra14cqsw04rl6lu5dghdzqz5984rjd3rryc2psu2d",
+    "lp_token_id": "terra1s9rf42yddzzxqr60l0a3dtf0qqkhq7cukql3p0",
+    "asset_ids": [
+      "terra1jw43a4x2jdftvk9ylfyuqhy9asam4ymjufme44",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra14fgsnt4y6x7npwnnpq7nepk85fzz59vqn562v2",
+    "lp_token_id": "terra1q03qkg493g267tyympe6qx5l5v4de20uwupnn4",
+    "asset_ids": [
+      "terra1c5p65p6q6ekfav0k72h5ez23mpntve5am07mpr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra14fkcayxsf0xg4dwvn7xgtsyhzff97zckpzlzhv",
+    "lp_token_id": "terra1ce4u5ecla5klh9a68mjugq2aj2zqffrar4vzwh",
+    "asset_ids": [
+      "terra1udknntc8sjm4ntxezhlqe6p9atct00r296aw95",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra14gsl8tl6pwe4xmtuc4c78w356n66klmh8xn26w",
+    "lp_token_id": "terra1uasdrlm92p47mvgtawcjmn24ut2a44mykyfz6j",
+    "asset_ids": [
+      "terra1ra0ljqpyt59k7z4xrx93ef5jvpy67f56lhudf9",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra14j82htz2rhn47jasltna6tnqy4gy2097zf2pat",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra153u8c40h2mm8nvs0daqxsnwgvpw43muxj3c28h",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra14m9xq2tvculdx22kunc40te7gfhylx0v44qj3r",
+    "lp_token_id": "terra14t4pe3avwql7s3d7euz3jrpsjzrgrl50x4asv0",
+    "asset_ids": [
+      "terra1elkjjsg4vm5u4tnesqcj3dzgvhanzld48lkqv2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra14ma9cyp3xt9rj3jz6nmz8zteujuphuyssv7vvj",
+    "lp_token_id": "terra14nszv45yz78hm2n69rq69g5xa2l4cznak4aa4z",
+    "asset_ids": [
+      "terra1smeev4u44zhv94cn4pyy9dtsshup53n9xefayx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra14pq5tphkfpd2wphq47g7mrwmvt7x63nskmkkrc",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1m2ar36pnymh6h4n0p7l2w4uxswc70e9auyvxh6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra14qtsl0gqwnlz5z72cl9yc52lt8q464zhsx08tq",
+    "lp_token_id": "terra1fpaehunc4mdk0vmkn4g32epcf7yl523nujrjsw",
+    "asset_ids": [
+      "terra1atcayac92cwn9x6fcpxnjzycvmkkhwsk53tg29",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra14t9rgrx4t53un932r8jtcsgtrqqvvucndte4cg",
+    "lp_token_id": "terra1ga4yfg9uclqmaeg8trv8yaydm9ufh82cdqea40",
+    "asset_ids": [
+      "terra145nmjpjhergp4uw02hp079phtnedslmxv4v3n5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra14tzfka0vjjw8sttpkg0nqlrs5a078ngmqxjv5h",
+    "lp_token_id": "terra12nl2t220t5504dgaxl7yj68vfs39xky7zux2pa",
+    "asset_ids": [
+      "terra1dd2qt59v86gwgzl2e6u3xexefvrkjmgd8mu638",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra14u4v5ms29m94jvu2nn37jep35frmg5u6a2qw8h",
+    "lp_token_id": "terra1fwx3235vfpcwkv68nu2vv0cm2sda3dxtdtnpuh",
+    "asset_ids": [
+      "terra1fhsljj6qc8f7cnu62e8uxqt82czflztge05dwk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra14u72dnthxnct8gqx8zxjpqza8dkr8nlc7w2dk8",
+    "lp_token_id": "terra1zrlt4v8jzrsst0zq4ug98xaz0rmerpajff63yf",
+    "asset_ids": [
+      "terra1rwph273axfefh8gh57scw3jfm7kn4s7t5hlu03",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra14v7q4ujj95wx0leltqsxdxy97gzgw4g4q9656s",
+    "lp_token_id": "terra1fj8zwe73graryv3jlmgtt8a74agw849jrl3tfg",
+    "asset_ids": [
+      "terra1uv3298xevlfdcjthfv4me7tn7gjxd3drv6ejvt",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra150cw99qkvwafxw95vyef7d9upswsmr2wf7xyh7",
+    "lp_token_id": "terra1nu25e6fzs456lh27gpzyq4gn3vpedf7cut5020",
+    "asset_ids": [
+      "terra1z49dpvu5g4st7t4j5lsaxaq7v9u6f390m28ap9",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra150scqwurj3m6d5n0yt82zer4w8vsdf6hzl6fcc",
+    "lp_token_id": "terra12ndzg4g6k6q48hasdrrk7rul428npl88ljugtf",
+    "asset_ids": [
+      "terra1hwcnalcf35p48lvj3wt7tztkzh5szmpnxwyvdc",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1558wqfc8ffq37qj3cjfkgfj6r5xflh7gnfytw9",
+    "lp_token_id": "terra17ntlqfva06ga9jdmz0t6mhqsmvr5lqrekrxnug",
+    "asset_ids": [
+      "terra1tdvvjf700gerwvkwncjc7nzythdewstk47ah93",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra156h9adaua27vcqtguttxk6pg3st07nrypcmy6f",
+    "lp_token_id": "terra17a0zdmq6xf9jgac89y2nyqcytkcchnneefu8nc",
+    "asset_ids": [
+      "terra1zfvr6uszt8khnf4damxrujfkhgl0mep0khcs7w",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra156wnmhqelwxwcmkfcn0j5fehj59ktjv6w4xca8",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra109vclyh90fkj77ruk299pkk460sjm54vs9x6et",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra15c30300aaa2gt43svqy40jedyh7mqgn02tyukg",
+    "lp_token_id": "terra10xqkk0p4nmgmpkh7faudc0ftmkcx6lhd23vc3g",
+    "asset_ids": [
+      "terra14qs03ha38aya45vac8q9wn8pjy92knwta2exdx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra15czn3ttmcsn9xl72hfx6muyr23u8h3nhgc5e2y",
+    "lp_token_id": "terra1gp5dpf7lqmx46ravzh64a6azarewy3n8tff6a9",
+    "asset_ids": [
+      "terra1qgt75fpc097an2vtqufx52anfcsu33n57wjkac",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra15ledqp3plgp9gqkalkf9p2skdg3kg7l7zd7uhc",
+    "lp_token_id": "terra1peq4pvfc0jzpgdnutdkpu5ad420zyr9lyrqr2n",
+    "asset_ids": [
+      "terra1pmc29k34jrv96wde08znhmjq4v2rmzy78y6dhg",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra15p4lwjtk9jkkvkz33pf5xelnrnqahac5ksj8cj",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra10jgqgc3vt34w79t4puharnzjxxv7s3fq8tmnkp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra15vy6lhftmg8jnhnsnyazxl44fkutx9yawemeq4",
+    "lp_token_id": "terra1u9nnlnvlqfgz04hvu7w2nqah034m0qjukfvrx2",
+    "asset_ids": [
+      "terra1ez8x6k2rru42w3z8lnfkzjs778rllmq6xhgf7a",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra15waumwnpjw488cgchv3x5j7g7qlca73sd4zmp6",
+    "lp_token_id": "terra12cwf2ge7mxjsaylmvpnpcy0q8t65fhevhasuxs",
+    "asset_ids": [
+      "terra1hvv3qzmzmmr9qkf2xj928hhy2yxuledwzn2v5u",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra15ytncdwh7yqttvvxjmw7cd2phj9a7cyldv8547",
+    "lp_token_id": "terra1wl74zp9lyhznusz7p3xcag9jur58njc7fqa0nz",
+    "asset_ids": [
+      "terra1kp8vne240370hn722ec5sacsdluyt2j0gc5nph",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra15z794we063zfzxtvlxzetnq9cv7ftymglqh0g6",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra10722f40cxl8tkxjk7f88uj0ehkcw6lu2j504f0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra15zfs6kf7c0f8u4layzwnwkzpqnkj8lrm86q8un",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1gjuhc34ccr6ajq7dm5266xyedu96sgkv4qnley",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra160vz23qwte45w6dcgkkae05fqpap8l4s4alaax",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra12jhul3zlafuvl4fd54pvaax4ls872z8p06p8qv",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra162ccsqcru4zy55r4u52rlm46plwzvzc2x67meg",
+    "lp_token_id": "terra14x387d844rddafa4v2swz89tljm2ux59qz954z",
+    "asset_ids": [
+      "terra1krtfgcavw64dc8nhnz89eafpqm5pdz95l9a89f",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra162cf20c6hrag6fhy9aqwaq9cvrp5lq5ffpvuez",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1qup6c3w83xjrfdtzujqkh5j8pcar96up8f0pdy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1632r5htxk5ctf4srh7v2teguz47aen7ygkvphr",
+    "lp_token_id": "terra1uz9zfvrltmy3gawmsedg790xjl25jpgdm6fl3y",
+    "asset_ids": [
+      "terra1veke25wgg7xk34c3gxsweuxsdqajemr307e8df",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra163ddeunmzqr90qw4j2nxxmk0fmz56mhly4g07e",
+    "lp_token_id": "terra1cw640zur4svu6942kq9eu6ruxupryjmz5sd9yh",
+    "asset_ids": [
+      "terra19j57fzwjahvf52wxffgrajd0jjm9m8akfsl0qw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra166j8s9pehm35egpmdfkrvlqj9a4248wqcg5s08",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1yx2z4j3wr55k7jns06qhn2hsw6agskvcke6zu6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra166lp9jpsca40cqhh78f9ve8t4nx446yxp6ra2s",
+    "lp_token_id": "terra1zqnywcumfdnueyccgzp9qjzcaf7zuzc8hu2fts",
+    "asset_ids": [
+      "terra19ur0s3h72v7t2qmy58z60e0cl0epkal3mle4mu",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra167d8as4vjhgn3m04x3jzl80re5sytn89lr8s2j",
+    "lp_token_id": "terra1em445q3t0ckevthda8enkd7v8v0wlncqyls06t",
+    "asset_ids": [
+      "terra1tj9zrn3myxvkct20ehzje5whu5j75c94s8r666",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra16c42gghky97m3g5nj80h3528m3l7m099xjlh0h",
+    "lp_token_id": "terra19unte8ca7uu34q5e0lktrd6esm7wq9j3cmfl4r",
+    "asset_ids": [
+      "terra1uwsnmc4fpalrv3xgvf0aedx8tfn22xcyrx4467",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra16d99plysndjucurqz87d8p0my7z3kffuhehl30",
+    "lp_token_id": "terra10rnu02fhw7lg7eka8f2yw2wn9j7kn3mgqs860s",
+    "asset_ids": [
+      "terra1j8nxezl70lfekdzaeanzyzn75htf4sz9vmwhu7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra16edju746kt6k44meljuql30scd6ml0ey0qwj8v",
+    "lp_token_id": "terra18kq50rff38rr6xt6etkkjvhv59msdst23pf9dv",
+    "asset_ids": [
+      "terra13l9e6lelggxjzm7dxhgkfgqwutwr67y5qvc7mr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra16g8fsnjsmys6dl25s7wvl4r7y68drvfjc7pszl",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra18vl2cypy8pdys2qdqlg7pzmcmpqmur8lmrnk2c",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra16k9sv0425t8prauxk680sj8aecgh4t948v8ktf",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1534wdj9s0c3c64pmgqk8544usm0jvfysn9zq2k",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra16l746rd5nspcav63emsj9uem7v7s7jflrf4mv7",
+    "lp_token_id": "terra1emk8xeed780j8extpdd5q42h0grdj0ad4ce849",
+    "asset_ids": [
+      "terra1vyusa796w86yh99l67dpd5g3hfva759vyuhn5z",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra16ll0n5lm5j4vp94mjr0xa4tqxfpvvgx57mdtg3",
+    "lp_token_id": "terra1tqgkra60jq5jzear9e3zm6knwwzdxvwl2hn5vd",
+    "asset_ids": [
+      "terra17rwgygp5y7tx83xyclwuxu654vjt2whpwxx688",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra16qj6hfx9t2st567eg0hzfd0vq3dtvvc8y0knxj",
+    "lp_token_id": "terra179nsfzyw6gpd4aqjxk644y662geq0rdyt90cay",
+    "asset_ids": [
+      "terra1wlwkuyv9g7d320dm5cqg6wsygplmt8tjjglc6w",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra16qjw56mjdzurqualderrjh4p0gprm66yd02dar",
+    "lp_token_id": "terra1ks60j2lj62jrpcn69eejtzvg0gatjmz44x0l6y",
+    "asset_ids": [
+      "terra14ldz32u9l0s9lh07zqqqxgmnzwyww04hmvs923",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra16s7w70jm98htj2v6mkhcx8uy03l7d4w5mjfnf7",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1vjgnhlv9h0nlta2v7s5hts75h2mc065c6ap3j5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra16u0mmxkx0tm7ll5674dqazj0rznft6jfeku0ve",
+    "lp_token_id": "terra1cxefedc77znngtrw5lfrf87kk6u7wus6mrf4ly",
+    "asset_ids": [
+      "terra1ufxgdde0fkmmc7mvmkuaxps9raua78r7f0vm3x",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra16v3cxjng86zd4hmahglj89k9gejh04nghnyavx",
+    "lp_token_id": "terra12sv6yvas2w2wrtjzly647h074tq8g48lxlqpaz",
+    "asset_ids": [
+      "terra1s44vplvv5fphrrv4g68gx46xwrmvnqm9e0hazl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra16yrzqhe84x86jzgaav5hszfsu4mhxjk0aqlk2g",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra19m0xqgdaltwkesdt6m383jkqh3m9xyxwtp0f6f",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra170hht9lwe50ugfhnruzjaezpj29l7nvw3l6725",
+    "lp_token_id": "terra1wdfhtdvsvjazrjnd37uyfzg45j2e0v32vz3ez7",
+    "asset_ids": [
+      "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra170lzdyflaamashcqkst23k9ew773dtg67tfu5m",
+    "lp_token_id": "terra1t8qmg9p583jcp2f7uuhga73yh7ze0u4ny7kmzy",
+    "asset_ids": [
+      "terra1p8y9f7dpmyzy85ldv3k8xccuw0u87lsn9fl86l",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra170uexnuckv87q2fl392269m6nt847fczs0yzuy",
+    "lp_token_id": "terra10klhxjnafqnt5mu6jugrcqs0kaepprmf425c8q",
+    "asset_ids": [
+      "terra1znvnhtdxxsy9vkvmqv85nscujeqmmtjlp2a3wj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra172nqk47g4vc3zfde06nkq0em69lcwf6dp9uj92",
+    "lp_token_id": "terra14e8sutnxhzgfzt4gdq84dqjymz422k75nglnp7",
+    "asset_ids": [
+      "terra18lk5y974rsknqmcqlruj636mvg57yln93ay0h8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17cfpltkk9ja3rcv3x9rwqzxdeqs9r67ga607lw",
+    "lp_token_id": "terra1udh2534z6lu609dtvlfp8y42w6tswvs5e9034d",
+    "asset_ids": [
+      "terra1jz9plajrq6knks3vgv9px4ezwshzaxsr2xz7jn",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17ds00wg6xtgy9f7apfl59f4978svh626f00238",
+    "lp_token_id": "terra1knn3f89x8tnf6h9aglz5rhz96wa2cgwfsx3mwy",
+    "asset_ids": [
+      "terra192dse96aslp5cduzvjqly4j7jaka6dlv2xx7f8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17fwqk93kurqedvdyrly3a0c9g2v8eax3j7l5ek",
+    "lp_token_id": "terra1k6mgu6smngvqhq63stjgj2vq9e49umxvr0e6cn",
+    "asset_ids": [
+      "terra1gdze0yyar2y6vs3un79my828cery0jea8mzn07",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17g2lqz62y4p40hp6f0caup374m7v0uptw38vev",
+    "lp_token_id": "terra1chlp9faqplsyc5y886trcffyzxhnsvuvj9qv5k",
+    "asset_ids": [
+      "terra1a54dqqqh4qlz70m43n3a0vqeu2dv5tkz6t2zan",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17gh85ddky3gqyzg5lh8xry0d4ee497wju497m3",
+    "lp_token_id": "terra15q4ypjhljlfkfmz86xddkd6y0vnwyh03mj6q6p",
+    "asset_ids": [
+      "terra1ayxfyasd2ursa5gt5zgzgfywsw999dz4yykjn7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17hfwmsfq7xmecrlzaqgqqsymzr6jz4urcvd9sq",
+    "lp_token_id": "terra1enjwdma23v5f7rm5xc7zqq8rra00ggmr464nkf",
+    "asset_ids": [
+      "terra10ewuq49hkk438jhd7q79hfetqpkkt04tfm7rzc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17j0yumlretpyprsxh3qk5zwyzfrdydgnpt0zh7",
+    "lp_token_id": "terra1c063gh7d06rdwem37tqvmqhfvwce7m2aypyrhf",
+    "asset_ids": [
+      "terra185fgz0v2wm79ujn58tm3qeucnvlnfuffa4wpjp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17jaq2p66s2n40wad52mfudk0z6u5tmyanhkc2g",
+    "lp_token_id": "terra1rkewqq6kkvpp787ltvpeccvz4qsqh4w7fv57xj",
+    "asset_ids": [
+      "terra12a39fn0k0duteqefme6zgr5efg0g5ya7eglvyu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17lvnk2k34us38zflqz4zze6zkn7vrktpeuszcy",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra10aey3n8rwxup6l2x68fa7fwdurxnu9hwxf0k7f",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17nht56uc42wj73z8u0gs5n2x9d74ur7z76vmz6",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1je4ll79zmy03zpl4wdhgmadvznqr08tzrncpqw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17qag5rxkfraheygnsq0xy6y4a8ay0vrmm5cftm",
+    "lp_token_id": "terra1l58a2w22pv0fgukypvqt9fdmkn3ktd0jznexyl",
+    "asset_ids": [
+      "terra1dxt75lk0m5g0wpucg0mz905akta99fjhuhafqa",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17rduyemsyel8jl5pvyh7j33ee78606zqzkzh8l",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17rt5kvtt7vgdnxyelqhctaa4p0wwszjqx4etr3",
+    "lp_token_id": "terra1q2xj2w477fd8vx4n4psa449hj03m8py8la423q",
+    "asset_ids": [
+      "terra15pv3xxp2d5f65qeu2v27vqf9zpqjx0fuztfwcu",
+      "100000000000"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17sh5yr9tcfl2qsltrm2tulnlpzz0c6ufk683dc",
+    "lp_token_id": "terra153k57e8cka9mutkp5g6f0elje02qtmh75nshny",
+    "asset_ids": [
+      "terra17t0uuy2cg7apfsqj4xqn6w5scxkd2ajgns9xvz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17supgps4aqq7nfkcqt97y0jxzh5u6mrzqlg936",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1hn8mghxm4qm2g654m3h4rmqccgs2wcdsvsex82",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17v05w2qmmxy864ltjtts0nzqlzw32gp6uynh0y",
+    "lp_token_id": "terra1wdmkqdhqmyv9csgwfdh8739fu65qpay7jj5vvh",
+    "asset_ids": [
+      "terra1d9ec4gm0c03p74d3qd95qvny2ptf0ge5twqpdk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra17y80pnvqu3kd3g5jwn5kpkfp6hh2stzxmvazjw",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra18we4g8y6u55x7atttzu5xgx46zzss0tpmktf9s",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra182n2psy6gl9u90gltznv2r0h6t5sz7ajgu4dl2",
+    "lp_token_id": "terra1xp7l5hahtcl23ghx5u6sw5fa7cds4anmarj5nn",
+    "asset_ids": [
+      "terra18m523525ntva277qramnc6x2hh56a28w0vndjf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra183kl26dv4ymz55cytumj77z5u6m383wgfvsrvd",
+    "lp_token_id": "terra10uz6jgxmj3ywj9xndsnreula337h05jpkzppnx",
+    "asset_ids": [
+      "terra1vn8rmcu3yywfndh2ze43v5h2wg28rycdekdr6u",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1854dxe6nw9pktdd5j5ulesv74k3ztqgdx6mcxe",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra17etsw9uywcmw79st5yp4saar97z22l3np0m3zz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra18573lxn0gjcs3fh2dc6qfv7l3afrws2k2dk2zz",
+    "lp_token_id": "terra1asqt56e65cw3dmszq47ru7vzrkua6spg9au4mt",
+    "asset_ids": [
+      "terra1epzqhvam83e7lfqtdmgzatlvlzwu23x8kd4t4v",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1867v6pwuaachav723ukq9sajaxgtpe7w3aefm7",
+    "lp_token_id": "terra1jmap9tuf59k5mmr5shgmywqfxmcmlzxusn49vl",
+    "asset_ids": [
+      "terra1ry60wuc8a7a4ujt3tmrp3upxzf6a4awj88eys3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra18atry8rvvpu35pp2tm87exk7y56jm2yhza4fgp",
+    "lp_token_id": "terra1ynzjmya27v8f2clle2dl5vw909ffxqlkxgcyfw",
+    "asset_ids": [
+      "terra1tvs43r9ry6s6g6j5mnmruw97s3fjhqxpc540hu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra18cwjyccu8snhk2tknk962h2vdvnmerwhrn57cn",
+    "lp_token_id": "terra1xdgsm8apwxuxgql7ll5uc34h4w3y0tnywvsg25",
+    "asset_ids": [
+      "terra1tesjetjz6q7s2etc0pa93ep6fwhzqqtcvreccl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra18f5npedpgufd4zyq8gae05c3htnkex7sld2rkf",
+    "lp_token_id": "terra148se8h985hfw3s3jl86vf95qgfz7hztdj0u7qp",
+    "asset_ids": [
+      "terra1xzk97nrq0ma7dzgy6aj5tm04sg92q720lq2yum",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra18g4d309jykk54l43k58fjqq8h2qdpzgdctxfwf",
+    "lp_token_id": "terra1mzpxqr5vwnzl822sjd3yskaekz2lyvfpavush6",
+    "asset_ids": [
+      "terra18neulu99zm7kj040tndhavjskjm7aaxsk240rx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra18jkyaayc7s3an3gn6xhz9ue75pdy46zrvzwle2",
+    "lp_token_id": "terra1ldy8tjaqa9zjq6h2290ac2k40ta94e4hky8caa",
+    "asset_ids": [
+      "terra1l4uygw365sgdgvasmckkd7lcawyemzn9k83lrh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra18k700765d9kyglezc07n64wnkdcfzf9d6juccz",
+    "lp_token_id": "terra1l6nvej775vwnlmf84gzv5utyjw6rh0unyyc2y0",
+    "asset_ids": [
+      "terra10rv8jte682eec8s3fyd522hhq577cl75zghx83",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra18kf909r8usm8l29t6krwtexyzd8wr3vrqqd9vm",
+    "lp_token_id": "terra1cu947swy2q3re6er4f8stuxlxdeljx0umlq9my",
+    "asset_ids": [
+      "terra1hxcsd8ttymrqzp5uh5f5885j0ms0tnzux9jzsc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra18kwhhu4fxcc2x7lwtct8jatwv9843n6de33g6r",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1rkn2d2yc0946a0gx0w0hwf3l2j32ve39egsjkd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra18nz2gztwduce3u40wuuafl8xj8e4s63nty75ym",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra13zs7w76g0u4qgagcen6vq92wxuvgfucr3dy4tm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra18paw08s6xkw23swl76w6njga2rq6kh80zch24h",
+    "lp_token_id": "terra1vwa9j8y76ew90v7ukh5slz9euj50dq22cs0qvs",
+    "asset_ids": [
+      "terra1duggxa56m97yfcat99ew27z3q4rnax4w4u8waw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra190r2p96klarzvdssdg77r6sd4nfutjra7wwz8d",
+    "lp_token_id": "terra1hl09j27s27407wkct646lqnxg3qskpl2ehuvn9",
+    "asset_ids": [
+      "terra1ma4frxgvc974je0xsxrzpa52j34h9swlww2yed",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1947q02rc7dcynzgywduaudwjmr9nucjzkd7l6e",
+    "lp_token_id": "terra1sedpm809sp8spmk7svhnxqdqyu0tzxn6h0zltn",
+    "asset_ids": [
+      "terra1aszsg6mzlzkydqtm46u42mf8zxur9m4ydh9vrr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra194d6fn47g5lztfxl42fq37mwlnd4lqwestky0x",
+    "lp_token_id": "terra16wlnwhhd0x0jp9lxqnms2ssmsdhg4v206uwysv",
+    "asset_ids": [
+      "terra152mtjjndwpwvtszd4cxnhvjm8nzxv6kdwtdugg",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1970uk99ys24x9xsck497709n4tzeaa5lgkw0ye",
+    "lp_token_id": "terra1d83udzk95gnk2np5wklqj3hxdq59r0ely8tdea",
+    "asset_ids": [
+      "terra1sf5tt6p6wnlhm0jqlflan8lw7pmv3f82sffsja",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra19825apq06ve8ae5mhdtljcssm77xrtdkvm55gk",
+    "lp_token_id": "terra1lm3mk44nft4mn74hajn0p8x4enp6e38yyf4ey9",
+    "asset_ids": [
+      "terra1yg4qw00d3cpdvs9zyhyh32jkfcl8un8nxc3f08",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra199cwj22qrsuqnuv4slrmhc3dfydxjh3894tajt",
+    "lp_token_id": "terra1yjvdd73lsjq49v7x80rhe3kyltg27gew5nrls8",
+    "asset_ids": [
+      "terra1mq6sw9dt57hlpe7ffjm2z3pytr98l4a00lnxp6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra19ak9slt8fmlv5p09j0y9edswgpvmk07p8nplrl",
+    "lp_token_id": "terra102pj92vh6cem9hyzyep465k0dw3ng4hqaaqsj4",
+    "asset_ids": [
+      "terra1thrmc4qul2e02y2rskm7583g6guvtrvc8pnlmx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra19hmp39k3dlwtywtqcs4nrr4lal66kzwc7ea42r",
+    "lp_token_id": "terra17jrxg9srhvhu2rcf5umt2lnrvahtgxwate8gej",
+    "asset_ids": [
+      "terra18jv5j86hjhc0zx280wu3kjggd9dvfyl9v4t04k",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra19luytfs7wt8l2e5fgg7del39m93sm64qsmufsy",
+    "lp_token_id": "terra1jfrngqdwqkfs25sgcmuxrlk6a7y8058purc4hx",
+    "asset_ids": [
+      "terra17w68lnnp47k4zkfkpcyzu2xeu6qw576ksfpp4r",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra19mzvauzmythgn8d8vl944vczh5egrlnqfqygke",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1ruz2e26humerfnd9uhurc9766a4at8x8e3m2e4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra19nhjua64eq04ulurrdayj3u0f6yw5qw6t4mc8g",
+    "lp_token_id": "terra1h30mmqyw6gu5dnresfzdcwsr2ahec5usf0vst2",
+    "asset_ids": [
+      "terra1n3l6xg66m9t342qcvgdqk6md5cqvtatgg8tw39",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra19rsnccnawx00kzynaxexxh4540qp5y6atfrkjj",
+    "lp_token_id": "terra19pztt2p6wuy63dehanjeuyf7vx399ptwdq93zj",
+    "asset_ids": [
+      "terra18ky9ln4g6x3n9f9s8a5ttshynv6lgzfppmrmyg",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra19ujj2teuw6m45v9c2wk33wzl4mjr22jlw3nqrs",
+    "lp_token_id": "terra1exs7v9pvkl90zjyd5h7lu26hzszwczfsedc3hj",
+    "asset_ids": [
+      "terra1rctv4sdztvscdxw890us4ewcuvh77t8wydxkxr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra19ypukqk0v8l2f04qjsc9pwullq7r24eufm6led",
+    "lp_token_id": "terra1yhlgg0kkm7vngmj68suf0jmx5fj7v7hpxy4udn",
+    "asset_ids": [
+      "terra1tdc7hmydg3es6lmn2asfwfgs8ykq7xa0nz9rkh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1a5pqgv432f3u25zu5q5r0t6e00pwd6xa8unwp3",
+    "lp_token_id": "terra13hcayvzgxur5f43qwauz3jsnf4j353ee9s7qq3",
+    "asset_ids": [
+      "terra172qlk30wwyux37m45w5c7mkypn7ks0t0s3d0ms",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1a5s9cgdzw4pz4nf8rxyqp77q0wuegahs78tpfd",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra12qgpr0fw773gc8lrkys3knnw6nkgdlc8ggaty9",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1a8t3w4ts39fu5su3dg60p9akhr8uf85fzccuxq",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra19hnegq0ed5w0gds64765uakh5huw7jepvjakh5"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1afgh029jj9nxglezr3jxmr0heujj55pgspvx4m",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1cq4lkf7dlygdp23yql8a4daunnxr4xd5tymszl"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ahygklrmejad3mmeugsd0m5lczv9jl8hjepp6r",
+    "lp_token_id": "terra16k9tt8q30dswt9ksp00wrfdmdlze9s2en5y7ts",
+    "asset_ids": [
+      "terra1478yfcsa6ycykstdfh2mclwdy3d6zpemkyfu4j",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ak3u2e0303wvnfsese2z382pn4sxl9etz9rrkj",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
+      "luna"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1aqd837959wjcpzssqqr56rhh7dcq2nrqpgqrdm",
+    "lp_token_id": "terra16c2lh2lr0xe92ayf558rgzw47gf8cmqh58v06n",
+    "asset_ids": [
+      "terra1tc7tcg8u54p3t2r5yfufgf4z340ggwpvlc2rwt",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1c0g493amwrzx47zxa0qcvrks7wyhmqkpsf8u2y",
+    "lp_token_id": "terra13mehc6ldhs2sryy388tuqn5cxq573gdhrq0cjg",
+    "asset_ids": [
+      "terra1pkfzenexjj6ne68xv2g9t8387s7d6z39c60ghr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1c0hc7ncedxaps2hxl0qazxlh79g4zdre5geq4m",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1pmmdfnmhrjnywsgkd6xplgp8nx03fxm6ygma09",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1c3zsqpvlev8x70cmekqxmqjjamvwdw93gzqjlc",
+    "lp_token_id": "terra17xhypskf3f0cqf0knvyqw844vm54fg2j4fxng4",
+    "asset_ids": [
+      "terra12zzantsa5trfm0ssrgsnhvlram502ats35qtc3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1c4r7vdd7f3cjts6kzjuv0sx4apesxr9p55kqc6",
+    "lp_token_id": "terra1hndks78y9k49jq35x4kwjsvpp8g9hn26e5n7d3",
+    "asset_ids": [
+      "terra19v4cg3w698qprsjwzw52cns6245vkxug74q9lc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1c535v3f7fz8a94wu2cev2p9wvzfv7x35uv7tk6",
+    "lp_token_id": "terra1xup47v2ypdhk4lpmjw68k8hlt9s2ejjg4pv83j",
+    "asset_ids": [
+      "terra1wzxpydn6z4z0us0wpx3n96gcs5p9qqavhw5sqs",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1c586ncze76sv75zlg3cqusqdmn6zluukdhc9cx",
+    "lp_token_id": "terra10qpu5aajfmkucfft53hs6hzn96ckaqa0cdmhje",
+    "asset_ids": [
+      "terra1vsr6l45yyqn58at6nymdx99kph9sw7zql70akr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1c59fgnldauz68wpxzawxy7w650r0yvhq34g6ng",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra158ut7lycly6ep0v334rpjtcjs8hlvwjzf5tfrk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1c5j97vq48wjln03wgtalfhlmlg6uyczmpj74vj",
+    "lp_token_id": "terra1we6ygtflu43kjgzj8ug6d43f4zkd3fmssax5sx",
+    "asset_ids": [
+      "terra14rq6etqgza9qqpgz9yjfmsclgnzhk9jsafdtyc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1c5khrjsj0q9l2pyt75cw7hrwst7xyr9vegutkv",
+    "lp_token_id": "terra1hd9hnlwtqm5s5mkngqdqytdc0a6elquh6n70nk",
+    "asset_ids": [
+      "terra17zeqmepm87d9g4dujjsctqjrfhz4xjkup26t03",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1c74x8j9caymapwg30z3gse2jlxvgkm56uhv6zq",
+    "lp_token_id": "terra1cgfghgpw8u832e9xlrya7pqpj0pyyfpyptwdte",
+    "asset_ids": [
+      "uusd",
+      "terra1my0tlq45u0vlpyt2n4qchxkzhzwnxrd2playfq"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1c78mey84ygre2ym4aznw28796qfuytcl32p83j",
+    "lp_token_id": "terra15gpwuqw3uezt69vxa5ftd2dt7yc8ap2fydqhat",
+    "asset_ids": [
+      "terra15plvf4hfgsrev5athn7wmnqgt6f0lddmduzp90",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1c9t0gzff3z4mh62ky9cj9hkunlj8zqz58kqa87",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra15q3lzrnfstr3rqgh55cqmp95z4xr3we5tfyqm9",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1cc2w6lgzxarvawywfr7v4q7nq30tfvnfs62u54",
+    "lp_token_id": "terra1zy5sjsw4aswykccwtvkaq27s2eedspvakut7gw",
+    "asset_ids": [
+      "terra1wdc6xjyng08qwssthzvd5u8a4z58r8jxxn3j5t",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1cdj55x2gj369g50g3w2uqjm6p2fchgy2ehjd0p",
+    "lp_token_id": "terra10z27h35npl969tp9d05qfs49k925rxm3w5sd96",
+    "asset_ids": [
+      "terra1fkwfm2w8kffl3ged3zulknz849rnfdxnwjgdnk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1cds3ru8n9s6cpuqszd6kupxjghj8r8rqk8jvmq",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1fpfn2kkr8mv390wx4dtpfk3vkjx9ch3thvykl3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1cf38v8qumxruarhxfsgnylkymz6935c6qhcrkv",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra16pem7c3h7renxuxa4jvw8efv4nhrdc3leguzyn",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1cj2du5dmwr86u56u3xp6kx5u9ww7z2vcz2vrrr",
+    "lp_token_id": "terra1hffx97vzfuj5ysxtpzjpatf5utpaqces0dvm3y",
+    "asset_ids": [
+      "terra10c4zqj4f7ze4keuwvm6hk2wrdj9p8h07sp4fg5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ck5vwpsz9nf95c7t84jjwfgpxtcnpj23aka3ml",
+    "lp_token_id": "terra1l46txnnqf0j4l7g6630dhf0vxqhpxyzzadchfj",
+    "asset_ids": [
+      "terra1pduqn0tpqce36ndwcv6z6xjlnujdddl6pedz9y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1cmvp86pqrt2r986v63mm5257ctplnf737rktl7",
+    "lp_token_id": "terra1wqa24s7qzqess0pwrx3q70lh0uj04vajx6uf58",
+    "asset_ids": [
+      "terra1y6mgy2ha0fwhtkd06jdca7hpep7z8hz9n2jz8t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1cpmqngse0kw0rkgv5pewgg8dvg9ep240xelxc4",
+    "lp_token_id": "terra1uzzyyxp6kj87q2ygm0d9se0pthnrjh7jy75jxd",
+    "asset_ids": [
+      "terra1f659ez3nysf06765jjjqnl7m65urrqaxx2t40h",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1cr5uef9rrl74xcw9vjsqklud2dstdfr4xj7hqm",
+    "lp_token_id": "terra1my49papxtmataag9arh9wdrqyyuqyjfw7cc44v",
+    "asset_ids": [
+      "terra1ce0z2295uajnvxltll75zuvh5mvecczy3fmlzj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1cr8m0mpdj5e7m34ekdrqgw59az5v98pgckha4y",
+    "lp_token_id": "terra1dsj8lxhuvtz8k8vt9v7zjm85cca4qjhsqgvced",
+    "asset_ids": [
+      "terra15tqztw9vjcuc9znkvmxn7rh30ffdnahhnw4vym",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1crkwlasutngkqdlfskk7rcgasehpq6aaerarqd",
+    "lp_token_id": "terra196f5vd4s9zn6deqv9shjktk348nk7k4kcl4apd",
+    "asset_ids": [
+      "terra142yp486a6jjelr87c0kx6vxv22nw6dsvkcnhma",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ct767uq6h75duwd0jl6t9lxt3zn3wvvnec3snh",
+    "lp_token_id": "terra1lkcazx0hn69qsw62tyhj6u0svsnepg73vj553h",
+    "asset_ids": [
+      "terra1ygrhf4zv86jp7hnyl358uj42llm75gt7w8e9s4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ctdwhvfkhrp8z8l78l85h0da6ywlmp2yjtws2e",
+    "lp_token_id": "terra1edy63xnmphdr47p97hw3h6fu72md3u952ra0hk",
+    "asset_ids": [
+      "terra1s9jnada32ld74gmng8ng5l3zfy9vk8kfds5828",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1cuxd5x9vs0m604pze90c0xgccraucv2kqcwlz2",
+    "lp_token_id": "terra1pgjfhamw0dv2t9a5d9q9eu7fm9etj4zcewyak0",
+    "asset_ids": [
+      "terra187zprsu04wnfs64pznf69mkls6vefhtmtwt8w6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1cvg3jjepvcxzkv5elvr3x5khk83wllvg4qygfc",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1lxpjyl6k60rsyp0x7fa40s8jsl5l0d27ycmwfh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1cxcxfa5hd60t8t8rphzgpwunwh3dxplzm0xpwj",
+    "lp_token_id": "terra1r099m6j4unzjxv77vxnt05hrszphpm69f5x2rs",
+    "asset_ids": [
+      "terra1m97d9028kdz002wkq23kp329w68yun7p0x6vlh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1dagf0h7ux63pqak79m7rqsnm5yujga48sg37pv",
+    "lp_token_id": "terra1mf2f35qq37pkmq6e657ha0asc6tzxm8zwaxg6r",
+    "asset_ids": [
+      "terra13yf7ukapmeznh2uamd0342g0hy872my8shc74j",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1dc84dhqyqrrzpt3tjnkrzsyky2yyzxr5tszzxw",
+    "lp_token_id": "terra1dj5q78dmy35a27dq97sl28ta78yw2qaz275xaj",
+    "asset_ids": [
+      "terra1tknq3prjtkzttvx2u48hn4r7xfwh7gz9cxzgqf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1dcqj2agjxrc7gz3zsfqxux8js3r2rz0wumch6t",
+    "lp_token_id": "terra1h0vyhc8ttqe2swxkvwl8v75wpfpp5c3vxwdxxv",
+    "asset_ids": [
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+      "terra16gx5th8mk5v62xpvgf675xj2vuaf3dg4v75ml5"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ddu6j495ephpxm8at7jzg55n6u0zc2yadvuz26",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1v6p9v6dqaql0600hmdl78h592ax5rxmheefgd2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1dfv0ww0tqu432aa9z6r0npucjyslu356602ayr",
+    "lp_token_id": "terra1n0hxydmnc55rzs8kyvefpj0xkp0524wc39euwv",
+    "asset_ids": [
+      "terra1gkfv34wapjun9w0qpg8f245greudfguzlhp87f",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1dj35t0w5w5knw7cq6dj3s68ry724nctq069w5s",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1xmd43yrfxm4xy3lnptc7kr4rr93pzh5u0z0wgt",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1djzkg6ghcwmlkcdxpqq7lw42e695ulzljrvavr",
+    "lp_token_id": "terra1u5qgpemcltd5y0mzwqsz44wws5z00zyusa8w7z",
+    "asset_ids": [
+      "terra1r8ak49p50g76zamn25h3u7lkmn9n4maq2k2le2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1dkhyzytlc99rf43n4jrxttwxcvg0hvmaa477cq",
+    "lp_token_id": "terra1mvht6zch65z2jstqfz6dye5wlazhhmc4eky6gz",
+    "asset_ids": [
+      "terra1yj7vlx4uj39u8x4ptvvpxhpfnmphypmlhfhq42",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1dq27eeasl3rtlc8j3ls5yz8wurnksahj240tsr",
+    "lp_token_id": "terra1prswk9yyayfkkq99fpaz5zs7h0lhcpsqa4swj9",
+    "asset_ids": [
+      "terra1zva2uegkvwr03p98mdaam4dtrkfxxvu330zwaq",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1dqz4zx0uecwjqafzyej7pzyhhqse2agq767al2",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra17qfuwapug8scgw5satxs4n95u3taw6fe8hdgty",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ds7gy9gyf9e7rl8zmmtfjt2e2dm4d6p9szu8tq",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1ss460ny4hl5zew0tlvywnw38rsy2ql3n420lv2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ds8u8qrqv87e5mud77up62rl34rtltg3v4w3tc",
+    "lp_token_id": "terra1maal7qmyn8vv4435wc3nx7nryu7swnj0n2v4dp",
+    "asset_ids": [
+      "terra1qv98rklgrdv89gvf47rrzx2lzehd43uwz2rus4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1dsmz3dfejj47wcxes66gktwqhsvyxe9n2pld0e",
+    "lp_token_id": "terra1cnryfady5636utnsvv9uj429mhnwfqmtr4als0",
+    "asset_ids": [
+      "uusd",
+      "terra162k5t3hl204lrwe8xvalh4pv4gdrjvdrjlgxst"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1duyea9eyua7uftths0n0kn5uzrdsguj7mmv666",
+    "lp_token_id": "terra14janxct88y74znp68z4jh5j6hq3nfd6shr3sjl",
+    "asset_ids": [
+      "terra1ykq4e3ca2e5qgeetk8k8m3w6tk9tclr0xj2st7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1dvwewun965qpex2k8hrpfpzt8t7qtq3ptwu6j3",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra133j6tpq7gcrjjgvgj4r3fjwda0hegmmrazmwt0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1dwsngznkraae33wufcz8qu4rd83elrzn9g03el",
+    "lp_token_id": "terra1zky7u7ynn6m67zequu5cgh7jefadg6ux46a22z",
+    "asset_ids": [
+      "terra1ptmrg9j7tcjphzejzlygehaxwtzrr6ywsu72qq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1edmq655dxqjk4dh52z6e0h9uajs5g0yl5lk7y7",
+    "lp_token_id": "terra1dt5n5tf9afjzms493nfkt3telqtvp5mmmftu0e",
+    "asset_ids": [
+      "terra1nh6theuhf4pv67pcyqnz58czljr382mxrp2rdh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1edrk0fflh8ve8d0dn8hna46ftvu9mrruhzeunv",
+    "lp_token_id": "terra1xajvgkhmt8lqkna2f5t28jegsywwkgxvncl988",
+    "asset_ids": [
+      "terra1d3pmqshpe6n5cs7d6mnffdun4tg0k05zfy99zh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ehdk7m3p7fwpmzhfh8pdnqueqy6ymmccsnjpsd",
+    "lp_token_id": "terra1lxx00gux7zl549dj98cd0rws0xv48ns4qdf2zf",
+    "asset_ids": [
+      "terra1f8m2ylcpzfeg3675yk7htw90d72jltgk4mkr9t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ejql0hjel8s7ywxansv3svrrv4hv8t7h0803em",
+    "lp_token_id": "terra16dv8v3v52s7ktxdgltxz6yje67xs8c3azaa9g9",
+    "asset_ids": [
+      "terra1zzfhavsjlhhx42rnjfvwk6u7taplh4qxqmhgfa",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ek0rr6pj76mtrukw9l90wd8xwcuknw8aqp48sj",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1247nlrmskhfu9qpg66zt5w6f8cw250878enl9g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1eky5etgq3jwhtyz2tqyuykkxpj6rep7jd7v7rq",
+    "lp_token_id": "terra1054t5v3fszukf4hajqvf4zsndcn2rdx4yz8crq",
+    "asset_ids": [
+      "terra14zj58ljhlyrgshe0n99un3k5ll2s0eucp332nu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1emetwzv9g6pc0gp5ghj7h9wyvwm902wtxj76d4",
+    "lp_token_id": "terra19kadah8p79e4m766e3q869jv5f67s60qfxznmp",
+    "asset_ids": [
+      "terra1mfek3m9s0sazd40kjraw5qv3963t5n3gwk408u",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1emg7lr0fxyqxkytdk7seupa4lvgda2frxjluz6",
+    "lp_token_id": "terra1drarcarn8y5hzw0hkjcpa9nhefpq8gqdfeq3rr",
+    "asset_ids": [
+      "terra1a8k3jyv3wf6k3zngza5h6srrxcckdf7zv90p6u",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1enwvvus429s4yxr0d5umud3k6eyhln6vn57v8z",
+    "lp_token_id": "terra1hp9saxd4mjfrmmzlzmkt9x9jk69vpu7vsh6lwf",
+    "asset_ids": [
+      "terra1d8uw3zddfrexn06f80nz6hx2cd3f32a7p45agf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1eryc869znes7ujk8usxrrhy2zru8f77478mn0e",
+    "lp_token_id": "terra16pj9ycwu7yvfwtkrew87ss2tqvr537fl2rl800",
+    "asset_ids": [
+      "terra1lrqv79tw447kk4ham08suw7vak3a7pf9de2qx0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1et3se39fd2nmnuygcvls2amujzmv4v6k4xwv69",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1mz858mn7jeglmzj0ay8z5zy6v78fvv7em9tljz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1eu62yulj5zjhs8wa9uvlj5l92a809a2hcp83uv",
+    "lp_token_id": "terra1zaqqruu0ch0qgq2s2djkelywfn9x9yfg7wjet7",
+    "asset_ids": [
+      "terra18glhvftntrqg00hv96qkpx3r37g34qh8qytnps",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1evfprrp4l8kratzm3hs2yxnly2t3ps2r5x7jh2",
+    "lp_token_id": "terra16kvs9y46p4lkj0dnyef6ly4fzs7883ztl2l9dk",
+    "asset_ids": [
+      "terra143dkyw98s3ksxu97zln8z5s220ytatygd5rqdx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ex4tn8m3g2c8xv3q9q5mlm0d8aa6684g40y3cx",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra12mvfnsk4r2chx7n032aztme7zcypyla5pllhzm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1eyyqh5a5w6sx36q0dgdewmnvxkud8yap2u2xp3",
+    "lp_token_id": "terra1fl4qcp5a3vs5unz3f3kgjwr7rxvq3g393jrk5v",
+    "asset_ids": [
+      "terra1agkfm4zumwkkudpj0882xaex7fne3rume0775y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1f27dfgcgx5zpa2f3zd9s79jrjmklwq0l8fa6el",
+    "lp_token_id": "terra1r3hc388xqf83u86ruvhfe3p7pnggz3stf694qc",
+    "asset_ids": [
+      "terra1e60jlze35lh05dlqrh2yjv3r8z3gktwchykrq0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1f3tdduzpsdrg33x6w8cqmzmyytnmhzcvwnharl",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1y8q4jk5xwag3sschctduxa43eesupjkk6kr452",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1fcgvdqe2dcgr7x2a9w3nfc0nhjh07zggzdlnfm",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1paulfn369vuz6s6ty65y56wj8gnamzpdzwk9x3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1feuaajpy0yyag7zsz2w2yxst6faeemn82mlnrf",
+    "lp_token_id": "terra1gpavmsf3snhltxnf7n6nyz2ehyswtflhsqk7de",
+    "asset_ids": [
+      "terra1rumme3vcguv9ly60p53j6wg5qanacfa9nl5uyw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1fgn8re8qf9am8ymkmaawgspym43en9f8w50f8c",
+    "lp_token_id": "terra10evwunz82kc0wucnwyxnzq35yjygl9huglrlgu",
+    "asset_ids": [
+      "terra1m9fuqymdz03umd88guyc79083hd7vppzu74vck",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1fgwk7tjfzcul8mc8xwdkf3ejswgcxkh7d087ku",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1yanmc0xxg9dl387qkudnysjkymgytj3cdhgeek",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1fhgksqjyawsym7myq04ddvm0sgxwzqqlw4pp5j",
+    "lp_token_id": "terra1xsv563k2wyuqkwza0mrz6ye8exx4a9r0hdvxs6",
+    "asset_ids": [
+      "terra1elveensfjwt270xzt8rcpvwmnhawrrqfx5atj4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1fhs5njpe2sy6acf7r3s8qh62mvs0dgs5wntdtu",
+    "lp_token_id": "terra1xapjctwprfuqpcte2h4mnpxtf7nh3jhurgv6sf",
+    "asset_ids": [
+      "terra10hr9gx9m9tq44xcxk2c5mzzlk7p22zd7x6esr7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1fjrjynsdxvgqsahquuun46w440d59020vxva9d",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1fcq75y4ezhsws0vudna3cddk20d3k0eg9nznyh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1fmp455y0fgee5dv68fxwfnylnpux6fv3th4m2f",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra10vwyclaux26l47hj2dgnjw2pcsrt4y0ukfgp9u",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1fpnmpty0r6fmyxnfzere7xd62cnjaumslzz7d9",
+    "lp_token_id": "terra1fwcdnx8flnyy4skav4fvurtmrh86ef9mkumgt6",
+    "asset_ids": [
+      "terra1spe82hmc9j2y2vjl6urue78zhrn9r9xyydkyx4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1fqr0y0djympq8zfgztev9dj7fpp248pff7860f",
+    "lp_token_id": "terra16800h94m9r3n8alhu2rsxxpxyesh9sylu3jgen",
+    "asset_ids": [
+      "terra16q2hhuva6u0zakfav0pmrdw2fhjsanvqq9y56t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1fvzjp7p8qy0l332qy8rpljcufmsqdxjyvckney",
+    "lp_token_id": "terra1dvkjth7zak3f5kvn7l8vfp9n0cu8dtjnjhdql6",
+    "asset_ids": [
+      "terra1ua6saapgern9jpmklkvxxq4l06nal2cwd0003t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1fx82cs3ttpcnd9wg32a70ajkfturmedrgup2vv",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1cxusd4uhgpgk2sp99rexrcknpn08anak3v9tz7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1fydslvtnl4d4dujz5kapslwty6were2aeerd95",
+    "lp_token_id": "terra1q3q8lrucdvs93walj4edxqlaj0lqqyrs2sgk7e",
+    "asset_ids": [
+      "terra1ejmg85y0vgsxv5r3cd4024j732pqnwudl0v2d2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1fyrvx3m5njh265wu3xycty3ynf04x8wqhpm2lh",
+    "lp_token_id": "terra1hqpfh2g457fuzrm8e0skagwwh79pffr3zzqwek",
+    "asset_ids": [
+      "terra1897wmaycufjr9hu894mt0g33ddcgm9vfsfcyyd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1g39kq9n6qmjzpls9kfxu86yvcz3p9ajy8fqjp2",
+    "lp_token_id": "terra1da3m78cejl8l396gahuqnllwl4qyxeeysm5vrq",
+    "asset_ids": [
+      "uusd",
+      "terra12y2uzvrn3j4y5390kfljtpq6z3wqflyg0wls2z"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1g6jmfxv2rangz50u335rfum2fxxqmk4cnl43kw",
+    "lp_token_id": "terra109kmkve0p4ksffjdfkry75d44hy038mk7x6ygc",
+    "asset_ids": [
+      "terra1866wzpwzmrnmh0s267twyhr8c4tc47tqj5aths",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1g7an9lfz22gkv74238dhc2j6ymfp4jy0k55yxk",
+    "lp_token_id": "terra1yqnd70kvrdfazu7aplalwqdp3ksnu35fv9cv9m",
+    "asset_ids": [
+      "terra1qw6sp3rjar2x7mfa0x4uj90ssemwap8p50f8kh",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1gk2nnql0vllx34dev6l9grl425leuehckwpx3d",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra14ec8v4c5dnwu2pq9plfquaffutu59tq9hld77e",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1gkrajyr342clv98p2f6dx72eyj5cx0t9pa74f3",
+    "lp_token_id": "terra10q52n4yx9nn7p2arhle32kyujt65euzh3vny4l",
+    "asset_ids": [
+      "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1gnwt6a5t5vw90q26va9fj3j0rsnjemptht0szr",
+    "lp_token_id": "terra1ewm8kaj2vvh2aknjzlv6cyqm4hjc8j0uvdnah3",
+    "asset_ids": [
+      "terra15uc875u7uu8xyqf833nxwh5x4dm2kmu29u04vl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1gqqc9f89a92h75m3hqt4c4hpc8466a5a8z4xt6",
+    "lp_token_id": "terra1dxu9d263z3rxdn3s72uswtszjewx573sh4mq9r",
+    "asset_ids": [
+      "terra1cvsfc32dkdvmla6urrscrtfceztecj0u5tvlvz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1gtu7lxdl878r02s2q7fx0thzfu852c3xhxj04n",
+    "lp_token_id": "terra1ekm4u8whtpzvna0arcxjpj5mx2qfcwku70nzgz",
+    "asset_ids": [
+      "terra1qsjs0a02jmyfhvaeul4zax22sayx5e8dl8527g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1gy92pyp6kwllkpqv4gmw63l50cglzqmtz2jjnf",
+    "lp_token_id": "terra1s72ztquh9j0rj5w84kxlflkwz0kwyaflgxtstd",
+    "asset_ids": [
+      "terra19qad83kr29qg89fpl4qh8m02wapmlwzpw5hvc4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1gyrp3pnw34wy0ptyjehfw6akwd9h4ed6kmxmev",
+    "lp_token_id": "terra1v29xuc4he907gkpc3zmrhqhuxcvy3jhfy50wue",
+    "asset_ids": [
+      "terra1mlhehkx4rgp357jmxhqepy0nr4tjetkje9t686",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1h279dtdp2jal5z46memvs3fqa9syfcnd92whp2",
+    "lp_token_id": "terra1dznxnr2k77nneklkd05jmxugp2j77mtt6v6yjn",
+    "asset_ids": [
+      "terra1yss9zexptelas8y4mqans2qscmw69cy2g0tycu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1h4mjl52nsy6y04r9snxe23fzdx85vzvpcnu6lz",
+    "lp_token_id": "terra16v0aunfk0tqswrldmyczz8aymwe9r279kknheq",
+    "asset_ids": [
+      "terra1ckrsweg4dtg47qv55ecayntlax3j8ja956nq2l",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1h9jyaf7wttw6txdy64608wc6k998dt2ny8zjwm",
+    "lp_token_id": "terra1xfq07tcdep6lujx480xqs02q5tk3ka3p4l2m8d",
+    "asset_ids": [
+      "terra1pmf2x6gp8u979q672lkkkruuhe9zarxyu5w7t2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1h9zcqxdcl89hwvgxh2v6l3e3lfyguawxcvtasw",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1pc253zfn4zns6awk7eks779uk3m7dna7y4cmlf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1haarsvn3uxmul3rt5vr8x0856pjj45js6fwkhz",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra15fvz44vh89rj4ykamk2tadw0f7wdnccn5qp0ua",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1hakq6c49989jkgpj4qcp4akxqgesazps2ss9lp",
+    "lp_token_id": "terra19c5fhtrdaarv2cly5su7w9a2ud7nk72g2vm0gv",
+    "asset_ids": [
+      "terra1gqmd09k8g3lggxxdzu9z94vqcxtr5zylvs95ke",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1hcqrfwnjvsp6y0hyp9sgfla6k2fqx23g9j9q9s",
+    "lp_token_id": "terra1k9tcrhdgh2q5wpzw8j4ap3fen3ryn6ycdmn4ru",
+    "asset_ids": [
+      "terra1ktugzem827nn5uh2ccjk8y6xr9z4szvdc7x39r",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1hfm049mt76s4kgsdrz7x0au4um4spyvyxe39m3",
+    "lp_token_id": "terra1rvsp3qg4k2vyd432xj9qzxx2p9hs2zzn5u43qg",
+    "asset_ids": [
+      "terra13zs7w76g0u4qgagcen6vq92wxuvgfucr3dy4tm",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1hjpke0qekl4q7uy758c9z5ve6xwsuzz5n783ek",
+    "lp_token_id": "terra188ff6qfccynwu3ge76ylp0k9hm9ke3fsnacmc5",
+    "asset_ids": [
+      "terra14g3uqp52dwk9qts40mr2skynkqdxsqwlv0862z",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1hke7ncmglkcevsgx0txma8a02pz4npypahcc0r",
+    "lp_token_id": "terra1xtxds95gvddytcxqu5larnuvxt5gekwfxclyu2",
+    "asset_ids": [
+      "terra1ltcad0e9cgf2jgtzqwg82n9k54fre68wdddfll",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1hn8m4250rgmtpx04uc75sfvqsyvcj4g9fdrmlg",
+    "lp_token_id": "terra140jj5n8yd52ucvntzfh02yslfuys3kxnd47lzr",
+    "asset_ids": [
+      "uusd",
+      "terra1pujanvsuhqsqf8vc7r3ky9ghr8sgeg4e3ngjun"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1hq3kf4353m5d858u08mymad5rvgkc4zeqhr8vs",
+    "lp_token_id": "terra1j02hv8ulc5yg7hc79ycsxfhgmys7jjc0m550c0",
+    "asset_ids": [
+      "terra1kuf3mxgrcwnlh4zfk5p5c6tcv436j5kza70asm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1hsyfna6jujxrfd86043w2tcydyvql7dks9v4zr",
+    "lp_token_id": "terra1gjz8xr2z92pffvzgp0khu569njf75jkhe6ta04",
+    "asset_ids": [
+      "uusd",
+      "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ht5zgyecp4w7s3jzgq9j4unjx44hx4se94yp62",
+    "lp_token_id": "terra1qts4ddzv4ndsv4mkccazupmfx8q978g0kr459n",
+    "asset_ids": [
+      "terra159tnr8a3uutvwxhgkea4f2hucm4v24evv2se2t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1hv6zykkt9xjhuqzumrkpvp5e9t6hrq0837c576",
+    "lp_token_id": "terra1mjvdm5ahr6l9yg2h6sn0khu6y2dkesfmy9dfnf",
+    "asset_ids": [
+      "terra1juul8ypgcs4wtuqsc7fjv76g0tq77nc44ymxph",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1hxekdhzzlqrytzvf7vl7jvz8tk36eldmaygdu7",
+    "lp_token_id": "terra1x32xraswsr08qg9dee6jkkjac4y2j3q557f8q8",
+    "asset_ids": [
+      "terra10t0rgfryqz5ds93z5tqed740nqh4ele9lm9fhq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1jccp3z6efd6r4f88p7ewy2qpjtahxtz3glqu6g",
+    "lp_token_id": "terra1lk96dy8w7cq4x09q780cfg7wwpkuxrxtqjpycj",
+    "asset_ids": [
+      "terra1fd0gy7f5dcgmvdl95mt3z9fh8se48gf0wxs68k",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1jftv4fh6wyxx8rnfw343vyl5ehcpn47syn8yzh",
+    "lp_token_id": "terra1k597uc4rzvlgmel8xkz434xdw0tsfmt7es0pwy",
+    "asset_ids": [
+      "terra1mt957lrc2z93f5utk509zma6pgtceaq6tqedc6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1jgrs4fnevw78q8rvutwyjzxhyy5fzqwtft6jea",
+    "lp_token_id": "terra1kw6qk3wpdzj7aklge6yegqjlmnrm83248v3vwz",
+    "asset_ids": [
+      "terra1pamyemqvkj8ws0easzq9pkl8usnjt424ddraff",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1jgzc2rkgl0nlxxqgy097wtq55c7qv224ysx2dw",
+    "lp_token_id": "terra1mqhv4thnf8mpwvj6ul7wrrjs2y5vua257yhxns",
+    "asset_ids": [
+      "terra1gdapfuda0dxtjc98raemhszntcxty7chyr0wpd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1jq6ud6xdljsrpgnmuhwc8e9sxjut5el6t5z9gr",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1qn4v9nnc2a0mdnkzl73rh60264gvhu6pxusz0r",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1juyxhxne0gm7nma4vrm3pz949lj3p5wg266x55",
+    "lp_token_id": "terra159je5qq2c45l4vl4j2uwpelyxvmf06nnqyyc3y",
+    "asset_ids": [
+      "terra10aa5cyfu879fm88glc099sjg8unejcp46cv6hd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1jvq9ufp4vvypp86hl56afvjn7jqgxxu30l5zhd",
+    "lp_token_id": "terra19yfdxaw7qexrzq8lr8mjs478uu53ptmdmgrhad",
+    "asset_ids": [
+      "terra1r3u50sue9akjnndgvxm7fe0fy5jdtnyxwuetw8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1jwl5rzg3xe0a3f8r26l0l3d957vlxm833srtcp",
+    "lp_token_id": "terra1srcv0x7huzrxce3awyl4u5g9rpt4fqn5nwcw6m",
+    "asset_ids": [
+      "terra1gpwkclxwwuzd5wyjw2qn3km0r5ge4t4f4mnf0x",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1jx3m7swaseumanezk3z6r73cptucc9dqg6hprk",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1pmcr4gjjsu62t2d9e33q6d75sydrhnpt37nayz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1jy57s4anzh959e6cr02dwt5s3vw03ajwtfr2l9",
+    "lp_token_id": "terra17tjnesmzly8gv3aj87mmtdrma77au2z6756x9d",
+    "asset_ids": [
+      "terra1hytrupk3argcrsl5x7dv55gyda0tn7f2qqlwkl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1k2sgkcw0z5drjcy4nl09v40xt6hgf0kpcm4rpc",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1gl3ywddjkukupa3qv86r8xy434frncmxna630k"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1k40xfmkswya285zwcsj0qlamg0f4kyrvn2cd0d",
+    "lp_token_id": "terra1ryc8v8srh8kwclxcay7dgqtkclty3g5n7gj0y5",
+    "asset_ids": [
+      "terra1xxze8dty562la0d6g9q3srlddh0qemk08kpgfr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1k5gg6rjgmmut6m3klz0sz36x7lt505p977pc9a",
+    "lp_token_id": "terra1y848ua0mxnczs6hslk6gug8tmtx9cmlgf2ju7q",
+    "asset_ids": [
+      "uusd",
+      "terra1t5r5ptw6ympy9npq0z7fa37nrk39n8054c6763"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1k5rnwftj26qlw6q746nv59jvg964zjr58ddsq4",
+    "lp_token_id": "terra1za869t75aa4tjatrtc8sqxfphymmdj3k56w7fg",
+    "asset_ids": [
+      "terra1mvgs32slrxy29qhfmd2vn7y6l8knmtw396uxde",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1k7ugqrw3jkk5auuudpnuf52wtzerx4a7cjjhfg",
+    "lp_token_id": "terra1ch9gwujlyz6pjptuqcdpyawn5a87dtw7a360v2",
+    "asset_ids": [
+      "terra18gtpe3cu99pp2ej4mmf5hanrfwy6qcvd5x5cmz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1k8fkje4xawkgtg0czxkp98qd2gu8uz4xgnuzsv",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra157n30a667ethsknneaavga2txtze58eajyfv45",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ka5d8934txtr2lhpdk40334k30t66hxyqswq37",
+    "lp_token_id": "terra13vxffk8n8a65lr9a24a7g28ls5hzkhcf3kzvtq",
+    "asset_ids": [
+      "terra133q7a0uctlld9kru6put3hk99qvxm9qzmklu9f",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1kafq6reya5v8ksdlnpyzv5gnyax3l3vp9l79wd",
+    "lp_token_id": "terra1g95dha38ht2y8qchz2zqa0kjnr372zpgsyyejx",
+    "asset_ids": [
+      "terra1g0rda5pawz0duymd37puescqsx2hgqu9hgrp8h",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1kag0uhcl2e7tddmzaavqr7agkhr9ukghutryjm",
+    "lp_token_id": "terra134cyuqglj8nmz2us3y7nl7z4mqsmj2dx8f3xq6",
+    "asset_ids": [
+      "terra19k974ngjsml8dtmk56cdhuy6pplr94rxqdt95p",
+      "ust"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1kcdknzuz8q5zjeyzyy30ykfpf3xs4dzxh57vgw",
+    "lp_token_id": "terra1t0mgl6lns0ff6wva27zjwqfpqrjdzw550ed652",
+    "asset_ids": [
+      "terra1aegvmfgdl4dclgpwtajll6382tcc7r0saa2eek",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1kd38g9rmfvklwyrszpe43dddhvl8zdgeya6ms4",
+    "lp_token_id": "terra1ek3f48k9xje7zr6ytfdm2p9xe5qkx959kgrle3",
+    "asset_ids": [
+      "terra10ypru3yma98ukk3anr5cjv02yq839pcvqc476k",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1kedzs6p7mc73lvnw87gvp5aa5azynafthhsxpc",
+    "lp_token_id": "terra1e8nn0zsqmlnhmxfmwe5qz5p3utyx2fljemtrya",
+    "asset_ids": [
+      "terra1qgvd7llck3nfav7n9k2qh35zcsmjwap073x5et",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1kgytwyu7aqah7cm97xeeurvsj3n6kxp0tc9esu",
+    "lp_token_id": "terra105wahgnrx7t2dsxfx9wer2mtcfrvfpr5hjxyt8",
+    "asset_ids": [
+      "terra1kd4rfff04cvw7vae0szgawj0xye90fkchljv7y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1kjlt8zsdvmxaw63u38krl658zunaj9hzxwknqs",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1zqyfp259xhhct6q2alp88pke90qrxgr5u2zc7s"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1kljzhnu4edtc8f8xzxu223n03hj82k66xp6mfw",
+    "lp_token_id": "terra1caxrxg3n67egv4u0v6klt66nsz4y90sydlatzr",
+    "asset_ids": [
+      "terra13k5m9dmcdm8y52j95tuppuz23lvjug6hrh7vjx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1klucl4s6jusuvrxag9hyay90cq4h80mkjhkw9j",
+    "lp_token_id": "terra1m28rcqy4fhhu9twwpuv6fdajwmfwlm02lwlzw2",
+    "asset_ids": [
+      "terra1u2tj2wy6gc8gw9g507a66796ej2csewp9asznk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1klw8gs2ra6tvf0s86kvye26lcv3ztf885p9fwy",
+    "lp_token_id": "terra19uvpg6ppn5jqh85c72rw8ywnyr9ecalgfe20ek",
+    "asset_ids": [
+      "terra1s56hsyhyvq4xxxvnz8qr0pnktm2dadsm4gkl45",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1kneyp2t00kehpwkaxml9w7dg5p7nl703dv65vr",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1gs2pykgl27l04e6lprgqs6uwlr7rm2vjcnya8g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1kngr9srtrzfwz0y8ckjhx7559xhdgsthu44y2k",
+    "lp_token_id": "terra12wmaguvdvjf225ua9xjwpj5k5euy6nhtu334n3",
+    "asset_ids": [
+      "terra1q0q09duq6jsth9m0gfj7fpxlxwlj5fcxgchuza",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1kngrh3kmwngq7t4kcnqdustp3qurvenrhphyxa",
+    "lp_token_id": "terra1d49ve0m99xz250uyj848yd9sgwuh5vw30kxm9h",
+    "asset_ids": [
+      "terra1ypgjelmtp0mv5akzwmnj5xhukhd3fy9gd28wpj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1kphghf722vxe0aq04n4erzflgcpp0pysrvtj0p",
+    "lp_token_id": "terra1ay647sah03j0zv7pn62sp46sys7gqtnawnf3u7",
+    "asset_ids": [
+      "terra1l0rnt55mf8q87q2nqfn9un3lxnmxkhqrl939x5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1kvg5qyt25nrgkqeuanz0k7cavxg0qxe2lgjh90",
+    "lp_token_id": "terra1k093hrmpy8l930ehgtvc7hrdkja3pnudr7ue5j",
+    "asset_ids": [
+      "terra160y9666sr9ctqfzk4mu7useh6g6swet8vnl7uz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1kwhysskh35wqrsuxyv3c02cenwd05l6pm96pnk",
+    "lp_token_id": "terra1zczk7ccfd2wfetyq8y6gkg0qghntahd5pq5qf7",
+    "asset_ids": [
+      "terra1edualxuj7afpm27uxvv38zr4e0zf4r4z6twfyf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1kx5dge4hsm5ke5vuxzp06as8lxv0d5dwl54xep",
+    "lp_token_id": "terra1ug8jeyh65zxffe5wwj3j88fntdjdaj8xft6g95",
+    "asset_ids": [
+      "terra1kx73zld4tmv24r66h7jp8gaz2rrl4asxlzq2g4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ky57u0437dszysa0qchyxcvuxs6ax9f3p6anrv",
+    "lp_token_id": "terra1nq8x3tc9gudc99pp0j58n2q50us7al8v0y9eh8",
+    "asset_ids": [
+      "terra12gsrt6nmp56x0q9t9h47frgr8praqyaqdvpaan",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1kyrnvh3l0natnqsapzalahmp4t29dz3ylxkp3a",
+    "lp_token_id": "terra1qwyfe8zymqtnhcrt46yhtk290h9cdpynx3gg3m",
+    "asset_ids": [
+      "terra13u7ddpvnxlephv6ltswy7c7hnq77agz5078l3y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1l0ldny298vsdln3gsd8xsfzln8yddgntuc3e4p",
+    "lp_token_id": "terra1g666d8h4hsqhw8s8axdrzeu6n7sul2w2zsgmn8",
+    "asset_ids": [
+      "terra138d8ek2zl48pp3el4s25jxnxn8m9nl2n4y0glm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1l649ch0y5nxnu5mrkefjfsgyyn5yj9pqjyfgc0",
+    "lp_token_id": "terra1k43ed8sql40cxd3mgaqujachuhhdrpzvuj7tvv",
+    "asset_ids": [
+      "terra1ddjp4wgu52cktzgzvahwkr4dcd95mxaqad2pmu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1l6s778y6gljerp0epa8wwmj7dxtlm7qfrmk8h7",
+    "lp_token_id": "terra1070nrsj5mf8qhess7f3vtylcmryhzpn9xqr577",
+    "asset_ids": [
+      "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1l7l9grndgnjagmgm7e0wf0aglwrj3wtzgcdtz9",
+    "lp_token_id": "terra10fmk0879fn2hm6728kgc40ytkqgn6cdxfnzyty",
+    "asset_ids": [
+      "terra1zrfd9hf3z6kwewxrt3rluzdj5d7ymzxnnptc6k",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1l9l4slsr2tllds0r85nuem4fcmqrtjdp655pdt",
+    "lp_token_id": "terra12ncluxlmuwkhq492dkd8y6g8p9kzt50dvdxxtc",
+    "asset_ids": [
+      "terra13awdw2dt45l958q274ukg0hvvmctghllv343lp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1la2j3fggypkv5v7rc3vdrs6f3nm5duexd7y4pj",
+    "lp_token_id": "terra13wn4sj9c09638wdxn73d2hgzlzg2dp5gh4fj4c",
+    "asset_ids": [
+      "terra1n6eltvex47mta0me66ygqw0fgvjx2ul7qm9fjp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1lc2jzj4x8r7f6asy6vf9jlwnjpuz83vuruutkj",
+    "lp_token_id": "terra15s5dsy04dkplkf7k8sggc5nwc40dhnx9eektvt",
+    "asset_ids": [
+      "terra1k5hx3egz7jnzqs7n2ze0d93mce80y4cndd5saj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1lku3pluvh5hgdr76d2mmz9uch55uxqkk2nzc42",
+    "lp_token_id": "terra1rxsqmtax455x5628dzhjtflcs0grpxar6hcgvl",
+    "asset_ids": [
+      "uusd",
+      "terra1v7q43s46ntt4p7cpxcvsxjk6srr7uxvldn6vuk"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1lskrhzzyxtm235j69ty3y4fk7mswczq5f93ntq",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra10l407saphqe2tc35ejhzg7xyulqkeqccvvc6uw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1lw2vz28ajmdntvgfz95rdgljq4gc4qw90wc6jm",
+    "lp_token_id": "terra1y0ej8fdyvcy4736m02eu8d9ftr892de78dypwp",
+    "asset_ids": [
+      "terra1zucgllq5ddqkfgsyjr7qnrfhymu0y4rgqsfyet",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1lz2uwr6jqjp08yqf6fee8n484hdxa2rzpte2h4",
+    "lp_token_id": "terra1je8e4j30696s3j2tv4rvscnzgsan87uqy694x3",
+    "asset_ids": [
+      "terra197txx8gsllv9rakjs6zh7pw6hnlgvte8yf8a8t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1m74nhtm9uj36jc3024y403h9cnh3uvthhpq6zq",
+    "lp_token_id": "terra1hfrwjf66e7ayc90p53t9h5qxcqthtg5ug4yejq",
+    "asset_ids": [
+      "terra1jvsfc3aedh7cyf3wd6vs7r5fmdsf4v6veh525e",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1m7n5p8e0mkh370mfp0e93jfk7uc34gxxxqegwn",
+    "lp_token_id": "terra1srwc8xh9d5zx700n7n7unq4eww620vw384pwvg",
+    "asset_ids": [
+      "terra1cu7zc3q8089cuu4z5ed5nl4c9w59qqhs2mmfyy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1m8dlx0g0j00xlxvavh972sk0gja2xn5gxjvtu3",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra16ygrvq7q2zxw7jj3f96racur50w0g7r0mj6e2y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ml720ts5kfg5s9hhsft74hy6clqsevsqkvu0du",
+    "lp_token_id": "terra1vkjgr2rsagh52jdcur4zgjyj7ag5xrfmyekne2",
+    "asset_ids": [
+      "terra1037zmxv6f73e5mlq6hsyadlev0fj4q462llw3d",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1mmc2z9znnl92338yquuhwzh2vj7gt9ez66nnt5",
+    "lp_token_id": "terra15hnvcwq69maqesv0497f45fez0lmunmghjqmwf",
+    "asset_ids": [
+      "terra1g5unnjllx9900hjsx6x3zhhv504ssqktdc82l5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1mp2d8zjhtenah2rgv7p4g6zaxp3s44pqx9z5ek",
+    "lp_token_id": "terra1zjxyrnfgf93kw5uhamvnqxdfnczqhwsgpe0evv",
+    "asset_ids": [
+      "terra1spuk4t4lxsmgx8wqq0ltqrxagnrzwvk6lmf4t4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1msws3xuf0ey3l0sdt0t3rw49gjcq4nya8h3lad",
+    "lp_token_id": "terra14jaq6qur7mafha4ky8u6ct67xav4zt054p865j",
+    "asset_ids": [
+      "uusd",
+      "terra1ld37cm20t8z3r0zvk7hx2qcfr2cdayteed8089"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1mtt2dpjah3mja54rg9exyexsdkw8u3pljdu34j",
+    "lp_token_id": "terra16ledesd9tn24fte454883p577qvr24hngmfefg",
+    "asset_ids": [
+      "terra13gdkkedrnd48kel0fc8sr08usdfpdce9ku6qku",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1mwsw7mzxqdv33naqg50quz9ataxfveur7u48aj",
+    "lp_token_id": "terra1sdlk96gvztayg9yayxksaghrkwv5hsz3psu3xn",
+    "asset_ids": [
+      "terra1ep337j8q9xm7t9ypqugr4yhgnvf0jgyjga50tv",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1n4kt65x0mmynpfdgcwfz36dwws2v6er3eer6dw",
+    "lp_token_id": "terra1ua0ehzs2z7qq05qehnzvp44gev2w7cc7vnuyh2",
+    "asset_ids": [
+      "terra1qlan324u6rsdevvc6ye3m02ump7dtp3z67uhqy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1n5nzqdktzh6j935y09244rghn6zl3ga6h8ktdk",
+    "lp_token_id": "terra1t32vjs5l5f5452kq78wvtaest5qkhr37vymcfa",
+    "asset_ids": [
+      "terra1mtm6l7xdmpuelf2q74sq58d2e5gwm72d42algk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1n5y7ym6x3ma0en8ff692406gtaagk8e7l4nyzq",
+    "lp_token_id": "terra1dntanjjlturgu2zn3t07evdf6cljepaap3vmfa",
+    "asset_ids": [
+      "terra1y4yx8w0p9v247w5uv5hfqv2fccda7rmt65mwcd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1n7kaxpxslz5aw36gx2mnc9a30n4yu0us7x2xj7",
+    "lp_token_id": "terra1237hndgalhuukzuccfvfjj538az8739td5cnaw",
+    "asset_ids": [
+      "terra1xs3pv5rd2xu36w9vg05shkgxcrxkvz40fhnfsv",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1n8jq50xnupyassyc3z4apwc33av3499v45tllv",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1lxh32h38lf8xdk6lv7k5w0ewy7gu6psy4gfmnm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1nayuuwy7mdcjtka7n9xt9gpcpldyqglt0jt5vf",
+    "lp_token_id": "terra17nwqqwfedrq50k779ulvl8da3jncj960xjylns",
+    "asset_ids": [
+      "terra1lgx3e9f6fhqda47zdyntfs07rdm5arp745mec7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1nazuk5vy7u5nwdnlxefcevy75yyr9z4mejq0a9",
+    "lp_token_id": "terra1mw45v6n4n3r4ekcqn73t9wmed9xv45sx526ty3",
+    "asset_ids": [
+      "terra1m6myw86l5zgw3z58z6rynr8zxaexprfc3m3357",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1nf6wl37jxthskggvesngsp7y50s0jchmur57v3",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dw6yapjv8k8anef2kg43hewg3g73wle22ncaje",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1nfkhe4vy2844352ev350ldpccw06ud88qptxd6",
+    "lp_token_id": "terra18ypccdtr2c57zd2q8l6fu0fw932ewawlx25pzk",
+    "asset_ids": [
+      "terra1av9tfs7k5gfuzm04e7p0d4ezrc53vq9mn3m08z",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ng3vjr2av7hgx9029pyc3v6y8l4zy2gf7nrk0c",
+    "lp_token_id": "terra1qwa26w5mdznxf52zug3qegzhq8pggutfqrdq5y",
+    "asset_ids": [
+      "terra1hnsqjjzerf2leaufj7dt9j54nyjvhyppj7khaq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ng4tm5a9sru4cgwqs77tm5fh47tt4sh6glzd9l",
+    "lp_token_id": "terra167c9s2r2jkze9xe989wfeek2zkc87ggjcu2u7k",
+    "asset_ids": [
+      "terra14yyepy06yw57f4x564xrfwxvv460vq0su5ype8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1nhsam29a0cnxv0sd7tk8s5x676wq9rar8vpqwn",
+    "lp_token_id": "terra1xgn0ffavkylmh0rh2upgapj0sa9j9apray0eu0",
+    "asset_ids": [
+      "terra170r0wm50x5eh47zkvlrjkxhajp4g7wrmgsz523",
+      "upepe"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1nksjldc9ze8ql6e93fms7d2y6t79h8qzv0q4yf",
+    "lp_token_id": "terra1xyzz6yvtvndqx4hp78vuvnzwt82xraw8xd5y6v",
+    "asset_ids": [
+      "terra1wlhgvtult73t5vpeng4sw9qmsq5jlujfm98gg2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1nsdxqpe5upkvy9jegqdkzyhetravf8vl7m496h",
+    "lp_token_id": "terra1e7d7325sjpfk02vnzqkwsnlu0xqejydleeh2h8",
+    "asset_ids": [
+      "terra1xs3pv5rd2xu36w9vg05shkgxcrxkvz40fhnfsv",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1nugs0qddjw9eznndg497ukt04cq0cxurql52qk",
+    "lp_token_id": "terra1fe089wx8cnm3pfk9am2rmexrwu0vkp5skzphnm",
+    "asset_ids": [
+      "terra1a2f4pxdqd98qclaeafdqxlc3dvnt3wqedx3l77",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1nurx5e8lh8pfg8hnxw35duczvsx6lhdjrxy5e6",
+    "lp_token_id": "terra1e6kja3hn04rhc8lslkdk63ry0gspr6zwufs323",
+    "asset_ids": [
+      "terra1zfcfvsw9m3gzk5l42cek0ukn5g4dmd8gl4lyra",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1nvmffcs9l6qv7c9z0unkt69jk2qtadaqw7skp9",
+    "lp_token_id": "terra1yek22pthmx98yn0k3jdgu5t9tevd79c9z8l60l",
+    "asset_ids": [
+      "terra1vl3khh0w2fydtd72ly03vjmlll4nr0ldcl9u4z",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1nvpfq78mfe6emt35f9fgys2vxwcdt3kx28g08a",
+    "lp_token_id": "terra1r2ec9hu0l8d2xrl6nnawy7exmjyrlu4usyr5fh",
+    "asset_ids": [
+      "terra1gq2yya7grd359c4y0wjfdusgrh805r6ml9jyyl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1p39xsp5j3e6e9703gguen049pkf4p52rmwf2vm",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1lrdzs5tgllwqgawtq2emuzn7snpxq87fzzl44y",
+      "uchf"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1p445mk3wsctep477kpzvp6a4xekyzu4fqcc456",
+    "lp_token_id": "terra1zeestkmhgk2vjwq9wg396qpjvryftwqt2u0xt8",
+    "asset_ids": [
+      "terra18m6fr3fk9xh0u9vrvyeu25w0k40dptfrhw53rh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1p6nzgyy7gq9hw54errcyrnjkf7p4expcsnmxz3",
+    "lp_token_id": "terra1wd25umnrgnfydwd7k7m364ykk79r76tclm5v4n",
+    "asset_ids": [
+      "terra1ctfsa4qfanzmz4my78m3u4r9k5qr9gpua9f6hj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1p7npd4c5f8vsr47ncvkm50qfkvddanwy4er5ls",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra13kr45ssru9cqhp2kaaan88wfaa7f2h3jfvuldp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1p7y8st3wjgs62vs3w9dw2sf603e4777v3jamhn",
+    "lp_token_id": "terra1y3c0z35uju9apsn0faewjdw630tqalhmtpgtc5",
+    "asset_ids": [
+      "terra1h0jk42weh0urhgdtjql93rrvgdccspnp7vyf49",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1pcjl6ammvypn4z4srs9dgzd2pgqvsw0xy85fj5",
+    "lp_token_id": "terra1qt6nek5pe7l0l3hwcarjd62mn24a6v7kz8zkxf",
+    "asset_ids": [
+      "terra1r7e9a5su34ne07e6v0r7n2xp4h6tjkxc8j2lz2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1pcwu6flzc3srtu44cyvt8c7dn59lkyckprhqht",
+    "lp_token_id": "terra15ggrlf3z0j7phzunfh90rjscuvrx4hgfljxhf9",
+    "asset_ids": [
+      "terra1j7p2fxrzryfpzrrsfe585klnkqutg94kca9vtj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1pdstq4vkeftz5kmvwk5dzaytpesv5f3kq5q6s5",
+    "lp_token_id": "terra1f0tup70r7ycf682vc9h65p6g59jk8eefvy67qn",
+    "asset_ids": [
+      "terra1ppuu0devppvm6d75sclj4vwh5ghwyx7grurlvx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1pfdfzk3qs55lwtd8l00da7cext07ufpn9fe2c7",
+    "lp_token_id": "terra10skty5urn3fzfkwg3f93z2f56xm52gufh2u76l",
+    "asset_ids": [
+      "terra1daa3rrcq6nk9vh3ecg08x7rmkx3h6egsfex3ze",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1pfkanl8ycczuzyj02rjr3vx3sw0us9vxhpr0mt",
+    "lp_token_id": "terra1n4cydpuvk8encunn0ag2h0y0pnzjkh4y8hr0ua",
+    "asset_ids": [
+      "terra1h4wq9krj88hcl0m2e2kxfn3gznga30g5rrm4qa",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1pksem0e9s7xdjf08j9swuyr5m677660qhyhuqk",
+    "lp_token_id": "terra1saxejc25jretqgp4z6wj9me37qx8zg4lgzrmrx",
+    "asset_ids": [
+      "terra12k6ua9et2dnpmmq2rgz0wn0ugzr9jtyps5l8vt",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1pkuqexqszqcxszy9fpmxdnl6gwefjd7vger0jh",
+    "lp_token_id": "terra1w4276v5yzxa94ess4ryyfwanssfr3psgyk4jm3",
+    "asset_ids": [
+      "terra1u4gx4v0nqgzm2kcajk3xf0d35gutwcvdyyjrnc",
+      "100000000000"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1pm4gx7u354nlgjdz0xf4kxpx977egdt6z5naca",
+    "lp_token_id": "terra17tdq6g3xqmwpk3q4mgfl0qcuyz7sqaxqa3n0rm",
+    "asset_ids": [
+      "terra1v58klw3jakaeas2dkppqdh4y4dzd52kzda2fgf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1pqpha5xe3fhtvyplcuwyzhls8hgdupahujpyay",
+    "lp_token_id": "terra1gdndzwhsua4zw90pef309ked5h6npusgcu2j2c",
+    "asset_ids": [
+      "terra15xf5wqprgzl59ckfyjtgavh7rqtxcju7gn57rc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1pr0nnzw0elpqk8q2shc5gjnzaz95q4j8qy65w3",
+    "lp_token_id": "terra16znt4xty0md2k7e6evq8thsumhn6lm4kavqzzy",
+    "asset_ids": [
+      "terra1n8awtfqa0wphx90pd2zc9v8vccc65f0gvv6rq5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1pr6tmhnve5cawzauzyzw5uscz558gzmd3d6wps",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1s8gu8mx2qcxpx9y90fxvdetpwq9mpyrapphw2u",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ps2j3kp3gwjx56fsahnnkmzv2y9e597gqkulfn",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1u02kfjra4q9272p0ckq8yjtfc5qq6584amvrnm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1psuy4666c74vz9exfxvupsxmkgytneq7gushws",
+    "lp_token_id": "terra13084cqs5f65aal0c7m4zefh7785t3wvvw6dx44",
+    "asset_ids": [
+      "terra14l9lspj9lp2rpnhp6qjpruwcqst0yvl9cm6l96",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1pvetz858samujj0gkx7rr5n8m0gcy5gz8lcxz5",
+    "lp_token_id": "terra1kxqugyrr0e4he5furrqrehr8qhzqpfxxnt3vlf",
+    "asset_ids": [
+      "terra14tc6kg4my06ckzugrukq0r903sup3a6agdmx4y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1pxlm7mjmqc4h4ht494jvmmwq840zn77eyex8yd",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra14dtgwushpvu2c8d8rtc58z9r2t4p67ug8wl4d7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1py6jq9p9qjjsqfg3sfj3stkpggyxl0sy5a006s",
+    "lp_token_id": "terra186hhp3gfmqf2353pekrcmdpajfveu56j0ej7ft",
+    "asset_ids": [
+      "terra1u2k0nkenw0p25ljsr4ksh7rxm65y466vkdewwj",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1q0vldkwqgc2y2crhrcsdw2pacdt8nnrgvzcsf6",
+    "lp_token_id": "terra12qz82rul3ukhgaw06n2gv32gehermzu4zd8pam",
+    "asset_ids": [
+      "terra1exgprpvwmn9we9xfxlqzchfqd533wtnafhg0w4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1q4nynp5mp4yhtxkyzegdkf594h94hhycmgxdq4",
+    "lp_token_id": "terra1s6acdmcz4dnphyw8yctl9qmkxluj8u6snankqq",
+    "asset_ids": [
+      "terra1hpz206wxjhta4x83ukmk4v9rvk9dky2h0texf3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1q6h4sgkulkxl6tq8tafadl899sc88zp4dj6yd3",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1p2enl6vfmhdfj7ud32p3fkgns22sg62ls9mh2e",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1q7hat4ymhtawg8agg70u74m8eu3q7qsg9rqmr2",
+    "lp_token_id": "terra1m7gu655my73ulr42zhaz466mgl65au8dwvp3vj",
+    "asset_ids": [
+      "terra15wwvprh6gddrc7yvshghc2g944ufsq79ay94da",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1q9cxc20mhr526qhrct46ucrwxywmv3daa7a36v",
+    "lp_token_id": "terra1fst9xfe8wv8jucvnn5afnsmkzqf3hu6yy2d9y5",
+    "asset_ids": [
+      "terra1vdpk5k7203r73fgl2ppwsg30vmtu5akgk0emse",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qgksgy6g76jx9732u8dpdy7epqgwtyy0rwj53n",
+    "lp_token_id": "terra1n45t7tamwtrnr48f43pcq8krul8yf4kap8xfcq",
+    "asset_ids": [
+      "terra1aa9kg8crxjq86ts54d4un6ku5skec9e98t6tau",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qhpgt8pglujysknesj6jnea5tjc47upuutmee8",
+    "lp_token_id": "terra1gzvdqgg9zrgv92948l923hjnvxgldwaqzshla3",
+    "asset_ids": [
+      "terra186qt4d07ghj7dm2x64tyc0muw6rl2876jlhv38",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qkjrvyzncs8h2w6zyctm7etv743x0vl5syrc3r",
+    "lp_token_id": "terra1uxgl9umfun75qkv4gctl3fk4cqv02crsl5y57w",
+    "asset_ids": [
+      "terra1vlrerpu78hdezzz8zzx34adpced73lmd0ujyqa",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qksw58xydjsqh9swyv764jptsdfskzx52qvalg",
+    "lp_token_id": "terra1eepaxpggqy23hefzwj57xtfukkaq240mrmlnm8",
+    "asset_ids": [
+      "terra1v8xzfedstujqexgz6vd902hppykuu2e7ar3pu8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qm7vvqg2jh5mwkd696luhvqe4mx96e4xuk60g2",
+    "lp_token_id": "terra1xxj9nsxffy6hcc6mfq84fjfwt9k9e0n4800pgy",
+    "asset_ids": [
+      "uusd",
+      "terra1lj0m5346vc6da9r9ljcyx7letcl3727g7wac62"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qr8vxrmlsyune368pd9nmgfuqt7kdek7yy6kwx",
+    "lp_token_id": "terra1trdcl3lw5ca8ta7nfm5qh7w0mudfn6fdhl2qm6",
+    "asset_ids": [
+      "uusd",
+      "terra1sa0klf6nt77z3afqlx7nq30xrvr7hsfz5jsqmd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qrlz2dl224glxn7sqa56wpdx7dz6yn5jlxm02f",
+    "lp_token_id": "terra184waaggxgdg4nevql50lmpeyferkmal7f904eu",
+    "asset_ids": [
+      "terra1sqagv65dlqj3hlg4fxrljlhfg5wulsp4nm58j7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qrrr4kqfqptd7wx0f45sgem6z8ejenh3k7esnx",
+    "lp_token_id": "terra12j3ye47a9jjk9jtjg7k8f0rs09hsvdpp6tpl58",
+    "asset_ids": [
+      "terra19tvczk4us839rsvet9ncwg8est73nmzecdewkm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qsf2sn65fjyc5hvm2v9a65qcyc23fnylr84fsg",
+    "lp_token_id": "terra1cazwgay0h75rt78q2vxr6eggfk25xf4d0fwj7c",
+    "asset_ids": [
+      "terra18f86dw6n40r6hqzjw0qsfe09nxesqs7vx2jkcx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qstd3t9jv9v24ew6v430c42xfx9qf7mg7sg28d",
+    "lp_token_id": "terra18zs698tsn3600gtv4egtzx34uppcahzg7qlh8x",
+    "asset_ids": [
+      "terra1kh0w04u79rhwvchmjsd7q4xxlm72y5wpf6a87v",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1quwpd8khrwhuvqqk42mfw0q56nh524gu5zm294",
+    "lp_token_id": "terra1vawsn9qcgq9dcrjwldmqtmp9pj4373eapurm0j",
+    "asset_ids": [
+      "uusd",
+      "terra12wlcu0kgdfrfutjydvvcmhlx8jrfsqhwqarc3d"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qvy5r6r3fyh6rk9j93e9w63z3qu4wlmxemd0kt",
+    "lp_token_id": "terra1z27p3u53z9tfagnpffqe64js9l77w38ywyvefp",
+    "asset_ids": [
+      "terra16gnk7mpqr84f4mnmqjklpdxxe602dn0fjslwhy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qxvf6f92f38wznvpyjqcd8ncppffuva79rvdeu",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kafnpwanfluj6ne5t8ayg8ykarx060a50l72sw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qyag7j7s5z0d02em5g09ltgcztxpdguz3pkxjk",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra18y93cy77qrxx65vdz959g2ngms55v3s3yythys",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qzlnxa9mdnxkhs6wwf0xvx0hxqday87dgxn9yq",
+    "lp_token_id": "terra1mfs0xeakt59wemvwyelmh80025a3m06jfylx2e",
+    "asset_ids": [
+      "terra1ulzl6vfexrk39vaje0qryarzlq2ahy80cdl4fz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1qzrqt3phmawkrrzm8x8hwngz26nrpdgpkw5pmd",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1p0w9hh9aea5mg26mjnx7tl695ldwxfksvw4yn4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1r3cjla7hlktc4vfa0dmzz8489e88k67yxjndpd",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1r66l8vkzyhduuq7dfc8nm6p9wlwtnclve4wpxl",
+    "lp_token_id": "terra10zlafqxy3zyfx2wh35mxh8xepp6fz3f3yl9e8a",
+    "asset_ids": [
+      "terra10yycj46tjfnfhkk5d6er49gvcn28jpqk0spthr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1r6dcz9whd2dxunau0vtp3g06n0yus9gfaq76pz",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra17ckx25kqhwzf3fudprs78kqgp3lhpr2w74yf7t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1r909kfjzeuj9nhwle2d6kg5jhn2af8j59lcsqj",
+    "lp_token_id": "terra1tc3llqz3ckh4ahepmv4sdxc3s4dvn9vqxtax9l",
+    "asset_ids": [
+      "terra1pafrxwl8ur3jzjgw5qhts9vku68xsenctgqvkq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1r96mse06m03de6jkx52ku45p36htc9zx8k89l4",
+    "lp_token_id": "terra158g4r6gglcsst7ddua65rzfvzqums08y5m5dym",
+    "asset_ids": [
+      "terra1vpws4hmpmpsqwnz3gljn8zj42rv7rkpc5atgt4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1rcdumk59pxaem9my3frynyu3jgrkj9v4han9eh",
+    "lp_token_id": "terra1w3z2lk8skrdw7ar9vq2kf5jeam9ar0m257k843",
+    "asset_ids": [
+      "terra1sdm7qux8u0qtfxa6ukuh3zgppazdxlhmmjks23",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1rfdh5rephrd37ga0x5cry9lek8eutf54umkk04",
+    "lp_token_id": "terra1wq2tmhvx2yn3zqdah26sg3xzlaaxwd3fhsnj2y",
+    "asset_ids": [
+      "terra1zdpymdwpyg5gj5ye4uvr0mqmxw8c88k5vqegfr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1rg9p352hcepvclfrxptpk0ua7a0tz4gcc0f0p8",
+    "lp_token_id": "terra1d2muut0rea9fkff6y304yn6qkr2uacau7ltggc",
+    "asset_ids": [
+      "terra187lnjdwluvfnzxcef4appgr4v7fwljj5d5wdhf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1rjdh8dj7jrjwz5dul7n8m9eyne92rvzftnjueh",
+    "lp_token_id": "terra1684j38r062hr2nlwgf4ludpt9zk5g24g85syzj",
+    "asset_ids": [
+      "terra15afvt8ch38n8qj4n6wvykwkl2fqvfla826qdqe",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1rjv0jjm9mzgrj3grs2p0gvyuwpuf5qt9p30wwp",
+    "lp_token_id": "terra184ufgqclvjkuycs82j0fp4xha8r6rryp7luj7g",
+    "asset_ids": [
+      "terra1lesh2dshyf8a7wfm9fkxfrxjxc6yuyqnvspuvw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1rn8stwf23aes786t37je7v8vxe9qwyzshrl9ft",
+    "lp_token_id": "terra12eruh2ggjy2q8wutzsg2ww90nrucxm4hmuzdct",
+    "asset_ids": [
+      "terra16z32tp6cqx2f7lpr8t4scv8hj9zlljagprxfh7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1rnenevclqn95uhszznh6v25gaqswfejsvcatu2",
+    "lp_token_id": "terra1gmvqnsr262yea2ltxvv6qxqgl26jsl4ah0cw2y",
+    "asset_ids": [
+      "terra1f887h6wqygswcp4arjjak6mpdhwlrv6nj8y9wt",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1rpcz0746qj4f6nwcpap8z5knjpf4fj6wmalupy",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kx4y3y4pn32jssqr90cj0rw89ds98dc0t5eqfp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1rr3rf5kptdtemsmf3g3jl8sy8rtamz2y6mcyh4",
+    "lp_token_id": "terra1syzg420suxvcarx38k7vep65tdqmpnsuth8a5w",
+    "asset_ids": [
+      "terra1jkrl0xap6ptp8rd5lecp2j2sx3kws8rzxljsxn",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1rvjjnmeq5a9fje6r2guaxuezd7mhghk4t9cw4p",
+    "lp_token_id": "terra1l22rm7mmajqgxep8lv4nuwzvuj9xc0xahfe9lv",
+    "asset_ids": [
+      "terra1vyenreh8z62r35rydtupkqnmjsalee4tl90vn6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1rwezyr03fs72talr7g2gjgr9jmfew834u7gl5l",
+    "lp_token_id": "terra17v6ravmxwz8v9je9w9c23px3zhcvajk4tndt63",
+    "asset_ids": [
+      "terra1y273xzgr58qsdkc89xa6qu5y9padxtm265am00",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1rwsyvg7e67rald7d45833nsw487f9mt2wk7a23",
+    "lp_token_id": "terra1lyldsl94d3w3jhcenqjwsp4cme9jufur8fahk2",
+    "asset_ids": [
+      "terra1tewnpkjdtqq37udf5c5wjfrtkpegthfmls8lp7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1rx428v0rr62qcwd0cppz0xwj9qrh8zpqkahkj2",
+    "lp_token_id": "terra12awz2khk7ccyzfhstnzzgu5um4vt5yts59z4dz",
+    "asset_ids": [
+      "terra1ts6qq7va0msf0se3cwjsppt3vkumkh3t6n4d8a",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1rxwlts8xqulfrmx66whcknczmqjh05hdhwm4zj",
+    "lp_token_id": "terra1vhw9kpcshkr2kfrjke3pgp5sr5vsxdu2cjrf43",
+    "asset_ids": [
+      "terra1ufsyu3ddskufc7nel5p4lyrzhv8qdddg3tl550",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1s0tfy4juc4pj4ke6mr9u68mnmgfapplhr52fr8",
+    "lp_token_id": "terra1aef680pzs5cm30655wdz664v8jgeqtw76ptmcg",
+    "asset_ids": [
+      "terra10led4w62hglspyngk0ydxjsdvelvwthftevq0f",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1s2tkg3l4h4hrlsq6dnatcfhv97lyutpmxw0uk4",
+    "lp_token_id": "terra1hfad2shn4h26g75t66yjasyg3qh84xlkp5g838",
+    "asset_ids": [
+      "terra1whwxszdwu6m4pup0glpfn7qhwmnh6a49mrsv2h",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1s846ywp9gdkjfmk48cs8pd0phtsnn842zsgsa5",
+    "lp_token_id": "terra1dkpn37uh5f5j3u9rjp6ynpekm5kzd7ysfffqwq",
+    "asset_ids": [
+      "uusd",
+      "terra1m86rdykfvtwucrd0y0gzlel7wpcdryctak5wyl"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1s9gquy9js5z64eehsf22w2zq7dwr9a7lavuxk7",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1hja2d2790m6hynju77t56nhmmyl0w09s5acqhc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1sez4t0zhe9d7lxlup0j8u4cnkz0qvzr7dj2lf0",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1qrq5r95txaregxpa2c7mhf549u5jkm28rzmvt5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1sk902qkn05mm3j94eh6qz0rmj2rq4gfj363na0",
+    "lp_token_id": "terra10fh6hy5f9t8mn09qzrps889qtew2km3zs44q9x",
+    "asset_ids": [
+      "terra1jwjweh50vrd2gg55y8cr50e32jwwc0vuhvdymh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1sprcgsnem4yrnzjd67wunkjnvndjr45jme060w",
+    "lp_token_id": "terra1aa22fmunt253n4hmuerm7p2jmt08trj9l43ne2",
+    "asset_ids": [
+      "terra1tw845kgt0uq0gfmavawacfvaq5t9fa9v57g6m9",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1sqaw3rsp5w84r5hwvcvcgweqcxlrhxl3e5a9na",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra17azgr4x2gz20uquy7vdacfdgjjkgd0h9lm377v",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1su2magsez6h9xwss3czd8wj6l3c8eujed09d8v",
+    "lp_token_id": "terra1shwul2pfd5x5k8am6ffpts369s533pcspjr7m5",
+    "asset_ids": [
+      "terra1745fzfxnd8wx5kdrf4uwgj7k0mkqk64pdrh56k",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1svequ729grnrj2d8x609e45axajrdjz87athfh",
+    "lp_token_id": "terra1gm9lk22dcd36c9s86pqdql6ll0w2c8tpnwye0x",
+    "asset_ids": [
+      "terra1zsaswh926ey8qa5x4vj93kzzlfnef0pstuca0y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1svqq5rsjpvsrt6g365wrrxz3xje0jnjljax42r",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra138zs0y4arp48v0vpzqa7r4ehxcy7sk3dpv606e",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1sx3clxk5yhqjq5j5q87jw7qu27cn7en37zk323",
+    "lp_token_id": "terra1hggkcl2v8wxzpy0vzxf2a5chw2h2fh7avl7j86",
+    "asset_ids": [
+      "terra1k9ltsdc6e4ay4g8f8nt8qd7my9yyd27m7eh82d",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1sxxn4rxuqgxn3um6ly5lf9wsjuewrr7j8tvjg0",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1lnav098k7vd006lz7d73mychha503pmw35la7l",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1t4ee4m2merzrmz5uwuacuhk773wq82g32v6zu4",
+    "lp_token_id": "terra1fvlf5y9uh3ylxff40eda4j60h52lnkthzhrsdz",
+    "asset_ids": [
+      "terra1qm5jjajyv5pmap9687sgckc0j9hurlks3xzpx2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1tetfz00c58t656cg2gtyyv23jwh34sd590ue33",
+    "lp_token_id": "terra1ysma0f8sw7254l8nnfylfl4nded9a8wj7mn8up",
+    "asset_ids": [
+      "terra13zl9thu8cgpkvpsx8r652hvgw4p2v42sahz6t8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1tf360u087hzhw54yymtat9wd5p5c9a3n5jvhek",
+    "lp_token_id": "terra1xcxlsvm6q2nk003kqnhhddfcfm7dtnze02f3yw",
+    "asset_ids": [
+      "terra1vg6wky3jm7qnr4w4qtw6hflhlhc0v79z9jvnxu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1tg8yu978lhcveq9j4emc9f7agn00dvecvx4wju",
+    "lp_token_id": "terra18c9war4ldlccnast92snzt78ty378e0ggh8a8j",
+    "asset_ids": [
+      "terra1tgv52cmga9s6ymah2efz877xlpc4v8phq7mn69",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1twxv2kaeuyf3uxc6uzpgh3twe4mtagzpmn6sj4",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1ghkclqug2jhanmjsx46x0vymcglchcesg98057",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1u2g4fc0k4tq6z6lrdwhm4gry3q55dg8k9anjtw",
+    "lp_token_id": "terra1z0z6hz96au9lr027uedxay3s09ry36md3wpm0v",
+    "asset_ids": [
+      "terra1qq4lemqmahjfhl68kpzx0kheuuvfyeu4ncnkaq",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1u8dt2feqxchklzft7n0s38d7kz2wwx7zqey8z4",
+    "lp_token_id": "terra1quraxjgn87qe63h53mu8ksulqywsdlas648axv",
+    "asset_ids": [
+      "terra1gwr8mq2ljqzwmufgm55yu58339k55wja9529sg",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1u9hhdcqsd25q72dqme8hp8jkq6gq67vtg3rdq7",
+    "lp_token_id": "terra18wnz4a622jvlhk5xnwuetk93j5xrkrpy23kqp0",
+    "asset_ids": [
+      "terra1zpke3t4nprnh4044a4n97hwv384v9vff688cyj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1uf6gyusnqzluacssjjdcjt2yme6wvx23ac3hpw",
+    "lp_token_id": "terra1dwnm3mxgp6svmtng5shfkc52m8d0xsagdx6z37",
+    "asset_ids": [
+      "terra1cp02hkhu2nq7zznz04shwfvh9hdsp3y5334n6t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ufrkf9n6nlq35e0gdjyc5s7qx63mfhkxrsxkmc",
+    "lp_token_id": "terra1wm2rpkpd3n0e6mkjxkc3fy3a2nw9mcrrl0npj6",
+    "asset_ids": [
+      "terra1cqxahw3zls3x5k9sngtyjt5qm8nzmzsleyx8hh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ufzll076stnpmlmndlss4uezlq58gmwc83c72n",
+    "lp_token_id": "terra1slr9qj73j3gn2muf94aysdaeex6ahk5ghq7ehp",
+    "asset_ids": [
+      "terra1zfqe2kf0kh8mvyy3ksa29qqnkhc64ncffufg7g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1umst8uwnuvd42aecxzf26jyy9eutghxk4xvlkn",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1rwskqpnk03hrh8z8rrprzdluxhzc5udycdn5g4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1unvncye5u9qeme7amjf8snd889hm9mp93w4m9z",
+    "lp_token_id": "terra1s9gjv7083uvz0l90hdq2mq5d9j8je6w9ttax65",
+    "asset_ids": [
+      "terra1l0zqxdgs5h6tfdsvhm34mvwrevyt5cuxj6ewzz",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1uqju4mlp0f000atx07xd49y3dlwe50e0d8d4xe",
+    "lp_token_id": "terra19t9e42yxukxuuqzyekccm5jpu3gek3nttdsz8f",
+    "asset_ids": [
+      "terra1j874eyvev9pm7uxm0h9l82raswe3qwcug8wxuf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1usq239ur4z4utc8s4ecdrk09hd062nrdcdc7yd",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra19pz3ehx9f2thr9t9jk5y89aalxmhzuq9j8ak99",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1uukk3m4qemzdjatzh8p0m2qrg95f2yc8wrfzav",
+    "lp_token_id": "terra13ae05947uryk5x2us5l5dgkhmedsxudnxjwfm6",
+    "asset_ids": [
+      "uusd",
+      "terra174c2cy42fl7hags7cap8j4xtsmcc0ql2s8q5du"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1uxwgfuyn57xqek4jgxajhd3270khgyusncarnv",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra10t5spcvn5m52fs4j5tnjerm6wzsn9vuqdsheje",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1uyd2jx409kdesatvpwrvzkuvfyhfa0es0r9s9g",
+    "lp_token_id": "terra1u47cpzrevxlld30cw6veflzj569k5ayyly4c59",
+    "asset_ids": [
+      "terra13zemc0wmem8lt0un0lya3qtg4cpf9jcdsgtvf3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1uyq0vtcmzhz754z5rpv62u4skf7s4e7fuancwn",
+    "lp_token_id": "terra17wctee086rxqzng25jsm80u2mf5wx5lnyghuhw",
+    "asset_ids": [
+      "terra10vvl9llw4p7ca2zhmcdljk5el9fkpp9hg6qy53",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1v73xl4qu05ahep8c8flf83vvrr437fftdxwn70",
+    "lp_token_id": "terra1p62jdngzanleq5wrwehehwl05nkwzhuuld6nae",
+    "asset_ids": [
+      "terra1zp4xkexmng539vylktxkf45hxjg68ufx673x8p",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1v8lsm7hmkdwrgcxtlv3ltzvpup0ez6dr8nxdl6",
+    "lp_token_id": "terra12a5st8kc8hlypk7lhe8tquljcs4z89shah98ce",
+    "asset_ids": [
+      "terra1aas795lj3dt6qrsp8n38fr39ypt43p6czgz3ra",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1v8mkxsvtjjdln52ltu6u6ak87uvmvgffwvt0vx",
+    "lp_token_id": "terra1fhzyy5jgrjl2adhk3swalzdl4hnh0rmnusk9hz",
+    "asset_ids": [
+      "terra18lxu0868tj9pek9xn3wlgnlv0hs3s9t6473saz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1v9lxv5kje00972tyf67qp7gwdc7msxwr8wf0j2",
+    "lp_token_id": "terra1ty6nleg3m2lq7rfrlsw0adulaevsk76p4mfups",
+    "asset_ids": [
+      "terra143h4n4h3j36z64t7l8ey7vny6x47ukpz8s2gvs",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1vd20ymyajdvafp3726ft5wlndnlsqmyfr6pr20",
+    "lp_token_id": "terra1hgr37dvhd2r4mz0x5c2g60z0ggfhxy0a3lq4vd",
+    "asset_ids": [
+      "terra108fs4ahf6zzy7tqpvczg5yrfjpqw20kxc43pq5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1vfwf4vd0yp47renczuqe8n7yrraxa2j7a7q0jf",
+    "lp_token_id": "terra1cps2jsd3flznjzce86qyma34a4d45v0wz0yy4j",
+    "asset_ids": [
+      "terra192g6ran4vfvyxhz0q7g4yls29fk6379hza6plw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1vjyvxsunxs6dvu5kh08chk69zffcqcntccgpf8",
+    "lp_token_id": "terra1hyt7x6duee8qxhnuyjdkmf5ucg27a2fjl7tdzw",
+    "asset_ids": [
+      "uusd",
+      "terra16gx5th8mk5v62xpvgf675xj2vuaf3dg4v75ml5"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1vm6whnkl54g5zy82533r34fhuaqp58f9kn826c",
+    "lp_token_id": "terra1g80la29wu6pnme68wj69sskcnnqg7zha69fej4",
+    "asset_ids": [
+      "terra1aa9kg8crxjq86ts54d4un6ku5skec9e98t6tau",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1vn3anrcp54lep043kqwvk9433r0a60xj2tlgpu",
+    "lp_token_id": "terra1h44ahd05f63yamv553rqa0qzmfyp86j56smv4p",
+    "asset_ids": [
+      "terra1u02lqdhuhdfwph8wsl9yx9r0jupfdsd22q60tc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1vnrd37f7cjwgu9zgn7whqcjjuclhhd38qrnqlw",
+    "lp_token_id": "terra1e92r33fhkft6p8fyamwu3zp300t5l35cjxf5tf",
+    "asset_ids": [
+      "terra1c5wn5quxclujf8n38cu0sh2r4hq697lpc9385g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1vqc0pcdz97llaglpf7gfjtykhxy5r00uex0hnz",
+    "lp_token_id": "terra12qzdpl39xj79ra7s8d5l9tvrqmwk4924hphlvz",
+    "asset_ids": [
+      "uusd",
+      "terra1ezkr298e3lef6hh5pzmvrtw0qd0kc6u7dgl5rc"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1vsyw78g3jfn5kelw09tttxfklrhewgtp62tw0a",
+    "lp_token_id": "terra1xm9vcuuyduxy8cc98tuaknnhv5tjv4x5350jvh",
+    "asset_ids": [
+      "terra1elt5czsf7sntku3qafxf7xrjxdx309kkkmc8up",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1vu0hrz47per5rgq3mqjw272z3wgvk2x2qudvcp",
+    "lp_token_id": "terra1v09eme9k7zfqjm8a5yf3wrc5t66qqfvm50x2ks",
+    "asset_ids": [
+      "terra1w5pzereyvecexd9hsmlsakgnpjnlw56fgrha4s",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1vv088zvmzzjv5qgpu25ym9mlgcuxhksqxnrcp2",
+    "lp_token_id": "terra1svsdduee7kk6ghh7hz4c2rk8tkagfkzaplltx6",
+    "asset_ids": [
+      "terra13j3uuywz8q3tljmqxt6trcgcxy29dd5exrnhtq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1vvvpchwf7rac404q070x2d0jr20l0sxkcgv8y7",
+    "lp_token_id": "terra1ppaywpn8kyde0c0xngdfagjyq9l3jwudmckxw2",
+    "asset_ids": [
+      "terra1pxuknzmg3kup7790vjzssjjuelrq3a3ys4aml6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1vzd3vra0zfnug80gtuwlc2j5rtucr87qkh4xmf",
+    "lp_token_id": "terra1cz49n0uhccm0qdyd4crhjgrvrfhtucelr3u0fs",
+    "asset_ids": [
+      "terra152qpnfe76pnkwe8msfjxf4wjq0tcjtuuunv7eg",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1vzhsu5x9f9sglyq3acm5vq7hv0deemvdneqqw7",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1ex5age9gqd5em86wg8hu0ak5wrqez9yufvlrat",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1w0hm732ejcvyp59pru5e77j6wf92rdnkknf7u3",
+    "lp_token_id": "terra18nvqp4lhezyw30kwuufplp0urggd0z9uge6ucr",
+    "asset_ids": [
+      "terra19qcznmhmwf88lm75nmrj3prr6cmvtnz02hvu4g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1w2aryua8k5s0a27kt9v8662jpsh4wglctu9z3h",
+    "lp_token_id": "terra1jx0n352z9jhxsu0ung276fukdcn64vvyujyp9u",
+    "asset_ids": [
+      "terra1pshxc56zwgm6j78mhjgn2rgkj5d32aa887l7j6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1w7cyg38vclgtlsw5vxgxxleky2x29p3lh36yru",
+    "lp_token_id": "terra17selfzmc4a3dlgn5ewtwkg99a4hkhgtshh4z7f",
+    "asset_ids": [
+      "terra19ztfg6l5k22cw8xg2h0uncpg3kwpv84ft9h6t0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1w94sqf77fzlv9eh3fz8j5kmcdv2x230hnz9gj4",
+    "lp_token_id": "terra13tlvdmr6x6fqddezpde0d3aadk3g6ye7u6l0ud",
+    "asset_ids": [
+      "terra1p0yttugxt3h2zvs9cghysmss3um6dp0mzt9vwd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1wcs60r56r743ws6nxv3tn9pgz4xqv3x4lgeqkt",
+    "lp_token_id": "terra1drs4cetuf7hxry0xrh0vz79242f8clmtjpwhft",
+    "asset_ids": [
+      "terra1s0y8aldsy3t6wtg5tpwe8xzq3lyet5e9grwmlz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1wgyq7kdeqeq70uzv04effzrgndtmtmevv4p9xr",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra19y395vzlylv3s3nasr7cu4yey7s22ghqd35ps8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1wkcrktmkp3wfvwqvydlx0a3g4tywjktke4pva6",
+    "lp_token_id": "terra1hyc2qcu25cgg2fm75zee79a8au038mevhgaaql",
+    "asset_ids": [
+      "terra17pv5zcuddm96m0nuanw25u4p8nkc9460hz0sy4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1wn34gxq3jyg9qtjxjfzlj42jzjeegvgymdld2c",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1re7as700g3gels30zak6ctnjtsjhhc6vjr93ms",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1wpawa65459fzfvf244rz8c8q56ampvpkjnpe6f",
+    "lp_token_id": "terra1q84pz7rtnmjr02uqkpjt75r5hgcjxf0l8qpwvy",
+    "asset_ids": [
+      "terra1zpp3fdnpkrhpehjxvzz3wwwujmk0zxw5h4y0rr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1wt43khwmzaeyxm77jnq47hyurrehzczyzxxds8",
+    "lp_token_id": "terra1e0dkhp72ted6rcz2ptnggnvtfea2hw4r2luc5n",
+    "asset_ids": [
+      "terra1wx4h5qzvgp90ez53fgqr2s9t4rqzzjc03cjxr4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1wvhxy96s86xk4mynuqggxhm46jaq7h30k8gphu",
+    "lp_token_id": "terra1uz6m6h6seck9q870hnc8g2t8rxtzn5nwg7txts",
+    "asset_ids": [
+      "terra1zce4mxwwdyk04txa2f3aqepzsq8jy7ca50gn8w",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1wvnw3nkwdx7ut3ua4wwm5u0lf7sl3fqgy8kltl",
+    "lp_token_id": "terra1yh6uxxmr2yhuwrswkhtvq7wq5ra8ecyucdtewh",
+    "asset_ids": [
+      "terra1klz458efcl7md99vafn5sdxtluauem0q5nqjtn",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1wweezy8awhrmqtszun57zh2xh5yat4pndv9ejz",
+    "lp_token_id": "terra1fxzmf732l2mj23wq3aryww50xg7gclhelvs2k3",
+    "asset_ids": [
+      "terra1fdg5u7nttkcw2v4sepgzlwsznfffn8pnml35pu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1wxl8ay7srh0cuwmtaew5yh7dap54f6vrayhnwj",
+    "lp_token_id": "terra1tyltj0lhs59mekgw8ej2dt49adue7mwa56xa2m",
+    "asset_ids": [
+      "terra18u4zkkm5ddge6decp83dk9zmkx7lvhv2xkynrr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1wysjqge8zc40e5g67vlaw0n2qu865pxxxv9sn3",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra13k03g6n38f4m90pchn5h3nmk55xrnzt5ksvsml",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1wzuyqt38l99tdxzttx9grktr3grllgsqe02dz8",
+    "lp_token_id": "terra14936pd4ptv3hkh2280qm3fx940srjvvx6gv8sl",
+    "asset_ids": [
+      "terra1mfwgs4aglpetsyy4y55k9g9hsnp5xtcykknldk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1x67kglh8uxc5rq4z0dsrv4az0rkfgs6k42fu06",
+    "lp_token_id": "terra1vz850g76xvryz4jhpf2juamv40yey0ugh0pyjf",
+    "asset_ids": [
+      "terra1epz3d7rmltreyt6chgnuv28cy8e0d3yad75xh8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1x6dvc72unfrdnrkyzvm8pz6kmugdzkzu66fd9v",
+    "lp_token_id": "terra16ut6d3kh5tw08lu9np7s9fqlxl0z3c2gpsqn64",
+    "asset_ids": [
+      "terra1t5y4xm7xdc7csud2j2aezxs6e4uuj3lqpqk7jy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1x6sxgww5nrclca4thc6f7m35fyk5mgepe63pxh",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1a95wwge5ut59aet6wx9m5ukq0alnxj0waf4sgl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1x8em0g87c30a3s5hqp4ar3ad732q7eclftwlwm",
+    "lp_token_id": "terra152jfl6s4fmte2pe8ct0f0wtdm2k3xu6uesdfj0",
+    "asset_ids": [
+      "terra124zh80answg0srxqynl8syswgsjx0heh9txxw9",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1x8rmne82kuy2gx26r3ecxrjns97ef8ckf9exvv",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1ldrmvk4n0le7tdaxj7r8gk5kny95r6mxw3ask7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1xe69w9cuwz4s8e6nsxsf439pr2jyuhjj24s0ch",
+    "lp_token_id": "terra1dypf4pfqw8a8whlkzhgrzew68f00z50r3hcd63",
+    "asset_ids": [
+      "terra1677xekxjqc4f3jqut8yr6p29e8h5zfay37et58",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1xen8n3l5sr3z9ad7mmmgdrhy8qa36wa00s45kg",
+    "lp_token_id": "terra1fsvjcrmalf6n9lu72p9cv9rum6x6nhg2343ghz",
+    "asset_ids": [
+      "terra1h56g0tp38whpxlgdwcqdtgmrkkdyqerkymyklp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1xf5x5gyg5x4n22v9tyv3mtxzxz86hmpd3jkfju",
+    "lp_token_id": "terra1aglpvqsrgcmwy4v93uezlmaftdqu3qvg9htlcc",
+    "asset_ids": [
+      "terra1rxl2tv8jhv3rkhnesashgk8dwuvfa9kdzv36rp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1xghv9y36n9nfvqmlksj8seysd3fftfgud3zgm4",
+    "lp_token_id": "terra1cvwy6kx24fhpeq4gjuyp2ynwcsxu8gtvk3mde7",
+    "asset_ids": [
+      "terra1dgwaqnzp9yt4w4g8l2kwxemrhlwqm50j7eehns",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1xk2dnaqynl297f6r2yp5xp83yd5k8kk3mv8s7r",
+    "lp_token_id": "terra1mywz0a0fzzv69fxct84jj2777t2err6sn6pyu6",
+    "asset_ids": [
+      "uusd",
+      "terra1atpd4n3u6tl9ttqeqdwk303lcj2j7u8tpnx53p"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1xlgl3xvkha2y6mssy9s4qe70sq295825sdmt2q",
+    "lp_token_id": "terra165k229vdtpng40rhdfn3tqtqphwxeyjx5wrwxw",
+    "asset_ids": [
+      "terra1q59h4hyxvfpu2hp3v39r8rpl4wykqe7axrc9rr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1xtaxvdlfjxyea7qpz37f5j3py3cyafkycgy8c5",
+    "lp_token_id": "terra1z364vxmwx7gadv0pd8ywul8k2k68rjahxq0c5w",
+    "asset_ids": [
+      "terra17n0sj0ed82upz3c38px5hl2zy7mestccskauva",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1xvvrm52lglquyp62kgpcww8489v4wqy9us6skq",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1r2p90ur2zy8javfhnf7ejdvzac60ax3wcvkvxz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1xxrx7rgpzlep532ulyyndpm7g2md3zspgepmfa",
+    "lp_token_id": "terra1m5gwp6ujj0frnwkgxlkmhwu5we9xaysnwa6f8s",
+    "asset_ids": [
+      "terra1ydznesu47hety3am8athucgp6hl4dcxsxqpka3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1xzk9vcd53j2eql8zfnds9xfxy6z9c6ran3ld7p",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1e3s670y5lns7vlq3gxdcn9rv8mdpydhd89jdwz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1y03ldlhcscet96kflc0fefnfkvug92ly3xmgr2",
+    "lp_token_id": "terra19hvxtwdprvaadfldxhyc0demuyhhz26z86r54r",
+    "asset_ids": [
+      "terra1su29mtytdsev3ty2au5xlfrqrjcy696yeqwvcy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1y0cfekprajjqmz9jth6veq8pe5t2qurwg9kk4m",
+    "lp_token_id": "terra18vvfrdsxefmheygjlw2d6835p969snpvm2xlar",
+    "asset_ids": [
+      "terra1z9yq8l5fn7y5msg37rx2p0up0pgkf52ml4uv0q",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1y53r7wkxtajtsmn0zjqu4keqyd2qn5hv3ykmt8",
+    "lp_token_id": "terra1smfcvgpdggf8jp7p3yvaqs0jl25ene6rwynn80",
+    "asset_ids": [
+      "terra1tn2upc52zce96qprewh0gk5thvqqtuhaz7r6qd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1y6x737xg3q0nrqfgjkzy9ggfjmanu7675vva8s",
+    "lp_token_id": "terra1td4yfemjtq38lq98vqhnywfmjec979z8qxqrx2",
+    "asset_ids": [
+      "terra1f85kt39ar3tkscq6w8ylxv2t9qh4ktzayw35ta",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1ya6tdm86gequ9wc7lusx374j2flgldv33426zg",
+    "lp_token_id": "terra1pl7nft4helwl8xt3ev0lknk4rkhrceve4s8lk3",
+    "asset_ids": [
+      "terra1zpz6dfn24cnykwausjt7qwfdqf87kny0trn94k",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1yag6m3d3q60wnhpd8fm2qhn4uhkzpufazwz6w9",
+    "lp_token_id": "terra1nl5wp6j8tna08ymthheynq0u0eam0gad5pgxku",
+    "asset_ids": [
+      "terra1g7fa8wpfp56tzdd5mgz5r5jsvqw7hm5e3tdlnq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1yeh80vf0yezluv2u5nc6e5n8d4phjy4c55zvg3",
+    "lp_token_id": "terra1vtz8425zxtpm8sng8u3grrdq5cruq4zeeh0cn8",
+    "asset_ids": [
+      "terra12fctlld90cakzkuhd2c3h246zxrhwqd6kp546g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1yje5awrwutgx5p4mg3e8vtpnttav5f6y9m3rgh",
+    "lp_token_id": "terra1h3a58p3haxgt95eq8fwkptwscyppq0laque0f3",
+    "asset_ids": [
+      "terra1mkw8x32086w0emr0wkprrns9j0c82nnxusn7dw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1yqrryqqnvq9wgqad89dhdxwspspqzzj2dy03yy",
+    "lp_token_id": "terra1l7hmc3k3zlg5r6jet9tuv846h735p3xjul2dh8",
+    "asset_ids": [
+      "terra1x5mhyxzmy8da89rh7dnt3v289qz988hclyl6kk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1yv9dr0suw8njr88ls6ya34y2pevq45k5yg0vl0",
+    "lp_token_id": "terra1w3xdh7zpllve9d72anjtr5lkxndshggdw3zdke",
+    "asset_ids": [
+      "terra1my8t2mhxxv5rzjtzc8cppj8y76hy3apvcntttw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1z0g2y0d3eemtcsd253qd8vpl74a089deqas2hp",
+    "lp_token_id": "terra1uu0xsadf4x7v5q9vpgp2dd9t9x2khwqlal5rl9",
+    "asset_ids": [
+      "terra1kujvztl5p8a45k56u42fq39jxldxcvuejtpfq5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1z2p2vs8q95frqntrnqwkwmj9nempl83l3m699n",
+    "lp_token_id": "terra1fnr2j2cfapcuxr90z83sj0qjrtzt88sutz4cpf",
+    "asset_ids": [
+      "terra17efcrd3glln324tqke56w5wgnfkfn5emz4um8j",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1z3u6mw3s20kt67ts9txrg2mjkzcwt7tgasp7gw",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra12flsr4mk5sxmu8yk7m8zc5f44tfx00yjvzj7v4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1z50d83kx5dke2fw2wtrs4kj6ae8ga2pe5vhwl8",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1pfynaj6mslxnlekjx7f6rxgfastl46c4hg3kg7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1z7w93yyhzl0vf6cxvt0c65ta2q48akft53uj3k",
+    "lp_token_id": "terra1naap0c8xly4fh5aq7vhayqrrj6pmt826r0uukn",
+    "asset_ids": [
+      "terra10722f40cxl8tkxjk7f88uj0ehkcw6lu2j504f0",
+      "ubluna"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1z96yec8dxc6ummv5kkksft3agxmsaur07zxgq6",
+    "lp_token_id": "terra1fn7psza4kxrmu3vhnelg08629uapvmmr48xnew",
+    "asset_ids": [
+      "terra1v2s7gkylfrnwsdcx8s83k5475nj3jykzs9gsqm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1z9d33epxt9jaa4d4ta6rf5fwfysfufeumz4zga",
+    "lp_token_id": "terra1vemqvqr0khzdtfl9909u27v977pthardrwf9zh",
+    "asset_ids": [
+      "terra1xp4uhylkhwgam5tc97m0xfaxarajgf6wtcqwp9",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1zl89gw3t5ykhfxtut3marguhyff9fwupmnmhrl",
+    "lp_token_id": "terra1pq9m7syytshndh2sckgxyrh83wsm59w4gduvg8",
+    "asset_ids": [
+      "terra1dszjh6392kc6avpztu4vdx8xl0qte4ntmue07r",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1znka2za38gsj3p8u8etlfejqz4prf3snz36tnr",
+    "lp_token_id": "terra1q7vnlkn4gqgfqucjp8hadz6nzpma759qvjttsx",
+    "asset_ids": [
+      "terra1wz8w0susqsraw2smttuymzkgr3p8tgkntqhcre",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra1zzqkcp3e5apwdpsnavfrdrf6q0qf4esd556xg0",
+    "lp_token_id": "terra1tk7a0hcs3yehfzrscjhw824jq52ndvsv07d7zk",
+    "asset_ids": [
+      "terra1m9w3pdjst86dmfdamq5tuu4ny99e89eaavdz06",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "TODO TYPE"
+  },
+  {
+    "id": "terra102a44aeeq4x78pmv5kj79qxaq2ghtsk24gj6g7",
+    "lp_token_id": "terra1x6dwnqnr890whm0wtzz9td052s7008g2tg8ffp",
+    "asset_ids": [
+      "terra107pw6g56gfch98r3xw9gr3glcxvmmm8326rdg7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra103ttjgs24wak64epwd7pl5qmqw44jzujr8l3hd",
+    "lp_token_id": "terra1wvnwpt66528vajjps7m9daux600sck8mhx5wmr",
+    "asset_ids": [
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
+      "terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra105yxgufwjx5gsapk0n0rkea0dxvykyujx379g0",
+    "lp_token_id": "terra14z7t45phqgnx67n6qdvs4ac4cwy0rvflugzyew",
+    "asset_ids": [
+      "terra13awdgcx40tz5uygkgm79dytez3x87rpg4uhnvu",
+      "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra108a6djt665wvklxwhyr7lepvy5ej87c7szl99g",
+    "lp_token_id": "terra132njtndm2rjcn4x95tq5qm5h98smn8a7hnvwj7",
+    "asset_ids": [
+      "terra1qxfl4e8gjnunk0t3kq7a6ladu2p4cddk95s5jj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra108ukjf6ekezuc52t9keernlqxtmzpj4wf7rx0h",
+    "lp_token_id": "terra17smg3rl9vdpawwpe7ex4ea4xm6q038gp2chge5",
+    "asset_ids": [
+      "uusd",
+      "terra137drsu8gce5thf6jr5mxlfghw36rpljt3zj73v"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra109wt0lvwk560kjpdhuusj3a7ldnzasv028gmvt",
+    "lp_token_id": "terra18tc6j7mmqk6fwt38la3uvespuxvefkw3703xdx",
+    "asset_ids": [
+      "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10css4arzlu5ws98tz8dmsclurck3lawgddu0nz",
+    "lp_token_id": "terra12fprsw8chwm405m92vseldjp72mwge5ldv27nz",
+    "asset_ids": [
+      "uusd",
+      "terra1nkf3aaal2j93pqdtytf73x6dqnpxy2u75ezauh"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10dtff8drpwtfx4976m7cxwpptfy87l5p264xgy",
+    "lp_token_id": "terra16gqa7q433a2q7d6ankxz0qk4pwet53fakazqv9",
+    "asset_ids": [
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
+      "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10ex2fzy8wwwykgcdl8p3ruvvh536f4mw8fxzzh",
+    "lp_token_id": "terra1dluesh3lqcgatxpcy4c4jg6hydkcc0echunw0c",
+    "asset_ids": [
+      "terra1vpws4hmpmpsqwnz3gljn8zj42rv7rkpc5atgt4",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10fkdl22gefrydr762n5gah45du54ykwgxw2smx",
+    "lp_token_id": "terra168j6qa84dmcuamp4pv7xuudgp96884ktp3cxuy",
+    "asset_ids": [
+      "terra1f85kt39ar3tkscq6w8ylxv2t9qh4ktzayw35ta",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10h5gc8e59wtz3rxhrngjrk3m9lqvc9xs6hy5gq",
+    "lp_token_id": "terra1mmjzshcvdhtalmtugqalam7l9vk507ncmpu3q2",
+    "asset_ids": [
+      "uusd",
+      "terra1w94fk75p0qeas276kfvy0m0zhnwgcy49c7vu77"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10jyd2dy3ul5z2qqh9gej2zd3d46kv9dtk7c3a0",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8",
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10k7y9qw63tfwj7e3x4uuzru2u9kvtd4ureajhd",
+    "lp_token_id": "terra12v03at235nxnmsyfg09akh4tp02mr60ne6flry",
+    "asset_ids": [
+      "uusd",
+      "terra1nef5jf6c7js9x6gkntlehgywvjlpytm7pcgkn4"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10l7zllh9hduam4tugygj9x3f6976auj2xeyegp",
+    "lp_token_id": "terra1ftd4p3rfcry6sgrwjs78s0562kmut3p6cpnq77",
+    "asset_ids": [
+      "terra1vru3mk2ne3jqpwg24wm5mg2356cg5ead0tae2s",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10u8rwg2wjj4x2wyyhddjkpkkp8v40thyyg0gwj",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1mqsjugsugfprn3cvgxsrr8akkvdxv2pzc74us7"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10vatx9jkv4lcksugsrkajstw2duh834j5psxzs",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1r7qpupdxkkh58vw9u8y9n9wjp6d9lr08u39j0z",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10vpqzvhmy25pjgwkqt9eq22w3t7r7hta60gxgk",
+    "lp_token_id": "terra1y3k5urh9ahwzsxr08dlspds4vpywsat49aklvn",
+    "asset_ids": [
+      "terra1t7apedqrzywmrl89feackcalpknfzu5mr8t3xg",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10xafj6lu07e7at9nccfwgjyrqqjfnsp8wp0f9q",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
+      "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10xf7yakydjc5q4uye6zuuux8d3hxet2wpfk4se",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1mjhrlgwv8dnvc7mp0cynfxna947hxnm5m4tp6u",
+      "uchf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10xlgqrh0uhc8tt50wwqv3peh9w5zjjq3cz00n0",
+    "lp_token_id": "terra10q7p02sacknlxay0a26j7fhm75xryx2jppunwj",
+    "asset_ids": [
+      "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap",
+      "uchf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10xyreshk74gx9ygw4q4j0m9pr9je4spzas0n5f",
+    "lp_token_id": "terra1m9dlyzueyqy3pdl3tzwn60lc7myhum7j0zq5p6",
+    "asset_ids": [
+      "terra1txlylfvu2s9p3tt2fa82xj6qy6pp86avs0t43w",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10ypv4vq67ns54t5ur3krkx37th7j58paev0qhd",
+    "lp_token_id": "terra14uaqudeylx6tegamqmygh85lfq8qg2jmg7uucc",
+    "asset_ids": [
+      "uusd",
+      "terra1227ppwxxj3jxz8cfgq00jgnxqcny7ryenvkwj6"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10z6670zcw0787a6p5ydxtct5ff37g3tnz2dfaa",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1u43zu5amjlsgty5j64445fr9yglhm53m576ugh"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10zaw5l7aa8hcgfml5eugkmg3dgvrxhnxnsrtdr",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1afgfjpny09lvxl06llcy7hfu0m2epfddzn0f75",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra10zcf3z97m34kks7ly78ydshrcqf57fttc5sdrt",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1jl0egxpdfw0eqkzsgedzzet9zgwmhet2rd3s6u",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1228ck5ztqu455fye2yg8jwm9nr7w7yzdjqzj8n",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kf3ez7z2kzvvv7z7kte4en35gxm8keurgl09nj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra123ttrnasfv5htzt88phmm7v0r302z0lqh7l25t",
+    "lp_token_id": "terra1aeusm5e93ptz2twem0vpfy370c7d7vy2dp0vke",
+    "asset_ids": [
+      "terra1jwnz2uet8f4yjqyntgsfrplp503wutt24n7srk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1240yffve7kq7xam0huv6scn9kdr688lflstkfy",
+    "lp_token_id": "terra1pxst9epy9cz5rmdh3d7f4lvch9xz4xp30xa4sj",
+    "asset_ids": [
+      "terra1qxfhvu3w83azgs4ghk3v5z2nvmzg8td5gqfd69",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra124rkw63yj56t38c5y2kahfxm5cwhl8s0zzma2p",
+    "lp_token_id": "terra14cee0hdd45fu3wwvkw5nr942f54dp0jsuta203",
+    "asset_ids": [
+      "terra1tqjzureahwdezhy64uw7x9vpywgxvxcngexecf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra124vedvwx3nrwepzc2kmdhuhqn7j6zxq0jq2p2h",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1uxqd9gmtxz45yq53t2m9vrs74twwfrjmrqmdjd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra126fv7f8e3qgpc0g74vnp0gzks57r8z2ec2jh6j",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra129a0pp22q8m2m9lvd7n93pzx5eyjw2tj0ueunn",
+    "lp_token_id": "terra1w22ns4l6sz3t39tx2z4lvxlnu8ejus20k0f2ts",
+    "asset_ids": [
+      "terra19th22mng47zxe9ndrtvd470fjkn7n7ymmn28mr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12arl49w7t4xpq7krtv43t3dg6g8kn2xxyaav56",
+    "lp_token_id": "terra1hg3tr0gx2jfaw38m80s83c7khr4wgfvzyh5uak",
+    "asset_ids": [
+      "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz",
+      "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12ch7qqv9nulaak6wey00nlm8mfj6cmuhkgwayw",
+    "lp_token_id": "terra1tp8csj5nsx4m5t4hdn4ff5u8vw96j4wpvz2emv",
+    "asset_ids": [
+      "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
+      "ueur"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12cvs56jef4cp6xgwln62yp33fapqtr2kfa3h2s",
+    "lp_token_id": "terra1yq8pm98kadrxj835eeknhuhzrhzgxv7hy9nelz",
+    "asset_ids": [
+      "terra1hj9g4kecf9gncxsa2257w4glhwgrdp7vjsnncv",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12eazlqlhzxhmp546vvhd0ukqwqfjzv55es8fgc",
+    "lp_token_id": "terra1wwaj9xx6apx5d3pta8rss4tn6lzgdhavs6wgnu",
+    "asset_ids": [
+      "terra10qjtgmpsnx7kn53nxmw2mfx626g8y4xaw04pd8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12frjaujnaddrfxjdlet09nlf75waxclze5s0rm",
+    "lp_token_id": "terra1s54fm8ttuwavqsc7m9salge348upw5p53jnj8a",
+    "asset_ids": [
+      "terra182vnsj0rv9dnrc7xnccz0wajp69hu73706h2p4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12gkp648mkgj6esr5y6dwc2q4mftnfzk2pudka8",
+    "lp_token_id": "terra1cahp2lp0zjcuyx25rcau04v8x7jk3qllmmhrx9",
+    "asset_ids": [
+      "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12j29ct74f4wx0vrz54c96sl4gvz5a3k7mynzrq",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra178v546c407pdnx5rer3hu8s2c0fc924k74ymnn",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12jl0hnmgrs9j0tv8u7pfqdey9nukmmk7vehgkz",
+    "lp_token_id": "terra1tq025m6ms5jz6hwhjp9akt420mhe8t3evu0rc4",
+    "asset_ids": [
+      "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12ka6n7ujku9wzddy56war52dqmk2hfq7ysdwpt",
+    "lp_token_id": "terra15n4mgtumehlzy3h4ldnz5m4vrp7n3z8yu9c005",
+    "asset_ids": [
+      "terra1j4kt7mns290trwlwyxrun5n7nlfkxxcak57ck2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12kuvl9ljytve26q5nd5khnrw2hdkaa68sh5t0j",
+    "lp_token_id": "terra147g92kn88fhyjxgt4lut827smfgtjqngpg8873",
+    "asset_ids": [
+      "terra172xf4zehmdla56h2x8ergqmejg70f4zczzt74w",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12mehtwqlcypjlp6u6mf7k39c2esjd2w4fw4ke2",
+    "lp_token_id": "terra1xy8hnu2rdzl4agj2qraw022z2xy3u6a5ldd4cc",
+    "asset_ids": [
+      "terra1dameg63csxum2hspscam9h6d33chnqa4wsn3sp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12mzh5cp6tgc65t2cqku5zvkjj8xjtuv5v9whyd",
+    "lp_token_id": "terra1hvz34zmk4h6k896t94vd8d5qjdchhnkdndunzx",
+    "asset_ids": [
+      "terra1vtr50tw0pgqpes34zqu60n554p9x4950wk8f63",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12qjaagzpkz28ngtpg5ugelsmcmtl7x4w4nuuz0",
+    "lp_token_id": "terra1uyv9trfhqk2wf9m6x5ksm7j4yq9hfemr5swqnh",
+    "asset_ids": [
+      "terra1z8ta6q6tfvp3sec0f4yftt8ew656d0x8zhgp66",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12tuqcyr3aw6fuky8l2xfp0uyje5kmdf7yr6spa",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
+      "ueur"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12wfnxnvzd9fjt3gyw38mhncw027n2kd3p8jf2x",
+    "lp_token_id": "terra1s3v0ftwx0vuhy9482hudf5z8u0vsmrkn4nremh",
+    "asset_ids": [
+      "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7",
+      "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12xus7trxaqjnd30q4z7xzvvwnqar2ne4f7304w",
+    "lp_token_id": "terra1dp5pt02qxmla9a88alp3ljl5m97p5ge690p50h",
+    "asset_ids": [
+      "uusd",
+      "terra1m6j6j9gw728n82k78s0j9kq8l5p6ne0xcc820p"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra12zwtkdu6qhs4f8jw9zvdgrwl24mwag5kuh7gus",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1ay3729yle6u6wxj3wcm8racn50a2yq5r8vxvkx"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1305xtjl5qtlpdlp8gg0k8u4yl05hj7qvyffvd4",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra132qjgv0evru0em6v2rcwakgxzafjhwfz7fc7hh",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1drsjzvzej4h4qlehcfwclxg4w5l3h5tuvd3jd8"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra133308rh6p96pxw0cztmfln8av2jkxnjlfvfcyq",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n",
+      "ueur"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra134ce0ucmswxcsjl0st8p36hgxk0edty06nhhv9",
+    "lp_token_id": "terra1p5qffpcsqjk6t9v0dn3luzj2lhxnep09d8pgep",
+    "asset_ids": [
+      "terra14kat7dptmcydvhn0l5ur3g3evs65n33925n7w7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra134mvek3w6tp9rzgdklv9pndpdkc2gqvf24um3l",
+    "lp_token_id": "terra1epjldscwcyn3nerwmnf0qnfk8rue7pc73v6u20",
+    "asset_ids": [
+      "terra1c5fr3wdf2trj3dkxcckhmzzxlnnpepqn8cu8f8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra134xk6kqtwzw46qchkjsg9dwvufacmnulex2xwr",
+    "lp_token_id": "terra1qvuhgne7qp9gre8zmfrea6ekjgmda8r4hsf9ch",
+    "asset_ids": [
+      "terra1skjr69exm6v8zellgjpaa2emhwutrk5a6dz7dd",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra136vrkx8kq7x5w0kgklzh9vxmn2x93q0edqe3nf",
+    "lp_token_id": "terra15uzdzdpv7gfzl84yhx53uz6769krhf6krd3s7c",
+    "asset_ids": [
+      "terra15pv3xxp2d5f65qeu2v27vqf9zpqjx0fuztfwcu",
+      "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13awymgywq8nth34qgjaa6rm6junfqv3nxaupnw",
+    "lp_token_id": "terra1aw52tgnmu3dfeguy36vm3we3ju0v6dhnvkj2cg",
+    "asset_ids": [
+      "uusd",
+      "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13eyn98smadfflnm0jgt04q5dqzs3dtjg6kjjrj",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1hfyxtste6842zulmjv9n92srv803q6rhn7t8d4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13h83g8cv50e98kk450pkpk76fmjeryd32zvef6",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1w7zgkcyt7y4zpct9dw8mw362ywvdlydnum2awa"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13hmvr56ld8lhtdxkzw9q08lkzscnjlsa8jff2r",
+    "lp_token_id": "terra18y8qtp8slkdrfdf8hvfjhk6w7rn5vm4hhegngy",
+    "asset_ids": [
+      "terra14a2t4c4a8us6q24k2hkfm7kdenzxu0yxph35wd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13hprd7adym4cf2hgjmnjdv48akxj8fplelp6pz",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1xzn8e3h9k4qk7082z330sn8ptz99lnghyua9xy"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13htj4202asg8fdmyq002zm53j7h4my8q4kdddt",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13kvcwhxa0ym2tpgcchk0rn0zrrl7r7w0mgv74q",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1lkszqh6duver9s9h0qfr2dcktj605km3hzfzjd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13nerldmwsc5gal4jtjr2t04vng02q5d7nthqtj",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13nwgt8kxyat5pt70faxnm8dje0c67hwsp53d5x",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
+      "ueur"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13rprqshf7dxn48v0aaztv5c7ytct6t6u7djtlw",
+    "lp_token_id": "terra19ahlx8uhyslmt8u6a6tzsugepm8a3kfemjeucl",
+    "asset_ids": [
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13szfqtcjq98yjyalghplmyq0fdlafaga09z40q",
+    "lp_token_id": "terra1egnufc5nzjch6r9nuan4ywc90nmtyr5fqq6cv6",
+    "asset_ids": [
+      "uusd",
+      "terra137drsu8gce5thf6jr5mxlfghw36rpljt3zj73v"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13x30y5swfdjw4hhwpur83gljsf50s4afmmfrj4",
+    "lp_token_id": "terra1rkqdu7n85zqhgg78ktgv3rj5zvw6vp7m0dkx4y",
+    "asset_ids": [
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13xh4kjkx2xd0nn5tzwnqpmzwrc9mhrfdvl4axp",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra13yc7dcphaxpgd538msys7r75d3lwa5mu9u6d88",
+    "lp_token_id": "terra17vddhyh8zulk4yx2zapsk9z5y5r5mjaf9w6egv",
+    "asset_ids": [
+      "terra1z0ewtcsaskfmsp6ue59skulunehzv27ndw5yl0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra146c06de7zllrc3r960dmxq4m5q076fvw95529p",
+    "lp_token_id": "terra1s0y08x9qxn0xy0ph43lk24h8wchzwx932ewlej",
+    "asset_ids": [
+      "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1473vrcpk28pc2smude02a98ft3ff05gqv5xtl9",
+    "lp_token_id": "terra1p3pky64g3jq6s466g8jskszt2k7e07ygt9z8z2",
+    "asset_ids": [
+      "terra16hhm24fc3wle66m3529n2jctqqsds57wv4c087",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra147adm7pj9nzsdulnkqv2pnslp2en2dnpvs24qq",
+    "lp_token_id": "terra102l9yp0zpzrgse96mwgnfyc0rmunpyzrxg7999",
+    "asset_ids": [
+      "terra17zhwz3s95dwcw373eklrscvn4jr6f7sd7qpk7y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14c8m8anc8u9llaf2tq0d80986vmeprehkrwpnq",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra16gqgpuy7z64chzz3su2xugjgrhuj3h89wx2z59",
+      "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14czsfcd6j4z8ffyekkgsr4zkpw8tdnec0v9jz5",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
+      "uchf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14dvkhl6xzg7dj2e60vasr6vcvh3354wwnfpv0d",
+    "lp_token_id": "terra1s26qlejx4lhqd3ruc7tp2lg3xu40rk2wpxssrn",
+    "asset_ids": [
+      "terra15pv3xxp2d5f65qeu2v27vqf9zpqjx0fuztfwcu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14eey9rfl9we6hurlf9q44nfffrm2cd8xjkdqmz",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
+      "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14fyt2g3umeatsr4j4g2rs8ca0jceu3k0mcs7ry",
+    "lp_token_id": "terra16auz7uhnuxrj2dzrynz2elthx5zpps5gs6tyln",
+    "asset_ids": [
+      "uusd",
+      "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14h9hukadz5qwm4jtxjrvnpnj52ynrnrcq6wjfq",
+    "lp_token_id": "terra1rhy9tsda27exlwlwkx62u4t2e6c0uq7469p0el",
+    "asset_ids": [
+      "terra13km0x6rn7fj23ruqdqdqut7p7p7570xyjz35qe",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14hklnm2ssaexjwkcfhyyyzvpmhpwx6x6lpy39s",
+    "lp_token_id": "terra1jqqegd35rg2gjde54adpj3t6ecu0khfeaarzy9",
+    "asset_ids": [
+      "uusd",
+      "terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14hpees7gp0addrkgavwpylsr9tnzg57c0vdxav",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1jkkt5638cd5pur0u5jnr2juw0v6hz5d6z8xu8m",
+      "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14lg4pfn3s5p4zcmujnppvpr09n5a7583cz4czd",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
+      "uchf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14m7prknmsyxjey7mkafl6340ckvnn6ve0uuxlr",
+    "lp_token_id": "terra1e4uxrgeezzcw33cfek64u7kq55jyn5dsartakt",
+    "asset_ids": [
+      "terra174tuptw39sd3s5yqq466xc5lygh9z8gp05wf4j",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14n525nzgnsqpy5ne28ffj6e2ul3c3n7hkv5ql9",
+    "lp_token_id": "terra1ktld67cnuc592xd6xjgfh2n4d3f8av4mn53lul",
+    "asset_ids": [
+      "terra1hmxxq0y8h79f3228vs0czc4uz5jdgjt0appp26",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14pfzu2umpa3m64ad3qpsxu0qgkvfl42qmq4l6p",
+    "lp_token_id": "terra17cfp93qzf62qyds74jpcyxvs04cvrmf7dd4hau",
+    "asset_ids": [
+      "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14q2h9nce4spj8n74g6kppj3yf86qx8hsrqngfh",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
+      "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14rmvvzfs88axcrk0farsdswylj55umpj6kqh79",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra16ea8pnh3hu69kzqqps5gqw0zdd94hgul9tfnzw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14t6yzxt5vhx4dyjknzj78tge6j8385awnczxpg",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1ucme9gd7wr7lx0sysnydhdhaqtrg4403nrqm0l"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14tqq6d7n79sfjmeeqgkmewyhq65dvczgym5rhq",
+    "lp_token_id": "terra1z6x7xnsgye3gzs2mlj5v2gmyw8c35amrgu5327",
+    "asset_ids": [
+      "terra1lm2lwzrpmyyt2qfhkmj7rwvh7yrh0npzpl6k7v",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14wt2rhghhtuyl07h4ls78hjuh5gk4nxj66u2tp",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1vlqeghv5mt5udh96kt5zxlh2wkh8q4kewkr0dd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14xpe4dx4xt3cxmyhlnnm4rhpn3umhw0peyva5u",
+    "lp_token_id": "terra1h0y6p9c6njvagcd7sar7kazpx4djymuzft3jns",
+    "asset_ids": [
+      "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
+      "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14zcs4sshhncym3ahuczw2rg7r70xhd9zl90mzt",
+    "lp_token_id": "terra15ua5xjmgyurtrltn9gp6r7cap79xdfjksxecms",
+    "asset_ids": [
+      "terra1sussd2d7r3y5k6up6n6sxap3ee75gegxah96up",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra14zhkur7l7ut7tx6kvj28fp5q982lrqns59mnp3",
+    "lp_token_id": "terra1y8kxhfg22px5er32ctsgjvayaj8q36tr590qtp",
+    "asset_ids": [
+      "terra178v546c407pdnx5rer3hu8s2c0fc924k74ymnn",
+      "terra12897djskt9rge8dtmm86w654g7kzckkd698608"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra150jz4237l3dfhhpppdrnz78hp0kw2ujqczf2e0",
+    "lp_token_id": "terra1vheyufspfcfh3ka9nafmxec0lwzls80cuf3sd7",
+    "asset_ids": [
+      "uusd",
+      "terra12yvwzt5ayh396hgmyd0rwnamgg4g3mxrdgg7c6"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra153xclqwcvxch99mclac5fxuu4cmeu7w7mamghu",
+    "lp_token_id": "terra1ze0k9tty5hrn0t0m2dt4j0sde7vgjsrttczt7g",
+    "asset_ids": [
+      "terra10pvdslu4j8x6rqm2uuvh7dwd3rtaw9qq37g7v7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra15587sd3nkaqhlve76nxxhp6a5ep6qejh4lnnca",
+    "lp_token_id": "terra1tpx744z60ysm4ntrpk84whqp9tunmrgzm6utcf",
+    "asset_ids": [
+      "terra1c6jwuklh3262naafvnlw8llvns9856uvc50z95",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra155rgjn955ppq9vz5gapcfgwaf6vg9294xp2kcj",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra15hp9pr8y4qsvqvxf3m4xeptlk7l8h60634gqec"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1580sp4lade7khxntaq8856we6480p4gg6xrzw7",
+    "lp_token_id": "terra1nrs4azly4lur2e525pfalvucf5vhe4vgh4htd0",
+    "asset_ids": [
+      "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
+      "terra1u553zk43jd4rwzc53qrdrq4jc2p8rextyq09dj"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1583mexe3t5gwfjf97paz3r8m23dxw9gjqa2ap6",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1cjf3m2zsx4lu6c0edhfcvp0v4hps6gfr79hyc4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra15asyerx0su2j3urlsn2xea0klrr5dpd75jamwj",
+    "lp_token_id": "terra1g5pe82m6hv90h2ed8esz5ldw8jpcw6y209k788",
+    "asset_ids": [
+      "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr",
+      "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra15ge8z5l33w4u2lnq6udk8dpywglcpgxyl0h0dc",
+    "lp_token_id": "terra1fep5kj2pr4t9u4d5552qlfdhuc9m4h0g6g9mam",
+    "asset_ids": [
+      "uusd",
+      "terra149755r3y0rve30e209awkhn5cxgkn5c8ju9pm5"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra15kkctr4eug9txq7v6ks6026yd4zjkrm3mc0nkp",
+    "lp_token_id": "terra1ndlx5ndkknvmgj6s5ggmdlhjjsz0w6wrnwn5cf",
+    "asset_ids": [
+      "uusd",
+      "terra10h7ry7apm55h4ez502dqdv9gr53juu85nkd4aq"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra15n30h56p9zva8gfp7ejd0smw2zf5xlxwelgg95",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1tt9jmf58nvaj8l0lckwfekfl43verjdpywcdwa",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra15n7vemjsxv7w4wgnwqtzufp6tddmycqsklgqe3",
+    "lp_token_id": "terra1e3t3td7uas3ed0gyu9xcyvmh6gxn6xe96yat8w",
+    "asset_ids": [
+      "terra1esezx70a44cqc4pjq0qt3k7k93ksuvepfksscy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra15nqcvvt4mag63ezmejxrdqehsydn7d3520hx7u",
+    "lp_token_id": "terra1d9myqs75njsaymp9yhrnzkkwhg0rsv9gpwcx60",
+    "asset_ids": [
+      "terra1jm9jv95f0w3e0kk3kxxvtqg50456mf2c92xd7f",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra15qa20t4hrq27ugcyut363mum72hdlgcqnannm2",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra15rl2agmgqjwlx3qqqe9rfjcvs3lxl2e3srzwda",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1a59ns8fnk04sj982ymkvx9ygscmf4jjtm4sltg",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra15sut89ms4lts4dd5yrcuwcpctlep3hdgeu729f",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra12hgwnpupflfpuual532wgrxu2gjp0tcagzgx4n",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra15yyefja9as60nfn5dmyqt8tm3flddyvn3apf3s",
+    "lp_token_id": "terra1y4z7u7psjqyxu4uw5rwz8wmhwrpweay4t0le42",
+    "asset_ids": [
+      "terra130fhr9jz0nylzhdvuwcpp3hne2s5qlft6hfzgv",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra15zv6wcyqkw9ye86qku2yesqdgpr9qsz2xus4yx",
+    "lp_token_id": "terra1ylqfv4ykp65gxxx5e39qe5ahzm52f20u8equxd",
+    "asset_ids": [
+      "terra1u553zk43jd4rwzc53qrdrq4jc2p8rextyq09dj",
+      "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra163pkeeuwxzr0yhndf8xd2jprm9hrtk59xf7nqf",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1650mr52prhczyyjz9rec0ye38q5j55v7gq6wc7",
+    "lp_token_id": "terra1srmemhy8etjaam7ksnl2062x9emwg7ykrfvnz2",
+    "asset_ids": [
+      "terra1js38ca30k0gt9rz53jc8x47yt638l8f86d5lpt",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1670lwuaqtzw43q402anw4aj44ud9nqd87d639f",
+    "lp_token_id": "terra1u6ua0t8url95p2dh7tp6kvqp04h48dxx5njclp",
+    "asset_ids": [
+      "terra172hwjglf7rsgrnwet52zqnzjhg7vjgcpm7nctn",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra167gwjhv4mrs0fqj0q5tejyl6cz6qc2cl95z530",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1zsaswh926ey8qa5x4vj93kzzlfnef0pstuca0y",
+      "terra12897djskt9rge8dtmm86w654g7kzckkd698608"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra169l808rtk42ukexh3wqyx2cgxp4gvn5fqmn5zq",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
+      "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra16aunxdkl5pu0ftz8q7sgapmwtlls078lj56r9e",
+    "lp_token_id": "terra1myejqyh8u3q5prx6h8p9hplswdhwtuxuk5stc4",
+    "asset_ids": [
+      "terra1r6pcn0wdes6lrtxty3xu253c02grcvuxmqg4s9",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra16eecm8exp3p82ld5eh5feweup0qvfv8468np6j",
+    "lp_token_id": "terra1yrthzcrf6p0l568rk2uumzfg0355zedywmaf8z",
+    "asset_ids": [
+      "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
+      "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra16jv42g5t95zj2rvddzqvvd5sjvpvtz5fz5sksz",
+    "lp_token_id": "terra1z038v5j6mlwluahjjy6z73q6ckq6rwkllj5xue",
+    "asset_ids": [
+      "terra1rfqm5zwkep3jk845nf565yyua66uj654y2vzx3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra16kgssn83sz92u22mmqtgmd795edtttu7apjsm9",
+    "lp_token_id": "terra1gk602sa0jwk73xlr8tpkd3fpukhfa8hjety68r",
+    "asset_ids": [
+      "terra17zucl25842g99vytr9yzw0eqmql3wwpql357cx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra16pwrn7frj4d8r4dfc3l8y3xkt5uk2505ad7nvm",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "umnt",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra16r4zqs04jzyrert9udg2s8g4qnrqy9syw4kxhp",
+    "lp_token_id": "terra1gjasf5qq2jlmzle066tylul3d0s7vd6g667p7e",
+    "asset_ids": [
+      "terra1ml4r2ry9pf9evmahn0nh5nzjzntf63wzmnull3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra16rzrqaa3srgffadx3al0cjf9s6au0dy6ertxtk",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
+      "terra1nagqpmyw55yjphea4rhntlfv87ugmeaj8ym756"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra16w76qmlwdevxvt9xnfafmczrjyar6rh5rtsyhw",
+    "lp_token_id": "terra122tkw2svjgx50027hlf52xqca94sq6s4mkk9d8",
+    "asset_ids": [
+      "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra16wwzrfv28lhqzv7l9m9qnpzyae600dsratzqg7",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1yeyr6taynkwdl85ppaggr3zr8txhf66cny2ang",
+      "uchf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra16x00f2haetp736xgj8v0t2p3ju6tgnc4f8pzd8",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1skjr69exm6v8zellgjpaa2emhwutrk5a6dz7dd",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra170athjxhauwzdn3tejfcv49pej3atyv4qwffrm",
+    "lp_token_id": "terra1xhjavlxlfwqw2w5hj4395m7stl4ut5zus6mn4x",
+    "asset_ids": [
+      "terra1jx4lmmke2srcvpjeereetc9hgegp4g5j0p9r2q",
+      "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1774f8rwx76k7ruy0gqnzq25wh7lmd72eg6eqp5",
+    "lp_token_id": "terra122asauhmv083p02rhgyp7jn7kmjjm4ksexjnks",
+    "asset_ids": [
+      "uusd",
+      "terra1vxtwu4ehgzz77mnfwrntyrmgl64qjs75mpwqaz"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra178jydtjvj4gw8earkgnqc80c3hrmqj4kw2welz",
+    "lp_token_id": "terra1rqkyau9hanxtn63mjrdfhpnkpddztv3qav0tq2",
+    "asset_ids": [
+      "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra17dh7ekvz3qeghj50rqphx9es33qr5z5c5dhgdz",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra17eakdtane6d2y7y6v0s79drq7gnhzqan48kxw7",
+    "lp_token_id": "terra1azk43zydh3sdxelg3h4csv4a4uef7fmjy0hu20",
+    "asset_ids": [
+      "uusd",
+      "terra1m6j6j9gw728n82k78s0j9kq8l5p6ne0xcc820p"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra17ef74ttzva3fg7kc29w8na3nut8ugcdmxyycw2",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+      "uchf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra17gtlmwdasc0p8rzms7wzhts4nshu47f5xud05w",
+    "lp_token_id": "terra17mwkhsau43y602yev5nmgzjhel5jsen433wf22",
+    "asset_ids": [
+      "terra1vchw83qt25j89zqwdpmdzj722sqxthnckqzxxp",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra17lrhh6zh99g2u2d92y77xn8sg3j4sp9frkga3d",
+    "lp_token_id": "terra1fwj38qsjpj7huatrms3ptp5spgnmz03ghmdhtw",
+    "asset_ids": [
+      "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
+      "terra1hj8de24c3yqvcsv9r8chr03fzwsak3hgd8gv3m"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra17mu25k7a2lj7pn8vjgtc5vjvah6gkt6njgh4q5",
+    "lp_token_id": "terra1yjvlgj80jkzwakqv65tzfwctdehqav4jujgx37",
+    "asset_ids": [
+      "uusd",
+      "terra1ptdxmj3xmmljzx02nr4auwfuelmj0cnkh8egs2"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra17mwfdz84uee5vsq28463vng93s9w9v08l2m83r",
+    "lp_token_id": "terra1z9xh489wp8wksdqh43wsmmyvm9qepdltq87aqy",
+    "asset_ids": [
+      "terra1dwvauhhpsmhwjf2x32uqeukg3zdgm89zy6004g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra17nntay5n5c7za2yzgrgfcl9jaytyq37qzrwg6z",
+    "lp_token_id": "terra1ydqalj4l3ztvn3pr0rmz42d6wam95nae2e2xz5",
+    "asset_ids": [
+      "terra1tm2jhnfh6hmnpvzsyfteqhcn6h5uw2qafr48yh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra17q7jut5sw89jcad93ww25m8xmqxfx4hymdk4c9",
+    "lp_token_id": "terra1757aqwhfgdjdadpwvy9hv324g4ss73nn43eqp4",
+    "asset_ids": [
+      "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
+      "terra14lpnyzc9z4g3ugr4lhm8s4nle0tq8vcltkhzh7"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra17rmhzak7ymvwlwr275neppvxkrr3xl6vj0dczr",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1e6lfxnuyqg3wxvczuz0zkmvr40ldvqx26eqk5g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra17rvtq0mjagh37kcmm4lmpz95ukxwhcrrltgnvc",
+    "lp_token_id": "terra1p60datmmf25wgssguv65ltds3z6ea3me74nm2e",
+    "asset_ids": [
+      "uusd",
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra17vk5j4mhxnpl74xmndmyjfma3ynpef6kj7jhuj",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1zawrkv57eh7rne45zjta7s876jqc59slrev9xy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra17y0ujwl2far0rtm5qqjlx6ghtndcpyzqulur3e",
+    "lp_token_id": "terra14r3jnk537uwkgvuwg227jj3z50xcetwtjcj7sh",
+    "asset_ids": [
+      "terra1u72jtyujxu8dmpxedrrtmt5tekn0usf09r2a9h",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra17zp4dqu3d2sj9kq8uqnsvwy4ll66g7380uh03s",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dwyd6vds479kv54f7kucevny97lge20c3s9w2k",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra180jp452au9sfwq4kuxtsd9q2wzjfu6v9ghrkax",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1dj2cj02zak0nvwy3uj9r9dhhxhdwxnw6psse6p"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1830q85e520kyhh5e0a254gvt88z8ngxa05tj6q",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1h8hmr0em0avkz4kzuwgakyxrdvxqwg5d3cg4sd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra187406r5f8nl09xskt0p6zeq54hs86m6j04q35f",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra187pxc9su35stqfdd02xy2r778qd83lruaey3fq",
+    "lp_token_id": "terra1lcrpz5rgtqu6dejec7nrglh6qqgt8326ecwral",
+    "asset_ids": [
+      "terra19mcqz609t5vcudfatwexuhta0mrs49fu9dqj2s",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra188xye9e9w0yg39qtxq8tnzfmprjz6h646zgz72",
+    "lp_token_id": "terra1hdthg6xxx5svjh079x0frrzwl5wyytw2l5qm65",
+    "asset_ids": [
+      "terra1gxztmp6dlu8xv8kdlty6259gl845mw53gakw9t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1896hql9gx7m8wpxaulqk453jm9r9fcm2q2jrlk",
+    "lp_token_id": "terra1f0zagera2smyvl3qr6vr3uvtsem8m2t60lufr2",
+    "asset_ids": [
+      "uusd",
+      "terra1cc3enj9qgchlrj34cnzhwuclc4vl2z3jl7tkqg"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18adm0emn6j3pnc90ldechhun62y898xrdmfgfz",
+    "lp_token_id": "terra1x3musrr03tl3dy9xhagm6r5nthwwxgx0hezc79",
+    "asset_ids": [
+      "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18cxcwv0theanknfztzww8ft9pzfgkmf2xrqy23",
+    "lp_token_id": "terra1m8mr9u3su46ezxwf7z7xnvm0jsapl2jd8vgefh",
+    "asset_ids": [
+      "uusd",
+      "terra18ej5nsuu867fkx4tuy2aglpvqjrkcrjjslap3z"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18dtgqxmc30g92pshm2u2pj9h64q2v4snqh8tma",
+    "lp_token_id": "terra1h70xcjaq5a4p4r02qjwqgvvpe9k5l9aafnyelh",
+    "asset_ids": [
+      "terra1ffute26m0e5uq3wmzys3452dge62m99u0xz30u",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18em0a2s6ca7j00sa87h8ypdvxw6cyxvddt9a8p",
+    "lp_token_id": "terra12wg09c4azptm8yaw7cadhz8u2nvthj0xm99rva",
+    "asset_ids": [
+      "terra1hd4hgml43g4k50nlyhuntsaw8p7rvnrht0f9e0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18f063y03tq2tdj20gcm7w5t0an29m7yex0cvy0",
+    "lp_token_id": "terra1kr5twwkkdr38wa3t2477cmmrwwpjuggxl962y9",
+    "asset_ids": [
+      "terra1z454qecteghkd8m3shgd48cdc7j7vtnsgxh4z7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18gdjzd5p76dwywsqn7kgxsadfllw6csghl37vv",
+    "lp_token_id": "terra1tnpd7tzz7nyd7a2uq2kcu0r9pue5fwmafph9qg",
+    "asset_ids": [
+      "terra1twcwynuvhs778m8x46n7e6gyvu7srtkjcaufxd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18j6lacah32zsxfmx8uevzq93ryzx5qlt3r3jk5",
+    "lp_token_id": "terra19rc9ttpt80k7mgmy8e0t9e3r6q4m5mwvwyjwul",
+    "asset_ids": [
+      "uusd",
+      "terra1ax3mp4cs78xkryavm733s2m4exsv72kd9c4c5g"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18pykmlsv9llayy0j252h365vkh9h787jla9vg8",
+    "lp_token_id": "terra1lgr4y6xd92m53mdrtw2jk4zs87hahyw72k0kh6",
+    "asset_ids": [
+      "uusd",
+      "terra19cmt6vzvhnnnfsmccaaxzy2uaj06zjktu6yzjx"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18raj59xx32kuz66sfg82kqta6q0aslfs3m8s4r",
+    "lp_token_id": "terra17mau5a2q453vf4e33ffaa4cvtn0twle5vm0zuf",
+    "asset_ids": [
+      "terra1jx4lmmke2srcvpjeereetc9hgegp4g5j0p9r2q",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18rwpsjq4pcyv2cj2555a74yykwkrn3yktktlrc",
+    "lp_token_id": "terra1erl67wndtyf2nngpy2lr0xj5z7yrustt3v2jew",
+    "asset_ids": [
+      "uusd",
+      "terra1lj2t6zem4kk3cf400srvhaczpv2lg8kzpy5xr5"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18sdrrnm8v283m57pwr2d8m5hlxmwj2tgajj7nl",
+    "lp_token_id": "terra1ter57huylshhqmkjr0m8kkl773tk7f5p3dgjqv",
+    "asset_ids": [
+      "terra1jzvh42e8auxk63dg5vdp4lh0fct8vw8pn2s34d",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18u4fdqhlsxraltxj9xq6rdf5h8ttp6quwtqhxa",
+    "lp_token_id": "terra1arxzxdelkjpz6fgh37vszpw23qpsncy4rfatsx",
+    "asset_ids": [
+      "terra1av86k92kuj9jem24pmrv3j6xkrltr2xluz4665",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18xk94xj3qyrv4laxy25hhvwggr8d4g5z6ynl3p",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1s0fnj6cz44e2j45293320wmwmjp5pmdkuuv878"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra18z9fg8nd7dvccqnmyhy2p5t4pdak9c8j9qkr4y",
+    "lp_token_id": "terra17k56585u8yu084060vjlgf4jgmswxahguee47n",
+    "asset_ids": [
+      "terra12hesat74nzz6av5hw2c5qxxqkhafxsgjhgnd6y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra19073h5d7rczrnu49r8aje5yly5llenv878eekm",
+    "lp_token_id": "terra1k67ut87c2up66tury4qc4n96d85t43u20v24sy",
+    "asset_ids": [
+      "terra12qxyx2l90c37kylw4jqe8t40ppnrnu8wqmx940",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1935xkvhhrv8aeq7sl5hqez5uxlwvld3098mjmp",
+    "lp_token_id": "terra1l0yxvzzszzfcrfcle55wdf2xxmalc9eg5c28ej",
+    "asset_ids": [
+      "uusd",
+      "terra1y0spkg2up7ddqd98f9d45wacfwjmdvpq702y72"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra194j4rhezku4dmfz2vsnpzqv0actlg3xepg7l3t",
+    "lp_token_id": "terra1efsarez7elxhvgeulu4zgmtg6g9rm3smasgglg",
+    "asset_ids": [
+      "uusd",
+      "ibc/FA0006F056DB6719B8C16C551FC392B62F5729978FC0B125AC9A432DBB2AA1A5"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra196s9l7x89eue0tw37zy3ghxh42lpyfn4v5qsk3",
+    "lp_token_id": "terra1zck3zn662n00tvfhmwaf4ujltr885qt5v2n4sn",
+    "asset_ids": [
+      "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra198q4sqvt4yczlxxs9cjtktqdy7tzthz8vhz6xq",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1aaqzva7adgwtzfkt9nmrmuvkg9s6lmsgtkg3jd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra199dwfkrv44n52nrtyf4fsj0tp9s60vl0xuaaaw",
+    "lp_token_id": "terra1y6frqkq3ghvypja2t9uqxkfulpaqeuhfzm69vp",
+    "asset_ids": [
+      "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra19crn3jxwjspu29kc8ftn27lw5vr3vzk42qar86",
+    "lp_token_id": "terra1cv5l73x70wjcs7tz94tz24y874wgu8xktn02t9",
+    "asset_ids": [
+      "terra1jju99w456sm6w2snkmatm00gve7cvvzda0j6pn",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra19fjaurx28dq4wgnf9fv3qg0lwldcln3jqafzm6",
+    "lp_token_id": "terra1h69kvcmg8jnq7ph2r45k6md4afkl96ugg73amc",
+    "asset_ids": [
+      "terra13awdgcx40tz5uygkgm79dytez3x87rpg4uhnvu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra19jjgf89q82d84fag9qqr5lyhcmctljjygt2yac",
+    "lp_token_id": "terra1uf5xpl99zm7c8jxtq4c3y32ygjufjk6x6ggrav",
+    "asset_ids": [
+      "uusd",
+      "terra1l2stn9sszzg6qwfqd6ckfa5n58hs4x5wwjaehh"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra19kagxwyn0hj9nyjwzex5w5w609zggp52a58d22",
+    "lp_token_id": "terra1w34xlv8euhjfffp3mu98qtc9umcwy79jw7pfxe",
+    "asset_ids": [
+      "terra1we9tgz73r6q3nqxwre5375l0nxh0s7ry47s6j8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra19pg6d7rrndg4z4t0jhcd7z9nhl3p5ygqttxjll",
+    "lp_token_id": "terra1uwhf02zuaw7grj6gjs7pxt5vuwm79y87ct5p70",
+    "asset_ids": [
+      "terra13xujxcrc9dqft4p9a8ls0w3j0xnzm6y2uvve8n",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra19pkpq2hmmag2954jdwpd4wqrhqp64umrtw6tmc",
+    "lp_token_id": "terra1a6unyqwce532dq9z9uez3l5du2zqhqlek8cg2p",
+    "asset_ids": [
+      "terra1yfjk0jn42krryudpv04mg0c3ghuq4u3qtyztgq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra19pldqzpsglzusuj59tw750yp5um885c4u888cp",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra18zg84fg56lthpjd8skj70l4zd3puyul5weqfer",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra19slzdkvt3kekyq4ydp3ky4pjuus5lmedafkkzs",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra19vrx0crmjpkahyhmmtlsgcnzgss32nwgnqudfq",
+    "lp_token_id": "terra1lfffm32qqz3lt4vt36tcslmdayuh2lyvm0yhdp",
+    "asset_ids": [
+      "terra16t8cdhps9sxk7sje2w77fay8lh4se3p4gqjeya",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra19wz5r5kq0qewqhghvgrceqhq6fj2aw43j68u92",
+    "lp_token_id": "terra1xtrwsa7dh7jz0whaa5fsy0pu9x83z93r7lhmy4",
+    "asset_ids": [
+      "uusd",
+      "terra1drsjzvzej4h4qlehcfwclxg4w5l3h5tuvd3jd8"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra19z6n7l67rkg6y7vggwr3jh889t9vg6yn2jdl9n",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra19zmlnmj5pqpwvtzzgyzqurlul972myjzntsmn8",
+    "lp_token_id": "terra1aarnpmtzs2nrkpr7tylsh8zevewjgg8gjp3djr",
+    "asset_ids": [
+      "terra1lcs47eqhugywzrf83xhk65skmfqmxgvkqfq64g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1a2k9k9g5gyuats98z69ssk4aqjt38a9z943xd9",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1zvhvg09zeyl3txrc7v3crnqnnwc0d2nvgxvdhd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1a4cjrs86m97rk0g5yuds8yjd7f0en5drqnynwk",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1vsl7etwe53vglc2xq2rdt7mujarcjy9j694hdk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1a5cc08jt5knh0yx64pg6dtym4c4l8t63rhlag3",
+    "lp_token_id": "terra1veqh8yc55mhw0ttjr5h6g9a6r9nylmrc0nzhr7",
+    "asset_ids": [
+      "uusd",
+      "terra1qqfx5jph0rsmkur2zgzyqnfucra45rtjae5vh6"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1a6uk8kz25l59krr2m683ph8l6waky0nphm5l66",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1g0pm8xm5c2dq4qtv8j9a80hg4mhe5ndy8qad07",
+      "uchf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1a852hrcu4rsafrf9wftvqstl2vqn2argplnnmp",
+    "lp_token_id": "terra1kdx0f3un67ds5a0pnx38krgpvkfar98gl3myfu",
+    "asset_ids": [
+      "terra14q0a4tfmdkwrvzakv7nq9jg2d36w8uj9jkhgee",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1a8gkw3a2kc05wrnqv2tmvl0h3ej2gwenlakakh",
+    "lp_token_id": "terra1dchs757cqkjarjyl3cwk37kcd9tkvhkuypfr2f",
+    "asset_ids": [
+      "terra1zvncquef39sne2adlvl3xpzcsge0fypakp00zx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ad4crwtu2vpc0qcmw4xmypcy3asp54w3kg95cv",
+    "lp_token_id": "terra1vv83fgkfng78attun85wqgkp9yue39euyz40k3",
+    "asset_ids": [
+      "terra1hj8de24c3yqvcsv9r8chr03fzwsak3hgd8gv3m",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1aduehngz4gzd68k8v474yaejfh7thf7cx8ml93",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1u553zk43jd4rwzc53qrdrq4jc2p8rextyq09dj",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ae0jhhxlwx46xp9uf9cwlca6pm5wa79wf8ppgj",
+    "lp_token_id": "terra1nannmaymqrxt00ya03ytfkhr027zrrgckuq7fg",
+    "asset_ids": [
+      "terra122anargqcp9anz2cmuwc3u5m4nww6fpvyc39tz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1afdz4l9vsqddwmjqxmel99atu4rwscpfjm4yfp",
+    "lp_token_id": "terra1stfeev27wdf7er2uja34gsmrv58yv397dlxmyn",
+    "asset_ids": [
+      "uusd",
+      "terra1w7zgkcyt7y4zpct9dw8mw362ywvdlydnum2awa"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1afslx9uqz7gw348kae05drt39uu2nxnrhlgupu",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
+      "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ag6fqvxz33nqg78830k5c27n32mmqlcrcgqejl",
+    "lp_token_id": "terra1tragr8vkyx52rzy9f8n42etl6la42zylhcfkwa",
+    "asset_ids": [
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1aghtgj6c4m83cuyzfdq7cagh3e4yvksyh0afjk",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ahzjyx9l523fs5s7xe6luqy9auc5tdwzgqz0k9",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra18yqdfzfhnguerz9du5mnvxsh5kxlknqhcxzjfr"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ajj4klvt3gpf5mmkmlsaz7t23paaanm68xn9dj",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1t5kcd9285mqczsyy2ztu96h8h8ecpy5sf6h0qu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1alaaant5ykususyuv0x6k298sh8kl8qkpkuu8e",
+    "lp_token_id": "terra1668hdgce50nwxs8myp33f4ywvs6lanzxvvu9sx",
+    "asset_ids": [
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+      "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1alrzkvqfe2dczdr33kf8et205eeclcqzyvpez8",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1amv303y8kzxuegvurh0gug2xe9wkgj65enq2ux",
+    "lp_token_id": "terra17gjf2zehfvnyjtdgua9p9ygquk6gukxe7ucgwh",
+    "asset_ids": [
+      "uusd",
+      "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1atzg5zp4p9sy7k9urun8q703upffm2maffm8tz",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra19cxwwhtkpp4qvf4tvjmhh8lnh8lle7uw7ndqjw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1au85utmuaskgd0uhgmhus35hpaca2munlzuhrd",
+    "lp_token_id": "terra19lttrz4lxk8pxaz8w650t3rupzz2avzud9lm3s",
+    "asset_ids": [
+      "terra1q9ec5g6q0s3ncl9v068jkk5s2eae8ng3lxqtlf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1avv7dftyck6smyxl8k4juw4qkg8pef5stc7kmx",
+    "lp_token_id": "terra1xj8v6a4wajsjdc4r74a0285zuvst2rmkau5txl",
+    "asset_ids": [
+      "terra10en35kwlud79z2nljssvhp85ep5kx9k0ezzz8s",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1awhdnu3pug33yr86gfu8kmkw4kn4cn720gkc3d",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1v7vp6ywlymprx9mk7ngm4uf0xgrz2ektg5wd6z",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1axd3wejrvzx27sn54yjlxlhrrr49zphqw9fpn5",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1pzjd5axw303jt40l4pmakfa88d0jpjf8rpmj8n",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ayqus392c2fzs4mgrsnlkzjaqfd5efla72el85",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1l670q2m9j3npltmsqe428mwu0msw336m8jtq00",
+      "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1c0afrdc5253tkp5wt7rxhuj42xwyf2lcre0s7c",
+    "lp_token_id": "terra1jvewsf7922dm47wr872crumps7ktxd7srwcgte",
+    "asset_ids": [
+      "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1c4ddm3ds2zwun37r7ldek908ypkxxpkvkcat5f",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra100yeqvww74h4yaejj6h733thgcafdaukjtw397",
+      "ueur"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1c5swgtnuunpf75klq5uztynurazuwqf0mmmcyy",
+    "lp_token_id": "terra1l8jgxd9uv430rdt2u58h4h7kdfxsle4w6w2ecq",
+    "asset_ids": [
+      "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
+      "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1c7uxt89gap5gcclvhtqvx3wpd0ee2dpjhf0ct6",
+    "lp_token_id": "terra19umy5s6eal7kekrddw792wmcftxvsktc2wxzpf",
+    "asset_ids": [
+      "terra1vtr50tw0pgqpes34zqu60n554p9x4950wk8f63",
+      "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1c9cu5ny2kc0j2njj4lydpetgwrjm9t3raqu4tt",
+    "lp_token_id": "terra13698ymrlv2xpy8l28r6qx5fx420w744zg24qzp",
+    "asset_ids": [
+      "terra1k7pvdmk0z4hxhcncanp4pxl6ev3hqzeekzu437",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1cc660x0c7w8ln0rvqftrjt09sjs0wg4xaxtx6s",
+    "lp_token_id": "terra1mr7mh33nyf86vzutwr6ypcv3ceeecfvfdwz0l6",
+    "asset_ids": [
+      "ibc/73A56F04D27FC4CCF6F75C7516A9698B7411E1CE763E240C8A29A50404F86B53",
+      "ueur"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ce7rky5mjrjhyadp976r25r05jhslyn0q3rl86",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+      "terra1042wzrwg2uk6jqxjm34ysqquyr9esdgm5qyswz"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1cgsuvt2nyxxqc6gfg39q2h99s3877mhyhd29uf",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1qqfx5jph0rsmkur2zgzyqnfucra45rtjae5vh6"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1cmehvqwvglg08clmqn66zfuv5cuxgxwrt3jz2u",
+    "lp_token_id": "terra1z0vaks4wkehncztu2a3j2z4fj2gjsnyk2ng9xu",
+    "asset_ids": [
+      "terra1ustvnmngueq0p4jd7gfnutgvdc6ujpsjhsjd02",
+      "terra1ln2z938phz0nc2wepxpzfkwp6ezn9yrz9zv9ep"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1cpnemrjze8904e4ggujp86y0vs737uapqqfmjz",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ctt2k8euhqny20vqynjpxqv32nlr0r95gr2eeq",
+    "lp_token_id": "terra16r76trzhj48rj8tmq82f8set2mm6v7qrje3rn3",
+    "asset_ids": [
+      "terra1ktrxxylv7796wsd8rm7u0dftqhrjfs75r72wnn",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1cvur5qlnaqulwt987f2crk8ccttlvztuq9w66a",
+    "lp_token_id": "terra1wrwxmmea6nxktx09hf2f2m5m0473wnq9lxhn66",
+    "asset_ids": [
+      "terra1zey5xuv48yfjf9y0v6zkyfdtv2du5kau2kdrna",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1cyu32h09k6djqt3a0pgljgan2vass3etl6vcng",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1lnrphdxwfre5w7rwazzfnp0k9d4glm63t7gg70",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1d3jylrg6w94akvu0dky0y6l62sktrfzd4zfkq8",
+    "lp_token_id": "terra1w3ffc33tpmwc3fa0ga8jlqne647k3jtjftrsfl",
+    "asset_ids": [
+      "terra1gtjr689cyaau20k8ezdxy8eup34tntun5xr9l2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1d6h7dqr20lrtv4zhqntvxpxgwqw694cfvhh4st",
+    "lp_token_id": "terra1ym24m9vg93hgq8hmvc8njquls9sq2x0wqjssvw",
+    "asset_ids": [
+      "terra1677xekxjqc4f3jqut8yr6p29e8h5zfay37et58",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1d6k2mnhpqttsqhae2hwu7rs78nrrwymeq8p40j",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1vwz7t30q76s7xx6qgtxdqnu6vpr3ak3vw62ygk",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1d76u99glatdeep6qjkhg48u2a9fvuejcwnasut",
+    "lp_token_id": "terra10etw4xh7ymehx3ngpknfa0p9nq2w7c97vhjzw8",
+    "asset_ids": [
+      "terra14lmsae6e4d5lu74yt67pkfsdaut4csjtq32a7x",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1dcq5sd3y34q4fjwgcja7uhw26xn5ylq33tk3gn",
+    "lp_token_id": "terra1ade4g64fk6jx3udjxrxz0lppqne3y2turx7cc7",
+    "asset_ids": [
+      "terra1d633fx8wlpgqnns9j4xw66cq6ypdy4u8r0rr7j",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1dcs9ja40rmdax9g4ffc756w4cf6yvrf4auxye5",
+    "lp_token_id": "terra1wn8t6kcaqhxrhtexkctyfaftrtvczkkh4u4p5w",
+    "asset_ids": [
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+      "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1dd7g5js5xqqkl2fse28hee38sdes7sv6f79pfd",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra10gpgrr85u4g42uu6c3hkkxkggg2nw5kt95yc7x",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1de8xa55xm83s3ke0s20fc5pxy7p3cpndmmm7zk",
+    "lp_token_id": "terra1cksuxx4ryfyhkk2c6lw3mpnn4hahkxlkml82rp",
+    "asset_ids": [
+      "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1dgqs3aa66l24natsgslvwwkj3henn4c9uesfz9",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1dh2kva6kd99fnq0xa0rn3yjp4dqaw7h806klyt",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1jsxp2vt60nqfsuru6s6ewgfld7vpwgkvv5qqgl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1dhs8euwxt0hu2vj0cne7v8qnxycsmwef36cshd",
+    "lp_token_id": "terra1u9s0hj3sw840xkygjhemt4rxazv7gv2dgnu45c",
+    "asset_ids": [
+      "terra1n2rujfc5lscglry30zaptfgncfc0gq4n8my0gv",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1dkc8075nv34k2fu6xn6wcgrqlewup2qtkr4ymu",
+    "lp_token_id": "terra16j09nh806vaql0wujw8ktmvdj7ph8h09ltjs2r",
+    "asset_ids": [
+      "uusd",
+      "terra1csk6tc7pdmpr782w527hwhez6gfv632tyf72cp"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1dl6h9np5xhtwe520ksjawy5q9lh4cznmhmzkw2",
+    "lp_token_id": "terra145423sy3utrl5fh403tj0gpka36aqwu0nvktun",
+    "asset_ids": [
+      "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
+      "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1dnz5katpc8374kkuwl6c7pak604u50gfpj6zuv",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1afgfjpny09lvxl06llcy7hfu0m2epfddzn0f75",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1dnzskpmnl0s9la8g4jczfgpzfq62kh766cg3pg",
+    "lp_token_id": "terra1qsem5279xw6ry5ntcffwh0ypnexhhz474j4yhm",
+    "asset_ids": [
+      "terra1dy469h5zdej955zgn4dlewrqxw2nq2wdegq3y7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1dpp6zc305d4fux8j3sp2c2x3kaykha8enhl3ur",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra13x03uqz06gkam3dq4dgx0tj89dpw3vs2nlftjq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1dqjt2jm908qaayw5hdl36w50sshmgem37suawr",
+    "lp_token_id": "terra1lzacmnuaceg2578lpxemnx5mts5es8fnf2d6u2",
+    "asset_ids": [
+      "terra1td743l5k5cmfy7tqq202g7vkmdvq35q48u2jfm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1dtsjzg6g5zkqsfwrw0uxlyl6e6u4kna0xzk0q7",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+      "ugbp"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1dv8tp8nustr58z0mlg8v4jpxjd62s2g2dflwhr",
+    "lp_token_id": "terra1yxlq4zezzvkha2e8wmck0nzx9e26xrjylk2dax",
+    "asset_ids": [
+      "terra1xktc8znx48tuypg3p47fcgfxrhc07hex0qgpex",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1dy4dpuxev7y4tqa0rhwjrc6e4yz3w9gqr6szz3",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1e3d9xx54vc4fhepvgqhrwt7m97zftaxet2zayz",
+    "lp_token_id": "terra1qchhau7xaa5dtl6mvfftk5qh32qytt9pk9u0c9",
+    "asset_ids": [
+      "terra1mt2ytlrxhvd5c4d4fshxxs3zcus3fkdmuv4mk2",
+      "ueur"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1e4vke4x2tu4xuh6s9zz42rnvghgcuxqcm3t9qx",
+    "lp_token_id": "terra125gygqsnr8sv58w7y8nh2ewdcexxrfkae53pak",
+    "asset_ids": [
+      "terra1vpehfldr2u2m2gw38zaryp4tfw7fe2kw2lryjf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1e59utusv5rspqsu8t37h5w887d9rdykljedxw0",
+    "lp_token_id": "terra17fysmcl52xjrs8ldswhz7n6mt37r9cmpcguack",
+    "asset_ids": [
+      "terra1dy9kmlm4anr92e42mrkjwzyvfqwz66un00rwr5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1e8dxc7saepd8l7cru73eryaakmrk67fc4qgw5j",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1e9zck0ak5ufz94csu83p90xu37q22dhk22trh7",
+    "lp_token_id": "terra1qffrtdpnj9afjw30njnw84f5rfmkxv8c86246h",
+    "asset_ids": [
+      "terra105hjuy8z0j0w4m0frlaynrnu8smk8qrsk36mas",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ea9js3y4l7vy0h46k4e5r5ykkk08zc3fx7v4t8",
+    "lp_token_id": "terra1fc5a5gsxatjey9syq93c2n3xq90n06t60nkj6l",
+    "asset_ids": [
+      "uusd",
+      "terra1cc3enj9qgchlrj34cnzhwuclc4vl2z3jl7tkqg"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1eazr5t02gql7prqus2a8p6cc78y8vks04xc4za",
+    "lp_token_id": "terra1fwwxakw6ue3jt398uneyf8agnwyf2pys8dcjcz",
+    "asset_ids": [
+      "terra10thstrfuexp5nf9rnazzs433p7zeu9yxr322r9",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1efwf7jw3tgyy7uqx3u8j9p0kpl9ts39avgnzec",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ejyqwcemr5kda5pxwz27t2ja784j3d0nj0v6lh",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ek3g47rves5tmulz3h7twl04fawldwhdr7pyxf",
+    "lp_token_id": "terra1gj5azdr9y80d3reegwumpz48ww09sqqym68vrz",
+    "asset_ids": [
+      "terra1zf00lfqwe6ackx0lcl5ys6lzmdhmvmn6sz2rh8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1elte83u4a6yrw90qmaeee58w94sy6yq7mrf8k0",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1d8h5yckrkgzneng72c8yskgdfd2s9870fuxnfy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1enhh46s0ry3mnj6zx0rd2jjr0pyuspmueywaxl",
+    "lp_token_id": "terra1hwdhxcm974vmlva2u9cd272ck5aegna8uh9t7n",
+    "asset_ids": [
+      "terra1w45ywafn2srq3q6svsam067uh8l2smlu7ljzv4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1enlwzps4sr4g84jwr3qnx3czcvf5ayjgfyfxuw",
+    "lp_token_id": "terra10dlmpyedw742sjg99kkh3sfyy4e0tqkjfd3qyh",
+    "asset_ids": [
+      "terra1x95tutcwe4tjxcdvtgrjg5jxkf24sm74xz3leq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1eqclhzm2d9r7kecf2v87lja6ghgc4s6fmh9prt",
+    "lp_token_id": "terra1kjk5nxkmz26nds873qml7mqtuv45yqcak60ekq",
+    "asset_ids": [
+      "uusd",
+      "terra1227ppwxxj3jxz8cfgq00jgnxqcny7ryenvkwj6"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1erdxk0afwhq0hwpftndeayeqct9eluxyzt0v2e",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1lrdzs5tgllwqgawtq2emuzn7snpxq87fzzl44y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1erfdlgdtt9e05z0j92wkndwav4t75xzyapntkv",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "ukrw",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1esaxnyzts8256a8afsgqsghvm263ngzr32c9km",
+    "lp_token_id": "terra143v5xc8zll66xq8zljxulacqylsdhlzwaraz02",
+    "asset_ids": [
+      "terra1zf5jn0nsureuqaeqmj4pwkrtcm9m7rmlkdjxra",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1et63aq9nclyehc6j05uv5j3nvm8sqfey99u9g2",
+    "lp_token_id": "terra1qn4mpmcjwky96v0cqk0ru8azrk36ghasn8raue",
+    "asset_ids": [
+      "terra1mgyht7c5usg40gqt57zmcd93cdwt49eehysm9p",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1et8gmg0khfmv04vznevg5fx9ngucauh6hg3dm3",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1etdkg9p0fkl8zal6ecp98kypd32q8k3ryced9d",
+    "lp_token_id": "terra1c9wr85y8p8989tr58flz5gjkqp8q2r6murwpm9",
+    "asset_ids": [
+      "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1evjf2hq2w6y9t53d2fmxrfddauz8manutpykp4",
+    "lp_token_id": "terra15g2lqpqvv2zn3hz63q2m26vfle3vlgj6cqvny8",
+    "asset_ids": [
+      "terra1tzkc6jejskv5qnqfa866qrlltx4240n3hwpeay",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ewyn79c2nnzp7g57a54vv6l99lxcjdcd4z770n",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1f9h22l730vxxj5jmrakuwh3neuhdynwy42ezvv",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1f22zcf6m4600eajay6wnzw03lmjdy0f8mjxphe",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra14xulq5g99rfmrm6qkgzmrrspvknupajdqyd92k"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1f2d4qd9wdwrwkksezst20u0dgk867vuf438pah",
+    "lp_token_id": "terra1g7a4hl64r0pmjmdrd3cwsy2cdg2st5x7xlc6m0",
+    "asset_ids": [
+      "terra1ddjp4wgu52cktzgzvahwkr4dcd95mxaqad2pmu",
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1f562s8g3y45cqxqn4qftvwcwxh2rc3v68ug2cx",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1u3cykdenv7z3hveg6vfc0w23gfhwkdktftka9a",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1f6d9mhrsl5t6yxqnr4rgfusjlt3gfwxdveeyuy",
+    "lp_token_id": "terra178cf7xf4r9d3z03tj3pftewmhx0x2p77s0k6yh",
+    "asset_ids": [
+      "uusd",
+      "terra1kscs6uhrqwy6rx5kuw5lwpuqvm3t6j2d6uf2lp"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1f9aln0c98j9w749szx958la7x25chdnz9hqx0v",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1sn208s2cmya87707w4r9hf36znv8ml8dcnhr2d",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1f9l20gvf6vd7wtkga89n2vu69jmpqg0qyzapa5",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1ng9dsq2m5mw993s0uljj06scrj5g07sq36lq8t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1faaael2u6jp9wscfvwqu0376djt8t4rnjmn9p6",
+    "lp_token_id": "terra1twkxlsys3e02tw5kx8x4uw8xvhhv40ym3tsaky",
+    "asset_ids": [
+      "terra102cjx95xvww7cl9l6usxltk75ww3mpxtyw4lpm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1farlsg7xvnj55ttp7y8t39t9e252fusuvqhm85",
+    "lp_token_id": "terra1hq2t2lgg6frwpr9sycwc5cyqqdlv7pam5qehe7",
+    "asset_ids": [
+      "terra1cxaky6tfw4j0xqx8ezxw60cukmkewpx70kr9du",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fcr6s373mxsw000z5xv9zftmpz2uvc4u0x3dxk",
+    "lp_token_id": "terra166h9t9xrsy0wq8t7hpdjx52eecze4gcussgr44",
+    "asset_ids": [
+      "terra1ch852sflpmw500y9jzvkpspzw8ej2jf5934g2n",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fd9hxy2ajycyywzgvu72mj0m75myqy75dwuhtn",
+    "lp_token_id": "terra1u2ksckpcec73mmy3gl3l2uc473vl4vh864npt6",
+    "asset_ids": [
+      "terra1z09gnzufuflz6ckd9k0u456l9dnpgsynu0yyhe",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fdwsevq7skhfq93zkg0xxr6zrv29aqupw2fura",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1zd6let0zg0xjn2sestagxv4ax24a4ml6j40qdr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fehg72ukrnmt56evclq023rpefzjmrwre9k6vl",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1y8w753jk2x2j6f7a9ea30xc2qk5esharn89sk2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fg8f9s8ltyw59crjde6vrv2chvcprndayk9gt4",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra16wggm67a34msdxasg2vergm2pt289y7930wv7d",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fggg5s5eayyqm46p6m27xh3manl6c4pt8kfvn2",
+    "lp_token_id": "terra1jaw7xw5904fsarqgugk0h4tl32w385zv5zaax9",
+    "asset_ids": [
+      "terra15as2k330rp40z3yp8ufs2uqnmdurlzgl643fsp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fh2j8kr484725ra3hwc9q3j52h2qdnnwargzhp",
+    "lp_token_id": "terra1a3n5ryr8ud3mw0cdu6gm8yqdcjjmelu5d79g7q",
+    "asset_ids": [
+      "terra1k8fakrhcg5h87zux06hlds3eswej8389l8fdlc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fl3x3plfat8y82c9wpu6uv97wkqap7lp04a4jr",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
+      "terra1nagqpmyw55yjphea4rhntlfv87ugmeaj8ym756"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fmv3g96s4xc9nrnlkdn87vxyaydd22xsxzel5r",
+    "lp_token_id": "terra1edum55hjxu0fts7wxq5j0umjzm359fenausrup",
+    "asset_ids": [
+      "terra1l0y8yg0s86x299nqw0p6fhh7ngex3r4phtjeuq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fpg2dkcnaca8su8chw6e0m3jlvw0fax8p6ls3a",
+    "lp_token_id": "terra1luejncg2je82xgts7sg3f3g4ytq2473ge5z3px",
+    "asset_ids": [
+      "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fqf55gk7a2znglw3kh8j5gu0zgfj6sxv4q9ng4",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1lvmx8fsagy70tv0fhmfzdw9h6s3sy4prz38ugf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fqhyxfrvlhguw97nuhxm34uvzar8vfr63ft7km",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fts4e488k0u9xc6etggjdqrcnxvmj48vmd23ly",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra14y5affaarufk3uscy2vr6pe6w6zqf2wpjzn5sh"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fxn30f9j9a2slvlxxxk6gyjlqnznhprh0wu0mv",
+    "lp_token_id": "terra1wy2cweqqxf0w23g3c9t8e8n5wukcf24fujfhpt",
+    "asset_ids": [
+      "uusd",
+      "terra1a7ye2splpfzyenu0yrdu8t83uzgusx2malkc7u"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fykaggpacrhy6rjh2u7vs3ec8p9u3l7ynf6gy8",
+    "lp_token_id": "terra12apekfpt3pzjrcwz7rqjswqr0nsrezjkvlzvzm",
+    "asset_ids": [
+      "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fzjflxpv8e0d8ue7hu7faap6mnd0ckamwje5zp",
+    "lp_token_id": "terra1fhvkxz23x2w5kgsag0dteecwmfu9zk9l0frurh",
+    "asset_ids": [
+      "terra1pwu44z0gwlfqecwxuxh6kwn46d8930x226drxw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1fzlm4rzcctes3g230vfgcqwth94wupgsht96xn",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1ng3nsd3u3emflmp4rv7ac70ug3g87pt930g6t5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1g8kjs70d5r68j9507s3gwymzc30yaur5j2ccfr",
+    "lp_token_id": "terra1qf5xuhns225e6xr3mnjv3z8qwlpzyzf2c8we82",
+    "asset_ids": [
+      "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn",
+      "terra188w26t95tf4dz77raftme8p75rggatxjxfeknw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1g9rrgs63wm55ad7rv6rmj8hu8nauc0ru4yussv",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra188w26t95tf4dz77raftme8p75rggatxjxfeknw",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gal8pckrn8w0mxk3q5lkwa0grw2qmdfpkwgex4",
+    "lp_token_id": "terra1fkkffszqrmskfynchj7pr3yrjq7ug27vsah26c",
+    "asset_ids": [
+      "terra1kvjscdgwuvwc6uzm4rqfjl6nlmuhj28tequlnc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gc46an30tdv0n25ch5twgzcsw0wpk2h32gp4nq",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gg00qrm9l7ghqs2c2ey55uwtc7cvu39c799lr9",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra17ggkh9upvkmeyew240lz95zcdytpd2j9m55he5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gg0snqxxxhjcma4095nn7lduwtv3k5xw34lzks",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1gun7mcfjq965gm2jqmq2upxkeqd2lay4qrzfej"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ggqhles03a4zcxp470s0nwctm9n57ggae0vmfj",
+    "lp_token_id": "terra1hu7f7es3y2y20a55h7v3fe460nhc368wnptx35",
+    "asset_ids": [
+      "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
+      "ugbp"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ghjp8h6kn3rgtdw6kgkx4h4lnnwdtca90q4ymp",
+    "lp_token_id": "terra1zaj3vee3qrperz3djkmjzhvsdnt80vy2a9szgw",
+    "asset_ids": [
+      "terra1hpkk7ar777hx8ne5vgkkg5tvntm8j9m32w6zam",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gkdudgg2a5wt70cneyx5rtehjls4dvhhcmlptv",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg",
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gkx2ft0568avqalllpj0d29gxkfq6spk967vzu",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
+      "ugbp"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gm5p3ner9x9xpwugn9sp6gvhd0lwrtkyrecdn3",
+    "lp_token_id": "terra1gecs98vcuktyfkrve9czrpgtg0m3aq586x6gzm",
+    "asset_ids": [
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gpc8f9t9fhehjqlhxlq7aug4vgpw0rfrzsgwd0",
+    "lp_token_id": "terra1q3qrs5q54m0u8ws8vtluwyfppt9ummqp52wftn",
+    "asset_ids": [
+      "terra1mt2ytlrxhvd5c4d4fshxxs3zcus3fkdmuv4mk2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gq080qp496gncf20z8vh4sl0jp504dywm3cw5n",
+    "lp_token_id": "terra10yk2ujugpd4ank5pvp2ewr9en4dnlrul0zqeur",
+    "asset_ids": [
+      "terra1n0pfp0ygz4sqpcjck8ntvlhw74l3tzhe4k9xd6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gq7lq389w4dxqtkxj03wp0fvz0cemj0ek5wwmm",
+    "lp_token_id": "terra1jmauv302lfvpdfau5nhzy06q0j2f9te4hy2d07",
+    "asset_ids": [
+      "uusd",
+      "terra1g4x2pzmkc9z3mseewxf758rllg08z3797xly0n"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gs8pm90pllcz5t7hsqs2fnxjv6pxzf47gg3eua",
+    "lp_token_id": "terra1hrrdpncsr6z978kekdamdaw9jrxjr5r5qtsdas",
+    "asset_ids": [
+      "uusd",
+      "terra1f0us6p9axmzacwq2fn7sm5ke8k302tx7hg7s49"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gv6t0xkxdr096gkad4kksxr0kjl4rxuf583rgr",
+    "lp_token_id": "terra13u54znnd3m8xx6cmujxk6z8mgmr8mzmcjvkc0a",
+    "asset_ids": [
+      "terra1wky9xanuqfjjy4kxt8xa2pcrf7x6lf0zlwenq0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gxxu7stjnshv7c7l87upcs9pqv7n6k07qfr7wj",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1p5k0vl2g22zv0r07fxm627pf8u5frazevqgkw5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1gxyn0lewraduax9lgcqekpcxf0yx2cqtl9pq99",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dssh7fk2gjjgf7yhcrd29repaz2gnxcs9yj9ay",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1h205tvn624npz49snyha3l4cv60d9kccvdr3cn",
+    "lp_token_id": "terra1klc5n2zy79ttxur0mdvhqldyzhkmcehaqm877w",
+    "asset_ids": [
+      "terra1xs3pv5rd2xu36w9vg05shkgxcrxkvz40fhnfsv",
+      "umcp"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1h2mpd99j8mcuyjcxh2wa5xsdkhwtrhyucsyrzr",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
+      "ueur"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1h7t2yq00rxs8a78nyrnhlvp0ewu8vnfnx5efsl",
+    "lp_token_id": "terra1ktckr8v7judrr6wkwv476pwsv8mht0zqzw2t0h",
+    "asset_ids": [
+      "uusd",
+      "terra18wayjpyq28gd970qzgjfmsjj7dmgdk039duhph"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1h7zyvfmu3fqy6ew43c38t0f3p795c8lyyghhnf",
+    "lp_token_id": "terra126pa5vgw2ca80yd8gnk4fs08ef94g6j2f4kjcu",
+    "asset_ids": [
+      "terra1fj06x3hq2xum56htlrdeame70knzl765cq4txr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1haay9t8vvpvdrtd6t9c6pzl2cpr8m4xeadhykv",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1vwvpvamj60rtnzxzr00thgtv5hplhu55jx67d6"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1he8as5az55glkg7rye69ujsgl8f8gs3khjxwm2",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1cczv3ck2r909w64n9rdqs3gh5gsmwumh4utz49"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hgzc444yxhgrdj4g9js9j87uarvsk3ze0uv4mn",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kntmj30tuu0fyu7vmgcrxuzax8gzt7mdmuppwv",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hh5c3yuq9q2rnvndkdqp0nxr3yh7hwkfsnuwwl",
+    "lp_token_id": "terra1x9rpp68cesaf9mavgyy037pqpdpvp2mllt8yg3",
+    "asset_ids": [
+      "uusd",
+      "terra17qkws34rpkzp5clc86xkyal8235lugj38dhk5v"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hh8zw9ppkfrqg6h3lxft5qlz0svqhg2nwutmp3",
+    "lp_token_id": "terra1wjw2f93ntqtahv9unlwhx3jjzmmy0npnkjh6f2",
+    "asset_ids": [
+      "terra1tht79ct6uqe4ngg6wwjpxcu4ep3wdjhlttkthz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hkp4hulmttwzagzphr6vczvjm46e6ryxv99nan",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy",
+      "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hl4624c6pkza6jyxnzpyxf07vyhuwt34c67ujf",
+    "lp_token_id": "terra1f2mpaw7jmm7jzhkgf2x7yg50vr9m4aplu7gkxg",
+    "asset_ids": [
+      "terra14eqahu3wavvesuyplmstsrnfu7uglxxy3m96dl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hm4gfvl5d65v03wzgvy5lh780dnwk6xtnaeurj",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra16xtp5rmhx4agcas4cyg3srp6m6gauqagh02v9z",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hmcd4kwafyydd4mjv2rzhcuuwnfuqc2prkmlhj",
+    "lp_token_id": "terra1qq6g0kds9zn97lvrukf2qxf6w4sjt0k9jhcdty",
+    "asset_ids": [
+      "terra15k5r9r8dl8r7xlr29pry8a9w7sghehcnv5mgp6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hngzkju6egu78eyzzw2fn8el9dnjk3rr704z2f",
+    "lp_token_id": "terra1t5tg7jrmsk6mj9xs3fk0ey092wfkqqlapuevwr",
+    "asset_ids": [
+      "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hnpr3uukuryj72al4knes8a2eerpfjpf7phmd5",
+    "lp_token_id": "terra1gs3hkq6qylxukkklscswd98ar9lxqguzu8aed2",
+    "asset_ids": [
+      "terra1999psgmwex5f7fs0u9nnxrnu82c0c6s7qczhxy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hpslekgztdgykswwhgu7udnqkqudvjdqpns605",
+    "lp_token_id": "terra1j0j79nurur9fhqf5hrl8uav75pqmrt0t06a4ap",
+    "asset_ids": [
+      "terra1c0awzlg4ujlt0c2prwtukqeapg2m4qty5fdgs2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hqnk9expq3k4la2ruzdnyapgndntec4fztdyln",
+    "lp_token_id": "terra1kg9vmu4e43d3pz0dfsdg9vzwgnnuf6uf3z9jwj",
+    "asset_ids": [
+      "terra14vz4v8adanzph278xyeggll4tfww7teh0xtw2y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hr3dnvgw5lp36gj5chc9k8te525sa6yr44zeps",
+    "lp_token_id": "terra146ndl4j5mrps92ksc39wm6uc9j2w2hq9ha928f",
+    "asset_ids": [
+      "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hrffg85q6gph9rktyluglcwfpffh2t98jctu3c",
+    "lp_token_id": "terra1gm0vm4fpr9xe93tw3nc2vdp9ju3g9knwd75afn",
+    "asset_ids": [
+      "terra1j0te9qwyxggd9xq7vhscnnek7yg7cv5gpgurer",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ht8f0pnym9tcnt5srxmlnyndsfl84nntphqfsl",
+    "lp_token_id": "terra1ku5mkpj7nr402ncduym4mgs8ggva67qcjw72hd",
+    "asset_ids": [
+      "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
+      "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hts7pmh590w6hd264pq6pm8ya0ck8qxsethpfp",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1htymlk5xlkzezmd6sy3rmucvhgdcglv5e8jzay",
+    "lp_token_id": "terra13k9lu3kcvee27lw66fw075t9jvza9xjyhyaz0z",
+    "asset_ids": [
+      "terra1clqsjgv98sa2ewwlmyt3pv4uuzz68u45w9pkyw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hukf5q2k0pphwlmc752aay5qtq29mmd5nn2s7a",
+    "lp_token_id": "terra1kksfhstvdl9ht4pxzx900279s7fdaqp3un6l40",
+    "asset_ids": [
+      "terra18cs7aktav46v3pwxr8r2hfkl9pdfmrthcn58qf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1hwaaf5sj0039qf80q3e5cce37rw6kgdce44q0f",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1j0927vf9tuawu3k85q73jjrp58mn26psmmyw75",
+    "lp_token_id": "terra143h0kw3eyt8xjfl8pg77xpjd4alpkns4su3gls",
+    "asset_ids": [
+      "terra18n2k7nwwkgn20epntr4usy8nrs4l9ecu6wzqv6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1j20n7e6klfkp2xjruh000u5lhpj2fgfng3an84",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a",
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1j3dc7eh7tus3jn476zwz9waf37w6hy5qgtjhc3",
+    "lp_token_id": "terra1k7er6xrdmyuqrsevhv9h25gxxpwl43hxmmtd82",
+    "asset_ids": [
+      "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
+      "terra1u553zk43jd4rwzc53qrdrq4jc2p8rextyq09dj"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1j4nl03rhuf9ww53w0626jpng4tz40qm5uuqgnd",
+    "lp_token_id": "terra1susaylhx8sed45ljaww6wrdafqm7hccxhtwyyt",
+    "asset_ids": [
+      "terra155kdqp7le4fw8z8m7wk6c62d6dg5mgdug924nq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1j5l4c2n9x5hjrluk2k746jx60hpgycva4kg5g9",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1ewvul5j47zpsr6dtyt0fup6q3tquqq3cvxpjhp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1j5rqw5vtxsx7el0mptyjqhtfaqnxgg6yu90ek7",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
+      "terra130fhr9jz0nylzhdvuwcpp3hne2s5qlft6hfzgv"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1j6dx9d05sdpynkxexvp4jqdlgqv2adp7uls4we",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra12qeh8p79q6jrnlmw09hvtytv9e99yl2077cmgz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1j8cg2ncvtkfm00lvhsaa80rckq7cerhlvs9r5s",
+    "lp_token_id": "terra1q6ktjyy3mpk4edjz5lq3wphu860sqp2rkhchkt",
+    "asset_ids": [
+      "terra1042wzrwg2uk6jqxjm34ysqquyr9esdgm5qyswz",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jdzll6cwkmeeqjjkm4vfljmjx7aats8fyqmvda",
+    "lp_token_id": "terra1ujttg4pcvkjj9z8xazhzemv8kpexn3vexq4vpp",
+    "asset_ids": [
+      "terra1jvg4ls8jz098g77t04u4hw2gg2c64w8t5g8jdz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1je2lsw0720h2w64ca0559zcav5ltsqcv3230ze",
+    "lp_token_id": "terra1lzqkq68yfgtuu5hkmd38f3tsnw9khgaj7362t6",
+    "asset_ids": [
+      "terra16p7wv0m0upx763r5aux6qatzyve44ezdyqpq5m",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jgvh68gc0zedgrs0fne2y8r0zvc2z7u4sdemwh",
+    "lp_token_id": "terra122pv8ln4s5kled99288gn8sfk4ep5pw05yynez",
+    "asset_ids": [
+      "terra15a9dr3a2a2lj5fclrw35xxg9yuxg0d908wpf2y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jhvqagr7mqf0nn749et3qz9nc9rfehq6n8xgv2",
+    "lp_token_id": "terra1w4kqk5dxef3f6mlc6rcx35csyc4qk5axd0g827",
+    "asset_ids": [
+      "terra1cxvsl5qdvctc537a8q9ynv0seu4r5ceacptwx0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jpf8pnqqswwwnpygsk4eudsujr9fjkh9f4gjcv",
+    "lp_token_id": "terra12pltplchslx9wmsc2mey5hvramycnmnra974f2",
+    "asset_ids": [
+      "terra1gtjtyyhj2cu0ekzju4rj86vsvg7d2uu576rrl7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jvhqxjzezxvss9d0rfpttvz4hv6lp7urvwmx0j",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1tthplnk67e7tvga2dh49jk6l6cn4furuuffu9x"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jxazgm67et0ce260kvrpfv50acuushpjsz2y0p",
+    "lp_token_id": "terra1nuy34nwnsh53ygpc4xprlj263cztw7vc99leh2",
+    "asset_ids": [
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jxzxyjf2cvl7d88un4pp9dak8tljvxhfpgrqh7",
+    "lp_token_id": "terra1qjlakmnnswdzmssfzurpdg48ygu5cnw4lg9h80",
+    "asset_ids": [
+      "terra1wfau60yqgdtrqay0cdtcp5rre3l50khacyyhhz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jyqk0rg9wty4nvvxej9qhnsg3ef3agcc5nmkqp",
+    "lp_token_id": "terra1llqsh0fr47vxpgv2s8l0d3k8h2g2lqcg87zhts",
+    "asset_ids": [
+      "terra14pv5z9j9auwf7p4dg3ds0gch8sr8gnnf0psk8c",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jz5jv3kwnr7mk5yfpp4f2n9yytlywrqpyh6zqr",
+    "lp_token_id": "terra123hvqls8hltc6t5llwfeegjfyp08rtysdvgk2r",
+    "asset_ids": [
+      "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf",
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jzkzn2hdvlq2d8lr8rj77r5lsqckxd0hj52mek",
+    "lp_token_id": "terra1e3fdfzrs0dw2tr9hkv8r3d649rydcwrx9zhum6",
+    "asset_ids": [
+      "terra12j5fqlxaurnvxr27dfsg2lku57rnmgqs6nm6ja",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1jzqlw8mfau9ewr7lufqkrpgfzk4legz9zx306p",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1r5506ckw5tfr3z52jwlek8vg9sn3yflrqrzfsc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1k2ez4u7fnmwv30gysa2rhj4gs4pkngatnl6vxw",
+    "lp_token_id": "terra1ka9qplck0h0kj2jxmnagt8vh64c5qczwkwp0hx",
+    "asset_ids": [
+      "terra1cvdaetw5ljrtkxax8z0pgpdyhhhln3saxl8xsg",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1k30c303e059kqhz705a77kgdhr2ndldfdxjvsr",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1k3nh2pqgxm0clwm8c4d3stggytn824kejht7v8",
+    "lp_token_id": "terra1mxup2qhrk0d5pd57erhxa9h4uwl9ugh2yn32ef",
+    "asset_ids": [
+      "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1k6na35qccghzvdcrmp8djyw9vxklrkxx3vd49p",
+    "lp_token_id": "terra1k0zuu3ljmwqmvaufz0d22d37evsrzju3cz4xru",
+    "asset_ids": [
+      "terra16pj0sful7hl87j8h5qwnv6j4vv76mxj6a6026v",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1k8dax754ampumzvrkq9770p7x40tnvamglg8kd",
+    "lp_token_id": "terra1njsea05lp96jt50f7nc0euc8sjmak6drz8ajdf",
+    "asset_ids": [
+      "terra1jusuf8pcuw56pmj0len5tcsdu9dm4xpqwqk48p",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1k9ndjyjxmyqe3kk7sq92p42kz8ptrtz9wuyq6n",
+    "lp_token_id": "terra10jmlz5uwz6w5hks8y9tretjjk4f8ad2me44lve",
+    "asset_ids": [
+      "terra1nzvqd5mr0jn58cvam9j06k9kry4myu0vp7a9ug",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1kaed40250kxfhy60sy2zf6g665l50m2ms3zjw4",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1kf6ctpmz72mta3h2y68jyg2mlnxktaudsjcxdm",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1kg3ngv5j7jmef9vkrtdgaglrkxs9csruur822y",
+    "lp_token_id": "terra19ur8rp69x37apddlqlnmty8uvckxlgy60r6gqa",
+    "asset_ids": [
+      "uusd",
+      "terra165nd2qmrtszehcfrntlplzern7zl4ahtlhd5t2"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1kg52fgp0e45nt0wjlg8v25zn4v3gkmatz5xk3g",
+    "lp_token_id": "terra174gmmzaxtrxq6z0tamu2lcekjkjy4vwhvxn93y",
+    "asset_ids": [
+      "terra1cnsxjj0378qwu3p5vmrja6j9f84gepvt6r62rw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1kg6emvfc38xtvvlpxr6z8z89t3zwu3etugkzz6",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1pkp0pkxp9mtlan7cg0qatu65hmkgyq2342g27g",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1kgcv6dq7ajlh98t34puyexhy08ltnnx2tycrtu",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1g77epr507pp572hnhaprjuz9fp6yn3e4mgyxar"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1kh2g4fnhvqtnwwpqa84eywn72ve9vdkp5chhlx",
+    "lp_token_id": "terra1c5khguw3ensqawepuxh7vdzfpxa9ulwauhm0r5",
+    "asset_ids": [
+      "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1khjnf8qwlun4k4c2pvn92qw8e77e6ctkpq9n2e",
+    "lp_token_id": "terra1z7ura0m4gg6zcp53fw5vx9cjhjsndvvpdy92ge",
+    "asset_ids": [
+      "uusd",
+      "terra1vxtwu4ehgzz77mnfwrntyrmgl64qjs75mpwqaz"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1khyj5x39ryfn26thsv2l499pz0upgkye277ljf",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1jsxngqasf2zynj5kyh0tgq9mj3zksa5gk35j4k"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1kj8zfkf3nsc2wcad7gkjjza45qnd5lgslpz4pr",
+    "lp_token_id": "terra1lsx5sjly4yc8szw6w04cwhp7tzmlrssh2g7trr",
+    "asset_ids": [
+      "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55",
+      "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1kluzznl8srzx3ssxqw5las5ym9rwqtnrgcl5wu",
+    "lp_token_id": "terra1u7v3aqt6uv2y60kwur5zk3sxpcjn609s4xyzx6",
+    "asset_ids": [
+      "terra1cyaj8agnyzqtw2k5095ysxxgjpgqptyam283dj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1krny2jc0tpkzeqfmswm7ss8smtddxqm3mxxsjm",
+    "lp_token_id": "terra1ekd58y58vq4gmxlzpc27dwuhw7wmms928ftuep",
+    "asset_ids": [
+      "uusd",
+      "terra19cmt6vzvhnnnfsmccaaxzy2uaj06zjktu6yzjx"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ks267e2cr5r3rxsvh728ghg5emz5e7d5kxxks3",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1vsyyg4rs483uzd7jzw5fqqlm2q5n2yd37yylfc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ktsswe96kkjwvcx8md8dt4k8szt2wkr5fh7px7",
+    "lp_token_id": "terra1npak6kyfz07etkg7hk027yge7h83pp2h5u0t26",
+    "asset_ids": [
+      "terra1f3gyvkfwy6lvst5c63gx7alp6547clceaamyyp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1kxvdprmwjxpfl4e87vazwmzdu3pphxgkmt7j2v",
+    "lp_token_id": "terra1v5e88rv3easl8630pf8g2ylzlg73nv5hx0km4k",
+    "asset_ids": [
+      "terra14pwhc79alqnxdhtzm0rrxt64uh4s568u8mluhu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1kytqskj07g0d5qwk3jr3l3z8fdvzjytyntda9v",
+    "lp_token_id": "terra15mewh6pgu8lvwjvyp692ez0yfu386mtydw3vp7",
+    "asset_ids": [
+      "uluna",
+      "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1l3gn79zdchj977p5cg9etzv97cnmcp2yze4ulz",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kqf8ua7al5tdnkz95ue4zkuv4gcu52pt63ya54",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1l5lxw4uucaserz6f9g7av9ejyfyac5jpw94fh3",
+    "lp_token_id": "terra1c6p2vl3xcc2ggufa0a9mkn2wjh9qy0v8y9zxha",
+    "asset_ids": [
+      "terra1zppj8uz7w6xz3ktg6nj2r4ntzzypgpcy07t5qa",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1l5xws6n5wyhjr46cxhvnmfdqqck2xd9tyq0ze4",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1l774jntnhr80wsj758fr9hlj49t8j5qf0dxhsg",
+    "lp_token_id": "terra1knrlem7cg0ywg5hldmghlj8eqh0f8lw2fhc599",
+    "asset_ids": [
+      "terra153qrdszuq65avs9flpeve43e46ypvt4clj6p4p",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1l7urxwu5txjsy56xcuaxac4et42ll3jnjnjrsk",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1g2dz304juraseqdqq6ufnktqgeqen67sct3p7d",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1l7vy20x940je7lskm6x9s839vjsmekz9k9mv7g",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ldpgn35p9m2ksumh8dksp3edvv4nz9tdj2pwv2",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1enj2np0785hw3vt2gn2yga9y75306g6e9lq799"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1le9jy02n73ghxkus40dldgrpeez24pa0t0yl65",
+    "lp_token_id": "terra1u4474h3hqesjwkrtkxekjw065fduc92wke4clq",
+    "asset_ids": [
+      "terra15kqr498g9r2j5mnddy27qgppcp8a759lcegsz0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1lj3z3hfc2hms3r2yc3q4r5w83m2zwktpkuvmmq",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1rdqy74e080e96qhk5gntnr882awm4pfc7t6dn4",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1llf5gsmqnql3rvztx6zv0ej3fdes7nqmhrwvfw",
+    "lp_token_id": "terra1ed7rjhvld0rum7uk6pdkwp7jwawsystzdkttc4",
+    "asset_ids": [
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
+      "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1llhpkqd5enjfflt27u3jx0jcp5pdn6s9lfadx3",
+    "lp_token_id": "terra1ah6vn794y3fjvn5jvcv0pzrzky7gar3tp8zuyu",
+    "asset_ids": [
+      "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1lp6exls2fpz3lv9yc7mtmc6r070zy4lg3lse6u",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra102cjx95xvww7cl9l6usxltk75ww3mpxtyw4lpm",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1lr6rglgd50xxzqe6l5axaqp9d5ae3xf69z3qna",
+    "lp_token_id": "terra1s0dgcsdy9kgunnf3gnwl40uwy9rxtmc39mhy2m",
+    "asset_ids": [
+      "uusd",
+      "terra18yqdfzfhnguerz9du5mnvxsh5kxlknqhcxzjfr"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ltjtvt27ra3vrhyfmv4x4wymez7kwal5tzx3mq",
+    "lp_token_id": "terra10g77x9yzy2tchs8d02tjrr3dtmt5qcq97mteqa",
+    "asset_ids": [
+      "terra1vchw83qt25j89zqwdpmdzj722sqxthnckqzxxp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1lullqskr4jqh6fweuh9ret8k4f9ppy9nf9awtx",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+      "ueur"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1lvkkwhzgchq9n9xafag9u4q96q057vge0q87zd",
+    "lp_token_id": "terra1snem5zhmzj3q4wzm59tf98f0czsf6hcfpf703z",
+    "asset_ids": [
+      "uusd",
+      "terra1246zy658dfgtausf0c4a6ly8sc2e285q4kxqga"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1lxug53rtdtv5c8k7alxum9pfnayzhq5mu4y880",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1l6nqyv78m3kj8v4wa7r5fr3vhp0qzrauwkx5av",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1m68xcezywdvdwr7tfe9lauygx99h7wyx64ss7m",
+    "lp_token_id": "terra15kezlnepzjk40sx4d0e3q46shkwwv4j63hwt7x",
+    "asset_ids": [
+      "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1m6kxrr0uvyy7as6fu2p65p4kgzg9rww9j9yhj9",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra17n223dxpkypc5c48la7aqjvverczg82ga3cr93",
+      "uchf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1m70c962mz88gesrp2ascej5pr2027vs324vynh",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1vsyyg4rs483uzd7jzw5fqqlm2q5n2yd37yylfc",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1m97h5kfh9gf8d42vuvhsq7es4t8y6s6dte8kz5",
+    "lp_token_id": "terra1un3hm3atn9kw5eavtsp84awhhjgjn4crr639y9",
+    "asset_ids": [
+      "terra100yeqvww74h4yaejj6h733thgcafdaukjtw397",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1m9hm6cxlf0907yy7lsssyfpzswlu54r99k9dxf",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1vwz7t30q76s7xx6qgtxdqnu6vpr3ak3vw62ygk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1m9wn7rpc570tsgfuk973m4c8u52k8gmks4f3ej",
+    "lp_token_id": "terra12mh2afj5mpsncshgm2pnwwp3svaqwattvzjaza",
+    "asset_ids": [
+      "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1mgun8jhvfd4zcqzl73rc04447vn3kuhfjasnpt",
+    "lp_token_id": "terra1q5mgsnqdnlca3zlffy8mc2fu5y4xmm9hd9w3gf",
+    "asset_ids": [
+      "terra1vtr50tw0pgqpes34zqu60n554p9x4950wk8f63",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1mhtsdde76nulexf5p5fawnlnq2trs65zrd98zp",
+    "lp_token_id": "terra1jyy5a49r77le4l566m4wfun3pkpm0ed7n0luk8",
+    "asset_ids": [
+      "terra1yv2fdec6ej4g8pv9sru5ezcz75a2zrczllxn86",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1mlz0yv4j8rw6saz5v7fq35m0qtacag8qj4hr83",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1lladdxhn49jz0hrvwgalu4a548txh94mcec595",
+      "uchf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1mp40g7sneygtnxdm2ncxmjq45pgut2hryxck3a",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1u9hgxjw5k0aje9xjf0ejfu6uwmamc2k8ylzd7l",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1mp8mm0m43s926dqmwv3mgfaagvtpx8e4w84ur6",
+    "lp_token_id": "terra1kg0wdgxsqgy4trqmjmag5qd00hlygh2df8th8m",
+    "asset_ids": [
+      "terra15dcd0j3tqtefj96nhqryt59qyr820tyxq3l0dr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1mqcremxfr90hu5a7nvyrn7zkx3zu26ndl4zeua",
+    "lp_token_id": "terra1dugqpn2r79rqlyudz7xtfd0nqlt53ek628a0vk",
+    "asset_ids": [
+      "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a",
+      "uchf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1mspf3g3fx3j0u9p6y7nxaf23wetn54hgm3z753",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc",
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1mv3tksqwfextmnejw8s7ada9qu3pwav098qfxu",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1mveechnw84gnylqjs7v5wrk9ky9jyly6lsfmfr",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra193c42lfwmlkasvcw22l9qqzc5q2dx208tkd7wl",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1mvjm8g5zmwutqmqsjaq6q4rtv96c825v3lpep3",
+    "lp_token_id": "terra13dvh4d653c6tyu7f30hwcpjnrz8xhx87yduphr",
+    "asset_ids": [
+      "uusd",
+      "terra1xhqxa9c3z223lt67lt86r2lsvtmuguddc9g55m"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1myn9wsgv02jny8jwhnxdf8lrfy6gvdnv2c3wk3",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra137qvfdvlkj9vfhrctz4rlkk7lmgql7xalqlwpw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1mz0p4wzz5tmethu7rca2jjrw077hv2ypj7h06z",
+    "lp_token_id": "terra1mxpq2xc6k7zasj4wmlz07x4wh9la8dqn3nrxja",
+    "asset_ids": [
+      "terra1hnezwjqlhzawcrfysczcxs6xqxu2jawn729kkf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1n0v5y6t5qakqsl504q6x5f2qvstqujaavxcapd",
+    "lp_token_id": "terra1vcecxknz3rc8ktpc9pgrxg578fsxlkksnuwx72",
+    "asset_ids": [
+      "terra18tc5vrxzvxwlcchq83d4nxy635cu87v8g0030y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1n3khk8w48y8jf5cgjjhccg5dg9qua0xdkt98we",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra176eej9z5upauemz7wg2q6n86472xyy836v6smx"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1n4cqpg6yrgrjy3znfyx0pka5gyh6hysv5vqudj",
+    "lp_token_id": "terra1dp54cd4mq449w0x6gnxlw6v0yg9dtpjpm4urv3",
+    "asset_ids": [
+      "terra144w7e54fwkpz2aavq33p6d2upyc0u006udf32g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1n66fcrg3hh2q36jrk8j900jx6xf72zw0thf3h7",
+    "lp_token_id": "terra1vwts232nu2r9nhaacmsnfs6fmfr6tf49yhd7s4",
+    "asset_ids": [
+      "terra1l95pyqf2ahqy7c53pejt8v7nnlg060fghs2499",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1n6snwmgzpfs73juuxurwxmt2md49s2l5ggf5f2",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1xt9fgu7965kgvunnjts9zkprd8986kcc444q86",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1n9dgrp7e8fxds75ffflaqfk9f7edeswnd7x2pc",
+    "lp_token_id": "terra19ynuzuwg9eymlyk745vw8suna2r2f20fu8uc8a",
+    "asset_ids": [
+      "uusd",
+      "terra1csk6tc7pdmpr782w527hwhez6gfv632tyf72cp"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1naeq3qjrd0mzw2amr0yr42mmkpmq5nrsxvnyqp",
+    "lp_token_id": "terra1hv0xq2uyav58w57dckcvcg3fu39gvrjca737sg",
+    "asset_ids": [
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
+      "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ndvg44ygupqwq8xqzvtyqjq7agl50wwfpm0jfq",
+    "lp_token_id": "terra1fepqumj8lea8w0au7mqluuthv0jly22tx0rcls",
+    "asset_ids": [
+      "terra1nl9dx4pkat90gzw2j99n338n984e4cw7nxq65w",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1nfe80fnw2d0wax64ag7j95evqglqelhkh78l6t",
+    "lp_token_id": "terra105j7u0yn7gjx6sdnahd35a6n6f2hm6y6saqz07",
+    "asset_ids": [
+      "ueur",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1njhvhtgvteu08dpgnhve9gpa0wmcrzyf80s76t",
+    "lp_token_id": "terra1mlkgz49lqndlgjfe3m5m4et7kz258fx89re28p",
+    "asset_ids": [
+      "terra17yjdhu7pk865t0jeswtpecukg0uw8xelzvfmdq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1nlk3qg58gu88kfm2j34qydaxaxu9rw3yf2scvf",
+    "lp_token_id": "terra16w4f3frfyqkkd8gvc2r04ynyvykc558ssw93jw",
+    "asset_ids": [
+      "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1nlrtp53mpvlged7pp537avj8uf59j3s0qlwrga",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1cwretz2zmeqe2uhq4fuk2mrp4ptuvsct890c6f"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1nr2hvucfvtnzxm39022jal53wker54thdkll4r",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
+      "ueur"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1nsmppls52m3fmphznag3f7lue5wp6ffrp9e4s5",
+    "lp_token_id": "terra1dmuw5wyluxe6hf85x7waepwuqjgs2460fmj8qn",
+    "asset_ids": [
+      "uusd",
+      "terra1h4hvry62zk4zh0udecqmatfg02phnyu6hq74xd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1nszsz38jnmfs6xl9tsq093sc23stm7xz33dqqx",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra19xk3rsesaupv72se69y8v6y6m04fl8yj6vnmtv",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ntdceldg23ymqljh94wcp78dl6qmzndq8u2hwa",
+    "lp_token_id": "terra1swpfg0q9uz0ct4tqfdunrumnxx8zxxzdlnlfkw",
+    "asset_ids": [
+      "terra14mvkydkwm2pzz62cgrkpeusphm4trrqrzd88ju",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1nx3rggxrpv0yekes85kg3fa7v73qgphst6v5gj",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1aydw57mpa6jg5n3xnrau9g7mftd3ch6fh7qzal",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1nytaqyhspr05thllfkl9lgnvmfwxdxmcy42k3s",
+    "lp_token_id": "terra14fy4yzl893m0wqh89mv6c00lnutmgrml08ndrm",
+    "asset_ids": [
+      "terra19u8cgzsmgg27mnevcc22293yl3j82f26l8nvtz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1nzepxu4scprmc6ly4amam0f2teufy69uu02wzw",
+    "lp_token_id": "terra1v6s4drn5hyp4jhyn797ddn8w3zjxl50c647y3v",
+    "asset_ids": [
+      "terra14v9wrjs55qsn9lkvylsqela3w2ytwxzkycqzcr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1p0sjx8kg9zeuefzwu0ac9ftemrr0usdyypsnty",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1c00vskhyzdv0z63z2tyetzx2qma67n2z3vzyn0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1p2462m98je6pk3n03fwrnmngkm05mcr9pn6cmt",
+    "lp_token_id": "terra198pmh4mhd42ltqlcntja99fzg4psw7en4w3z7l",
+    "asset_ids": [
+      "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv",
+      "ueur"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1p44kn7l233p7gcj0v3mzury8k7cwf4zt6gsxs5",
+    "lp_token_id": "terra1khm4az2cjlzl76885x2n7re48l9ygckjuye0mt",
+    "asset_ids": [
+      "terra13zx49nk8wjavedjzu8xkk95r3t0ta43c9ptul7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1p4jvensmff8knpp76ej35ugaj2l75yrk5aufux",
+    "lp_token_id": "terra1k0q9wnqs4c8kuy2gudva5dl3cucf8xqxfjwsek",
+    "asset_ids": [
+      "terra1g53pyke8jtmt4lwvk4yl0xaqc4u0qlsl8dz3ex",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1p5a83hq638z7l5eqr0ll8tnayy3gecakzftc8m",
+    "lp_token_id": "terra126evm399rxsvzw06qe9kxcmv3ly5lwarycq5nw",
+    "asset_ids": [
+      "terra190tqwgqx7s8qrknz6kckct7v607cu068gfujpk",
+      "terra1c00vskhyzdv0z63z2tyetzx2qma67n2z3vzyn0"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1pc0r79hmaznqh7tnsmzmh9zsl5y87t02zz2fmr",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1uhwhrypcnucvcc2ayt92mlky2xtatslrn7tte4"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1pc7pufyc4z5lcwm0fhrsveu3fxly97htyh2hnu",
+    "lp_token_id": "terra1ea6srqjggq3j8spanguqfekcklwnqwren6km9t",
+    "asset_ids": [
+      "terra19953ttzk3mxghgwpdt85gua3gzzcj9a6wjwek6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1pcgx4257v8lskc9dul37searsf8uh8zyrj077x",
+    "lp_token_id": "terra12jcvk4ltvdygacp2k56vnre42cjwr60jmv77py",
+    "asset_ids": [
+      "terra1mt2ytlrxhvd5c4d4fshxxs3zcus3fkdmuv4mk2",
+      "uchf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1pd3sdj23u85w3vlrtmrpadud4qmxhppyy6dsyq",
+    "lp_token_id": "terra1rdjzzqdcqasnu4kgk796e3rr9nvrhx5y9xdg7e",
+    "asset_ids": [
+      "terra1mqug8fps3zqsywzrukz5m6shcnj4j4rqna3kzf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1pdxyk2gkykaraynmrgjfq2uu7r9pf5v8x7k4xk",
+    "lp_token_id": "terra1ygazp9w7tx64rkx5wmevszu38y5cpg6h3fk86e",
+    "asset_ids": [
+      "uusd",
+      "terra14y5affaarufk3uscy2vr6pe6w6zqf2wpjzn5sh"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1pdytx5xzs57t6qqdrnf9vn4ejxclpdn7eqs6kt",
+    "lp_token_id": "terra1wegnql6drjz35m68xjnfrz4w9tp35fhn5e40y4",
+    "asset_ids": [
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1peyurud64sjajna3s9g2s9er4uv3tftyj9avwf",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1pgf2ntzk2gh2lar6zh0yjwchmrtym8zfzp296y",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1uc4fwlh2wn59qqk8y7ld0vxc9hvsufaa5gv5z8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1pgla9506h2ed9p93y6ryvxgj5admukssrcedwx",
+    "lp_token_id": "terra108gn88qjjm0zmd0sjg39dwnksq6j2ehmp6pf27",
+    "asset_ids": [
+      "terra1akwn8y34upderjyw07hgepunte8mza00vafzfd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1phjmfqsajhrzdq056nawr55kqqerylpthpvlat",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra10h7ry7apm55h4ez502dqdv9gr53juu85nkd4aq"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1pk77hewqerplsemc7wu9h78zwxs7cktfejdq5s",
+    "lp_token_id": "terra1ukk0exsl5cejgnsn4jrdju83wrpdcwg0thfzpm",
+    "asset_ids": [
+      "terra1wwpxtgrrfn0jxq8f0hlrzngx8m28r8kd5umaq8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1plf355sg3tntq72wa35qlrv99tduhhjax0vxjr",
+    "lp_token_id": "terra1ufumstplfqt5c9qs6zjzr5vp3dew7s29u7e7jd",
+    "asset_ids": [
+      "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw",
+      "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1pn20mcwnmeyxf68vpt3cyel3n57qm9mp289jta",
+    "lp_token_id": "terra1t4xype7nzjxrzttuwuyh9sglwaaeszr8l78u6e",
+    "asset_ids": [
+      "terra1ez46kxtulsdv07538fh5ra5xj8l68mu8eg24vr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1prfcyujt9nsn5kfj5n925sfd737r2n8tk5lmpv",
+    "lp_token_id": "terra1d34edutzwcz6jgecgk26mpyynqh74j3emdsnq5",
+    "asset_ids": [
+      "uusd",
+      "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ps8wcwxt783qq07gfza0f67xf3kuaguq0r0e4y",
+    "lp_token_id": "terra15qmh9jl388v2hr2yn75v8psdj0q9ghfwwxzckg",
+    "asset_ids": [
+      "terra1x5t6zkvhc6dg2jjug34tfreme3hcufpuy77da2",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1pufczag48fwqhsmekfullmyu02f93flvfc9a25",
+    "lp_token_id": "terra1xwyhu8geetx2mv8429a3z5dyzr0ajqnmmn4rtr",
+    "asset_ids": [
+      "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1pyc4z680nrvd00xnqh24dtvap2840w0a44x7ns",
+    "lp_token_id": "terra1udkgg8n4ynny7njj7fra88lkmjw8f3ggy0crdu",
+    "asset_ids": [
+      "terra1m09t5cs473tvl7lsregj024d3dwg65su6ufpfh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1pyx0xvdeqmn8r7ljakjwx6z852zg25kxpesyn0",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1g4x2pzmkc9z3mseewxf758rllg08z3797xly0n"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1pzhcs3l028l8dzvj9hvxgt93ez4uq203askad3",
+    "lp_token_id": "terra18jwvd3w34eudhvz97gtut5qtas57al7ez0kg4c",
+    "asset_ids": [
+      "terra1kqsgl8p84szmmv0npvsv0u5qlq5fng3zk8c4w0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1q00r9whldewsktqne5sux6gtaxn2vlfvu5geej",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1q2cg4sauyedt8syvarc8hcajw6u94ah40yp342",
+    "lp_token_id": "terra1jl4vkz3fllvj6fchnj2trrm9argtqxq6335ews",
+    "asset_ids": [
+      "uusd",
+      "terra15hp9pr8y4qsvqvxf3m4xeptlk7l8h60634gqec"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1q3pem26pyxq7qggmxkh5egd4km0a7l0gxe84wk",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1q4xywudqrgsuvdc0n9w0mhmrpzqj9lrl5wcf6j",
+    "lp_token_id": "terra15pclv9fqytszqlmjymshyk9cfytaaqrs4h87sf",
+    "asset_ids": [
+      "terra145627szryw7lxr58cvclx9aj468qupld4vnf88",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1q5uy25egxd95tt6j7kxu26xtnn50pl7w6grq0z",
+    "lp_token_id": "terra13wgcwjzgcphqgcay6k06th604rdggjf2plcyjz",
+    "asset_ids": [
+      "terra18lx7nzwlp8sr83y2wymhj37fnrlehm7rj6lhlf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1q772ps7jxy57kgfhhpmg8gxsgn9fr7npwsn4kw",
+    "lp_token_id": "terra1jm8tx0aump43epcd8u0fspqp47agykvmmfrzh6",
+    "asset_ids": [
+      "uusd",
+      "terra15z4tj56cdpdk5jxf28nep3ep0myu0frhlh6f3u"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1q9lnctytu3c4p5ekv3xpmyxnegxe83adeufemv",
+    "lp_token_id": "terra128pdzd65aju0q94vwj98j9lphnklgvkdpz7q83",
+    "asset_ids": [
+      "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
+      "terra1nagqpmyw55yjphea4rhntlfv87ugmeaj8ym756"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1q9lvy34kjnwr9552yd3thv39nmrwg7ej46cvy7",
+    "lp_token_id": "terra1f0l9d3dedr3au4frre8uc7w7s2chs73a9xqwjp",
+    "asset_ids": [
+      "terra128vws7v3ruqpysj0wwy95nl8a7an7nnyctmvle",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1q9mgca3xh5ka3jtsunjsdy5vjjwaykkynx00ld",
+    "lp_token_id": "terra1qs8frq6vn59u4hv6l7k0rvf8m5xd4n46n0vzwa",
+    "asset_ids": [
+      "terra1czqey2sj9h2w625ez5kefp6j7d5s08e7lj2yhd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1qdvgzumzmfjzyjkvr647n8el7pq05jm958f6ml",
+    "lp_token_id": "terra15rsfe8x9w3p7hl9n4ptawzw40x29t4w4h0hhnq",
+    "asset_ids": [
+      "terra1lchkxy5ednukxepwxejak8xevqlmz89ukjh6hl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1qhnylhd7vdu87sdyjs908ndxc4ck0pgzpr7ky0",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1948uvsah8aw40dhsa9mhl3htq8lraj0smlh77g",
+      "uchf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1qjus04wsfvxgg0k5k4hjdr20ttlcxewq2lu7vk",
+    "lp_token_id": "terra183pmt26qpwy4xnpunzmckjydsnyw43hejgaucf",
+    "asset_ids": [
+      "terra1ckvmptla24qm80yrwkxluhptee4y8h3gemwkw7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1qkf2kffhu3f6x4d34tu67eu2u8nkrqrn6w3a2n",
+    "lp_token_id": "terra1mspnuehp4h68f03t35lr0dzz8ajhzdq9jazjk8",
+    "asset_ids": [
+      "terra13sg4qarsjual8ew8sr4nwtkv6ut4dd3378820r",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1qll0dwhllspv30xnekl2csr6k3ykygtqdzuxl8",
+    "lp_token_id": "terra1fgc9vy7hhzjgv90chemxgs0p5j5dfhkzsfexlt",
+    "asset_ids": [
+      "terra10famrcyze8z9c84x5726aplefwuf4k2zqf3rxr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1qp6jp2sfsv8gmdh2tu33w904qqym394fzkxnxd",
+    "lp_token_id": "terra13ek9x87hp9t3gf5ltchzhl3xuhhakm26jyj4vz",
+    "asset_ids": [
+      "terra1ukk89gn25p7xseqc4s4d45yarjlwychrwx7umv",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1qpd9n7afwf45rkjlpujrrdfh83pldec8rpujgn",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1qr3jrdwrkqhntnkpvx39efrmayx45ysuhpg9qk",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1g0pm8xm5c2dq4qtv8j9a80hg4mhe5ndy8qad07",
+      "terra1mjhrlgwv8dnvc7mp0cynfxna947hxnm5m4tp6u"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1qs0zjzd6j0kwrwwf2qj5kmqqhav5ygq3q7p8s7",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1qthlsaqccp8mxr2z4vvkhf5ynqjl86ccxg0pqn",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1zjhsuvuy5z7ucvx56facefmlrrgluhun27chlf",
+      "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1quf8yfhqkt38fa2j3zhgfv93ra6tvj9t0q6sgn",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1quz6cfd40l6qsfjyrmu0xe5xsnufg6g4rr00a4",
+    "lp_token_id": "terra1fd34ray6t095g3rnj9yskjum0kglrym44qnmra",
+    "asset_ids": [
+      "terra1pr2swnalac9ny993tgvtcfyhe4h9cuqm3rdmnf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1qwk53cmt2j50ge2vkmt5sgcnmua5va5gx2s6yr",
+    "lp_token_id": "terra1nazd47xg74dg4a2eld2qxaynarv67d2l24z3y4",
+    "asset_ids": [
+      "terra14zeffuryjlzw566k7cfrnzf9dy94qeat2xvcda",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1qyynd88qccpjrdn4yghhf8n9dm9msayrtqwwva",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
+      "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1r0288hx3mjgx0zrpmpc8rulm6ca8jheqtwhwq5",
+    "lp_token_id": "terra1nafrz6yep84lvphmj03gryht3exa624ttgkf06",
+    "asset_ids": [
+      "terra13xujxcrc9dqft4p9a8ls0w3j0xnzm6y2uvve8n",
+      "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1r2hhqmwh68uslcw0np3gwkrdd36thfagq6hzj6",
+    "lp_token_id": "terra1j33rxfgdpuv3dpxaexhsuc64n6ltlascr5te2j",
+    "asset_ids": [
+      "uusd",
+      "terra1kscs6uhrqwy6rx5kuw5lwpuqvm3t6j2d6uf2lp"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1r3djf4znn0vknjhdmlyg89hd8955v3vhr7jj5h",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1r6pp7pp0pgvp06nh80qmu697qfjsegddqnsg8t",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra194a6jn3cyydhrfpdnz5r5zkj6wx3t3cr673z4r",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1r786pmp9z6edc0qufxgxxaheh5ag735avkfm30",
+    "lp_token_id": "terra1tsg6xz8n86lz538psktzfca7fe35gp84pn487v",
+    "asset_ids": [
+      "terra1e47v67sld3p2pre5skqh05ddld22rwhu30fnwm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1r8k9pea8wmt93l703azhs82kpjva0cpq8tq5at",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1wvk6r3pmj0835udwns4r5e0twsclvcyuq9ucgm",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1r9e7efml7zk8fd5x5atk39e8jua9kdt7n7lp5r",
+    "lp_token_id": "terra14dgkwkplgmw9tkdf4rc72ppk6q5p2mu0uhfl09",
+    "asset_ids": [
+      "terra1gmpn6gy7tdm39tc97te2f5prjdpgml760pke8k",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1r9n03pheztcxrfcykwazvxzd0rnvzrdrdwpsf5",
+    "lp_token_id": "terra1gvakrl38c6ygrvzv2srnp738z43xy5prpmy78v",
+    "asset_ids": [
+      "terra1mpq5zkkm39nmjrjg9raknpfrfmcfwv0nh0whvn",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1rds4mfy90pxtn64px8dq9d68d2vwkcplpt6sl5",
+    "lp_token_id": "terra19uca4zxqr8e9t9l6lcz3rztzaygnawwlex8g8l",
+    "asset_ids": [
+      "terra1xjxegty6mmdr5jwqwde9rqhz758sy8c73vxzea",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1rh6rwrekv3r7ep89lmkysxugsvuaqljmmepx5s",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra16qsk2zwv5fsqd944p28f2dkddr7eq9uzuxeh8h",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1rhsh5xxl52xkuj7qq9240hwmcyzq2gpyj9hl0x",
+    "lp_token_id": "terra1s6e449z6xz0vm0tx2h5p6drxwz9r2jvrcvcc62",
+    "asset_ids": [
+      "terra1skjr69exm6v8zellgjpaa2emhwutrk5a6dz7dd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1rnc5cp7r9nxrskhup9uqs9v0e43hmm6u9xydec",
+    "lp_token_id": "terra13p6glny4ltdtrlptq2g9gs3e8m35t55uwgs9ea",
+    "asset_ids": [
+      "uusd",
+      "terra1aa00lpfexyycedfg5k2p60l9djcmw0ue5l8fhc"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1rq55zs9w6s24wmlmd540j2q2p6whanurfj26eh",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
+      "ugbp"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1rre03e5p2w39uuvgxpxygnmtalj7cu7sp540zk",
+    "lp_token_id": "terra10n748ua6aktwge5387w5gez45nvava0dzn2r9e",
+    "asset_ids": [
+      "terra1ghnll5fz4n6c0vt47jdnnyrjgfg4fgnqnchwys",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1rrek47kf0t968g2jcg5ww8fw58n93jkclkk4v5",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1lkjq6f2sqlqjk0crs2a7fv6m5pquhl8nuesp3j",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1rsuhf9cfvrfcj5h2h28ad72hhqgxxqyg2pf74y",
+    "lp_token_id": "terra1ce5l6em2gc58lu0ltxq5xsn4d9u3nj49qdntjv",
+    "asset_ids": [
+      "terra1mt2ytlrxhvd5c4d4fshxxs3zcus3fkdmuv4mk2",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1rtyprjhqks470dgggn6nvx06ny388np6uy53vr",
+    "lp_token_id": "terra1zc86cnlsmgz50swt9nluhpmn45k2fc0w9du3ys",
+    "asset_ids": [
+      "uusd",
+      "terra1ptdxmj3xmmljzx02nr4auwfuelmj0cnkh8egs2"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1runncker37zx0wlp43xchzep33udsn6yje3rt3",
+    "lp_token_id": "terra1zn5ycnftj4lplwwtjrt6jtvqtqwc2xl0ypyegs",
+    "asset_ids": [
+      "terra1cetg5wruw2wsdjp7j46rj44xdel00z006e9yg8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1rvnzun0xww86xnhu88prga8qt2n2trkjm72s4m",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra15k5r9r8dl8r7xlr29pry8a9w7sghehcnv5mgp6",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1rxn03zjqscvv770h0ede4v4649y62zlr0lxlx8",
+    "lp_token_id": "terra1etsh6y54ew6jcud4yhuu8awfdcz4j6jev6ej3u",
+    "asset_ids": [
+      "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1rxzs4rs28rx89dt57nnph6xz8zmycf5js2d4ey",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1srp2u95kxps35nvan88gn96nfqhukqya2d0ffc",
+      "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ryajnmy7npuzq3de9yt9c7x8ac2awdtf8ekaw8",
+    "lp_token_id": "terra149zg8aesny2xasfkc4wd6z8agewjfq5uve3pfe",
+    "asset_ids": [
+      "terra1djd0hmv2hq8s0g9hs53s7gmc2phgg33kqq4uul",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1s47rsyk3q7h8ketsuw2swdtgqr4lqfvt9jfdx3",
+    "lp_token_id": "terra140a886v0e6nl8s8gpzkrunk443pr0venvvt32e",
+    "asset_ids": [
+      "terra1gecs98vcuktyfkrve9czrpgtg0m3aq586x6gzm",
+      "terra1nuy34nwnsh53ygpc4xprlj263cztw7vc99leh2"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1s5w4yymch3y85n54pma0qkuyqek0s5a9kys39k",
+    "lp_token_id": "terra1svwqdq0gcuw2q2vzmy76qjvl2pnwaz65d4xvs0",
+    "asset_ids": [
+      "terra1tgfw423t34rwaezm4u4vwy5d80tfgzuyx2s6x0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1sa70wy0857fzu2gjcrg4mm7n5767k7lhj3yrct",
+    "lp_token_id": "terra1juspa927c7kdr0jf7wc0lxg6wfjz2cersm9r82",
+    "asset_ids": [
+      "terra183x8jduwtdgcqkwtqxdzjlq2mq0rlnj6hm22j7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1sc02s2q53678ase0uh5e02x95dv6knkkgf6xwx",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra10ynpvp8trmlkf6n69qx0kp9qjs54d8wsh2pddc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1sdmk3k5ajmnk5zdfujmr8q3yfvlp067h8syq5l",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1sdu63qdzkndpavvl5ephzwl7jj2slvcy89qu9s",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra158y6aypem94yj34ycvgdm3py23afhnu2dj24ak",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1seh55ualnngk9jau3qsw7xrl4q7vqhc8y64w5q",
+    "lp_token_id": "terra1jnn5xpmeythug88hu66pwl3x9fz2s0ms034aw6",
+    "asset_ids": [
+      "terra1yjlqptvn3al5402jp600l7n3l5yl8man8d4kex",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1sg6tzmqegqhacd6nkrkrxn6hy4lx59ex7tt6mv",
+    "lp_token_id": "terra19w95ffdpqeweglhzadwcaa0amu0g7m490kx5ch",
+    "asset_ids": [
+      "terra1t0csdwp5u9592522n35ededwt2e46sur5u4mkg",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1sgpvnwxmd9gmhhxzw03t7qftu00x35994denrm",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra130fhr9jz0nylzhdvuwcpp3hne2s5qlft6hfzgv",
+      "uchf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1smwa4uj94ecy8qtenezzew0z8mur9vy443pqc5",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1sndgzq62wp23mv20ndr4sxg6k8xcsudsy87uph",
+    "lp_token_id": "terra1xqeym28j9xgv0p93pwwt6qcxf9tdvf9ztfxf0w",
+    "asset_ids": [
+      "umnt",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1sprg4sv9dwnk78ahxdw78asslj8upyv9lerjhm",
+    "lp_token_id": "terra19ryu7a586s75ncw3ddc8julkszjht4ahwd7zja",
+    "asset_ids": [
+      "terra1f62tqesptvmhtzr8sudru00gsdtdz24srgm7wp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1squzmwcpr5486f0zp759d5zyt0q3yykaf6e4zx",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1st3tr5ppd3cs8zfl7ygqtc50y5thn5h6chdpmr",
+    "lp_token_id": "terra1qqecag8xppl7faec4rrxp5v0vheex0s9dtvhte",
+    "asset_ids": [
+      "terra1zn26hzdegq2c9qa0etqcthk2kjcr6cqeaud7q9",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1stdzf28wlq7llzfecse366r657rtdh6wtrdfk2",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra140k6k2pmh2lmy4q4wyz5znqmtgwvs3gkgfeevq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1su90khngc8fe80dwu0xgwt49262ytaye6zsv4l",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1swdaspvv9w0wtf9sylmkdmfnzjx7eu5734n64q",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra190tqwgqx7s8qrknz6kckct7v607cu068gfujpk",
+      "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1syp7rzmgtp9r6m4qlhu9x6luh4ltqyglkd22u3",
+    "lp_token_id": "terra1mgz7rsnqzvdfem9zg55afdzxvzfhymeed42uw7",
+    "asset_ids": [
+      "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1szj7qd0azfzf4sarhxr2wfzf0k8js3vng545cv",
+    "lp_token_id": "terra1p3urvqahfp6pup8xw6lp3zcruw8kv3xrkjwk4l",
+    "asset_ids": [
+      "terra10f2mt82kjnkxqj2gepgwl637u2w4ue2z5nhz5j",
+      "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1t0pd5uqsqp85cgly5cvggm698asez55ked2ftu",
+    "lp_token_id": "terra1768vz98dnfxlvwjnx25r520pfevk7djfc3ymhx",
+    "asset_ids": [
+      "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
+      "terra15tztd7v9cmv0rhyh37g843j8vfuzp8kw0k5lqv"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1t228agv0gpw0uryk7j2lcqhcwgylwkgumf2eej",
+    "lp_token_id": "terra14j965wgdyyrkryjem570jh7y7lzgyrs0jp6xud",
+    "asset_ids": [
+      "terra16pektynpxqrs66gk6cgqpwr7rjsudyfzustm6s",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1t33pflkepsmky9smma25ne05ghre3zk5wgz9u6",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
+      "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1t4z4tdtn8ka6q5g7x3mx4h5w8ufh07c3s6eca4",
+    "lp_token_id": "terra1n8fwsrf3qruwx99eg87dmw7x4pjc8n0a35vlef",
+    "asset_ids": [
+      "uusd",
+      "terra1td527f09l7lgf55fqtr0zvtx5ek0yl0fdrx574"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1t5kr723pn2nv9rz576lxtqhjlaevhhfw30g7z3",
+    "lp_token_id": "terra19fg28zjmr6fukx0jfm5q472yn8jq83mhlwphrc",
+    "asset_ids": [
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1t5prq6e8pygcyv7zwd4zs2nkxn7808fnqf5lz8",
+    "lp_token_id": "terra1y3k4vj8qhgultc388wwmx6m4mdlt2098fyj2h8",
+    "asset_ids": [
+      "terra1ye68rx8etwj7xylwc4nd4vp58zz236mlhk0cpx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1t7zq9ujczprlqss0dec7akfmnc2wumvsl8dr2v",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1hqgzrrtsft73pjnlf7w946u3m70a99cxjjm879"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1t82m784qavjuawu2n6m47u6gch9wvfne38pftf",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra18ejpjp9eyx9t8j07jd7kzah9p0rvkzdfeeva6n",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ta3lth8wu992m20qjeucg59rlxeez6qeygsxtm",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1j7ft2ze4phmcj4x2mnr7cfcns5x5hqjnnt8myj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1tcrpkhxurjj2qcl5sksxs4cqc8mgz8dp0kfvhm",
+    "lp_token_id": "terra1v0qd7s259lr83t7qp8aknmn6jeq679u4xnnhpz",
+    "asset_ids": [
+      "terra1p3z96mc9gr66yruc3c0v73u0e574kjpgeledm3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1tn8ejzw8kpuc87nu42f6qeyen4c7qy35tl8t20",
+    "lp_token_id": "terra1y9kxxm97vu4ex3uy0rgdr5h2vt7aze5sqx7jyl",
+    "asset_ids": [
+      "terra1s5eczhe0h0jutf46re52x5z4r03c8hupacxmdr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1tndcaqxkpc5ce9qee5ggqf430mr2z3pefe5wj6",
+    "lp_token_id": "terra17dkr9rnmtmu7x4azrpupukvur2crnptyfvsrvr",
+    "asset_ids": [
+      "uusd",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1tnt6qdre3htcd6wwf2asj40ch4fys5x5wzz35v",
+    "lp_token_id": "terra1ldlsayhau0qdj92j9r5nzy4mfr2gunqv6qukdj",
+    "asset_ids": [
+      "terra146fhkmq8d7ae3e6jemufy4h5eq9zerftm8wzmt",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1tpk0tu4qstvzd5px7yc39urweeqj3yvm9wlauc",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1246zy658dfgtausf0c4a6ly8sc2e285q4kxqga"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1tq4mammgkqrxrmcfhwdz59mwvwf4qgy6rdrt46",
+    "lp_token_id": "terra1t6chem282fju8jhgnkrpcm5ltc3frxq93qsped",
+    "asset_ids": [
+      "uusd",
+      "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1tqk8w5zzkv0affe375m7pldgwvx8m496lrhcsx",
+    "lp_token_id": "terra17y23mq28m6df9gghnf0d4tzedrsga2v4k36k56",
+    "asset_ids": [
+      "terra160hntqlsd7wzyydhzw653lw8puftnwaj327xyd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1trsmqwdgej32welv329ranjf60edtl0q4qrm7w",
+    "lp_token_id": "terra147kcqfp5kw9m5axds4ulz0h9z4wcc9uga7yfsh",
+    "asset_ids": [
+      "terra1ckkyhfxnqkumqrvmpl6rnrjzvklephzvsse57z",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1tu9a790fj5mv2qlxmsqaxejysutmtnqyf86tlf",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1dj2cj02zak0nvwy3uj9r9dhhxhdwxnw6psse6p"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1twvmq2yfahhdpelavz94d9xhcmrfyazrn08lrz",
+    "lp_token_id": "terra1wdjsxymg424mw4sv6zmw4luqajwxa5e7qfvfxw",
+    "asset_ids": [
+      "terra1ltfq7n4x383t8wjmp8ujjzrvyskk6eu4y2p3qh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1tz76786rwwnfra68jx3rhfnst3p6d3dscvuduj",
+    "lp_token_id": "terra120zjj4dze8wll9c0xtxsmds7zv26n0cam852kp",
+    "asset_ids": [
+      "terra1dkhqqfc4gkrcs35xjndvea7fl3mur0uptzmaxr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1tzfcwlfyf8608y6m6xhelhckd97hquqpu3rp7j",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1cdg2m5swqzatvzuvseef9xcxpwqylx2h983hm4",
+      "uchf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1u3pknaazmmudfwxsclcfg3zy74s3zd3anc5m52",
+    "lp_token_id": "terra1mv3pgkzs4krcennqj442jscg6jv84cejrs50n2",
+    "asset_ids": [
+      "uusd",
+      "terra1u43zu5amjlsgty5j64445fr9yglhm53m576ugh"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1u475wh425cs3wmgjqn4fqxyqpv7qmsnw7qs0sd",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1yrch507vhsmd9rue6q3v8pz4pe445jl09nrvz6"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1u4je05rr7galjya4pn2c6s4gutg4evmt9qlxl5",
+    "lp_token_id": "terra1wfms03rc04cdc0xvs7rh8z3s498ns2zgqctq7y",
+    "asset_ids": [
+      "terra1ghtspakevqnazc3jtceag7uc3tnjujs94edlkf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1u4uuvku6lupcwn2w8h3d4xmfedf6fz5x6xup8r",
+    "lp_token_id": "terra1423vexq03kadycrhzu4phqrwal8nrls6yzzv45",
+    "asset_ids": [
+      "terra1qt0j6rzqrc0rxpxxlyrvljmjkxrss2frsef5n0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1u522uyxu6t9lku7gawf6k8evmrlqkjazgj4yk8",
+    "lp_token_id": "terra1wg3dhzz6m5q3dm738u6sxzxhld60l0chgvpele",
+    "asset_ids": [
+      "terra1c2mghp27ysrmmw0na4cvvsmn5s4n27hq4hhfqd",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1u56eamzkwzpm696hae4kl92jm6xxztar9uhkea",
+    "lp_token_id": "terra1falkl6jy4087h4z567y2l59defm9acmwcs70ts",
+    "asset_ids": [
+      "uusd",
+      "terra1h8arz2k547uvmpxctuwush3jzc8fun4s96qgwt"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1u6dhkawjqxn0za9w8kvr7588ng9y73l0vj62fa",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra169edevav3pdrtjcx35j6pvzuv54aevewar4nlh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1u79vnslyaxprhmeqla6lj7dkcecg800ssclhu6",
+    "lp_token_id": "terra13sjghs2r7seamgr4g9c4p2eeacknggetsrhcar",
+    "asset_ids": [
+      "uusd",
+      "terra149755r3y0rve30e209awkhn5cxgkn5c8ju9pm5"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1u993cu7zuzsgt4el5f6qu235xw2shezrde393r",
+    "lp_token_id": "terra143szxpzsamn9x6z2uwjm58369n9dmzt2rr77sk",
+    "asset_ids": [
+      "terra1v60qvtprpwt65w5tfamt4l4wpp3jk5mfeh64rt",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1u9jgz9t8huvxcfc3u4w78u3fdxftcmzv297nc2",
+    "lp_token_id": "terra19zkcq8cq3w8vl58w7nkz07n6y9ujc47ftcakgh",
+    "asset_ids": [
+      "terra190tqwgqx7s8qrknz6kckct7v607cu068gfujpk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1uahrcwj3k2vjngvmr646226zg2fe2q3dguhlc5",
+    "lp_token_id": "terra172unvcgg9tys53l8m5hxedw7uey4cya39e5agc",
+    "asset_ids": [
+      "terra1laqzmwrpyrd5tumpx5hs638tzhle4nc42k9jak",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1uenpalqlmfaf4efgtqsvzpa3gh898d9h2a232g",
+    "lp_token_id": "terra1mtvslkm2tgsmh908dsfksnqu7r7lulh24a6knv",
+    "asset_ids": [
+      "uusd",
+      "terra1qelfthdanju7wavc5tq0k5r0rhsyzyyrsn09qy"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ufl3mnqqkucdgp68zrqxwmth9yy3ja5hnjv2c0",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kp8vne240370hn722ec5sacsdluyt2j0gc5nph",
+      "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1upmgq76cn9fcyftawd5a03nm88y8c82gnwhkhp",
+    "lp_token_id": "terra14lvlk5z3kcdpm0026w4a7wfv5cvvegdyrpwjnh",
+    "asset_ids": [
+      "uusd",
+      "terra17ana8hvzea0q7w367dm0dw48sxwql39qekpt7g"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1upuslwv5twc8l7hrwlka4wju9z97q8ju63a6jt",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1ustvnmngueq0p4jd7gfnutgvdc6ujpsjhsjd02",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1urmuf440vzkj48uh7x89vgmsp3w4tyzs0dln02",
+    "lp_token_id": "terra1uc59nf6kzep09k4fruxh2kzfq5kztlqwrnezk5",
+    "asset_ids": [
+      "terra15pr9sk7qkr46ys4gaxmsyl825m4fgl7fdjwqaj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1urnd4esuqwq89ylqrrh6lktp3rdaew9hqm8txc",
+    "lp_token_id": "terra19zju3mkymrhfefd9lv7mq0u9ke0xmveemuu33g",
+    "asset_ids": [
+      "terra174muj5m4c83mvtr49dm4gvf5h2zp24nzphwvmc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1urt608par6rkcancsjzm76472phptfwq397gpm",
+    "lp_token_id": "terra1pc6fvx7vzk220uj840kmkrnyjhjwxcrneuffnk",
+    "asset_ids": [
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+      "terra1042wzrwg2uk6jqxjm34ysqquyr9esdgm5qyswz"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ut8zf8q03vcutkqgfhd8vep4xzkstt4jhap4cc",
+    "lp_token_id": "terra14y8396cv7trzufwknxy0jd545jdagx5d0n82ce",
+    "asset_ids": [
+      "uusd",
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1uvchkwq4kv0vhy23c78hyy72zks2hqtpctklh2",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kvjscdgwuvwc6uzm4rqfjl6nlmuhj28tequlnc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1uxduyw72vlrh8t0hvmrwn270l7z650ykeevx03",
+    "lp_token_id": "terra1qajzf4lefy6wcvpc0dk7fvundp8arcukz7jwp4",
+    "asset_ids": [
+      "terra18ykszsm06k0suqjvz0q040lm36u7pn9eeq4uc4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1uxf47plxtc9tj4lnfwrlah0xp04hhhquye0wcf",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1vte2xv7dr8sfnrnwdf9arcyprqgr0hty5ads28",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1uytrvr6hqkptkkyesmf78qgwz9rhhcsxul9zsf",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1rxfw0y02hfhnase727dqpn8kn2uu49qwrwul8t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1uyvksaz9xpgxpqnq8vz9vzg59up8mlhx3463tf",
+    "lp_token_id": "terra1wlssklspcq2arkl0vqgha5rg2sz8jfufvmjj82",
+    "asset_ids": [
+      "terra1u2k0nkenw0p25ljsr4ksh7rxm65y466vkdewwj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1uz8dm5nfyrqxq0qutlx3xsgqq0ca4v7jr75zuz",
+    "lp_token_id": "terra1fvy3m6z2rsdzg5qkuuwptusw96k2ayp4fw42a5",
+    "asset_ids": [
+      "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
+      "terra1lladdxhn49jz0hrvwgalu4a548txh94mcec595"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1uz8hhjwg3472744kgkz69jfqf3d2uwl5aw66mw",
+    "lp_token_id": "terra1svt83amwsvghu9elhme382em26vupp0uprur9p",
+    "asset_ids": [
+      "terra14f7u8z4eqpxcrp4xr6knhgfp5n4h68nwy3yzg5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1v0lwlpagxy4mpyd4j9xg37tq3nz4wrrgz98e5q",
+    "lp_token_id": "terra1hdnfxxn7j84t4jwjxsegd9qmcksfa8zjldc37l",
+    "asset_ids": [
+      "terra1dyptd3795l57lencr2eltut973kum8wgu36f7p",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1v25n4wuld4zyuglmurx32tru56qtk5hxqe4vu3",
+    "lp_token_id": "terra1sr3r222uaw80q0rnu04atj2hxtak3kwcgkvlj0",
+    "asset_ids": [
+      "uchf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1v2yed2jlgunnh4u2xejd7c30ys7r33fheea7n4",
+    "lp_token_id": "terra1jv3g5g7sew53wzgu3ngn4e3ljdzcgsuzmhjsg9",
+    "asset_ids": [
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1v42wjhpntmq8nxjuqm6tttkx4q8zfrdd7ps3z7",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra13jkds0xx2hy2xrqwggzkt4navhremx2cjyl7aw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1v4kpj65uq63m4x0mqzntzm27ecpactt42nyp5c",
+    "lp_token_id": "terra17pqpurglgfqnvkhypask28c3llnf69cstaquke",
+    "asset_ids": [
+      "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1v62azzxe9np653n09q5v0p4v0xrrzausukwq45",
+    "lp_token_id": "terra1s89gf74pdhen0lgugethgf2jv3y2kc44xtyake",
+    "asset_ids": [
+      "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1v846hwep6tr3wfwe2phu3z5ht9ufm9kwqzn7w3",
+    "lp_token_id": "terra1hz2xxt4saxl79k4p3c9pqutldyqcugwuh8fzpl",
+    "asset_ids": [
+      "terra16hwgds2089kktskluq8dh5ntw7eu5e4q4z6ud4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1v97030v5lhr3f65qen0pc5k0723qhs5uplxnxp",
+    "lp_token_id": "terra166y3h6l4k42lrrj83y4lp9cdyqyxhv4cnkrjs7",
+    "asset_ids": [
+      "terra14s3g6jmytjjg2jcxmmaj6k837vcr6h98muxc07",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1vau3jl4x6206qx9acy6pya4vk8utv5gex0sm9l",
+    "lp_token_id": "terra1xsfjx985rvkchme4wws0fjt79x3wylmjyhvvv2",
+    "asset_ids": [
+      "terra1p8yhtrp8ttcrrl90kqez0602yl2sx2gvrw4h23",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1vayuttjw6z4hk5r734z9qatgs8vp6r5a2t043p",
+    "lp_token_id": "terra1p4pfnpsv8ly4mgzsmegz52kgjq8gp64almryky",
+    "asset_ids": [
+      "terra1m3tdguf59xq3pa2twk5fjte5g6szj5y9x5npy7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1vfk7qfdchgjadv2l2rgmkfnswe5n277kwcjafk",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra12lvpnlphqh3q0cxp8y47e5km8k2ad5ydw5asu4"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1vjn47wdahfwxe0qm68e6k2c9uhcy4mltjdjup7",
+    "lp_token_id": "terra1ucfttyyfm48fepyrstxlkjpp0qa9ygvln6jez0",
+    "asset_ids": [
+      "terra18yqdfzfhnguerz9du5mnvxsh5kxlknqhcxzjfr",
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1vkvmvnmex90wanque26mjvay2mdtf0rz57fm6d",
+    "lp_token_id": "terra1q7m2qsj3nzlz5ng25z5q5w5qcqldclfe3ljup9",
+    "asset_ids": [
+      "uusd",
+      "terra165nd2qmrtszehcfrntlplzern7zl4ahtlhd5t2"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1vmvsdr04xdhh7mure2v9lgwy7l6js6s3689qyg",
+    "lp_token_id": "terra1a05a50wz2n8mlr5nzwlsftzrdf9gvy5sypxdg9",
+    "asset_ids": [
+      "terra1yuvwz0wzd49mjlvh24g23jst89dllua0nc3knt",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1vnpmtslwxr76ar3wmjy8jlp6c5y0sckvh96esl",
+    "lp_token_id": "terra1hmuhs99qw938edq07c4sguhnpmwaulxjmufm9u",
+    "asset_ids": [
+      "terra1p9wk5tns7jagwch6cdasgd753nzfj544v75qxr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1vq8ygvc47qn277pke8k3jvuyslh3ljtqkxka3m",
+    "lp_token_id": "terra1mc4tyswf0msvm2358x7eyrlswn54n6x973v60a",
+    "asset_ids": [
+      "terra1aft2zjfhmetslqvy0jg6d0ywhf9r5zf5zqratc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1vs2vuks65rq7xj78mwtvn7vvnm2gn7adjlr002",
+    "lp_token_id": "terra1mljg7dvzknqh3gc62emagf7hwxxg8efemennp8",
+    "asset_ids": [
+      "usdr",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1vwk0dhr5lha56ssddl58ntxlcunfru36d0jfuf",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra18xyl0ees6ueyhkhn0mjdtrm82e393ult2dazl3"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1w3uwnguslkntkm3wsq86zan0a6jgtgwk0wr8z8",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1w8symfluw393l0f83wv7rv64jklhegcjk2yv0p",
+    "lp_token_id": "terra1p9hy2wvdgzdngexhtqfhllme89gvjpsj4uqe9w",
+    "asset_ids": [
+      "uusd",
+      "terra1qsnj5gvq8rgs7yws8x5u02gwd5wvtu4tks0hjm"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1wcpqg4pr62dku9cry6r6xp7pagarvtzjtpql3n",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra14vw4sfqwe7jw8ppcc7u44vq7hy9qa2nlstnxmu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1wl3ravhhyqmtslfrwvpap0xda2pwq4epxd0adu",
+    "lp_token_id": "terra12ma0hyjetxx2w2vz0vagd4huyuf54v4uf69uc0",
+    "asset_ids": [
+      "terra1hc9zu9jx0vy5gt8yl7evu0wk6xvjl0ylnsg75x",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1wm0ht8upyxy6lkn236hmzp657m58wlwsahkgn9",
+    "lp_token_id": "terra1fa6hue6yjt90ytjuxqv6mlsmrm2agc7w6vjhd4",
+    "asset_ids": [
+      "terra129796y06jrejsk9hjmvhkhat92mxt76k6qpyfw",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1wmz6qgayzam40lzplz55mmss8xadcqm7mx6f93",
+    "lp_token_id": "terra16x0yfryw50tr8a4mhkh2jv2fccdtm8nyavcfxe",
+    "asset_ids": [
+      "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1wqvhrrzkcn7dv2rkd5gdq2prawm64g7lnasy47",
+    "lp_token_id": "terra14ppflprywpsgwds6wn6ffrlruyqv4sl3m90mjq",
+    "asset_ids": [
+      "terra1hjyl8ymsd9sn59kx733aka4rxfelf43pw6fjjf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1wrcvvmwcy5kfqlmdfv4jsekv4uxjxhyl3s8hk4",
+    "lp_token_id": "terra13p06gkedafgwg57fdhvsrxra88q6ydx97l55nl",
+    "asset_ids": [
+      "terra1t4hgtl3uqukaas9lzswl9hr7d55mn3tq3tt3rd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1wrwf3um5vm30vpwnlpvjzgwpf5fjknt68nah05",
+    "lp_token_id": "terra1qxlp0q3z20llu0gz9c7urzw7rmlnchm23yk8xc",
+    "asset_ids": [
+      "terra1nuy34nwnsh53ygpc4xprlj263cztw7vc99leh2",
+      "terra17dkr9rnmtmu7x4azrpupukvur2crnptyfvsrvr"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ws34kqg6kek40jy8amdz7j4tyzqx8cenz40rem",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw",
+      "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1wwtdsvlakd9dxstp85vyawrh5t6ftjuuqern0n",
+    "lp_token_id": "terra1kucdkxvceeue4lknqdjc49jazkuw3hmx6jqr2l",
+    "asset_ids": [
+      "terra1t9m52s6gey6mcy9upq5ucujl5n6ewwqk80hp8t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1wwyh5grgm8h7y2k0jy0n6h8em3su0cverprwgm",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+      "ueur"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1wye679e2zq7pu55yzs9g9ptq054waaang0frfn",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1f62tqesptvmhtzr8sudru00gsdtdz24srgm7wp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1x2jjzqv55f3gvrh8ytejkt998p8vnhn0gcg26w",
+    "lp_token_id": "terra1vxplg3wdnz4xtqu8srfvsgh2ws7nt63qx77np9",
+    "asset_ids": [
+      "terra1a8an0aqzjghcukqrdgnkt3ygzhmaaqza03mc3h",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1x5m76lyeklv2hl50kqlmw5893qawq22k30yw45",
+    "lp_token_id": "terra1gq6ulqmrxnzx8uyrmjmqu4kguqxyy8xwky5mh4",
+    "asset_ids": [
+      "terra1em52fj74ezgeqp5s6mp96y494s2gkjmtqy46sq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1x5zatqdvtxkc6fz96h4zslfj4zueqr8rmdvfje",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1v8wg6yr69cu842w053f8qk909f4swp4cn2waqp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1x6umr9xk86l37gxsayt4fz26cku4dya7qr2gtn",
+    "lp_token_id": "terra1t46rhfcgqpz9xkx33qpzk55yudp7wdaygj7yfw",
+    "asset_ids": [
+      "terra1r98ydsd3jdjpnq8hhcdd5rnptf2l0r7zvaxu48",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1x8h5gan6vey5cz2xfyst74mtqsj7746fqj2hze",
+    "lp_token_id": "terra1spagsh9rgcpdgl5pj6lfyftmhtz9elugurfl92",
+    "asset_ids": [
+      "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1x9jv7vjcpy46k7eadp9ldx0jkkx3f8n2yvwtxe",
+    "lp_token_id": "terra1tctqptkl50uxqt3wgpt02cmk8vxye3a3fvcm7f",
+    "asset_ids": [
+      "terra1xk0a738cxushekjtvf6f9qtr7uz36yxc3egne4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1xf3u2ka5tvtq23wqy9dk94zx3kyaqvttzfetvv",
+    "lp_token_id": "terra17a995wgrz7ch4qvk3s748tzs9u89a274yk8qh0",
+    "asset_ids": [
+      "terra1d6vy3aueuucu3sf5qkrccnq7v58uwegh9m9x74",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1xg660nndl83z5n7j4jd0cnrygs5dndcj30sazn",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1ehcjwxwf96c278n2ks84zes3ece5fqy78fa749",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1xj2w7w8mx6m2nueczgsxy2gnmujwejjeu2xf78",
+    "lp_token_id": "terra1n3gt4k3vth0uppk0urche6m3geu9eqcyujt88q",
+    "asset_ids": [
+      "terra100yeqvww74h4yaejj6h733thgcafdaukjtw397",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1xk2tjgs43pv3pkfv4cmwauvnjd09wxsaedshg4",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1h8arz2k547uvmpxctuwush3jzc8fun4s96qgwt"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1xk72vswca7jkjg8cpl9dz0qvfadam3ms365lp7",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1jxypgnfa07j6w92wazzyskhreq2ey2a5crgt6z",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1xljkuseertrcrguycjwvqhht22u75epe6hdcxr",
+    "lp_token_id": "terra1s4jnf3gaw27ju6x9jll7sar06e6m2hj5hklmsj",
+    "asset_ids": [
+      "terra12l53n0hg4kh9y8jlafd7lyakj3lrejedpryj7s",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1xly8628q4w7ytfq2dtxt7c39knnhqnaj83zzsx",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw",
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1xqsumj7ydu0dwnsf66hf4aye8l0gyaawz87rrk",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1qsnj5gvq8rgs7yws8x5u02gwd5wvtu4tks0hjm",
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1xskmucgxkzf3quwry3dazerw74q4aqplu0vgg4",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra1rh2907984nudl7vh56qjdtvv7947z4dujj92sx"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1xtm4yzrd3a7k6pzqjnk0kag0gea7w0rkkzmqg3",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1xw6yl2vhnlusw5gnj7l2mk0em80c2mw03n9ny0",
+    "lp_token_id": "terra1muk54uc0pqjwe6w26tpwun0x55ncttnadxrr6l",
+    "asset_ids": [
+      "terra1gcfdqwp2ztyn22mu845n7axlua6nwt38s4nkdl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1y0z6ulatz6puwdrjk3lnyltc2vg9rvgwyztrg3",
+    "lp_token_id": "terra1dwr0kh0gpv0xmk0u57m8j7clg3s0zq9d27aawt",
+    "asset_ids": [
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
+      "ugbp"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1y24vfnpcr0f037tww6t87cwuxq3dul74rstkl0",
+    "lp_token_id": "terra1ll78pl5a256d7lgqk49mc0r4cj9fnn544pwr0e",
+    "asset_ids": [
+      "terra15823sstx9pl2fqacnpaxsj9jsku2rjrk4aj34z",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1y7vdguewgus669kcxjlwughyxtdt3kheys05q0",
+    "lp_token_id": "terra10t6a287n4flvjpvdwuhre79ws9plufaagdj4r4",
+    "asset_ids": [
+      "uusd",
+      "terra1qsnj5gvq8rgs7yws8x5u02gwd5wvtu4tks0hjm"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1y8mwewf406ayd8uquekh5a7yljpfdcjekkle9c",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1aa7upykmmqqc63l924l5qfap8mrmx5rfdm0v55",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1y8uendv07j259m26dmw0mtcy4mvc5wc2qhptyr",
+    "lp_token_id": "terra1kmf20rwahh3e22af9u6vq2h5s7kh89fhd9g5ds",
+    "asset_ids": [
+      "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a",
+      "terra1cdg2m5swqzatvzuvseef9xcxpwqylx2h983hm4"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ycp5lnn0qu4sq4wq7k63zax9f05852xt9nu3yc",
+    "lp_token_id": "terra1l0wqwge0vtfmukx028pluxsr7ee2vk8gl5mlxr",
+    "asset_ids": [
+      "terra1cl7whtrqmz5ldr553q69qahck8xvk80fm33qjx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1yecrrjs5alr5vakfrvvh0yrufvfla50fpcvefk",
+    "lp_token_id": "terra1rfrwm60zydsdsr9hy4smp7sckuq57nt56s3tp9",
+    "asset_ids": [
+      "terra1xy2gf523j92khfn8nx0uurkmkguul2u95cwv8v",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1yfpksrlypf5c3xc9ktsup9mtxw24r6sshck3g0",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1a07n2cp4wd49ezxdgm9xgtfrnpmxfcdp4yrdnv",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1yg74xslj94r7cjweu8gg6s5c497vs2sdd6zwgy",
+    "lp_token_id": "terra1z36hglaqjgv867xr7e4jsz32pr7mcstjg2xm6u",
+    "asset_ids": [
+      "terra1rp3mdhrwxhdlx923t2q50f0n6z6660z9yqghpv",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ykfz4hrq8en2f098j8a4ppaq8u8hangpw9tnqu",
+    "lp_token_id": "terra1vwx88jskew3sdf2wpzj6e03mtw2t0c0rajg72u",
+    "asset_ids": [
+      "terra193c42lfwmlkasvcw22l9qqzc5q2dx208tkd7wl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1yl2atgxw422qxahm02p364wtgu7gmeya237pcs",
+    "lp_token_id": "terra1jh2dh4g65hptsrwjv53nhsnkwlw8jdrxaxrca0",
+    "asset_ids": [
+      "uusd",
+      "terra1mqsjugsugfprn3cvgxsrr8akkvdxv2pzc74us7"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1yl9lv57fq5txrfzwevjdh5v28z9tt0cn3rsyx6",
+    "lp_token_id": "terra1m386g65qjvcf6nrz6p0ael59y37l5suf6ys6sm",
+    "asset_ids": [
+      "terra1hw6q5ecr0gp09v668szzx3qz86w08jru9rqyq7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ylw3fvy4h5ll9tyaeuxrqngwnlqp3jtaegtjfq",
+    "lp_token_id": "terra15lnt74xvhhrz528gkhtz9xe23r77w00chktddr",
+    "asset_ids": [
+      "terra17raumdxxxlm8smtx2pcxmqpz7qq9am4zfxzl8d",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ylwwchhdvck0n07sks7703xzke7vk2yudu3s7d",
+    "lp_token_id": "terra1et5tavdywdx5ug6ywph9uhnwnkc70zg8e26x0l",
+    "asset_ids": [
+      "terra1cuku0vggplpgfxegdrenp302km26symjk4xxaf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1yn9quy0xsvjenh3l96lc2ff7l0s3r7yk43qn9f",
+    "lp_token_id": "terra1ttul46957r00dkxuduqcadn5yuhqrspdk7hvga",
+    "asset_ids": [
+      "uusd",
+      "terra18wayjpyq28gd970qzgjfmsjj7dmgdk039duhph"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1yngadscckdtd68nzw5r5va36jccjmmasm7klpp",
+    "lp_token_id": "terra1cmrl4txa7cwd7cygpp4yzu7xu8g7c772els2y8",
+    "asset_ids": [
+      "uusd",
+      "terra1zp3a6q6q4953cz376906g5qfmxnlg77hx3te45"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1yphapr9zkd7eq60n2nux0xfldzs58z9ncs7s6f",
+    "lp_token_id": "terra146dmpuj9zyzk6a47qdfn0djup3kddey5vdpk0c",
+    "asset_ids": [
+      "uusd",
+      "terra17ana8hvzea0q7w367dm0dw48sxwql39qekpt7g"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1yppvuda72pvmxd727knemvzsuergtslj486rdq",
+    "lp_token_id": "terra1mwu3cqzvhygqg7vrsa6kfstgg9d6yzkgs6yy3t",
+    "asset_ids": [
+      "uusd",
+      "terra1jsxngqasf2zynj5kyh0tgq9mj3zksa5gk35j4k"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ysac4wfu87qgu0qkkz8yrh57wwgx2upytva3fx",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+      "ueur"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1yusz6qz86wuhd7vlkkc89e0y6j8au6w93f24fm",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw",
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1yvfnqxcksy6007sp6rfu776chtugm2u7qfhved",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1yx5487aewxagnrg8s0s5aar7kzzjyhtr52gtyr",
+    "lp_token_id": "terra1epnyjjcg6thvxrm0mzffrcx7wyludl9t7z3ja5",
+    "asset_ids": [
+      "terra1n2rujfc5lscglry30zaptfgncfc0gq4n8my0gv",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1yxfvmmy6ftelwk9ke2y7kmyxh7pkd0ev6d47e6",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1353an33z0u5dd0yajwjazfnyt4585q5085c5mg",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1yypalnanxp26u5uypunlj7mwx0mrkrfw3juqtf",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1f77l2dprlhg2h47uvhzp2zhkdrkcy8fse90xkk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1yz9qsxe70p6j4vdhrmsg45gs858lhqzxq3dgh7",
+    "lp_token_id": "terra1peprsfuh0kt3xz8zgjmy9rfgx40jpf36cp24sa",
+    "asset_ids": [
+      "terra1gazefv0j5m0hhalp0qea5smypej2r0matncl88",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1z4pwt3nqrwkvw26vl5tr0pm595t5qf7a2s20kk",
+    "lp_token_id": "terra1y7rnxw089cv0a5t5jlaa6wuh5uaa78rnm5k7n6",
+    "asset_ids": [
+      "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1z50zu7j39s2dls8k9xqyxc89305up0w7f7ec3n",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1z6tp0ruxvynsx5r9mmcc2wcezz9ey9pmrw5r8g",
+    "lp_token_id": "terra14ffp0waxcck733a9jfd58d86h9rac2chf5xhev",
+    "asset_ids": [
+      "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1z8masgnagfxvjwdqc43mltrzpa3t4x5u873vz6",
+    "lp_token_id": "terra1yxaczswtwnlqqyn9x9ccsa495lm2tlrte5aa9g",
+    "asset_ids": [
+      "terra1drsjzvzej4h4qlehcfwclxg4w5l3h5tuvd3jd8",
+      "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1ze5f2lm5clq2cdd9y2ve3lglfrq6ap8cqncld8",
+    "lp_token_id": "terra1pjgzke6h5v4nz978z3a92gqajwhn8yyh5kv4zv",
+    "asset_ids": [
+      "uusd",
+      "terra1l5lrxtwd98ylfy09fn866au6dp76gu8ywnudls"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zey9knmvs2frfrjnf4cfv4prc4ts3mrsefstrj",
+    "lp_token_id": "terra1utf3tm35qk6fkft7ltcnscwml737vfz7xghwn5",
+    "asset_ids": [
+      "uusd",
+      "terra1lvmx8fsagy70tv0fhmfzdw9h6s3sy4prz38ugf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zgrz3dc3cpgk9qet8r7767yvpdpsuvlc6ymvee",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1dzhzukyezv0etz22ud940z7adyv7xgcjkahuun",
+      "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zh33l9e6pj385jpum6uyngwhhe62p9gfaph2gl",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra13awdgcx40tz5uygkgm79dytez3x87rpg4uhnvu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zhffgf949uvq8sxgynmxa3n477sgvd4gf64w49",
+    "lp_token_id": "terra1jlme2556ygty3va4sw2k2p8j7lz5felpclvq0q",
+    "asset_ids": [
+      "terra19cnnyaah7c32hhcdt5m83pvdxa7ts64caarcm8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zjn2vpgstwl75qk0v7ae48yx3yd5layuy2s9vs",
+    "lp_token_id": "terra1nknmv45l04ft6t38zvw3xg0kqnwgqtqrewf2dh",
+    "asset_ids": [
+      "terra1q2k77qmnujgk0w89wx55rsnqxecz5wd86y2p2q",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zkyrfyq7x9v5vqnnrznn3kvj35az4f6jxftrl2",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1xfsdgcemqwxp4hhnyk4rle6wr22sseq7j07dnn",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zpets4h5zyvhln3muemyvk7cwvmwmam4tp8c5w",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "uusd",
+      "terra18ej5nsuu867fkx4tuy2aglpvqjrkcrjjslap3z"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zpu7lgsfw3l4q782wdjskn8t6nn6rwlpq3d6j6",
+    "lp_token_id": "terra1f3wqhqe7sad8f8vjvsjjv0na3w2xcc639njxjm",
+    "asset_ids": [
+      "terra1asq6hza8spaeghqt4k7fnj4m7nfaag07ljdqz7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zr24fxhh5hf8k9vqv0xp63rhyy2g373m83scps",
+    "lp_token_id": "terra19ekpmkxnysep0tuxza66z475vfd79xput6dw9l",
+    "asset_ids": [
+      "uusd",
+      "terra1k637r8ucfp585tv57gsnqzfdmsw6mnm9zn59zy"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zrl9mugl97mrhtkacvws70w95sjemyxmq5ydwk",
+    "lp_token_id": "terra178lvrr8aa3fl70ar3kp9rgvny2qrnmgepa2ctw",
+    "asset_ids": [
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
+      "terra1c00vskhyzdv0z63z2tyetzx2qma67n2z3vzyn0"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zrsuu42fnz2zaj0hgl8s9fzz78wgzau3464luh",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
+      "ueur"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zrx57z4qhsejk3r0ug6pt3xvz2efpee39rle5n",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra182740uw8nh6tk3yjfcf7gu5phg3kqryhtuxp0p",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zrzy688j8g6446jzd88vzjzqtywh6xavww92hy",
+    "lp_token_id": "terra1halhfnaul7c0u9t5aywj430jnlu2hgauftdvdq",
+    "asset_ids": [
+      "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zv2q88u7pslnj00w6u7ketjq77tu6lupc2twav",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1y77avpcwxc49ezmex8nsupklgc0qt7le44z4qd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zvn8z6y8u2ndwvsjhtpsjsghk6pa6ugwzxp6vx",
+    "lp_token_id": "terra1tuw46dwfvahpcwf3ulempzsn9a0vhazut87zec",
+    "asset_ids": [
+      "terra10f2mt82kjnkxqj2gepgwl637u2w4ue2z5nhz5j",
+      "terra12897djskt9rge8dtmm86w654g7kzckkd698608"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zw0kfxrxgrs5l087mjm79hcmj3y8z6tljuhpmc",
+    "lp_token_id": "terra12dnl585uxzddjw9hw4ca694f054shgpg93cg90",
+    "asset_ids": [
+      "ukrw",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zxcmcjurg5jrml8kv2vhupdlfqn4n6euasuc5q",
+    "lp_token_id": "-1",
+    "asset_ids": [
+      "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
+      "uchf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  },
+  {
+    "id": "terra1zz39wfyyqt4tjz7dz6p7s9c8pwmcw2xzde3xl8",
+    "lp_token_id": "terra1k5kumxd24cyvhf52r5u4ywlr3ztktj657wnf7a",
+    "asset_ids": [
+      "terra17jnhankdfl8vyzj6vejt7ag8uz0cjc9crkl2h7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk"
+  }
+]

--- a/terraclassic/pool.json
+++ b/terraclassic/pool.json
@@ -7,7 +7,7 @@
     ],
     "dex": "Astroport",
     "type": "stable",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1snhuxa7zjmy3cpa3d85uu3pe7m5q8h66xgsqss"
   },
   {
     "id": "terra10y0jqynfchuadr7cycl3qqaugl2jd6s76660w7",
@@ -27,7 +27,7 @@
     ],
     "dex": "Astroport",
     "type": "stable",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1pwc77c6a588cualln2uypyyvg5r76tfaazgk62"
   },
   {
     "id": "terra15rx5ghq4nxrv62fqvdvm78kuasfkl95c6mcmqs",
@@ -40,6 +40,16 @@
     "lp_token_id": "terra16aurvlp5xctv0ftcelaseypyc89ylf4y0s5q0y"
   },
   {
+    "id": "terra17umn0xctu4qj8w6psqfjfp20nx454csspuvdur",
+    "asset_ids": [
+      "terra1e6mq63y64zcxz8xyu5van4tgkhemj3r86yvgu4",
+      "terra1pepwcav40nvj3kh60qqgrk8k07ydmc00xyat06"
+    ],
+    "dex": "Astroport",
+    "type": "stable",
+    "lp_token_id": "terra1gl3j25d8gnpehga2dr8ycxj6d7f0gg2kdnwzx9"
+  },
+  {
     "id": "terra18fl6aywx2c8xlfp5epl40dygqnrvqp9a678a9c",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
@@ -47,7 +57,7 @@
     ],
     "dex": "Astroport",
     "type": "stable",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1g3cf0ml4yr2qkz6k3lkh07yykwuhlpsg6x5lvz"
   },
   {
     "id": "terra1c868juk7lk9vuvetf0644qgxscsu4xwag6yaxs",
@@ -77,7 +87,7 @@
     ],
     "dex": "Astroport",
     "type": "stable",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1m4j80w4lustnjhszqm9ltdvfmrfptlwcznek4a"
   },
   {
     "id": "terra1dawj5mr2qt2nlurge30lfgjg6ly4ls99yeyd25",
@@ -97,7 +107,7 @@
     ],
     "dex": "Astroport",
     "type": "stable",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1h2lasu3a5207yt7decg0s09z5ltw953nrgj820"
   },
   {
     "id": "terra1h2g2mldq2fskq0sqdhupnzpfj396d03ds2yfkd",
@@ -107,7 +117,7 @@
     ],
     "dex": "Astroport",
     "type": "stable",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1yhdl908nq6m4hmgce2psjw2tw88epaahxtj6e4"
   },
   {
     "id": "terra1j66jatn3k50hjtg2xemnjm8s7y8dws9xqa5y8w",
@@ -127,7 +137,7 @@
     ],
     "dex": "Astroport",
     "type": "stable",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1v8svt8mte4rd3ypqdx9v4l2fxzzqzeactzz6yd"
   },
   {
     "id": "terra1pxexyejamkg856vmspyttcy4sva84qgyaq445z",
@@ -137,7 +147,7 @@
     ],
     "dex": "Astroport",
     "type": "stable",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra140ss694rxten5r6l2dxqta0xgzt60ev5pnh3pt"
   },
   {
     "id": "terra1qmxkqcgcgq8ch72k6kwu3ztz6fh8tx2xd76ws7",
@@ -157,7 +167,17 @@
     ],
     "dex": "Astroport",
     "type": "stable",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1k7lexx35v4lutnfdf7n7luf3hmt2wphn633fau"
+  },
+  {
+    "id": "terra1r5m5h9nvnw0hhzwn4gzz9p2wzg78q2jsq0alvp",
+    "asset_ids": [
+      "terra1e6mq63y64zcxz8xyu5van4tgkhemj3r86yvgu4",
+      "terra1kkyyh7vganlpkj0gkc2rfmhy858ma4rtwywe3x"
+    ],
+    "dex": "Astroport",
+    "type": "stable",
+    "lp_token_id": "terra1l6jgxephuj6uggg4hvdvcg8ys0twkm7t68j0kz"
   },
   {
     "id": "terra1szt6cq52akhmzcqw5jhkw3tvdjtl4kvyk3zkhx",
@@ -168,6 +188,16 @@
     "dex": "Astroport",
     "type": "stable",
     "lp_token_id": "terra186cxwpreuzqm9nhmaltycxfyqxz379aef752qw"
+  },
+  {
+    "id": "terra1t59ywlkkmvy7rmkdmdpy0z7wdqez5tne9mrd0r",
+    "asset_ids": [
+      "terra1pepwcav40nvj3kh60qqgrk8k07ydmc00xyat06",
+      "terra10f2mt82kjnkxqj2gepgwl637u2w4ue2z5nhz5j"
+    ],
+    "dex": "Astroport",
+    "type": "stable",
+    "lp_token_id": "terra1jxhmcjh3ymd32v7e8f5uar92pg3e05yts8z6lf"
   },
   {
     "id": "terra1wgdjvp388mlvhad8u7ly5d34ga4zyyfvf3e5j8",
@@ -190,14 +220,24 @@
     "lp_token_id": "terra1lapdj4fcg936fpgdwewx55h7n79p4p9tzrg4lw"
   },
   {
+    "id": "terra1092tamrn3w8j7qp0uu2ltml7sjts7z9hkj2wga",
+    "asset_ids": [
+      "terra1unewn6sa7hg3z0pvhrc9u9rmph7z975h4nrfvq",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1uplecvt5ju6g85kdru28q0ccgx89yp3hhnnew0"
+  },
+  {
     "id": "terra10cw43kz2ujn4ur938u2qsrr9duhsqydkrxl07p",
     "asset_ids": [
       "terra1hqr3l4je2yvn3l790ly0y6r0vgfs7yukwwj0ak",
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "type": "xyk",
+    "lp_token_id": "terra1fyv03ps5xr79xkk3t6q9z7dz8ymtt5cq8s2k73"
   },
   {
     "id": "terra10k05ec24u8nrd3889c6zydr8tlv73cyhaufs4t",
@@ -206,588 +246,8 @@
       "uusd"
     ],
     "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra124yter7w9e5mf6m843erql48xy5szsxd75zjxw",
-    "asset_ids": [
-      "terra17e6sxcxxxp6j2xf6rzhcwnafk6sggrrl5wdvw3",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1p7l5qx277ql2rql6lxz3wsgusc53lfv097ckyq"
-  },
-  {
-    "id": "terra12sf5en42qlfc3qle4m4pew6n4vjc6lrpwvhh2h",
-    "asset_ids": [
-      "terra1cl7whtrqmz5ldr553q69qahck8xvk80fm33qjx",
-      "terra1jn0w9ttjavzqeqmp79jzx3da6dx3p6jwmm6tk2"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra12z67dhctkvsw8u8pr95rlefr5zcs2d2dwa0pth",
-    "asset_ids": [
-      "terra1p0w9hh9aea5mg26mjnx7tl695ldwxfksvw4yn4",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1vwdjaak7rtqc7wc0zf9car40rt0qv79dppyxyt"
-  },
-  {
-    "id": "terra130w5j5yu7rc29wuc49qdcm2su72pljl77jlmk6",
-    "asset_ids": [
-      "terra16x6mn6ulxzg4pgg7gpachkkgrkuac59vl7xgyl",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1366x8d5h0mexk83c8hjkqafk72a4rcwwwdk62h",
-    "asset_ids": [
-      "terra1xmd43yrfxm4xy3lnptc7kr4rr93pzh5u0z0wgt",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra14m6dv3w66u8nk6nmrmvh4lxyd7fnw98tfm8qh9",
-    "asset_ids": [
-      "terra1779kwh0aux9mesns3l7laxtu7njjpzqd7k7m3r",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1jd99306zw03cp937l7cugennqcscqz920vqftx"
-  },
-  {
-    "id": "terra152655kx8ff6fa393h642uu075mmu9dz8xlfqvv",
-    "asset_ids": [
-      "terra1rwph273axfefh8gh57scw3jfm7kn4s7t5hlu03",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra152wlyd53nfcltuwcje9ale8qv3hpyna4sv9mvg",
-    "asset_ids": [
-      "terra1mpq5zkkm39nmjrjg9raknpfrfmcfwv0nh0whvn",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra15av79vdec34egtwt9dhyuy73pdhfztazacs2tw",
-    "asset_ids": [
-      "terra1w724lm9qt5q8rz9n0kqlfglkulz7z98yjvxzn8",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1pctrnkng8ev6swvjmg5vfu5uwv6zcznutcjpct"
-  },
-  {
-    "id": "terra15pehlkssvyu8e7x6s9gz0j9x8q2qthvcf6hdqh",
-    "asset_ids": [
-      "terra1pc253zfn4zns6awk7eks779uk3m7dna7y4cmlf",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra167lmzjrfvrqm59ycxvr4f937vgap4uytnkyrat",
-    "asset_ids": [
-      "terra1mely4fttd94g5kgjmz05dmclgdahq45xnv5n22",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra16af3ksetslvny2ypwe0nync0lahs87t9csvyz7",
-    "asset_ids": [
-      "terra1n6eltvex47mta0me66ygqw0fgvjx2ul7qm9fjp",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1xer502ejxn9g3elanqgrh4cl7zzk9dzxkwmy9q"
-  },
-  {
-    "id": "terra16lle05y09g2eazntxdx89m6u8d4y68t2tglmk3",
-    "asset_ids": [
-      "terra103ws85fnvy3j9vr3ss9va2zr26vepemqx2n88u",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra10fwytprs0lnnwtdkvst0dpy9v5ql6ydwq278l7"
-  },
-  {
-    "id": "terra17ds7t9z2pu3cyqtlnklhfpruc0nnahddzr49wn",
-    "asset_ids": [
-      "terra1vfhh44f57a72vaqdk69k2y9pllwlrhkv32n6nr",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra17umn0xctu4qj8w6psqfjfp20nx454csspuvdur",
-    "asset_ids": [
-      "terra1e6mq63y64zcxz8xyu5van4tgkhemj3r86yvgu4",
-      "terra1pepwcav40nvj3kh60qqgrk8k07ydmc00xyat06"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra17w79y5ptp63dlr79tup9rkh6294qe448phup3f",
-    "asset_ids": [
-      "terra17ktj9hq69ae9mj49dwqfzmj05t6eqlkyywukf8",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1awy55useu780l3hsprulg0s26maxgtx2pjkev0",
-    "asset_ids": [
-      "terra1zce4mxwwdyk04txa2f3aqepzsq8jy7ca50gn8w",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1ccwy34ygpj9qav05y2d5akzeeflvz6lzvsz9l9",
-    "asset_ids": [
-      "terra1a07n2cp4wd49ezxdgm9xgtfrnpmxfcdp4yrdnv",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1rm36n8c5zacf83aljwzzxtq8ctge7wlym689we"
-  },
-  {
-    "id": "terra1cylvlytxzjywy0wpf5mrtua3q37esduhqfk9w9",
-    "asset_ids": [
-      "terra1vyusa796w86yh99l67dpd5g3hfva759vyuhn5z",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1d5uhps2w38fqnx2zzfrkhk96sw4j4twjpr5s46",
-    "asset_ids": [
-      "terra15k5r9r8dl8r7xlr29pry8a9w7sghehcnv5mgp6",
-      "terra18vl2cypy8pdys2qdqlg7pzmcmpqmur8lmrnk2c"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ztj6x5exa33w7dsvjxmdxam8w7j7t2phglmpea"
-  },
-  {
-    "id": "terra1dleq0ve3wlkcqsj93d63u4t7c8h8d65uztnfl0",
-    "asset_ids": [
-      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
-      "terra1kujvztl5p8a45k56u42fq39jxldxcvuejtpfq5"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra192nxzlpw8kgtppmrr9uqzn27cphpyaqauxd6qw"
-  },
-  {
-    "id": "terra1e46tre2rxhuxq58ygxsxm2m8djup7f3gasen6w",
-    "asset_ids": [
-      "terra157n30a667ethsknneaavga2txtze58eajyfv45",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1r0wdunh0nrn65863hrs0p72us2502x525m62sg"
-  },
-  {
-    "id": "terra1egk8w9eeta7dehmhsf4v3fjkrxucc6ygamj5sz",
-    "asset_ids": [
-      "terra1h0jk42weh0urhgdtjql93rrvgdccspnp7vyf49",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1jy6r3knmz2a62k5vpy6f65smm6nrgsaqreqj0d"
-  },
-  {
-    "id": "terra1eguektu6mgqqc8rxprsk5nadpxpr7v5k7ttpqx",
-    "asset_ids": [
-      "terra1hauj2lpsnye4jsxxww8kpze4mzyq76e5cjr2wp",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra175jguvthv6m7xj20eqc609ftcnddk9mhxkhmkc"
-  },
-  {
-    "id": "terra1equ0rx0hhk4q22v2rlg779war57rhgt7d8vwls",
-    "asset_ids": [
-      "terra12qgpr0fw773gc8lrkys3knnw6nkgdlc8ggaty9",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1eqv7ldavhp8lvgesk0083g6jwqktgwp7cm6hq6",
-    "asset_ids": [
-      "terra1ew3yvrg0ejpgvswyw70gcqqp3g2j45d24se5xq",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ntcs04cq40vqyj5qjr8w43yrhqx5zcwx0nm2kd"
-  },
-  {
-    "id": "terra1f37ftdeeke582crsdc9exf8n6m05awzpjjm60c",
-    "asset_ids": [
-      "terra1mfek3m9s0sazd40kjraw5qv3963t5n3gwk408u",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1tr6l7vugxjtzm2jtmm53rguxh6j7qdu46jnatu"
-  },
-  {
-    "id": "terra1f87y5r6xmt37sf09nl0fw3mgnk0xsnnyeecgnn",
-    "asset_ids": [
-      "terra1teh62le6cndl2ch9yw5vkjk30h2fd4mhkrt5wc",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ylug28lxeykpag00rl59ethqy8tq2n65stld3d"
-  },
-  {
-    "id": "terra1fqqtkhx8c3jxfl94jzzldvjmu4u9jeuyful6ma",
-    "asset_ids": [
-      "terra1jp4r38w4j2qkxavjs9ypqv6mv833wdar3tywe2",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1gpel5uny2f2hw3e7kln4y3mluwtdlcpukaeukk",
-    "asset_ids": [
-      "terra1ypgjelmtp0mv5akzwmnj5xhukhd3fy9gd28wpj",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1hhpgcp2stvzx952zfxtxg4dhgf60yfzchesj3e",
-    "asset_ids": [
-      "uusd",
-      "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1kt26adtzwu4yefw37snr73n393vsu8w0hmazxc"
-  },
-  {
-    "id": "terra1j3se2lhn7kwzu0zpa9zgc2sk9r20gmrrxz0n88",
-    "asset_ids": [
-      "terra1krg7amkeenvqwkaarp4r4grmrnldd83lmkl26u",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1tzlc5g00ny7vh78mc8fnw2qqe4wmy7mmjgv497"
-  },
-  {
-    "id": "terra1lnr6aacxfng34m69076s2mdfjzt8nev2p6z5q0",
-    "asset_ids": [
-      "terra1dw6yapjv8k8anef2kg43hewg3g73wle22ncaje",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1rx4xd94l74jupghnrn27r8ymauap9fy7tr3js7"
-  },
-  {
-    "id": "terra1mxd85ljdjcm7ddfh8qvnxx8tyggnh3zsahy7aa",
-    "asset_ids": [
-      "terra17n223dxpkypc5c48la7aqjvverczg82ga3cr93",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1nq6ty6lppp7kz58nkshhmyfe8tv4p85ueh50mp",
-    "asset_ids": [
-      "terra1tf6ukhukcqwfasm6e3ae2406c87vc8zhrh5ex7",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1nvzgfu8yyzcsm7a3je2hnn597ndz74g9a22zzl",
-    "asset_ids": [
-      "terra16ygrvq7q2zxw7jj3f96racur50w0g7r0mj6e2y",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra14jqrnf75jaqwyz5q6j4fk4503qyvfult6juytl"
-  },
-  {
-    "id": "terra1qkzw4cfr74d0n5s9mf865vcpuchv0ssygkmvuy",
-    "asset_ids": [
-      "terra1nq9epqtswmj7uaymsw59w9n5h5e78k9rwduets",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1vhustrxwexul87cj7yk5wr993rk68p8mkwuvkw"
-  },
-  {
-    "id": "terra1qpu9ve7lle9wl7npkqq745j8fwekw5ghfnttkj",
-    "asset_ids": [
-      "terra17ckx25kqhwzf3fudprs78kqgp3lhpr2w74yf7t",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1zejyjpwf6fpeg7fpa42vu0d5fjwejv7tx4ts3z"
-  },
-  {
-    "id": "terra1qv0j5udg2lcnqkuy5rqt2n6n2z9m2zps6zfx2v",
-    "asset_ids": [
-      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
-      "terra18ky9ln4g6x3n9f9s8a5ttshynv6lgzfppmrmyg"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1r49ew9xrpauml4chelxd6mt32xwpywlmcnt853",
-    "asset_ids": [
-      "terra1gjuhc34ccr6ajq7dm5266xyedu96sgkv4qnley",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1r5m5h9nvnw0hhzwn4gzz9p2wzg78q2jsq0alvp",
-    "asset_ids": [
-      "terra1e6mq63y64zcxz8xyu5van4tgkhemj3r86yvgu4",
-      "terra1kkyyh7vganlpkj0gkc2rfmhy858ma4rtwywe3x"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1l6jgxephuj6uggg4hvdvcg8ys0twkm7t68j0kz"
-  },
-  {
-    "id": "terra1r5xu0edlqgjd9t7smsaww0tr7jvqh0805x8nd4",
-    "asset_ids": [
-      "terra1fx6ffswrmgyuf5nsxruce5gertr8vgsm7krrp7",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1t4fsj0eu0jg9h9um8wmj9c9r05mjj2pvcevyp5"
-  },
-  {
-    "id": "terra1shgwa4xwdegsxvtr0qaergjq689sakzvn87fvy",
-    "asset_ids": [
-      "terra1l385362dg276797k7lzsfktskfssg22n7hn4at",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1suwlj0tlfqngq67gy2pjyqjwx3rfry2klvtxe5",
-    "asset_ids": [
-      "terra1cvsfc32dkdvmla6urrscrtfceztecj0u5tvlvz",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1pth0gsyh8j0x08zv2fqq930xq6assges0zg82u"
-  },
-  {
-    "id": "terra1sz988qp6vma3j0xj5w7fsskqcuc8kjn0mmtcqc",
-    "asset_ids": [
-      "uusd",
-      "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra152e9whmpjlgenfhjj6rm4lcffcpdfgqc0u5qx2"
-  },
-  {
-    "id": "terra1t59ywlkkmvy7rmkdmdpy0z7wdqez5tne9mrd0r",
-    "asset_ids": [
-      "terra1pepwcav40nvj3kh60qqgrk8k07ydmc00xyat06",
-      "terra10f2mt82kjnkxqj2gepgwl637u2w4ue2z5nhz5j"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1jxhmcjh3ymd32v7e8f5uar92pg3e05yts8z6lf"
-  },
-  {
-    "id": "terra1uqsny2clznnhrmq2rvlhv72l78lmlss32uzuyh",
-    "asset_ids": [
-      "terra18ejpjp9eyx9t8j07jd7kzah9p0rvkzdfeeva6n",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1v67ycjhzup787j9efpygr4fcky7rpxgkfkf89d",
-    "asset_ids": [
-      "terra17nekftv2yp8n4lsex85008sphchs4t3rnfcqzf",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1nxgs0pfu89wyx6wfg3yssmeykg3nuh5mae4uyx"
-  },
-  {
-    "id": "terra1v6vmpgpq3lky0w9jhmqn8ccr0sgetkgus70e62",
-    "asset_ids": [
-      "terra1kggysvv0q3tq2r58f5nt03hqa8pqj87c2m8k09",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1zadxq9h0aw40tna7ytrnn57ymc57chwluxkhyc"
-  },
-  {
-    "id": "terra1v7hcllx3l7namvvffg3jfl7vc3ksy089yr3ewu",
-    "asset_ids": [
-      "terra1mh7nlhzvvesgc4whcx7dg2nhj3p0dhl9fwrexu",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1vfxjj237nsyxu8034syv46d4gzmrajksrdnvdc",
-    "asset_ids": [
-      "terra1lyppcm0cjc5nrge6hmwdkkeqeh4m9cat8nyf3e",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1xlrclrh3zu8vpjmnlnkjealnw6ggtf287ms3ly"
-  },
-  {
-    "id": "terra1wau74j4ykmx5nfjad4wjra8m02x9vg5h8g7ym2",
-    "asset_ids": [
-      "terra13kr45ssru9cqhp2kaaan88wfaa7f2h3jfvuldp",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1x2l3qhtcp2jlgn3duwrt7f6pqaz3tq3qydmkp4",
-    "asset_ids": [
-      "terra153u8c40h2mm8nvs0daqxsnwgvpw43muxj3c28h",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1xckx7r8ay8hr6qneqlftcejzaqme4jw0k35e0l",
-    "asset_ids": [
-      "terra1fhsljj6qc8f7cnu62e8uxqt82czflztge05dwk",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1xhewlp3h0kh82t2n33x2cc200t3zcxmhmrsyqk",
-    "asset_ids": [
-      "terra1z4pfv9rrm53tg72cwkcv6ddvd4x6wcce43nua2",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1y6e5xmqxcq9zm9mdncf4nwneyp27d98awgqjv7",
-    "asset_ids": [
-      "terra1vm507q46f2sm8jltjcvp3dtncttquwld0tfkdl",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1ymh8xk3uv522vs2g7m8j6v059s7cmcxyr5vqtc",
-    "asset_ids": [
-      "terra1ult8nl3u83p7vdjdehtjfn9ylkm6u606nmdry3",
-      "uusd"
-    ],
-    "dex": "Astroport",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra13fwa5e5m95tye2jtnkxjmwe3632hp2pampxjk7"
-  },
-  {
-    "id": "terra1092tamrn3w8j7qp0uu2ltml7sjts7z9hkj2wga",
-    "asset_ids": [
-      "terra1unewn6sa7hg3z0pvhrc9u9rmph7z975h4nrfvq",
-      "uusd"
-    ],
-    "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1y0l4ghzlrrelwawxzgrsgz0xdd0az2h9tvf3hg"
   },
   {
     "id": "terra10lv5wz84kpwxys7jeqkfxx299drs3vnw0lj8mz",
@@ -807,7 +267,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra156sdvmjkezv5yxpgcxug0s73zkvdqk72pldkva"
   },
   {
     "id": "terra10xczfpmpryl3m434jjvvv0rre70yyscw98pueu",
@@ -817,7 +277,17 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1d43k757a7p3zh6eagfvfwwll0pywtns4an3psr"
+  },
+  {
+    "id": "terra124yter7w9e5mf6m843erql48xy5szsxd75zjxw",
+    "asset_ids": [
+      "terra17e6sxcxxxp6j2xf6rzhcwnafk6sggrrl5wdvw3",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1p7l5qx277ql2rql6lxz3wsgusc53lfv097ckyq"
   },
   {
     "id": "terra126j4psud93ee83n6uyxq5m9zd40yzlmjvmsf94",
@@ -847,7 +317,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra19dkkjtyrmkhxx7weg2xp9aftks7yjmzmc7xz6m"
   },
   {
     "id": "terra12qna5j5nehx7wamqelxg7pup877wd3jwd0dnpz",
@@ -857,7 +327,37 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1nz30cwp0mragea6k2j6qak4l5vlfqrhl3vj4vm"
+  },
+  {
+    "id": "terra12sf5en42qlfc3qle4m4pew6n4vjc6lrpwvhh2h",
+    "asset_ids": [
+      "terra1cl7whtrqmz5ldr553q69qahck8xvk80fm33qjx",
+      "terra1jn0w9ttjavzqeqmp79jzx3da6dx3p6jwmm6tk2"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1cwep5yu2l3xlre6tdtnrqcvth6tgpsjr7gwc94"
+  },
+  {
+    "id": "terra12z67dhctkvsw8u8pr95rlefr5zcs2d2dwa0pth",
+    "asset_ids": [
+      "terra1p0w9hh9aea5mg26mjnx7tl695ldwxfksvw4yn4",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1vwdjaak7rtqc7wc0zf9car40rt0qv79dppyxyt"
+  },
+  {
+    "id": "terra130w5j5yu7rc29wuc49qdcm2su72pljl77jlmk6",
+    "asset_ids": [
+      "terra16x6mn6ulxzg4pgg7gpachkkgrkuac59vl7xgyl",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1keqn8tkxltmadd4q7x9egpk078hz28xlhnfst9"
   },
   {
     "id": "terra132qwlqxffksjfg6ntzp4m5786lrlmgrufzx5c6",
@@ -880,6 +380,16 @@
     "lp_token_id": "terra16unvjel8vvtanxjpw49ehvga5qjlstn8c826qe"
   },
   {
+    "id": "terra1366x8d5h0mexk83c8hjkqafk72a4rcwwwdk62h",
+    "asset_ids": [
+      "terra1xmd43yrfxm4xy3lnptc7kr4rr93pzh5u0z0wgt",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1skz0kyzhyywgzv9wthz6vx6advsrmhyx6mph40"
+  },
+  {
     "id": "terra13krvk2ujpkfx8zk8sqsjq6nmzul287jfwy9e26",
     "asset_ids": [
       "terra1z3fvf7tae0586jjn5ve580thc3pyj9vwandw4n",
@@ -897,7 +407,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1y6r6vnq4aem54r0uxwrqvrvumvg03gr4zlyx9t"
   },
   {
     "id": "terra13xz77zwk9jvulch92uwzuk3astcp0uvymh7f2p",
@@ -907,7 +417,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra10ky0rku6xq7lphdxej65x47tzq64ep2detdga7"
   },
   {
     "id": "terra13yftwgefkggq3u627gphq98s6ufwh9u85h5kmg",
@@ -937,7 +447,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1tgg6ccwy42aya75rjtpx4cagpg64p5rz59vxtj"
   },
   {
     "id": "terra143xxfw5xf62d5m32k3t4eu9s82ccw80lcprzl9",
@@ -957,7 +467,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1javzm3n4nqvlz308kfq6rdjask77t0vdzpgngj"
   },
   {
     "id": "terra1476fucrvu5tuga2nx28r3fctd34xhksc2gckgf",
@@ -967,7 +477,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1krvq5hk3a37yeydzfrgjj00d8xygk5um9jas8p"
   },
   {
     "id": "terra14glht7py7e3zp09wex9awej5cu4jql90yygdw0",
@@ -978,6 +488,16 @@
     "dex": "Astroport",
     "type": "xyk",
     "lp_token_id": "terra1tr7w28vzsx6pl7z8wvps6t57k3uw29fc735rnc"
+  },
+  {
+    "id": "terra14m6dv3w66u8nk6nmrmvh4lxyd7fnw98tfm8qh9",
+    "asset_ids": [
+      "terra1779kwh0aux9mesns3l7laxtu7njjpzqd7k7m3r",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1jd99306zw03cp937l7cugennqcscqz920vqftx"
   },
   {
     "id": "terra14pds7y2xdal7l96heq03mhfsadt6ezes8wyvn6",
@@ -997,7 +517,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1s0cg9adk0c76swm5qqcv5lt8n9uaqwg9e5puw9"
   },
   {
     "id": "terra14sal7lg7ny207yz0ue4dc02mdqs03zytegsn2r",
@@ -1007,7 +527,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1nv2un60yflp8rxe6vhhgx976l74n64gyye825m"
   },
   {
     "id": "terra14xxxh8mq4rkxr6uy0q78chn5nu2jkj2uk09fwd",
@@ -1020,6 +540,36 @@
     "lp_token_id": "terra1geh0qnt0u8e8jqug08cnfmkwnjyrpv3t65ur64"
   },
   {
+    "id": "terra152655kx8ff6fa393h642uu075mmu9dz8xlfqvv",
+    "asset_ids": [
+      "terra1rwph273axfefh8gh57scw3jfm7kn4s7t5hlu03",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1mck50s2d6stclzsarecaahzkhhnujt2283fjz0"
+  },
+  {
+    "id": "terra152wlyd53nfcltuwcje9ale8qv3hpyna4sv9mvg",
+    "asset_ids": [
+      "terra1mpq5zkkm39nmjrjg9raknpfrfmcfwv0nh0whvn",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra17d8upenj35204z9x73vqx43alps0vfe0sfdrm3"
+  },
+  {
+    "id": "terra15av79vdec34egtwt9dhyuy73pdhfztazacs2tw",
+    "asset_ids": [
+      "terra1w724lm9qt5q8rz9n0kqlfglkulz7z98yjvxzn8",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1pctrnkng8ev6swvjmg5vfu5uwv6zcznutcjpct"
+  },
+  {
     "id": "terra15env0fa3z9jsc65cun7m37dhjypzwejqpy80vp",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
@@ -1027,7 +577,17 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra14t7et779hl9528e9c3nlylc02wy2fnvp70czm4"
+  },
+  {
+    "id": "terra15pehlkssvyu8e7x6s9gz0j9x8q2qthvcf6hdqh",
+    "asset_ids": [
+      "terra1pc253zfn4zns6awk7eks779uk3m7dna7y4cmlf",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1xl3v900cw7w2z9mey2u6f5y0hn7y5qx8fkwc3r"
   },
   {
     "id": "terra15s2wgdeqhuc4gfg7sfjyaep5cch38mwtzmwqrx",
@@ -1037,7 +597,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1lw36qqz72mxajrfgkv24lahudq3ehmkpc305yc"
   },
   {
     "id": "terra1605aqnlpve2tes8vzqajg0ntzm5vx470vgrhta",
@@ -1058,6 +618,26 @@
     "dex": "Astroport",
     "type": "xyk",
     "lp_token_id": "terra1h087pv7lh2pulshddjm3wyem0jcs7cpm0pera9"
+  },
+  {
+    "id": "terra167lmzjrfvrqm59ycxvr4f937vgap4uytnkyrat",
+    "asset_ids": [
+      "terra1mely4fttd94g5kgjmz05dmclgdahq45xnv5n22",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1rzju3x9yqzd9lmfqxvtu5huvc6tulqtmfnamjz"
+  },
+  {
+    "id": "terra16af3ksetslvny2ypwe0nync0lahs87t9csvyz7",
+    "asset_ids": [
+      "terra1n6eltvex47mta0me66ygqw0fgvjx2ul7qm9fjp",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1xer502ejxn9g3elanqgrh4cl7zzk9dzxkwmy9q"
   },
   {
     "id": "terra16e5tgdxre44gvmjuu3ulsa64kc6eku4972yjp3",
@@ -1090,6 +670,16 @@
     "lp_token_id": "terra1pme6xgsr0f6sdcq5gm2qs8dsc2v0h6gqzs8js5"
   },
   {
+    "id": "terra16lle05y09g2eazntxdx89m6u8d4y68t2tglmk3",
+    "asset_ids": [
+      "terra103ws85fnvy3j9vr3ss9va2zr26vepemqx2n88u",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra10fwytprs0lnnwtdkvst0dpy9v5ql6ydwq278l7"
+  },
+  {
     "id": "terra170x0m3vmc7s5pdvpt5lh9n6wfmsz6wcykcr0vg",
     "asset_ids": [
       "terra1mt2ytlrxhvd5c4d4fshxxs3zcus3fkdmuv4mk2",
@@ -1110,6 +700,16 @@
     "lp_token_id": "terra170qpzy04ad3dnahw53ng43grcervgr7caglvyz"
   },
   {
+    "id": "terra17ds7t9z2pu3cyqtlnklhfpruc0nnahddzr49wn",
+    "asset_ids": [
+      "terra1vfhh44f57a72vaqdk69k2y9pllwlrhkv32n6nr",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra13x593s7kzrfgptjamjtxdhjvc3h93xtkf9s83y"
+  },
+  {
     "id": "terra17sswfv8mvvdx75j9q33l83j3cnahnta3wqqpa3",
     "asset_ids": [
       "terra1kqf8ua7al5tdnkz95ue4zkuv4gcu52pt63ya54",
@@ -1117,7 +717,17 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1329yk4ex6dvzsma9a526zueu6q6lua23087kf5"
+  },
+  {
+    "id": "terra17w79y5ptp63dlr79tup9rkh6294qe448phup3f",
+    "asset_ids": [
+      "terra17ktj9hq69ae9mj49dwqfzmj05t6eqlkyywukf8",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1vzm3xgte5hzqycdqrwugwrwppjl6ytxk55pm6d"
   },
   {
     "id": "terra1820d2zqjqu3jkkdatsf4lktrkjkxslr4t4qf76",
@@ -1147,7 +757,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1k64h44gjk3l0cv5dskkfvcljkm4mgffshpf3wv"
   },
   {
     "id": "terra18hjdxnnkv8ewqlaqj3zpn0vsfpzdt3d0y2ufdz",
@@ -1177,7 +787,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1d9h62r2aul7uyft3sr5dhvzeh76wruct346jj4"
   },
   {
     "id": "terra19rcpzd2w35trvtwkjt4lrckqeqdstlplnqz2ny",
@@ -1187,7 +797,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra169ul6vsjd9nxfukepw4azvme5svsgf4pmpmnfd"
   },
   {
     "id": "terra19wauh79y42u5vt62c5adt2g5h4exgh26t3rpds",
@@ -1207,7 +817,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1m35ugve6eqfralljaf5n04pjgf6hl52hqh75mv"
   },
   {
     "id": "terra1aa68js6yxavg9zzzle2zaynem9cstvmaj3xyu3",
@@ -1230,6 +840,16 @@
     "lp_token_id": "terra153p2zvds95vavrenmtcrv8xqxy2sm8xhrl3784"
   },
   {
+    "id": "terra1awy55useu780l3hsprulg0s26maxgtx2pjkev0",
+    "asset_ids": [
+      "terra1zce4mxwwdyk04txa2f3aqepzsq8jy7ca50gn8w",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1wkr40ytfyzxww7jkgjphyjnenqm6l26wvprqec"
+  },
+  {
     "id": "terra1c9yy9ftxpdg3drk9upg60hykyw2ardrgus00ew",
     "asset_ids": [
       "terra19qad83kr29qg89fpl4qh8m02wapmlwzpw5hvc4",
@@ -1238,6 +858,16 @@
     "dex": "Astroport",
     "type": "xyk",
     "lp_token_id": "terra1j495mkdh6tjxexkatae9xq4300dw0jga3p4xzs"
+  },
+  {
+    "id": "terra1ccwy34ygpj9qav05y2d5akzeeflvz6lzvsz9l9",
+    "asset_ids": [
+      "terra1a07n2cp4wd49ezxdgm9xgtfrnpmxfcdp4yrdnv",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1rm36n8c5zacf83aljwzzxtq8ctge7wlym689we"
   },
   {
     "id": "terra1crat7ql0q4z0wc3uhqvnckenlgjvjcduecdegg",
@@ -1257,7 +887,17 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1gmesktapz4ppsn909l4zwsyk5dlkh2ftn4rly4"
+  },
+  {
+    "id": "terra1cylvlytxzjywy0wpf5mrtua3q37esduhqfk9w9",
+    "asset_ids": [
+      "terra1vyusa796w86yh99l67dpd5g3hfva759vyuhn5z",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1c2eygasm7jhh8huse86gqr8mhywefzc5enyk93"
   },
   {
     "id": "terra1d3t80j3d4raeg8m94erljaqehutve52yelw7r3",
@@ -1280,6 +920,16 @@
     "lp_token_id": "terra16n47ledvk4ye47r7z4hwmdz0fpphavamslv0ej"
   },
   {
+    "id": "terra1d5uhps2w38fqnx2zzfrkhk96sw4j4twjpr5s46",
+    "asset_ids": [
+      "terra15k5r9r8dl8r7xlr29pry8a9w7sghehcnv5mgp6",
+      "terra18vl2cypy8pdys2qdqlg7pzmcmpqmur8lmrnk2c"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1ztj6x5exa33w7dsvjxmdxam8w7j7t2phglmpea"
+  },
+  {
     "id": "terra1d7028vhd9u26fqyreee38cj39fwqvcyjps8sjk",
     "asset_ids": [
       "terra1mpq5zkkm39nmjrjg9raknpfrfmcfwv0nh0whvn",
@@ -1297,7 +947,27 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1lcl35szwa5genlygz4f8nnexg3uaj7avfsw8z7"
+  },
+  {
+    "id": "terra1dleq0ve3wlkcqsj93d63u4t7c8h8d65uztnfl0",
+    "asset_ids": [
+      "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
+      "terra1kujvztl5p8a45k56u42fq39jxldxcvuejtpfq5"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra192nxzlpw8kgtppmrr9uqzn27cphpyaqauxd6qw"
+  },
+  {
+    "id": "terra1e46tre2rxhuxq58ygxsxm2m8djup7f3gasen6w",
+    "asset_ids": [
+      "terra157n30a667ethsknneaavga2txtze58eajyfv45",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1r0wdunh0nrn65863hrs0p72us2502x525m62sg"
   },
   {
     "id": "terra1e76nq6ll0vzy4apprphh0k5wqzzsndjakwd6x0",
@@ -1307,7 +977,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1qze0rv67swfl7zlr087snsxe6jdde5kka2ckx3"
   },
   {
     "id": "terra1eck465e7u33y95flte0sld8ndrhk2yssnkea37",
@@ -1317,7 +987,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1ftc40u7grf6cu9pd0eqtyx9cx53nwehmhenwd9"
   },
   {
     "id": "terra1edurrzv6hhd8u48engmydwhvz8qzmhhuakhwj3",
@@ -1327,7 +997,27 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1qz4cv5lsfw4k2266q52z9rtz64n58paxy9d476"
+  },
+  {
+    "id": "terra1egk8w9eeta7dehmhsf4v3fjkrxucc6ygamj5sz",
+    "asset_ids": [
+      "terra1h0jk42weh0urhgdtjql93rrvgdccspnp7vyf49",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1jy6r3knmz2a62k5vpy6f65smm6nrgsaqreqj0d"
+  },
+  {
+    "id": "terra1eguektu6mgqqc8rxprsk5nadpxpr7v5k7ttpqx",
+    "asset_ids": [
+      "terra1hauj2lpsnye4jsxxww8kpze4mzyq76e5cjr2wp",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra175jguvthv6m7xj20eqc609ftcnddk9mhxkhmkc"
   },
   {
     "id": "terra1egwcnkeqsf28y4k8wg399ptz5zcsek52qypgzp",
@@ -1340,6 +1030,26 @@
     "lp_token_id": "terra1v30r6lju6hs2kxrj2z0wdt2q38uwflh6mydx6k"
   },
   {
+    "id": "terra1equ0rx0hhk4q22v2rlg779war57rhgt7d8vwls",
+    "asset_ids": [
+      "terra12qgpr0fw773gc8lrkys3knnw6nkgdlc8ggaty9",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1hccq0nadxn283k0wygvszrq5uv5xm6ra4y3nma"
+  },
+  {
+    "id": "terra1eqv7ldavhp8lvgesk0083g6jwqktgwp7cm6hq6",
+    "asset_ids": [
+      "terra1ew3yvrg0ejpgvswyw70gcqqp3g2j45d24se5xq",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1ntcs04cq40vqyj5qjr8w43yrhqx5zcwx0nm2kd"
+  },
+  {
     "id": "terra1esm0pztzdq6hqgtj72w9dsnlfwtm343c7axvxu",
     "asset_ids": [
       "terra1kn85pdmrhhk2upjj8hf97lx3w3jg6gyzasyksp",
@@ -1347,7 +1057,17 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1zrt5t6lhtnn4324cs27xkh8v0dm22kp7929a9m"
+  },
+  {
+    "id": "terra1f37ftdeeke582crsdc9exf8n6m05awzpjjm60c",
+    "asset_ids": [
+      "terra1mfek3m9s0sazd40kjraw5qv3963t5n3gwk408u",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1tr6l7vugxjtzm2jtmm53rguxh6j7qdu46jnatu"
   },
   {
     "id": "terra1f57qu9cavwv9522gkr4pcpe78t8rmwxq7w5weg",
@@ -1360,6 +1080,16 @@
     "lp_token_id": "terra140eypk8cxgkrpvx4lfldqrtfwdakxgng3uwzc0"
   },
   {
+    "id": "terra1f87y5r6xmt37sf09nl0fw3mgnk0xsnnyeecgnn",
+    "asset_ids": [
+      "terra1teh62le6cndl2ch9yw5vkjk30h2fd4mhkrt5wc",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1ylug28lxeykpag00rl59ethqy8tq2n65stld3d"
+  },
+  {
     "id": "terra1ffjjxeu5l9f027qtkwseulgz6ddx5f04czyf0w",
     "asset_ids": [
       "terra1u2k0nkenw0p25ljsr4ksh7rxm65y466vkdewwj",
@@ -1370,6 +1100,16 @@
     "lp_token_id": "terra1u45sf0k8xr2dn5fl2hpll7tjrv0pn3l30c4jnt"
   },
   {
+    "id": "terra1fqqtkhx8c3jxfl94jzzldvjmu4u9jeuyful6ma",
+    "asset_ids": [
+      "terra1jp4r38w4j2qkxavjs9ypqv6mv833wdar3tywe2",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra19vxn3tsnxrmyguupvxdmtzm868wmk6p9876per"
+  },
+  {
     "id": "terra1fx2w5w8yfvncc7newqg5l08png5wln6s5k7qwy",
     "asset_ids": [
       "terra1rz964297kvt86rteajhtp4hsffhcum0ye8eljh",
@@ -1377,7 +1117,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1r5za42ylgj265q7narmzhwew5zavqrdh5k0gsm"
   },
   {
     "id": "terra1gfvp0tynfdeux2rlfryqjrurcjyqfadw7sl502",
@@ -1387,7 +1127,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1p4ulaks50ynw3ysljhpfzum59hlaxv7gsdx7vv"
   },
   {
     "id": "terra1gj2l0vrna4g73e0500hexzyy444g46vre3eaa3",
@@ -1400,6 +1140,16 @@
     "lp_token_id": "terra1waafz57kdr2y6y8wcqq0rx72cjwkj0pg5f64au"
   },
   {
+    "id": "terra1gpel5uny2f2hw3e7kln4y3mluwtdlcpukaeukk",
+    "asset_ids": [
+      "terra1ypgjelmtp0mv5akzwmnj5xhukhd3fy9gd28wpj",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1h4kxu3gw9vrx5vfc4jtxlcqg4fakex2mzuqm7g"
+  },
+  {
     "id": "terra1gs2zrwxz0szra07ks8xze04g4clwjsj6jjaq90",
     "asset_ids": [
       "terra1vchw83qt25j89zqwdpmdzj722sqxthnckqzxxp",
@@ -1407,7 +1157,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1celrlpn59teuz7j0pl5lak9k4qsx3h6vzlspgj"
   },
   {
     "id": "terra1gxluuw67zmflr7qun7vxgk04lqam8mt42m4945",
@@ -1417,7 +1167,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1lj4687036zu9fefc2mqpg6eaaqaneyvg443xax"
   },
   {
     "id": "terra1h574pqdsnj42scyyc66ec54757mlpsnn6gefjv",
@@ -1437,7 +1187,17 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1r0cq3zmc07dzf95h4du6ja59n5gmxr9fp3lkcc"
+  },
+  {
+    "id": "terra1hhpgcp2stvzx952zfxtxg4dhgf60yfzchesj3e",
+    "asset_ids": [
+      "uusd",
+      "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1kt26adtzwu4yefw37snr73n393vsu8w0hmazxc"
   },
   {
     "id": "terra1hlq6ye6km5sq2pcnmrvlf784gs9zygt0akwvsu",
@@ -1470,6 +1230,16 @@
     "lp_token_id": "terra1478nzcqhdpzmg6ztjkdjfkycdwrmeegn5r0yku"
   },
   {
+    "id": "terra1j3se2lhn7kwzu0zpa9zgc2sk9r20gmrrxz0n88",
+    "asset_ids": [
+      "terra1krg7amkeenvqwkaarp4r4grmrnldd83lmkl26u",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1tzlc5g00ny7vh78mc8fnw2qqe4wmy7mmjgv497"
+  },
+  {
     "id": "terra1jfuq655fmqp7uhkkqanmljqj26r9acs68drn2s",
     "asset_ids": [
       "terra1cdc6nlsx0l6jmt3nnx7gxjggf902wge3n2z76k",
@@ -1477,7 +1247,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1xjl8xqg2ahjg5yfslg4n6lyl7qam0jne0440ps"
   },
   {
     "id": "terra1jkjpcgn4wywcytpnq0y7wq9jsythz6azmyw5ec",
@@ -1487,7 +1257,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1669zy3zumlk040e9cjn6hw533saa47tj2ycm8d"
   },
   {
     "id": "terra1jlvyyp6hhy60g0um3cx4wq989rtcxqars5jyy7",
@@ -1507,7 +1277,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra17p5kfks2g2zy3jk8a8jjc6tyazll7fxkjdyrug"
   },
   {
     "id": "terra1jvvc4gh5ksydjqgryrdph2msa2aj0qgxj4pzhq",
@@ -1527,7 +1297,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra140r7a2r20l84sy38r3msesk0u7pus9xmm49vpy"
   },
   {
     "id": "terra1k8lvj3w7dxzd6zlyptcj086gfwms422xkqjmzx",
@@ -1537,7 +1307,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1drradty46zqun4624p8a3sp9h5jfg9phwlgnm2"
   },
   {
     "id": "terra1l7xu2rl3c7qmtx3r5sd2tz25glf6jh8ul7aag7",
@@ -1557,7 +1327,17 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1sfaglekwkqw8k2swsw54ut0k7erykt7dzufk7j"
+  },
+  {
+    "id": "terra1lnr6aacxfng34m69076s2mdfjzt8nev2p6z5q0",
+    "asset_ids": [
+      "terra1dw6yapjv8k8anef2kg43hewg3g73wle22ncaje",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1rx4xd94l74jupghnrn27r8ymauap9fy7tr3js7"
   },
   {
     "id": "terra1ls8hsss7tp3cna6nd95reevtmstm4uc644akxx",
@@ -1567,7 +1347,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1a9fz54uc03yjpj26jlyu26kj2w2v295yvjmf3m"
   },
   {
     "id": "terra1ltf9ss5syeeu5schnw6ah3t4arfqmj53kgtc3k",
@@ -1577,7 +1357,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra17dpamlm8mdw2ymuesv0q2ruta2pa6x84prgqyc"
   },
   {
     "id": "terra1m32zs8725j9jzvva7zmytzasj392wpss63j2v0",
@@ -1587,7 +1367,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1lmlv43teqcty6xldtg4f40sghnd2f8ehjz0qpk"
   },
   {
     "id": "terra1m6ywlgn6wrjuagcmmezzz2a029gtldhey5k552",
@@ -1627,7 +1407,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1sjqf9gw69p7g30s68wfencagpe3mw6q7mm3uwh"
   },
   {
     "id": "terra1mv04l9m4xc6fntxnty265rsqpnn0nk8aq0c9ge",
@@ -1638,6 +1418,16 @@
     "dex": "Astroport",
     "type": "xyk",
     "lp_token_id": "terra160jxnp3qfxrrjrfhul3xens4ggw6le7p4m4e6g"
+  },
+  {
+    "id": "terra1mxd85ljdjcm7ddfh8qvnxx8tyggnh3zsahy7aa",
+    "asset_ids": [
+      "terra17n223dxpkypc5c48la7aqjvverczg82ga3cr93",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1m9nc2c5txwamw96l64nqtumrewwhl36sfagpwe"
   },
   {
     "id": "terra1mxyp5z27xxgmv70xpqjk7jvfq54as9dfzug74m",
@@ -1657,7 +1447,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1dy8mq25x79jrdzz30j230suka37xt39lcgdcl4"
   },
   {
     "id": "terra1mzw4s868sagj2hgh5kfc4e722pug95wea3f87w",
@@ -1717,7 +1507,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1gxqhpka432v9zqktvkney2anvpx5kem7ws0g60"
   },
   {
     "id": "terra1ngs0xlmxan6ktqwtcj8c2l2ddp3z00wpxt43vr",
@@ -1727,7 +1517,17 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1lz898jzfs2l5w6afzucg90nwf67j8xtl9ugzcl"
+  },
+  {
+    "id": "terra1nq6ty6lppp7kz58nkshhmyfe8tv4p85ueh50mp",
+    "asset_ids": [
+      "terra1tf6ukhukcqwfasm6e3ae2406c87vc8zhrh5ex7",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1ph98tlff0kfpfnenp5f9aurj8n6zu95k72vwna"
   },
   {
     "id": "terra1nujm9zqa4hpaz9s8wrhrp86h3m9xwprjt9kmf9",
@@ -1738,6 +1538,16 @@
     "dex": "Astroport",
     "type": "xyk",
     "lp_token_id": "terra1ryxkslm6p04q0nl046quwz8ctdd5llkjnaccpa"
+  },
+  {
+    "id": "terra1nvzgfu8yyzcsm7a3je2hnn597ndz74g9a22zzl",
+    "asset_ids": [
+      "terra16ygrvq7q2zxw7jj3f96racur50w0g7r0mj6e2y",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra14jqrnf75jaqwyz5q6j4fk4503qyvfult6juytl"
   },
   {
     "id": "terra1p2fxxmkxsct97spt3f82acytxw2vpvm2f4f7t3",
@@ -1757,7 +1567,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1lpnjpsx368029u4rcppegq3cajy0dcxav8undx"
   },
   {
     "id": "terra1pzemhnxtmtp7z7hlecafjqpnrt29czhmyhyd2z",
@@ -1767,7 +1577,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1wxep2q6urg9cmnldngtu8jjdzc4djge2upr6mg"
   },
   {
     "id": "terra1q0eh3pct8da820t0san35pcg0sqqtmz4k532xh",
@@ -1777,7 +1587,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1wmrsczf7gzct56tygx6cmjh5tl43gwx4wvgat8"
   },
   {
     "id": "terra1q843tspwkcec87n5xrwdx8ygnmjjk7kj0lc7p3",
@@ -1787,7 +1597,27 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1pkxvyp4jct2ermvm8s0dc85fszzw8rdjmmg5tu"
+  },
+  {
+    "id": "terra1qkzw4cfr74d0n5s9mf865vcpuchv0ssygkmvuy",
+    "asset_ids": [
+      "terra1nq9epqtswmj7uaymsw59w9n5h5e78k9rwduets",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1vhustrxwexul87cj7yk5wr993rk68p8mkwuvkw"
+  },
+  {
+    "id": "terra1qpu9ve7lle9wl7npkqq745j8fwekw5ghfnttkj",
+    "asset_ids": [
+      "terra17ckx25kqhwzf3fudprs78kqgp3lhpr2w74yf7t",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1zejyjpwf6fpeg7fpa42vu0d5fjwejv7tx4ts3z"
   },
   {
     "id": "terra1qr2k6yjjd5p2kaewqvg93ag74k6gyjr7re37fs",
@@ -1800,6 +1630,16 @@
     "lp_token_id": "terra1wmaty65yt7mjw6fjfymkd9zsm6atsq82d9arcd"
   },
   {
+    "id": "terra1qv0j5udg2lcnqkuy5rqt2n6n2z9m2zps6zfx2v",
+    "asset_ids": [
+      "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
+      "terra18ky9ln4g6x3n9f9s8a5ttshynv6lgzfppmrmyg"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1u5dvpptphgq43qgvj9cg7ce8a3gl6qhcpl6jxf"
+  },
+  {
     "id": "terra1qvq38uhmtdqh5tu3ratganwapnjefs2elxduy4",
     "asset_ids": [
       "terra1yy0w2w8rkrfn5ul967rhpjrj4a0hpjy6m7end7",
@@ -1807,7 +1647,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1lp5vx80l9l0n06ylhrwlgtvkw0sl7qe06s5fhc"
   },
   {
     "id": "terra1qzqzvsr3hvgsfkvcl4jgv0l4lsdhap8skawqt4",
@@ -1817,7 +1657,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1ptwcpzdmyjvpz62agp9m4y9y467pujwswh4n64"
   },
   {
     "id": "terra1r0u977a90c5l8dxq8hu00eydm4ahl0mqwms9a8",
@@ -1827,7 +1667,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra19hut7h3rgyap5dv9mr77g8jj3m2tv8gfy832wy"
   },
   {
     "id": "terra1r2xwh4fd0gyrr3403v72j89354qtryvrg0rjc9",
@@ -1840,6 +1680,26 @@
     "lp_token_id": "terra1pmn4f2fcrhgtuetqr0wt3nldgr7zlufu688pfd"
   },
   {
+    "id": "terra1r49ew9xrpauml4chelxd6mt32xwpywlmcnt853",
+    "asset_ids": [
+      "terra1gjuhc34ccr6ajq7dm5266xyedu96sgkv4qnley",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1r777vhtrzfr20scew3rk5a86htl7xk6g46c9ae"
+  },
+  {
+    "id": "terra1r5xu0edlqgjd9t7smsaww0tr7jvqh0805x8nd4",
+    "asset_ids": [
+      "terra1fx6ffswrmgyuf5nsxruce5gertr8vgsm7krrp7",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1t4fsj0eu0jg9h9um8wmj9c9r05mjj2pvcevyp5"
+  },
+  {
     "id": "terra1r6fchdsr8k65082u3cyrdn6x2n8hrpyrp72je0",
     "asset_ids": [
       "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
@@ -1847,7 +1707,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1j2zvs6gwwnwta39smr0a8qq2grax96nky0xh2y"
   },
   {
     "id": "terra1repcset8dt8z9wm5s6x77n3sjg8hduem9tntd6",
@@ -1867,7 +1727,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1wyav7grhqaeqk30sexp393z80t3t7jx0fes2t8"
   },
   {
     "id": "terra1rjql89achu0aq3e69nxz78qnj7xfdjewndsk2v",
@@ -1877,7 +1737,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1s3jfvnm45ueratdk5ncnt4tesz3gmd49jnhjrd"
   },
   {
     "id": "terra1ruu2gxsuplha5r2uzh0fnxqyd4svx23njwy74k",
@@ -1887,7 +1747,37 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1ehxlddphl6sg09858g736p950t7jead30h4r49"
+  },
+  {
+    "id": "terra1shgwa4xwdegsxvtr0qaergjq689sakzvn87fvy",
+    "asset_ids": [
+      "terra1l385362dg276797k7lzsfktskfssg22n7hn4at",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra13fxx7gxay46up9ehx6t58kfksmy9mltx2sme4y"
+  },
+  {
+    "id": "terra1suwlj0tlfqngq67gy2pjyqjwx3rfry2klvtxe5",
+    "asset_ids": [
+      "terra1cvsfc32dkdvmla6urrscrtfceztecj0u5tvlvz",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1pth0gsyh8j0x08zv2fqq930xq6assges0zg82u"
+  },
+  {
+    "id": "terra1sz988qp6vma3j0xj5w7fsskqcuc8kjn0mmtcqc",
+    "asset_ids": [
+      "uusd",
+      "terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra152e9whmpjlgenfhjj6rm4lcffcpdfgqc0u5qx2"
   },
   {
     "id": "terra1t0qdxv523fxkuyhk9yv6hgal33cwnwh9hmzq55",
@@ -1897,7 +1787,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1kf605smmmhytc6mmpnus39pl6m9546er4u5859"
   },
   {
     "id": "terra1tehmd65kyleuwuf3a362mhnupkpza29vd86sml",
@@ -1907,7 +1797,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1wk0lev7qneurzp2dzcauh2ktctwx6v079uvn7w"
   },
   {
     "id": "terra1tkcnky57lthm2w7xce9cj5jeu9hjtq427tpwxr",
@@ -1917,7 +1807,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1k2y7sk3ltg064xt462a8ut22fpw85qsamujzz7"
   },
   {
     "id": "terra1tlmqtwj5lq27knn7x932mqwmwdlnppesvwt5pa",
@@ -1927,7 +1817,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra19sjjjsec56a60uy7nmeut294laesnyvcfd2ssl"
   },
   {
     "id": "terra1tteawchaue7myplvgm46ghszymh2wd4ghhcjq3",
@@ -1937,7 +1827,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1jmu5pq0t6wwclp9y7ra3crgtmt0q7zhtr3fmay"
   },
   {
     "id": "terra1uf36lmgl3jut9xfg50cel2fh67ja6e5gqd98kj",
@@ -1950,6 +1840,16 @@
     "lp_token_id": "terra1lt284v0t2psk9m9pj3ext0srtrzar6jsg70g8t"
   },
   {
+    "id": "terra1uqsny2clznnhrmq2rvlhv72l78lmlss32uzuyh",
+    "asset_ids": [
+      "terra18ejpjp9eyx9t8j07jd7kzah9p0rvkzdfeeva6n",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1wjwhd0pp64najr7hlhx43v90tkx55dqwwfg3ge"
+  },
+  {
     "id": "terra1v5ct2tuhfqd0tf8z0wwengh4fg77kaczgf6gtx",
     "asset_ids": [
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
@@ -1958,6 +1858,36 @@
     "dex": "Astroport",
     "type": "xyk",
     "lp_token_id": "terra1cspx9menzglmn7xt3tcn8v8lg6gu9r50d7lnve"
+  },
+  {
+    "id": "terra1v67ycjhzup787j9efpygr4fcky7rpxgkfkf89d",
+    "asset_ids": [
+      "terra17nekftv2yp8n4lsex85008sphchs4t3rnfcqzf",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1nxgs0pfu89wyx6wfg3yssmeykg3nuh5mae4uyx"
+  },
+  {
+    "id": "terra1v6vmpgpq3lky0w9jhmqn8ccr0sgetkgus70e62",
+    "asset_ids": [
+      "terra1kggysvv0q3tq2r58f5nt03hqa8pqj87c2m8k09",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1zadxq9h0aw40tna7ytrnn57ymc57chwluxkhyc"
+  },
+  {
+    "id": "terra1v7hcllx3l7namvvffg3jfl7vc3ksy089yr3ewu",
+    "asset_ids": [
+      "terra1mh7nlhzvvesgc4whcx7dg2nhj3p0dhl9fwrexu",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1udhalf5h39qsecjw5wxm02yy0zhlu4vyumk5u2"
   },
   {
     "id": "terra1vfpfncl2wcxjhatl08mt0j8ppx5vzr6eek0wj2",
@@ -1970,6 +1900,26 @@
     "lp_token_id": "terra1ggz8vxgngjc8atv8z70kdfhmlg534gg0zevfcf"
   },
   {
+    "id": "terra1vfxjj237nsyxu8034syv46d4gzmrajksrdnvdc",
+    "asset_ids": [
+      "terra1lyppcm0cjc5nrge6hmwdkkeqeh4m9cat8nyf3e",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1xlrclrh3zu8vpjmnlnkjealnw6ggtf287ms3ly"
+  },
+  {
+    "id": "terra1wau74j4ykmx5nfjad4wjra8m02x9vg5h8g7ym2",
+    "asset_ids": [
+      "terra13kr45ssru9cqhp2kaaan88wfaa7f2h3jfvuldp",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra13uuz5gcrja6d2ajjnchvvwaly5xuczaagl63uy"
+  },
+  {
     "id": "terra1wdwg06ksy3dfvkys32yt4yqh9gm6a9f7qmsh37",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
@@ -1977,7 +1927,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1aaqmlv4ajsg9043zrhsd44lk8dqnv2hnakjv97"
   },
   {
     "id": "terra1wr07qcmfqz2vxhcfr6k8xv8eh5es7u9mv2z07x",
@@ -1988,6 +1938,26 @@
     "dex": "Astroport",
     "type": "xyk",
     "lp_token_id": "terra1n32fdqslpyug72zrcv8gwq37vjj0mxhy9p4g7z"
+  },
+  {
+    "id": "terra1x2l3qhtcp2jlgn3duwrt7f6pqaz3tq3qydmkp4",
+    "asset_ids": [
+      "terra153u8c40h2mm8nvs0daqxsnwgvpw43muxj3c28h",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1lm3u93q4jp8w7wltq46248kdvgpxed2txgx2h9"
+  },
+  {
+    "id": "terra1xckx7r8ay8hr6qneqlftcejzaqme4jw0k35e0l",
+    "asset_ids": [
+      "terra1fhsljj6qc8f7cnu62e8uxqt82czflztge05dwk",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1dz4se8cf8kducyaqe0wnewe6uwa8f690x4sjda"
   },
   {
     "id": "terra1xf44m98wgzn8gx9a3et0k52wnrrlh2gs0m05jq",
@@ -2007,7 +1977,17 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1833sstcyxaaer8h5rdsrnp7f59fymmyhark7ae"
+  },
+  {
+    "id": "terra1xhewlp3h0kh82t2n33x2cc200t3zcxmhmrsyqk",
+    "asset_ids": [
+      "terra1z4pfv9rrm53tg72cwkcv6ddvd4x6wcce43nua2",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1zy2j6ahsk5eew0g3ppx3jtwe7hjya93sxpkw49"
   },
   {
     "id": "terra1xpzusa4cqukutgra7fysjfyh4pkds5euepfe3q",
@@ -2027,7 +2007,17 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1maajtm4h8xd9wxtjjs2mpxvsp2lrgcmpha60wq"
+  },
+  {
+    "id": "terra1y6e5xmqxcq9zm9mdncf4nwneyp27d98awgqjv7",
+    "asset_ids": [
+      "terra1vm507q46f2sm8jltjcvp3dtncttquwld0tfkdl",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra1f0pt3p2f0p3v7hqqgpxzqdx522k2628fvjn7dh"
   },
   {
     "id": "terra1yh5pcqpedv3uz6zuas2e9s944z3whhlh3lfq0j",
@@ -2038,6 +2028,16 @@
     "dex": "Astroport",
     "type": "xyk",
     "lp_token_id": "terra12hjjangazdveuxr6l839dd67kprzfkwkmc7fj2"
+  },
+  {
+    "id": "terra1ymh8xk3uv522vs2g7m8j6v059s7cmcxyr5vqtc",
+    "asset_ids": [
+      "terra1ult8nl3u83p7vdjdehtjfn9ylkm6u606nmdry3",
+      "uusd"
+    ],
+    "dex": "Astroport",
+    "type": "xyk",
+    "lp_token_id": "terra13fwa5e5m95tye2jtnkxjmwe3632hp2pampxjk7"
   },
   {
     "id": "terra1z7634s8kyyvjjuv7lcgkfy49hamxssxq9f9xw6",
@@ -2057,7 +2057,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra13jyqfza5udal5a3jrtmwfj90lpk59mc2stnxpa"
   },
   {
     "id": "terra1zjj37anlqt99tv5hwhsew0x7e007hcg3fsm8sx",
@@ -2067,7 +2067,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1whh5ce248vg837gqfhjpvcdxdfx4la5h4t44x2"
   },
   {
     "id": "terra1zpnhtf9h5s7ze2ewlqyer83sr4043qcq64zfc4",
@@ -2077,7 +2077,7 @@
     ],
     "dex": "Astroport",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1zuktmswe9zjck0xdpw2k79t0crjk86fljv2rm0"
   },
   {
     "id": "terra106a00unep7pvwvcck4wylt4fffjhgkf9a0u6eu",
@@ -2087,7 +2087,7 @@
     ],
     "dex": "Loop",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1f0nj4lnggvc7r8l3ay5jx7q2dya4gzllez0jw2"
   },
   {
     "id": "terra10jzrptpsx9y6uam6vfrxpmppyelevdkm39yxay",
@@ -2107,7 +2107,7 @@
     ],
     "dex": "Loop",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1c5nnnhghua9xdlpltvw9396en5ulvwch2xkv0h"
   },
   {
     "id": "terra123neekasfmvcs4wa70cgw3j3uvwzqacdz2we03",
@@ -2127,7 +2127,7 @@
     ],
     "dex": "Loop",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1r6y67560w0k6jmnnmw6tt8l45pz4g4ul3pdg78"
   },
   {
     "id": "terra13ay3hftcft25uazl76q8gmdk993y9nyv9avu2h",
@@ -2187,7 +2187,7 @@
     ],
     "dex": "Loop",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1p266mp7ahnrnuxnxqxfhf4rejcqe2lmjsy6tuq"
   },
   {
     "id": "terra15568nqrqcawm263yqcuuuvj5mh763tp8jyscq3",
@@ -2247,7 +2247,7 @@
     ],
     "dex": "Loop",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1skhdh4xr9en0wapp4jt4c2e2f2tpajux9sk0uh"
   },
   {
     "id": "terra18r6rdnkgrg74zew3d8l9nhk0m4xanpeukw3e20",
@@ -2267,7 +2267,7 @@
     ],
     "dex": "Loop",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1t9k57qtvcerkun9c4g6jw4klnuykvyuzt6v7pk"
   },
   {
     "id": "terra1a26j00ywq0llvms707hqycwlkl9erwhacr6jve",
@@ -2297,7 +2297,7 @@
     ],
     "dex": "Loop",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1lfmgcqkxpzr039g8v2qfd0u9zd5eh8xvvd8gh5"
   },
   {
     "id": "terra1dttfsvgwvpz0zy9x52zyxnc4pa5lcx7l7pzguc",
@@ -2307,7 +2307,7 @@
     ],
     "dex": "Loop",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1spy6tdg0ps2spraz48x6dgts29tchl4ark9waa"
   },
   {
     "id": "terra1dw5j23l6nwge69z0enemutfmyc93c36aqnzjj5",
@@ -2317,7 +2317,7 @@
     ],
     "dex": "Loop",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1j6l2m2e2q92zkd9v48cs2l4n74rxn2plphul96"
   },
   {
     "id": "terra1efvhm927dehrka0cgpcptt5gvjfdgqm07smawu",
@@ -2357,7 +2357,7 @@
     ],
     "dex": "Loop",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra107cm5a2f70af6xxtsslgy9ghfnxc9ed2yl63kl"
   },
   {
     "id": "terra1ga8dcmurj8a3hd4vvdtqykjq9etnw5sjglw4rg",
@@ -2397,7 +2397,7 @@
     ],
     "dex": "Loop",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1cwuv67djlrmqywqf7xxqmrrkphv3658kyna7fs"
   },
   {
     "id": "terra1k4aud54tprawf9l2uleh4ndjuf940m283yxvzt",
@@ -2417,7 +2417,7 @@
     ],
     "dex": "Loop",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1nuuq9qmyqv5td9297fktnf864pvlw9q79f65m8"
   },
   {
     "id": "terra1l60336rkawujnwk7lgfq5u0s684r99p3y8hx65",
@@ -2457,7 +2457,7 @@
     ],
     "dex": "Loop",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra14ypw4nhnjk4eym2jyfpm8mt0frfkhymf9g0ut4"
   },
   {
     "id": "terra1np5jr05v08vjk5f665qu5xjxak8dyxnswtujn6",
@@ -2467,7 +2467,7 @@
     ],
     "dex": "Loop",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1stz72cyyrztvcwhghv5j5m879vzmks30yqs3ck"
   },
   {
     "id": "terra1p0ne6gzy3mamyepm5c0r0wvwyac2cexrmvkz0p",
@@ -2487,7 +2487,7 @@
     ],
     "dex": "Loop",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra18m2slhwa92p8lew9h5x8m9vc3jm5wtcyr48800"
   },
   {
     "id": "terra1pmmfz205es7axymwpl4jj2ruxnevufu3462f02",
@@ -2547,7 +2547,7 @@
     ],
     "dex": "Loop",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1a70aj0dyrgn2d5jwznql0nm3tnqpl9ap9uz3ce"
   },
   {
     "id": "terra1ur6yyha884t5rhpf6was9xlr7xpcq40aw2r5jx",
@@ -2557,7 +2557,7 @@
     ],
     "dex": "Loop",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1n0y2ve7j28l65z3kdf5h0xljfmmpc75z2xpzeq"
   },
   {
     "id": "terra1utds4jwyg2x0ajpuvxu358ry3v5zx98e345cat",
@@ -2676,8 +2676,8 @@
       "uusd"
     ],
     "dex": "PRISM Swap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "type": "xyk",
+    "lp_token_id": "terra1wkv9htanake4yerrrjz8p5n40lyrjg9md28tg3"
   },
   {
     "id": "terra1czynvm64nslq2xxavzyrrhau09smvana003nrf",
@@ -2686,7 +2686,7 @@
       "terra1042wzrwg2uk6jqxjm34ysqquyr9esdgm5qyswz"
     ],
     "dex": "PRISM Swap",
-    "type": "TODO TYPE",
+    "type": "xyk",
     "lp_token_id": "terra1zuv05w52xvtn3td2lpfl3q9jj807533ew54f0x"
   },
   {
@@ -2696,8 +2696,8 @@
       "terra17wkadg0tah554r35x6wvff0y5s7ve8npcjfuhz"
     ],
     "dex": "PRISM Swap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "type": "xyk",
+    "lp_token_id": "terra1argcazqn3ukpyp0vmldxnf9qymnm6vfjaar94g"
   },
   {
     "id": "terra1persuahr6f8fm6nyup0xjc7aveaur89nwgs5vs",
@@ -2706,8 +2706,8 @@
       "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2"
     ],
     "dex": "PRISM Swap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "type": "xyk",
+    "lp_token_id": "terra1rjm3ca2xh2cfm6l6nsnvs6dqzed0lgzdydy7wf"
   },
   {
     "id": "terra1r38qlqt69lez4nja5h56qwf4drzjpnu8gz04jd",
@@ -2716,8 +2716,8 @@
       "uluna"
     ],
     "dex": "PRISM Swap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "type": "xyk",
+    "lp_token_id": "terra1af7hyx4ek8vqr8asmtujsyv7s3z6py3jgtsgh8"
   },
   {
     "id": "terra1yxgq5y6mw30xy9mmvz9mllneddy9jaxndrphvk",
@@ -2726,8 +2726,8 @@
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau"
     ],
     "dex": "PRISM Swap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "type": "xyk",
+    "lp_token_id": "terra1vn5c4yf70aasrq50k2xdy3vn2s8vm40wmngljh"
   },
   {
     "id": "terra10whh69k8p9df2ccchvq03ddqqdpxlsxhte99j7",
@@ -2736,8 +2736,8 @@
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "type": "xyk",
+    "lp_token_id": "terra1l3nkalakr0ljf3han030edjnfmxnw2knekjrv3"
   },
   {
     "id": "terra13wgvm70z5py4gee5r03statmxp4hjtc6we80jq",
@@ -2746,7 +2746,7 @@
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE",
+    "type": "xyk",
     "lp_token_id": "terra1e9s5wklrlw44xl76p5e4gxvj7symsk0c3s8273"
   },
   {
@@ -2756,7 +2756,7 @@
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE",
+    "type": "xyk",
     "lp_token_id": "terra1lsrjcwupdpzayeg3suc3kmtrr3yq405pppja0s"
   },
   {
@@ -2766,7 +2766,7 @@
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE",
+    "type": "xyk",
     "lp_token_id": "terra1hr08ry5nmm65m74cyp3jq3c2vr89rm958s4rpz"
   },
   {
@@ -2776,7 +2776,7 @@
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE",
+    "type": "xyk",
     "lp_token_id": "terra1yf8aduaysgfde4d4g4qrg5z3qxutk4cdwyfz28"
   },
   {
@@ -2786,8 +2786,8 @@
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "type": "xyk",
+    "lp_token_id": "terra1hu6rkf2ftuwy9w0dz77mntp5seuqjh6jljky6y"
   },
   {
     "id": "terra1k8pflcvj3mhrmthrgux2pk9a9ytthsr5trnq7z",
@@ -2796,8 +2796,8 @@
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "type": "xyk",
+    "lp_token_id": "terra1dgcwzzss9fwgvge5prjkqqkz6sgjp82emspa0u"
   },
   {
     "id": "terra1lq94l6w3eft9c95kj3rcex9h702ssp35qyaha3",
@@ -2806,7 +2806,7 @@
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE",
+    "type": "xyk",
     "lp_token_id": "terra1gtaly35ppahnheejtpcav38gd43ck8kmjmvepq"
   },
   {
@@ -2816,8 +2816,8 @@
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "type": "xyk",
+    "lp_token_id": "terra1pamjvlrc0v9e8whsvttfyrjjwr4yex4venmu7f"
   },
   {
     "id": "terra1t9ffaw69tfensrn2s0hx79tm68g7hps30unys8",
@@ -2826,8 +2826,8 @@
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "type": "xyk",
+    "lp_token_id": "terra1fah3wuk2r0ykv25d0euvzucrmpqtyswn6qk9ek"
   },
   {
     "id": "terra1wez50a5t3658m6zyydaeyprtwwt8gtt0dcswlw",
@@ -2836,7 +2836,7 @@
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE",
+    "type": "xyk",
     "lp_token_id": "terra1jer5s9ykl64cm7xxp6zea9myjgru6vp38h9yzf"
   },
   {
@@ -2846,7 +2846,7 @@
       "uusd"
     ],
     "dex": "TerraFloki",
-    "type": "TODO TYPE",
+    "type": "xyk",
     "lp_token_id": "terra1auxjy8f8al78g9ecmv85agaynj8wkjp5kjce2p"
   },
   {
@@ -2907,7 +2907,7 @@
     ],
     "dex": "Terraformer",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1v5s3t4yzh0vyhlgrsy8uh2czjh2ylk56a4cr9r"
   },
   {
     "id": "terra100k5zacnuzl0ksxrn6lclmdl0u7w6l8qalcn6e",
@@ -2916,4898 +2916,8 @@
       "uusd"
     ],
     "dex": "Terraswap",
-    "type": "TODO TYPE",
+    "type": "xyk",
     "lp_token_id": "terra1yg09m7lcj739wvr3ns6d67znhyp4jexvpx2vkg"
-  },
-  {
-    "id": "terra103kw7gde0cu8v7xm5fwm54dp7uyq8d58svtf8t",
-    "asset_ids": [
-      "uusd",
-      "terra1q93ws00plywc5prwv7mf2gdf7alhuqgk5w68lq"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1q88d7swxfd36kcfeqhgdncjrht9rsh7c0a9vm3"
-  },
-  {
-    "id": "terra105cnw8azykz23ec9gtm06prssq9aqxg8pchjq4",
-    "asset_ids": [
-      "terra10jyyy0ylv34lafqv2mldcuxhk4qpdmnckgfls2",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra105lwyhfuw0p0q39tghg2hxnjdarg6uy6n9s24n",
-    "asset_ids": [
-      "terra1xc5ll57yu269x8ysxvdpjmvxmac3js7pst5ddr",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra108hz9wugglvu2rjty2xaddvwtr09ukd7kwm78n",
-    "asset_ids": [
-      "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
-      "uluna"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1nzlw9mny82p598ue0d4skguwlffhl5vdszjr86"
-  },
-  {
-    "id": "terra10a9jdeled7uev64ugtmc8kzjlg9xv6eeey88xh",
-    "asset_ids": [
-      "terra1ewesd6y7dswxd8qdfff7vxl8g2p0dfwpanf5fv",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra16qlxlx3h5ty2t2fmdwrh8a35yqngg6hlmv0w56"
-  },
-  {
-    "id": "terra10apggvnqewuu3zg03l8nzqemuwtnfhnsp7pup4",
-    "asset_ids": [
-      "terra1gukawnd63qd9ptuqe0ejm0vvweql45084lx4pq",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1y02yk8gwl7efuv76le3lrct9fn3uzs5a7nq4xh"
-  },
-  {
-    "id": "terra10dua387cxqwuulwwpcvk6atwe5alkh6qky7xhu",
-    "asset_ids": [
-      "terra18ys4xv4yjy6c7984mv4sz08p3rpl8cdtxxhuhw",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1kdqt7wfvem3nmdsrr5pwqlnhzl6w8xklqey35v"
-  },
-  {
-    "id": "terra10f9t46rjhxjdm3324kkadhsm6adqhzva3y2g4j",
-    "asset_ids": [
-      "terra1nxwnngqr0ks3j842jlr6pnrmd79kztjqyycer2",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1tdhcdlugvx4wwx9metx92nqpumahw9mzn7mhrs"
-  },
-  {
-    "id": "terra10jnrtfv5vle4gdknnu55d2p8trd6lxzwc5shp5",
-    "asset_ids": [
-      "terra1f3nc4md37vcy9l89qte2p5tej42pr8rzch8mfe",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1v7wyvflxcxchx2zxu2n7e858wlx9u72pkku3hv"
-  },
-  {
-    "id": "terra10mwe766az3rz5u84h53z6u0hxq9jp6jx54z3jh",
-    "asset_ids": [
-      "terra1j9zvn74s7v2kylvv2xcg4p0s69pvejrw5qzv7j",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1tnj6gg7ntn9wht35uqxz5dpe6nw4fd92ukmhyl"
-  },
-  {
-    "id": "terra10qeuxxj46luwqk8huh4gcp2r0ve7w5vh3hrtev",
-    "asset_ids": [
-      "terra1ft9qff9fgumdca5qluxu3e8fh8xc7d4hfek8s2",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra10qnu9yudvcnm7we04xj8lu3mjrgx5lc247h0y2",
-    "asset_ids": [
-      "terra17ktj9hq69ae9mj49dwqfzmj05t6eqlkyywukf8",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1xra8v827ml3m6zfylvzfv5g72mj4qhdk7snchy"
-  },
-  {
-    "id": "terra10rqw6xrzq2y3whp2r9q44zxyu5f8cdk0f4qa63",
-    "asset_ids": [
-      "terra120v2mhzge3mxat8nsz8ctqgy6f0cnnfjymsgum",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra139kpcz9239c35dulyqkkyqsdhnx99vhfk6q4fe"
-  },
-  {
-    "id": "terra10ups2qsazavszk2ml0ed52rqdstuwr2qtuxdjd",
-    "asset_ids": [
-      "terra17pc8eq0u35yslg7zulkqzc2mvxryfj3hw7nmsr",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra170c9286vqw9vddvfg4pemue5nxx6vdswxyccmx"
-  },
-  {
-    "id": "terra10v3f4lprsjx7wsxnmmah99vx0xw8q5zeq8zhvc",
-    "asset_ids": [
-      "terra1n4g9jamjrxhe5yssczrlq55syhxvwqkx7jpkjl",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1v0wxjtv45n0emx87mlx8y8qy5e449wcj3t3gt2"
-  },
-  {
-    "id": "terra10yg2w6s5c38shu0l6mx0gn8u8ctdp8lr9xdplp",
-    "asset_ids": [
-      "terra1j3w0tswl56yxduhen4gnela7m4we86w9xkwaee",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra163fswxeuysgmnflm2hl75elytulp9qnxu4muqk"
-  },
-  {
-    "id": "terra10zgqdcpxhj0rgvm98w2slu9z09t8rk4fs5r8da",
-    "asset_ids": [
-      "terra1r5c53q49wu2vqerecdvua2zpvy9k8vlw7cnx25",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ces0z6rlujzjw2f6axxjxaqav8v8kh8tqmhpqk"
-  },
-  {
-    "id": "terra1238lf7cayjp4f4fxle5v87eat6vekqn2zfh9w2",
-    "asset_ids": [
-      "terra17qy9f5h35504jxexwprsf6gtj009d3gjcml5pp",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra127zvfgggng7zx3taaj8myslx28rrq28ffycqxp",
-    "asset_ids": [
-      "terra1ttm7w640scqrarn0qxqz26798d84u94sg7gshw",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra14un4rp20aqq7h07zpgzxrz2fcwsplj8jp0jham"
-  },
-  {
-    "id": "terra128s8lplqeqepy8vh55cr0rzdhe66v9h3n52qk3",
-    "asset_ids": [
-      "terra1lnucwh7feutx0y8dgh3lu759a6netxx4wjzm4w",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ekfxyvagzayn32m6jcqylzefdtjnhkcnwjvwre"
-  },
-  {
-    "id": "terra12guk0mlt4jknln7mu8y7kjdaglqehu2r2kk6d3",
-    "asset_ids": [
-      "terra1fc38stp3xzjh5q8u0nrlk4n0gagxrnen35rsq8",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1jcu9exrj6ejq8a4u67xf9htmrn2dup8gg9kwts"
-  },
-  {
-    "id": "terra12lvqty3v0ncnxn3s4agekcp94akp95n7qgv289",
-    "asset_ids": [
-      "terra1kdkcxnsldqmj50ll77gmq5x26u69z8m69hdas6",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1va79wsdl4zrs2f9z2eef3c76p7akhuk3n654gc"
-  },
-  {
-    "id": "terra12qgav8q2qa5x8me759ajhf3j64525qumznc8h7",
-    "asset_ids": [
-      "terra1572yxtl5yxa9mjyzg44gj6knemudreekplelxh",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1u3m39v7vs066wazhl3manl8ztmyxpafw7ysdr2"
-  },
-  {
-    "id": "terra12uem5pwjtllme9dnw8ccw39ewvgyetrhnlnhtx",
-    "asset_ids": [
-      "terra19245ct3nfz95j3peem0zxy0e8e0w2uq4n4ssr3",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1vv7cqzr6ppgkueq4qgykfjfjsdlufvpljcxf8x"
-  },
-  {
-    "id": "terra12vqe3zqn9t7j7k7r3u22mpr3pjq9w3gnmx6pd6",
-    "asset_ids": [
-      "terra1e05lrpp2tl6sfm8p095mgn8hqu9c42f9sn0eh5",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1y097nnhjger6l3ds9r96xfdpq7vcdp5yh70n6x"
-  },
-  {
-    "id": "terra12xwh5s8nxl2tr9lvshtv5ny02g349sdhgca4zs",
-    "asset_ids": [
-      "terra16mvysduudq3ys8vn08c5ts8yx08g5vahjaylq4",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1hqz4rpdymf0vdmmg54r8fzr95uwtq7m7stsqzs"
-  },
-  {
-    "id": "terra12y07m3ra6x6qgl4jl5jt5t0qvk7smft3ye4l3h",
-    "asset_ids": [
-      "terra1nccuq0ujp4hc84kjmfwjc3002z2q7xzmdu6crm",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1jv5v6cskf8atvn0hlnmuhp3vpqypk76qjw9xxn"
-  },
-  {
-    "id": "terra1323sdyuhfl05jkhlk47ypmhtyx2chzv92tnsn6",
-    "asset_ids": [
-      "terra1tmar57largkrtts55q8szey2q78zc9em43ej5n",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1phcujfuv584t5mrmmxtag00pn36kscspec80gy"
-  },
-  {
-    "id": "terra132hq2uqczg2d7l4czhtcdwwlgl6cga6rs3nv6p",
-    "asset_ids": [
-      "terra18zqpuua4d8u9q9d6zsn8fqtjj5k8hk845prz9v",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra134jare8j7annsu6fgtkpu6zp8gmfau88jrsnaz",
-    "asset_ids": [
-      "terra19fd35n93667mg020fj5lupws9rhkw59cw459wm",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1390zekgvzfwdvjfghh9fxmaxq4tzfzux59slpp",
-    "asset_ids": [
-      "uusd",
-      "terra1t8wkdq7kth8ngxgrpltwam0gv0h88ajh0get5c"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra14uuhfjnxewphya674fgf7t0g3cn32uryrgkm5k"
-  },
-  {
-    "id": "terra139j7k5lfre6kwy6lh2d37tkvyj07h7aafke3qj",
-    "asset_ids": [
-      "terra1z3ejshh0vwkdr35wt9eyxetsqm6mnraya8myxs",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1rcdp0wd0qww62h69kex8f9c99549902dp7huf6"
-  },
-  {
-    "id": "terra13eclwgxxns9v0m6nxveug7m54v49fsfx9fn88d",
-    "asset_ids": [
-      "terra1wdz268njqhhpy30qcd6zxmvtu5y0xr06cnkdqq",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1jmzlups5p4upfx995j824vyngnahsx5tjpk3m7"
-  },
-  {
-    "id": "terra13ha9p29fpj4cckj6jr3m743d9h9v9nv3xcmded",
-    "asset_ids": [
-      "terra1atagmw0ssv6wlgmrjjdaa22p7h4wmsy33eljgw",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra13kqma6mk7ylcvg8u4qmfcwyw3wfytdgwwszmqc",
-    "asset_ids": [
-      "terra1uf95uwdtg7rp734pmadujg2ukmuc88fph2925c",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1p9gjvxkdefm98aghrv98nj5g3j8vp2qq22kg6m"
-  },
-  {
-    "id": "terra13l4d3vq7kurmyah9fxcjv8zdqdpndm9n0zs954",
-    "asset_ids": [
-      "terra1nywvm8avu8medrj84x9dxdc4gfdqd2zg8gv049",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra13l96rf63hd9ysruu9ma0vpjwwnjuk4e05tj7xy",
-    "asset_ids": [
-      "terra1fd2f52tmq59mc093nrawdaey5mzgjnwyu7hwqz",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1f6jappjsusascekd2uk8djncfwsh6ygp07h7mq"
-  },
-  {
-    "id": "terra13le0pfhey5ltg42z8e2cq2yt8jxu4ry3tdmwu0",
-    "asset_ids": [
-      "terra1vnkmt0cwd5k870ny0e2crt2yrkmj0cfd3sylvc",
-      "ukrw"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1klgaa9lyrcgdwudd9mvu0ys2spdsxd8mk55ure"
-  },
-  {
-    "id": "terra13lnw7ytlt0cjtjtakgewfzydq3nmx7n9q60gs8",
-    "asset_ids": [
-      "terra1extnklxgx3sylp25zplvxsfarmvh3r4k6grskj",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra13r4plx4hme32jmzlmsyah9ulewyrq56krxh84j",
-    "asset_ids": [
-      "terra1g36mr60pqf8x4hr3ulpsptrg84w088m0eunsw0",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1qje7t49vxtulwq8lw5re455hnj3r266uc7lquh"
-  },
-  {
-    "id": "terra13tngwuhz27g97gue2wg36nsc73agv9axnjrmd2",
-    "asset_ids": [
-      "terra19k974ngjsml8dtmk56cdhuy6pplr94rxqdt95p",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra12zfj4sczu849y7q3kzdlxxd9x7y3wjx5xtjmau"
-  },
-  {
-    "id": "terra13vj9z3cjvtg0v7uu00m4pwd7qw5faznuvr6mhf",
-    "asset_ids": [
-      "terra158gqaxafjche7vtew0f4zk9g80224qr07kwfsk",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra120vlcdqz23ssmpvdeysq75a47pjy5shlxya4zv"
-  },
-  {
-    "id": "terra13vkjx8agphchqzlntq7qn3et86ev4nga6uz9dh",
-    "asset_ids": [
-      "terra1pjnfhsvg7g52hfkdegr4apz7ax9x9xn0n2eayj",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra12ms0jp4kt9r3s4g2w5dphu8vqf027x6u0t9z25"
-  },
-  {
-    "id": "terra13zhrlgpz2zmw6c9vd8lgc60qfysdn97sgf2hej",
-    "asset_ids": [
-      "terra1h067erdar0vs6466jafpjsd7nahzwghtemn6y0",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra10j58rxwrw5fqurt3yludmp9j7xxgxtn9k2thk2"
-  },
-  {
-    "id": "terra140dcz7t06l4llh38u62wh8rcm0gus9dd93envl",
-    "asset_ids": [
-      "uluna",
-      "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra13ynn6xnvm6pj9hgaw0ywkewr0nv33qgc0pt8dp"
-  },
-  {
-    "id": "terra1452cjwwujuejcyy2jujmw54aae96dsyg063ycl",
-    "asset_ids": [
-      "uusd",
-      "terra1y5ffh484f3jcy62zuslx3qlv0n6c4zsffjapm8"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1gzu6j09js98082arj8a0nxlz47enzp4m0sp588"
-  },
-  {
-    "id": "terra14572czl65ta5gqhpjfehk47yytdxerpntw2h5w",
-    "asset_ids": [
-      "terra1efu7hut9pywcgwj74klay9mlzswp542s6fa0zq",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra14cqsw04rl6lu5dghdzqz5984rjd3rryc2psu2d",
-    "asset_ids": [
-      "terra1jw43a4x2jdftvk9ylfyuqhy9asam4ymjufme44",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1s9rf42yddzzxqr60l0a3dtf0qqkhq7cukql3p0"
-  },
-  {
-    "id": "terra14fgsnt4y6x7npwnnpq7nepk85fzz59vqn562v2",
-    "asset_ids": [
-      "terra1c5p65p6q6ekfav0k72h5ez23mpntve5am07mpr",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1q03qkg493g267tyympe6qx5l5v4de20uwupnn4"
-  },
-  {
-    "id": "terra14fkcayxsf0xg4dwvn7xgtsyhzff97zckpzlzhv",
-    "asset_ids": [
-      "terra1udknntc8sjm4ntxezhlqe6p9atct00r296aw95",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ce4u5ecla5klh9a68mjugq2aj2zqffrar4vzwh"
-  },
-  {
-    "id": "terra14gsl8tl6pwe4xmtuc4c78w356n66klmh8xn26w",
-    "asset_ids": [
-      "terra1ra0ljqpyt59k7z4xrx93ef5jvpy67f56lhudf9",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1uasdrlm92p47mvgtawcjmn24ut2a44mykyfz6j"
-  },
-  {
-    "id": "terra14j82htz2rhn47jasltna6tnqy4gy2097zf2pat",
-    "asset_ids": [
-      "terra153u8c40h2mm8nvs0daqxsnwgvpw43muxj3c28h",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra14m9xq2tvculdx22kunc40te7gfhylx0v44qj3r",
-    "asset_ids": [
-      "terra1elkjjsg4vm5u4tnesqcj3dzgvhanzld48lkqv2",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra14t4pe3avwql7s3d7euz3jrpsjzrgrl50x4asv0"
-  },
-  {
-    "id": "terra14ma9cyp3xt9rj3jz6nmz8zteujuphuyssv7vvj",
-    "asset_ids": [
-      "terra1smeev4u44zhv94cn4pyy9dtsshup53n9xefayx",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra14nszv45yz78hm2n69rq69g5xa2l4cznak4aa4z"
-  },
-  {
-    "id": "terra14pq5tphkfpd2wphq47g7mrwmvt7x63nskmkkrc",
-    "asset_ids": [
-      "terra1m2ar36pnymh6h4n0p7l2w4uxswc70e9auyvxh6",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra14qtsl0gqwnlz5z72cl9yc52lt8q464zhsx08tq",
-    "asset_ids": [
-      "terra1atcayac92cwn9x6fcpxnjzycvmkkhwsk53tg29",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1fpaehunc4mdk0vmkn4g32epcf7yl523nujrjsw"
-  },
-  {
-    "id": "terra14t9rgrx4t53un932r8jtcsgtrqqvvucndte4cg",
-    "asset_ids": [
-      "terra145nmjpjhergp4uw02hp079phtnedslmxv4v3n5",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ga4yfg9uclqmaeg8trv8yaydm9ufh82cdqea40"
-  },
-  {
-    "id": "terra14tzfka0vjjw8sttpkg0nqlrs5a078ngmqxjv5h",
-    "asset_ids": [
-      "terra1dd2qt59v86gwgzl2e6u3xexefvrkjmgd8mu638",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra12nl2t220t5504dgaxl7yj68vfs39xky7zux2pa"
-  },
-  {
-    "id": "terra14u4v5ms29m94jvu2nn37jep35frmg5u6a2qw8h",
-    "asset_ids": [
-      "terra1fhsljj6qc8f7cnu62e8uxqt82czflztge05dwk",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1fwx3235vfpcwkv68nu2vv0cm2sda3dxtdtnpuh"
-  },
-  {
-    "id": "terra14u72dnthxnct8gqx8zxjpqza8dkr8nlc7w2dk8",
-    "asset_ids": [
-      "terra1rwph273axfefh8gh57scw3jfm7kn4s7t5hlu03",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1zrlt4v8jzrsst0zq4ug98xaz0rmerpajff63yf"
-  },
-  {
-    "id": "terra14v7q4ujj95wx0leltqsxdxy97gzgw4g4q9656s",
-    "asset_ids": [
-      "terra1uv3298xevlfdcjthfv4me7tn7gjxd3drv6ejvt",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1fj8zwe73graryv3jlmgtt8a74agw849jrl3tfg"
-  },
-  {
-    "id": "terra150cw99qkvwafxw95vyef7d9upswsmr2wf7xyh7",
-    "asset_ids": [
-      "terra1z49dpvu5g4st7t4j5lsaxaq7v9u6f390m28ap9",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1nu25e6fzs456lh27gpzyq4gn3vpedf7cut5020"
-  },
-  {
-    "id": "terra150scqwurj3m6d5n0yt82zer4w8vsdf6hzl6fcc",
-    "asset_ids": [
-      "terra1hwcnalcf35p48lvj3wt7tztkzh5szmpnxwyvdc",
-      "ukrw"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra12ndzg4g6k6q48hasdrrk7rul428npl88ljugtf"
-  },
-  {
-    "id": "terra1558wqfc8ffq37qj3cjfkgfj6r5xflh7gnfytw9",
-    "asset_ids": [
-      "terra1tdvvjf700gerwvkwncjc7nzythdewstk47ah93",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra17ntlqfva06ga9jdmz0t6mhqsmvr5lqrekrxnug"
-  },
-  {
-    "id": "terra156h9adaua27vcqtguttxk6pg3st07nrypcmy6f",
-    "asset_ids": [
-      "terra1zfvr6uszt8khnf4damxrujfkhgl0mep0khcs7w",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra17a0zdmq6xf9jgac89y2nyqcytkcchnneefu8nc"
-  },
-  {
-    "id": "terra156wnmhqelwxwcmkfcn0j5fehj59ktjv6w4xca8",
-    "asset_ids": [
-      "terra109vclyh90fkj77ruk299pkk460sjm54vs9x6et",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra15c30300aaa2gt43svqy40jedyh7mqgn02tyukg",
-    "asset_ids": [
-      "terra14qs03ha38aya45vac8q9wn8pjy92knwta2exdx",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra10xqkk0p4nmgmpkh7faudc0ftmkcx6lhd23vc3g"
-  },
-  {
-    "id": "terra15czn3ttmcsn9xl72hfx6muyr23u8h3nhgc5e2y",
-    "asset_ids": [
-      "terra1qgt75fpc097an2vtqufx52anfcsu33n57wjkac",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1gp5dpf7lqmx46ravzh64a6azarewy3n8tff6a9"
-  },
-  {
-    "id": "terra15ledqp3plgp9gqkalkf9p2skdg3kg7l7zd7uhc",
-    "asset_ids": [
-      "terra1pmc29k34jrv96wde08znhmjq4v2rmzy78y6dhg",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1peq4pvfc0jzpgdnutdkpu5ad420zyr9lyrqr2n"
-  },
-  {
-    "id": "terra15p4lwjtk9jkkvkz33pf5xelnrnqahac5ksj8cj",
-    "asset_ids": [
-      "terra10jgqgc3vt34w79t4puharnzjxxv7s3fq8tmnkp",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra15vy6lhftmg8jnhnsnyazxl44fkutx9yawemeq4",
-    "asset_ids": [
-      "terra1ez8x6k2rru42w3z8lnfkzjs778rllmq6xhgf7a",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1u9nnlnvlqfgz04hvu7w2nqah034m0qjukfvrx2"
-  },
-  {
-    "id": "terra15waumwnpjw488cgchv3x5j7g7qlca73sd4zmp6",
-    "asset_ids": [
-      "terra1hvv3qzmzmmr9qkf2xj928hhy2yxuledwzn2v5u",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra12cwf2ge7mxjsaylmvpnpcy0q8t65fhevhasuxs"
-  },
-  {
-    "id": "terra15ytncdwh7yqttvvxjmw7cd2phj9a7cyldv8547",
-    "asset_ids": [
-      "terra1kp8vne240370hn722ec5sacsdluyt2j0gc5nph",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1wl74zp9lyhznusz7p3xcag9jur58njc7fqa0nz"
-  },
-  {
-    "id": "terra15z794we063zfzxtvlxzetnq9cv7ftymglqh0g6",
-    "asset_ids": [
-      "terra10722f40cxl8tkxjk7f88uj0ehkcw6lu2j504f0",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra15zfs6kf7c0f8u4layzwnwkzpqnkj8lrm86q8un",
-    "asset_ids": [
-      "terra1gjuhc34ccr6ajq7dm5266xyedu96sgkv4qnley",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra160vz23qwte45w6dcgkkae05fqpap8l4s4alaax",
-    "asset_ids": [
-      "terra12jhul3zlafuvl4fd54pvaax4ls872z8p06p8qv",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra162ccsqcru4zy55r4u52rlm46plwzvzc2x67meg",
-    "asset_ids": [
-      "terra1krtfgcavw64dc8nhnz89eafpqm5pdz95l9a89f",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra14x387d844rddafa4v2swz89tljm2ux59qz954z"
-  },
-  {
-    "id": "terra162cf20c6hrag6fhy9aqwaq9cvrp5lq5ffpvuez",
-    "asset_ids": [
-      "terra1qup6c3w83xjrfdtzujqkh5j8pcar96up8f0pdy",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1632r5htxk5ctf4srh7v2teguz47aen7ygkvphr",
-    "asset_ids": [
-      "terra1veke25wgg7xk34c3gxsweuxsdqajemr307e8df",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1uz9zfvrltmy3gawmsedg790xjl25jpgdm6fl3y"
-  },
-  {
-    "id": "terra163ddeunmzqr90qw4j2nxxmk0fmz56mhly4g07e",
-    "asset_ids": [
-      "terra19j57fzwjahvf52wxffgrajd0jjm9m8akfsl0qw",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1cw640zur4svu6942kq9eu6ruxupryjmz5sd9yh"
-  },
-  {
-    "id": "terra166j8s9pehm35egpmdfkrvlqj9a4248wqcg5s08",
-    "asset_ids": [
-      "terra1yx2z4j3wr55k7jns06qhn2hsw6agskvcke6zu6",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra166lp9jpsca40cqhh78f9ve8t4nx446yxp6ra2s",
-    "asset_ids": [
-      "terra19ur0s3h72v7t2qmy58z60e0cl0epkal3mle4mu",
-      "uluna"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1zqnywcumfdnueyccgzp9qjzcaf7zuzc8hu2fts"
-  },
-  {
-    "id": "terra167d8as4vjhgn3m04x3jzl80re5sytn89lr8s2j",
-    "asset_ids": [
-      "terra1tj9zrn3myxvkct20ehzje5whu5j75c94s8r666",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1em445q3t0ckevthda8enkd7v8v0wlncqyls06t"
-  },
-  {
-    "id": "terra16c42gghky97m3g5nj80h3528m3l7m099xjlh0h",
-    "asset_ids": [
-      "terra1uwsnmc4fpalrv3xgvf0aedx8tfn22xcyrx4467",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra19unte8ca7uu34q5e0lktrd6esm7wq9j3cmfl4r"
-  },
-  {
-    "id": "terra16d99plysndjucurqz87d8p0my7z3kffuhehl30",
-    "asset_ids": [
-      "terra1j8nxezl70lfekdzaeanzyzn75htf4sz9vmwhu7",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra10rnu02fhw7lg7eka8f2yw2wn9j7kn3mgqs860s"
-  },
-  {
-    "id": "terra16edju746kt6k44meljuql30scd6ml0ey0qwj8v",
-    "asset_ids": [
-      "terra13l9e6lelggxjzm7dxhgkfgqwutwr67y5qvc7mr",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra18kq50rff38rr6xt6etkkjvhv59msdst23pf9dv"
-  },
-  {
-    "id": "terra16g8fsnjsmys6dl25s7wvl4r7y68drvfjc7pszl",
-    "asset_ids": [
-      "terra18vl2cypy8pdys2qdqlg7pzmcmpqmur8lmrnk2c",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra16k9sv0425t8prauxk680sj8aecgh4t948v8ktf",
-    "asset_ids": [
-      "terra1534wdj9s0c3c64pmgqk8544usm0jvfysn9zq2k",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra16l746rd5nspcav63emsj9uem7v7s7jflrf4mv7",
-    "asset_ids": [
-      "terra1vyusa796w86yh99l67dpd5g3hfva759vyuhn5z",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1emk8xeed780j8extpdd5q42h0grdj0ad4ce849"
-  },
-  {
-    "id": "terra16ll0n5lm5j4vp94mjr0xa4tqxfpvvgx57mdtg3",
-    "asset_ids": [
-      "terra17rwgygp5y7tx83xyclwuxu654vjt2whpwxx688",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1tqgkra60jq5jzear9e3zm6knwwzdxvwl2hn5vd"
-  },
-  {
-    "id": "terra16qj6hfx9t2st567eg0hzfd0vq3dtvvc8y0knxj",
-    "asset_ids": [
-      "terra1wlwkuyv9g7d320dm5cqg6wsygplmt8tjjglc6w",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra179nsfzyw6gpd4aqjxk644y662geq0rdyt90cay"
-  },
-  {
-    "id": "terra16qjw56mjdzurqualderrjh4p0gprm66yd02dar",
-    "asset_ids": [
-      "terra14ldz32u9l0s9lh07zqqqxgmnzwyww04hmvs923",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ks60j2lj62jrpcn69eejtzvg0gatjmz44x0l6y"
-  },
-  {
-    "id": "terra16s7w70jm98htj2v6mkhcx8uy03l7d4w5mjfnf7",
-    "asset_ids": [
-      "terra1vjgnhlv9h0nlta2v7s5hts75h2mc065c6ap3j5",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra16u0mmxkx0tm7ll5674dqazj0rznft6jfeku0ve",
-    "asset_ids": [
-      "terra1ufxgdde0fkmmc7mvmkuaxps9raua78r7f0vm3x",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1cxefedc77znngtrw5lfrf87kk6u7wus6mrf4ly"
-  },
-  {
-    "id": "terra16v3cxjng86zd4hmahglj89k9gejh04nghnyavx",
-    "asset_ids": [
-      "terra1s44vplvv5fphrrv4g68gx46xwrmvnqm9e0hazl",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra12sv6yvas2w2wrtjzly647h074tq8g48lxlqpaz"
-  },
-  {
-    "id": "terra16yrzqhe84x86jzgaav5hszfsu4mhxjk0aqlk2g",
-    "asset_ids": [
-      "terra19m0xqgdaltwkesdt6m383jkqh3m9xyxwtp0f6f",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra170hht9lwe50ugfhnruzjaezpj29l7nvw3l6725",
-    "asset_ids": [
-      "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
-      "uluna"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1wdfhtdvsvjazrjnd37uyfzg45j2e0v32vz3ez7"
-  },
-  {
-    "id": "terra170lzdyflaamashcqkst23k9ew773dtg67tfu5m",
-    "asset_ids": [
-      "terra1p8y9f7dpmyzy85ldv3k8xccuw0u87lsn9fl86l",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1t8qmg9p583jcp2f7uuhga73yh7ze0u4ny7kmzy"
-  },
-  {
-    "id": "terra170uexnuckv87q2fl392269m6nt847fczs0yzuy",
-    "asset_ids": [
-      "terra1znvnhtdxxsy9vkvmqv85nscujeqmmtjlp2a3wj",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra10klhxjnafqnt5mu6jugrcqs0kaepprmf425c8q"
-  },
-  {
-    "id": "terra172nqk47g4vc3zfde06nkq0em69lcwf6dp9uj92",
-    "asset_ids": [
-      "terra18lk5y974rsknqmcqlruj636mvg57yln93ay0h8",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra14e8sutnxhzgfzt4gdq84dqjymz422k75nglnp7"
-  },
-  {
-    "id": "terra17cfpltkk9ja3rcv3x9rwqzxdeqs9r67ga607lw",
-    "asset_ids": [
-      "terra1jz9plajrq6knks3vgv9px4ezwshzaxsr2xz7jn",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1udh2534z6lu609dtvlfp8y42w6tswvs5e9034d"
-  },
-  {
-    "id": "terra17ds00wg6xtgy9f7apfl59f4978svh626f00238",
-    "asset_ids": [
-      "terra192dse96aslp5cduzvjqly4j7jaka6dlv2xx7f8",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1knn3f89x8tnf6h9aglz5rhz96wa2cgwfsx3mwy"
-  },
-  {
-    "id": "terra17fwqk93kurqedvdyrly3a0c9g2v8eax3j7l5ek",
-    "asset_ids": [
-      "terra1gdze0yyar2y6vs3un79my828cery0jea8mzn07",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1k6mgu6smngvqhq63stjgj2vq9e49umxvr0e6cn"
-  },
-  {
-    "id": "terra17g2lqz62y4p40hp6f0caup374m7v0uptw38vev",
-    "asset_ids": [
-      "terra1a54dqqqh4qlz70m43n3a0vqeu2dv5tkz6t2zan",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1chlp9faqplsyc5y886trcffyzxhnsvuvj9qv5k"
-  },
-  {
-    "id": "terra17gh85ddky3gqyzg5lh8xry0d4ee497wju497m3",
-    "asset_ids": [
-      "terra1ayxfyasd2ursa5gt5zgzgfywsw999dz4yykjn7",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra15q4ypjhljlfkfmz86xddkd6y0vnwyh03mj6q6p"
-  },
-  {
-    "id": "terra17hfwmsfq7xmecrlzaqgqqsymzr6jz4urcvd9sq",
-    "asset_ids": [
-      "terra10ewuq49hkk438jhd7q79hfetqpkkt04tfm7rzc",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1enjwdma23v5f7rm5xc7zqq8rra00ggmr464nkf"
-  },
-  {
-    "id": "terra17j0yumlretpyprsxh3qk5zwyzfrdydgnpt0zh7",
-    "asset_ids": [
-      "terra185fgz0v2wm79ujn58tm3qeucnvlnfuffa4wpjp",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1c063gh7d06rdwem37tqvmqhfvwce7m2aypyrhf"
-  },
-  {
-    "id": "terra17jaq2p66s2n40wad52mfudk0z6u5tmyanhkc2g",
-    "asset_ids": [
-      "terra12a39fn0k0duteqefme6zgr5efg0g5ya7eglvyu",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1rkewqq6kkvpp787ltvpeccvz4qsqh4w7fv57xj"
-  },
-  {
-    "id": "terra17lvnk2k34us38zflqz4zze6zkn7vrktpeuszcy",
-    "asset_ids": [
-      "terra10aey3n8rwxup6l2x68fa7fwdurxnu9hwxf0k7f",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra17nht56uc42wj73z8u0gs5n2x9d74ur7z76vmz6",
-    "asset_ids": [
-      "terra1je4ll79zmy03zpl4wdhgmadvznqr08tzrncpqw",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra17qag5rxkfraheygnsq0xy6y4a8ay0vrmm5cftm",
-    "asset_ids": [
-      "terra1dxt75lk0m5g0wpucg0mz905akta99fjhuhafqa",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1l58a2w22pv0fgukypvqt9fdmkn3ktd0jznexyl"
-  },
-  {
-    "id": "terra17rduyemsyel8jl5pvyh7j33ee78606zqzkzh8l",
-    "asset_ids": [
-      "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
-      "usek"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra17rt5kvtt7vgdnxyelqhctaa4p0wwszjqx4etr3",
-    "asset_ids": [
-      "terra15pv3xxp2d5f65qeu2v27vqf9zpqjx0fuztfwcu",
-      "100000000000"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1q2xj2w477fd8vx4n4psa449hj03m8py8la423q"
-  },
-  {
-    "id": "terra17sh5yr9tcfl2qsltrm2tulnlpzz0c6ufk683dc",
-    "asset_ids": [
-      "terra17t0uuy2cg7apfsqj4xqn6w5scxkd2ajgns9xvz",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra153k57e8cka9mutkp5g6f0elje02qtmh75nshny"
-  },
-  {
-    "id": "terra17supgps4aqq7nfkcqt97y0jxzh5u6mrzqlg936",
-    "asset_ids": [
-      "terra1hn8mghxm4qm2g654m3h4rmqccgs2wcdsvsex82",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra17v05w2qmmxy864ltjtts0nzqlzw32gp6uynh0y",
-    "asset_ids": [
-      "terra1d9ec4gm0c03p74d3qd95qvny2ptf0ge5twqpdk",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1wdmkqdhqmyv9csgwfdh8739fu65qpay7jj5vvh"
-  },
-  {
-    "id": "terra17y80pnvqu3kd3g5jwn5kpkfp6hh2stzxmvazjw",
-    "asset_ids": [
-      "terra18we4g8y6u55x7atttzu5xgx46zzss0tpmktf9s",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra182n2psy6gl9u90gltznv2r0h6t5sz7ajgu4dl2",
-    "asset_ids": [
-      "terra18m523525ntva277qramnc6x2hh56a28w0vndjf",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1xp7l5hahtcl23ghx5u6sw5fa7cds4anmarj5nn"
-  },
-  {
-    "id": "terra183kl26dv4ymz55cytumj77z5u6m383wgfvsrvd",
-    "asset_ids": [
-      "terra1vn8rmcu3yywfndh2ze43v5h2wg28rycdekdr6u",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra10uz6jgxmj3ywj9xndsnreula337h05jpkzppnx"
-  },
-  {
-    "id": "terra1854dxe6nw9pktdd5j5ulesv74k3ztqgdx6mcxe",
-    "asset_ids": [
-      "terra17etsw9uywcmw79st5yp4saar97z22l3np0m3zz",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra18573lxn0gjcs3fh2dc6qfv7l3afrws2k2dk2zz",
-    "asset_ids": [
-      "terra1epzqhvam83e7lfqtdmgzatlvlzwu23x8kd4t4v",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1asqt56e65cw3dmszq47ru7vzrkua6spg9au4mt"
-  },
-  {
-    "id": "terra1867v6pwuaachav723ukq9sajaxgtpe7w3aefm7",
-    "asset_ids": [
-      "terra1ry60wuc8a7a4ujt3tmrp3upxzf6a4awj88eys3",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1jmap9tuf59k5mmr5shgmywqfxmcmlzxusn49vl"
-  },
-  {
-    "id": "terra18atry8rvvpu35pp2tm87exk7y56jm2yhza4fgp",
-    "asset_ids": [
-      "terra1tvs43r9ry6s6g6j5mnmruw97s3fjhqxpc540hu",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ynzjmya27v8f2clle2dl5vw909ffxqlkxgcyfw"
-  },
-  {
-    "id": "terra18cwjyccu8snhk2tknk962h2vdvnmerwhrn57cn",
-    "asset_ids": [
-      "terra1tesjetjz6q7s2etc0pa93ep6fwhzqqtcvreccl",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1xdgsm8apwxuxgql7ll5uc34h4w3y0tnywvsg25"
-  },
-  {
-    "id": "terra18f5npedpgufd4zyq8gae05c3htnkex7sld2rkf",
-    "asset_ids": [
-      "terra1xzk97nrq0ma7dzgy6aj5tm04sg92q720lq2yum",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra148se8h985hfw3s3jl86vf95qgfz7hztdj0u7qp"
-  },
-  {
-    "id": "terra18g4d309jykk54l43k58fjqq8h2qdpzgdctxfwf",
-    "asset_ids": [
-      "terra18neulu99zm7kj040tndhavjskjm7aaxsk240rx",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1mzpxqr5vwnzl822sjd3yskaekz2lyvfpavush6"
-  },
-  {
-    "id": "terra18jkyaayc7s3an3gn6xhz9ue75pdy46zrvzwle2",
-    "asset_ids": [
-      "terra1l4uygw365sgdgvasmckkd7lcawyemzn9k83lrh",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ldy8tjaqa9zjq6h2290ac2k40ta94e4hky8caa"
-  },
-  {
-    "id": "terra18k700765d9kyglezc07n64wnkdcfzf9d6juccz",
-    "asset_ids": [
-      "terra10rv8jte682eec8s3fyd522hhq577cl75zghx83",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1l6nvej775vwnlmf84gzv5utyjw6rh0unyyc2y0"
-  },
-  {
-    "id": "terra18kf909r8usm8l29t6krwtexyzd8wr3vrqqd9vm",
-    "asset_ids": [
-      "terra1hxcsd8ttymrqzp5uh5f5885j0ms0tnzux9jzsc",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1cu947swy2q3re6er4f8stuxlxdeljx0umlq9my"
-  },
-  {
-    "id": "terra18kwhhu4fxcc2x7lwtct8jatwv9843n6de33g6r",
-    "asset_ids": [
-      "terra1rkn2d2yc0946a0gx0w0hwf3l2j32ve39egsjkd",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra18nz2gztwduce3u40wuuafl8xj8e4s63nty75ym",
-    "asset_ids": [
-      "terra13zs7w76g0u4qgagcen6vq92wxuvgfucr3dy4tm",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra18paw08s6xkw23swl76w6njga2rq6kh80zch24h",
-    "asset_ids": [
-      "terra1duggxa56m97yfcat99ew27z3q4rnax4w4u8waw",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1vwa9j8y76ew90v7ukh5slz9euj50dq22cs0qvs"
-  },
-  {
-    "id": "terra190r2p96klarzvdssdg77r6sd4nfutjra7wwz8d",
-    "asset_ids": [
-      "terra1ma4frxgvc974je0xsxrzpa52j34h9swlww2yed",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1hl09j27s27407wkct646lqnxg3qskpl2ehuvn9"
-  },
-  {
-    "id": "terra1947q02rc7dcynzgywduaudwjmr9nucjzkd7l6e",
-    "asset_ids": [
-      "terra1aszsg6mzlzkydqtm46u42mf8zxur9m4ydh9vrr",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1sedpm809sp8spmk7svhnxqdqyu0tzxn6h0zltn"
-  },
-  {
-    "id": "terra194d6fn47g5lztfxl42fq37mwlnd4lqwestky0x",
-    "asset_ids": [
-      "terra152mtjjndwpwvtszd4cxnhvjm8nzxv6kdwtdugg",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra16wlnwhhd0x0jp9lxqnms2ssmsdhg4v206uwysv"
-  },
-  {
-    "id": "terra1970uk99ys24x9xsck497709n4tzeaa5lgkw0ye",
-    "asset_ids": [
-      "terra1sf5tt6p6wnlhm0jqlflan8lw7pmv3f82sffsja",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1d83udzk95gnk2np5wklqj3hxdq59r0ely8tdea"
-  },
-  {
-    "id": "terra19825apq06ve8ae5mhdtljcssm77xrtdkvm55gk",
-    "asset_ids": [
-      "terra1yg4qw00d3cpdvs9zyhyh32jkfcl8un8nxc3f08",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1lm3mk44nft4mn74hajn0p8x4enp6e38yyf4ey9"
-  },
-  {
-    "id": "terra199cwj22qrsuqnuv4slrmhc3dfydxjh3894tajt",
-    "asset_ids": [
-      "terra1mq6sw9dt57hlpe7ffjm2z3pytr98l4a00lnxp6",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1yjvdd73lsjq49v7x80rhe3kyltg27gew5nrls8"
-  },
-  {
-    "id": "terra19ak9slt8fmlv5p09j0y9edswgpvmk07p8nplrl",
-    "asset_ids": [
-      "terra1thrmc4qul2e02y2rskm7583g6guvtrvc8pnlmx",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra102pj92vh6cem9hyzyep465k0dw3ng4hqaaqsj4"
-  },
-  {
-    "id": "terra19hmp39k3dlwtywtqcs4nrr4lal66kzwc7ea42r",
-    "asset_ids": [
-      "terra18jv5j86hjhc0zx280wu3kjggd9dvfyl9v4t04k",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra17jrxg9srhvhu2rcf5umt2lnrvahtgxwate8gej"
-  },
-  {
-    "id": "terra19luytfs7wt8l2e5fgg7del39m93sm64qsmufsy",
-    "asset_ids": [
-      "terra17w68lnnp47k4zkfkpcyzu2xeu6qw576ksfpp4r",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1jfrngqdwqkfs25sgcmuxrlk6a7y8058purc4hx"
-  },
-  {
-    "id": "terra19mzvauzmythgn8d8vl944vczh5egrlnqfqygke",
-    "asset_ids": [
-      "terra1ruz2e26humerfnd9uhurc9766a4at8x8e3m2e4",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra19nhjua64eq04ulurrdayj3u0f6yw5qw6t4mc8g",
-    "asset_ids": [
-      "terra1n3l6xg66m9t342qcvgdqk6md5cqvtatgg8tw39",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1h30mmqyw6gu5dnresfzdcwsr2ahec5usf0vst2"
-  },
-  {
-    "id": "terra19rsnccnawx00kzynaxexxh4540qp5y6atfrkjj",
-    "asset_ids": [
-      "terra18ky9ln4g6x3n9f9s8a5ttshynv6lgzfppmrmyg",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra19pztt2p6wuy63dehanjeuyf7vx399ptwdq93zj"
-  },
-  {
-    "id": "terra19ujj2teuw6m45v9c2wk33wzl4mjr22jlw3nqrs",
-    "asset_ids": [
-      "terra1rctv4sdztvscdxw890us4ewcuvh77t8wydxkxr",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1exs7v9pvkl90zjyd5h7lu26hzszwczfsedc3hj"
-  },
-  {
-    "id": "terra19ypukqk0v8l2f04qjsc9pwullq7r24eufm6led",
-    "asset_ids": [
-      "terra1tdc7hmydg3es6lmn2asfwfgs8ykq7xa0nz9rkh",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1yhlgg0kkm7vngmj68suf0jmx5fj7v7hpxy4udn"
-  },
-  {
-    "id": "terra1a5pqgv432f3u25zu5q5r0t6e00pwd6xa8unwp3",
-    "asset_ids": [
-      "terra172qlk30wwyux37m45w5c7mkypn7ks0t0s3d0ms",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra13hcayvzgxur5f43qwauz3jsnf4j353ee9s7qq3"
-  },
-  {
-    "id": "terra1a5s9cgdzw4pz4nf8rxyqp77q0wuegahs78tpfd",
-    "asset_ids": [
-      "terra12qgpr0fw773gc8lrkys3knnw6nkgdlc8ggaty9",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1a8t3w4ts39fu5su3dg60p9akhr8uf85fzccuxq",
-    "asset_ids": [
-      "uusd",
-      "terra19hnegq0ed5w0gds64765uakh5huw7jepvjakh5"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1afgh029jj9nxglezr3jxmr0heujj55pgspvx4m",
-    "asset_ids": [
-      "uusd",
-      "terra1cq4lkf7dlygdp23yql8a4daunnxr4xd5tymszl"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1ahygklrmejad3mmeugsd0m5lczv9jl8hjepp6r",
-    "asset_ids": [
-      "terra1478yfcsa6ycykstdfh2mclwdy3d6zpemkyfu4j",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra16k9tt8q30dswt9ksp00wrfdmdlze9s2en5y7ts"
-  },
-  {
-    "id": "terra1ak3u2e0303wvnfsese2z382pn4sxl9etz9rrkj",
-    "asset_ids": [
-      "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
-      "luna"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1aqd837959wjcpzssqqr56rhh7dcq2nrqpgqrdm",
-    "asset_ids": [
-      "terra1tc7tcg8u54p3t2r5yfufgf4z340ggwpvlc2rwt",
-      "uluna"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra16c2lh2lr0xe92ayf558rgzw47gf8cmqh58v06n"
-  },
-  {
-    "id": "terra1c0g493amwrzx47zxa0qcvrks7wyhmqkpsf8u2y",
-    "asset_ids": [
-      "terra1pkfzenexjj6ne68xv2g9t8387s7d6z39c60ghr",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra13mehc6ldhs2sryy388tuqn5cxq573gdhrq0cjg"
-  },
-  {
-    "id": "terra1c0hc7ncedxaps2hxl0qazxlh79g4zdre5geq4m",
-    "asset_ids": [
-      "terra1pmmdfnmhrjnywsgkd6xplgp8nx03fxm6ygma09",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1c3zsqpvlev8x70cmekqxmqjjamvwdw93gzqjlc",
-    "asset_ids": [
-      "terra12zzantsa5trfm0ssrgsnhvlram502ats35qtc3",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra17xhypskf3f0cqf0knvyqw844vm54fg2j4fxng4"
-  },
-  {
-    "id": "terra1c4r7vdd7f3cjts6kzjuv0sx4apesxr9p55kqc6",
-    "asset_ids": [
-      "terra19v4cg3w698qprsjwzw52cns6245vkxug74q9lc",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1hndks78y9k49jq35x4kwjsvpp8g9hn26e5n7d3"
-  },
-  {
-    "id": "terra1c535v3f7fz8a94wu2cev2p9wvzfv7x35uv7tk6",
-    "asset_ids": [
-      "terra1wzxpydn6z4z0us0wpx3n96gcs5p9qqavhw5sqs",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1xup47v2ypdhk4lpmjw68k8hlt9s2ejjg4pv83j"
-  },
-  {
-    "id": "terra1c586ncze76sv75zlg3cqusqdmn6zluukdhc9cx",
-    "asset_ids": [
-      "terra1vsr6l45yyqn58at6nymdx99kph9sw7zql70akr",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra10qpu5aajfmkucfft53hs6hzn96ckaqa0cdmhje"
-  },
-  {
-    "id": "terra1c59fgnldauz68wpxzawxy7w650r0yvhq34g6ng",
-    "asset_ids": [
-      "terra158ut7lycly6ep0v334rpjtcjs8hlvwjzf5tfrk",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1c5j97vq48wjln03wgtalfhlmlg6uyczmpj74vj",
-    "asset_ids": [
-      "terra14rq6etqgza9qqpgz9yjfmsclgnzhk9jsafdtyc",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1we6ygtflu43kjgzj8ug6d43f4zkd3fmssax5sx"
-  },
-  {
-    "id": "terra1c5khrjsj0q9l2pyt75cw7hrwst7xyr9vegutkv",
-    "asset_ids": [
-      "terra17zeqmepm87d9g4dujjsctqjrfhz4xjkup26t03",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1hd9hnlwtqm5s5mkngqdqytdc0a6elquh6n70nk"
-  },
-  {
-    "id": "terra1c74x8j9caymapwg30z3gse2jlxvgkm56uhv6zq",
-    "asset_ids": [
-      "uusd",
-      "terra1my0tlq45u0vlpyt2n4qchxkzhzwnxrd2playfq"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1cgfghgpw8u832e9xlrya7pqpj0pyyfpyptwdte"
-  },
-  {
-    "id": "terra1c78mey84ygre2ym4aznw28796qfuytcl32p83j",
-    "asset_ids": [
-      "terra15plvf4hfgsrev5athn7wmnqgt6f0lddmduzp90",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra15gpwuqw3uezt69vxa5ftd2dt7yc8ap2fydqhat"
-  },
-  {
-    "id": "terra1c9t0gzff3z4mh62ky9cj9hkunlj8zqz58kqa87",
-    "asset_ids": [
-      "terra15q3lzrnfstr3rqgh55cqmp95z4xr3we5tfyqm9",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1cc2w6lgzxarvawywfr7v4q7nq30tfvnfs62u54",
-    "asset_ids": [
-      "terra1wdc6xjyng08qwssthzvd5u8a4z58r8jxxn3j5t",
-      "ukrw"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1zy5sjsw4aswykccwtvkaq27s2eedspvakut7gw"
-  },
-  {
-    "id": "terra1cdj55x2gj369g50g3w2uqjm6p2fchgy2ehjd0p",
-    "asset_ids": [
-      "terra1fkwfm2w8kffl3ged3zulknz849rnfdxnwjgdnk",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra10z27h35npl969tp9d05qfs49k925rxm3w5sd96"
-  },
-  {
-    "id": "terra1cds3ru8n9s6cpuqszd6kupxjghj8r8rqk8jvmq",
-    "asset_ids": [
-      "terra1fpfn2kkr8mv390wx4dtpfk3vkjx9ch3thvykl3",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1cf38v8qumxruarhxfsgnylkymz6935c6qhcrkv",
-    "asset_ids": [
-      "terra16pem7c3h7renxuxa4jvw8efv4nhrdc3leguzyn",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1cj2du5dmwr86u56u3xp6kx5u9ww7z2vcz2vrrr",
-    "asset_ids": [
-      "terra10c4zqj4f7ze4keuwvm6hk2wrdj9p8h07sp4fg5",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1hffx97vzfuj5ysxtpzjpatf5utpaqces0dvm3y"
-  },
-  {
-    "id": "terra1ck5vwpsz9nf95c7t84jjwfgpxtcnpj23aka3ml",
-    "asset_ids": [
-      "terra1pduqn0tpqce36ndwcv6z6xjlnujdddl6pedz9y",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1l46txnnqf0j4l7g6630dhf0vxqhpxyzzadchfj"
-  },
-  {
-    "id": "terra1cmvp86pqrt2r986v63mm5257ctplnf737rktl7",
-    "asset_ids": [
-      "terra1y6mgy2ha0fwhtkd06jdca7hpep7z8hz9n2jz8t",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1wqa24s7qzqess0pwrx3q70lh0uj04vajx6uf58"
-  },
-  {
-    "id": "terra1cpmqngse0kw0rkgv5pewgg8dvg9ep240xelxc4",
-    "asset_ids": [
-      "terra1f659ez3nysf06765jjjqnl7m65urrqaxx2t40h",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1uzzyyxp6kj87q2ygm0d9se0pthnrjh7jy75jxd"
-  },
-  {
-    "id": "terra1cr5uef9rrl74xcw9vjsqklud2dstdfr4xj7hqm",
-    "asset_ids": [
-      "terra1ce0z2295uajnvxltll75zuvh5mvecczy3fmlzj",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1my49papxtmataag9arh9wdrqyyuqyjfw7cc44v"
-  },
-  {
-    "id": "terra1cr8m0mpdj5e7m34ekdrqgw59az5v98pgckha4y",
-    "asset_ids": [
-      "terra15tqztw9vjcuc9znkvmxn7rh30ffdnahhnw4vym",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1dsj8lxhuvtz8k8vt9v7zjm85cca4qjhsqgvced"
-  },
-  {
-    "id": "terra1crkwlasutngkqdlfskk7rcgasehpq6aaerarqd",
-    "asset_ids": [
-      "terra142yp486a6jjelr87c0kx6vxv22nw6dsvkcnhma",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra196f5vd4s9zn6deqv9shjktk348nk7k4kcl4apd"
-  },
-  {
-    "id": "terra1ct767uq6h75duwd0jl6t9lxt3zn3wvvnec3snh",
-    "asset_ids": [
-      "terra1ygrhf4zv86jp7hnyl358uj42llm75gt7w8e9s4",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1lkcazx0hn69qsw62tyhj6u0svsnepg73vj553h"
-  },
-  {
-    "id": "terra1ctdwhvfkhrp8z8l78l85h0da6ywlmp2yjtws2e",
-    "asset_ids": [
-      "terra1s9jnada32ld74gmng8ng5l3zfy9vk8kfds5828",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1edy63xnmphdr47p97hw3h6fu72md3u952ra0hk"
-  },
-  {
-    "id": "terra1cuxd5x9vs0m604pze90c0xgccraucv2kqcwlz2",
-    "asset_ids": [
-      "terra187zprsu04wnfs64pznf69mkls6vefhtmtwt8w6",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1pgjfhamw0dv2t9a5d9q9eu7fm9etj4zcewyak0"
-  },
-  {
-    "id": "terra1cvg3jjepvcxzkv5elvr3x5khk83wllvg4qygfc",
-    "asset_ids": [
-      "terra1lxpjyl6k60rsyp0x7fa40s8jsl5l0d27ycmwfh",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1cxcxfa5hd60t8t8rphzgpwunwh3dxplzm0xpwj",
-    "asset_ids": [
-      "terra1m97d9028kdz002wkq23kp329w68yun7p0x6vlh",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1r099m6j4unzjxv77vxnt05hrszphpm69f5x2rs"
-  },
-  {
-    "id": "terra1dagf0h7ux63pqak79m7rqsnm5yujga48sg37pv",
-    "asset_ids": [
-      "terra13yf7ukapmeznh2uamd0342g0hy872my8shc74j",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1mf2f35qq37pkmq6e657ha0asc6tzxm8zwaxg6r"
-  },
-  {
-    "id": "terra1dc84dhqyqrrzpt3tjnkrzsyky2yyzxr5tszzxw",
-    "asset_ids": [
-      "terra1tknq3prjtkzttvx2u48hn4r7xfwh7gz9cxzgqf",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1dj5q78dmy35a27dq97sl28ta78yw2qaz275xaj"
-  },
-  {
-    "id": "terra1dcqj2agjxrc7gz3zsfqxux8js3r2rz0wumch6t",
-    "asset_ids": [
-      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
-      "terra16gx5th8mk5v62xpvgf675xj2vuaf3dg4v75ml5"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1h0vyhc8ttqe2swxkvwl8v75wpfpp5c3vxwdxxv"
-  },
-  {
-    "id": "terra1ddu6j495ephpxm8at7jzg55n6u0zc2yadvuz26",
-    "asset_ids": [
-      "terra1v6p9v6dqaql0600hmdl78h592ax5rxmheefgd2",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1dfv0ww0tqu432aa9z6r0npucjyslu356602ayr",
-    "asset_ids": [
-      "terra1gkfv34wapjun9w0qpg8f245greudfguzlhp87f",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1n0hxydmnc55rzs8kyvefpj0xkp0524wc39euwv"
-  },
-  {
-    "id": "terra1dj35t0w5w5knw7cq6dj3s68ry724nctq069w5s",
-    "asset_ids": [
-      "terra1xmd43yrfxm4xy3lnptc7kr4rr93pzh5u0z0wgt",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1djzkg6ghcwmlkcdxpqq7lw42e695ulzljrvavr",
-    "asset_ids": [
-      "terra1r8ak49p50g76zamn25h3u7lkmn9n4maq2k2le2",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1u5qgpemcltd5y0mzwqsz44wws5z00zyusa8w7z"
-  },
-  {
-    "id": "terra1dkhyzytlc99rf43n4jrxttwxcvg0hvmaa477cq",
-    "asset_ids": [
-      "terra1yj7vlx4uj39u8x4ptvvpxhpfnmphypmlhfhq42",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1mvht6zch65z2jstqfz6dye5wlazhhmc4eky6gz"
-  },
-  {
-    "id": "terra1dq27eeasl3rtlc8j3ls5yz8wurnksahj240tsr",
-    "asset_ids": [
-      "terra1zva2uegkvwr03p98mdaam4dtrkfxxvu330zwaq",
-      "ukrw"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1prswk9yyayfkkq99fpaz5zs7h0lhcpsqa4swj9"
-  },
-  {
-    "id": "terra1dqz4zx0uecwjqafzyej7pzyhhqse2agq767al2",
-    "asset_ids": [
-      "terra17qfuwapug8scgw5satxs4n95u3taw6fe8hdgty",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1ds7gy9gyf9e7rl8zmmtfjt2e2dm4d6p9szu8tq",
-    "asset_ids": [
-      "terra1ss460ny4hl5zew0tlvywnw38rsy2ql3n420lv2",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1ds8u8qrqv87e5mud77up62rl34rtltg3v4w3tc",
-    "asset_ids": [
-      "terra1qv98rklgrdv89gvf47rrzx2lzehd43uwz2rus4",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1maal7qmyn8vv4435wc3nx7nryu7swnj0n2v4dp"
-  },
-  {
-    "id": "terra1dsmz3dfejj47wcxes66gktwqhsvyxe9n2pld0e",
-    "asset_ids": [
-      "uusd",
-      "terra162k5t3hl204lrwe8xvalh4pv4gdrjvdrjlgxst"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1cnryfady5636utnsvv9uj429mhnwfqmtr4als0"
-  },
-  {
-    "id": "terra1duyea9eyua7uftths0n0kn5uzrdsguj7mmv666",
-    "asset_ids": [
-      "terra1ykq4e3ca2e5qgeetk8k8m3w6tk9tclr0xj2st7",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra14janxct88y74znp68z4jh5j6hq3nfd6shr3sjl"
-  },
-  {
-    "id": "terra1dvwewun965qpex2k8hrpfpzt8t7qtq3ptwu6j3",
-    "asset_ids": [
-      "terra133j6tpq7gcrjjgvgj4r3fjwda0hegmmrazmwt0",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1dwsngznkraae33wufcz8qu4rd83elrzn9g03el",
-    "asset_ids": [
-      "terra1ptmrg9j7tcjphzejzlygehaxwtzrr6ywsu72qq",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1zky7u7ynn6m67zequu5cgh7jefadg6ux46a22z"
-  },
-  {
-    "id": "terra1edmq655dxqjk4dh52z6e0h9uajs5g0yl5lk7y7",
-    "asset_ids": [
-      "terra1nh6theuhf4pv67pcyqnz58czljr382mxrp2rdh",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1dt5n5tf9afjzms493nfkt3telqtvp5mmmftu0e"
-  },
-  {
-    "id": "terra1edrk0fflh8ve8d0dn8hna46ftvu9mrruhzeunv",
-    "asset_ids": [
-      "terra1d3pmqshpe6n5cs7d6mnffdun4tg0k05zfy99zh",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1xajvgkhmt8lqkna2f5t28jegsywwkgxvncl988"
-  },
-  {
-    "id": "terra1ehdk7m3p7fwpmzhfh8pdnqueqy6ymmccsnjpsd",
-    "asset_ids": [
-      "terra1f8m2ylcpzfeg3675yk7htw90d72jltgk4mkr9t",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1lxx00gux7zl549dj98cd0rws0xv48ns4qdf2zf"
-  },
-  {
-    "id": "terra1ejql0hjel8s7ywxansv3svrrv4hv8t7h0803em",
-    "asset_ids": [
-      "terra1zzfhavsjlhhx42rnjfvwk6u7taplh4qxqmhgfa",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra16dv8v3v52s7ktxdgltxz6yje67xs8c3azaa9g9"
-  },
-  {
-    "id": "terra1ek0rr6pj76mtrukw9l90wd8xwcuknw8aqp48sj",
-    "asset_ids": [
-      "terra1247nlrmskhfu9qpg66zt5w6f8cw250878enl9g",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1eky5etgq3jwhtyz2tqyuykkxpj6rep7jd7v7rq",
-    "asset_ids": [
-      "terra14zj58ljhlyrgshe0n99un3k5ll2s0eucp332nu",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1054t5v3fszukf4hajqvf4zsndcn2rdx4yz8crq"
-  },
-  {
-    "id": "terra1emetwzv9g6pc0gp5ghj7h9wyvwm902wtxj76d4",
-    "asset_ids": [
-      "terra1mfek3m9s0sazd40kjraw5qv3963t5n3gwk408u",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra19kadah8p79e4m766e3q869jv5f67s60qfxznmp"
-  },
-  {
-    "id": "terra1emg7lr0fxyqxkytdk7seupa4lvgda2frxjluz6",
-    "asset_ids": [
-      "terra1a8k3jyv3wf6k3zngza5h6srrxcckdf7zv90p6u",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1drarcarn8y5hzw0hkjcpa9nhefpq8gqdfeq3rr"
-  },
-  {
-    "id": "terra1enwvvus429s4yxr0d5umud3k6eyhln6vn57v8z",
-    "asset_ids": [
-      "terra1d8uw3zddfrexn06f80nz6hx2cd3f32a7p45agf",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1hp9saxd4mjfrmmzlzmkt9x9jk69vpu7vsh6lwf"
-  },
-  {
-    "id": "terra1eryc869znes7ujk8usxrrhy2zru8f77478mn0e",
-    "asset_ids": [
-      "terra1lrqv79tw447kk4ham08suw7vak3a7pf9de2qx0",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra16pj9ycwu7yvfwtkrew87ss2tqvr537fl2rl800"
-  },
-  {
-    "id": "terra1et3se39fd2nmnuygcvls2amujzmv4v6k4xwv69",
-    "asset_ids": [
-      "terra1mz858mn7jeglmzj0ay8z5zy6v78fvv7em9tljz",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1eu62yulj5zjhs8wa9uvlj5l92a809a2hcp83uv",
-    "asset_ids": [
-      "terra18glhvftntrqg00hv96qkpx3r37g34qh8qytnps",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1zaqqruu0ch0qgq2s2djkelywfn9x9yfg7wjet7"
-  },
-  {
-    "id": "terra1evfprrp4l8kratzm3hs2yxnly2t3ps2r5x7jh2",
-    "asset_ids": [
-      "terra143dkyw98s3ksxu97zln8z5s220ytatygd5rqdx",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra16kvs9y46p4lkj0dnyef6ly4fzs7883ztl2l9dk"
-  },
-  {
-    "id": "terra1ex4tn8m3g2c8xv3q9q5mlm0d8aa6684g40y3cx",
-    "asset_ids": [
-      "terra12mvfnsk4r2chx7n032aztme7zcypyla5pllhzm",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1eyyqh5a5w6sx36q0dgdewmnvxkud8yap2u2xp3",
-    "asset_ids": [
-      "terra1agkfm4zumwkkudpj0882xaex7fne3rume0775y",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1fl4qcp5a3vs5unz3f3kgjwr7rxvq3g393jrk5v"
-  },
-  {
-    "id": "terra1f27dfgcgx5zpa2f3zd9s79jrjmklwq0l8fa6el",
-    "asset_ids": [
-      "terra1e60jlze35lh05dlqrh2yjv3r8z3gktwchykrq0",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1r3hc388xqf83u86ruvhfe3p7pnggz3stf694qc"
-  },
-  {
-    "id": "terra1f3tdduzpsdrg33x6w8cqmzmyytnmhzcvwnharl",
-    "asset_ids": [
-      "terra1y8q4jk5xwag3sschctduxa43eesupjkk6kr452",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1fcgvdqe2dcgr7x2a9w3nfc0nhjh07zggzdlnfm",
-    "asset_ids": [
-      "terra1paulfn369vuz6s6ty65y56wj8gnamzpdzwk9x3",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1feuaajpy0yyag7zsz2w2yxst6faeemn82mlnrf",
-    "asset_ids": [
-      "terra1rumme3vcguv9ly60p53j6wg5qanacfa9nl5uyw",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1gpavmsf3snhltxnf7n6nyz2ehyswtflhsqk7de"
-  },
-  {
-    "id": "terra1fgn8re8qf9am8ymkmaawgspym43en9f8w50f8c",
-    "asset_ids": [
-      "terra1m9fuqymdz03umd88guyc79083hd7vppzu74vck",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra10evwunz82kc0wucnwyxnzq35yjygl9huglrlgu"
-  },
-  {
-    "id": "terra1fgwk7tjfzcul8mc8xwdkf3ejswgcxkh7d087ku",
-    "asset_ids": [
-      "terra1yanmc0xxg9dl387qkudnysjkymgytj3cdhgeek",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1fhgksqjyawsym7myq04ddvm0sgxwzqqlw4pp5j",
-    "asset_ids": [
-      "terra1elveensfjwt270xzt8rcpvwmnhawrrqfx5atj4",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1xsv563k2wyuqkwza0mrz6ye8exx4a9r0hdvxs6"
-  },
-  {
-    "id": "terra1fhs5njpe2sy6acf7r3s8qh62mvs0dgs5wntdtu",
-    "asset_ids": [
-      "terra10hr9gx9m9tq44xcxk2c5mzzlk7p22zd7x6esr7",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1xapjctwprfuqpcte2h4mnpxtf7nh3jhurgv6sf"
-  },
-  {
-    "id": "terra1fjrjynsdxvgqsahquuun46w440d59020vxva9d",
-    "asset_ids": [
-      "terra1fcq75y4ezhsws0vudna3cddk20d3k0eg9nznyh",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1fmp455y0fgee5dv68fxwfnylnpux6fv3th4m2f",
-    "asset_ids": [
-      "terra10vwyclaux26l47hj2dgnjw2pcsrt4y0ukfgp9u",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1fpnmpty0r6fmyxnfzere7xd62cnjaumslzz7d9",
-    "asset_ids": [
-      "terra1spe82hmc9j2y2vjl6urue78zhrn9r9xyydkyx4",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1fwcdnx8flnyy4skav4fvurtmrh86ef9mkumgt6"
-  },
-  {
-    "id": "terra1fqr0y0djympq8zfgztev9dj7fpp248pff7860f",
-    "asset_ids": [
-      "terra16q2hhuva6u0zakfav0pmrdw2fhjsanvqq9y56t",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra16800h94m9r3n8alhu2rsxxpxyesh9sylu3jgen"
-  },
-  {
-    "id": "terra1fvzjp7p8qy0l332qy8rpljcufmsqdxjyvckney",
-    "asset_ids": [
-      "terra1ua6saapgern9jpmklkvxxq4l06nal2cwd0003t",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1dvkjth7zak3f5kvn7l8vfp9n0cu8dtjnjhdql6"
-  },
-  {
-    "id": "terra1fx82cs3ttpcnd9wg32a70ajkfturmedrgup2vv",
-    "asset_ids": [
-      "terra1cxusd4uhgpgk2sp99rexrcknpn08anak3v9tz7",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1fydslvtnl4d4dujz5kapslwty6were2aeerd95",
-    "asset_ids": [
-      "terra1ejmg85y0vgsxv5r3cd4024j732pqnwudl0v2d2",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1q3q8lrucdvs93walj4edxqlaj0lqqyrs2sgk7e"
-  },
-  {
-    "id": "terra1fyrvx3m5njh265wu3xycty3ynf04x8wqhpm2lh",
-    "asset_ids": [
-      "terra1897wmaycufjr9hu894mt0g33ddcgm9vfsfcyyd",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1hqpfh2g457fuzrm8e0skagwwh79pffr3zzqwek"
-  },
-  {
-    "id": "terra1g39kq9n6qmjzpls9kfxu86yvcz3p9ajy8fqjp2",
-    "asset_ids": [
-      "uusd",
-      "terra12y2uzvrn3j4y5390kfljtpq6z3wqflyg0wls2z"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1da3m78cejl8l396gahuqnllwl4qyxeeysm5vrq"
-  },
-  {
-    "id": "terra1g6jmfxv2rangz50u335rfum2fxxqmk4cnl43kw",
-    "asset_ids": [
-      "terra1866wzpwzmrnmh0s267twyhr8c4tc47tqj5aths",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra109kmkve0p4ksffjdfkry75d44hy038mk7x6ygc"
-  },
-  {
-    "id": "terra1g7an9lfz22gkv74238dhc2j6ymfp4jy0k55yxk",
-    "asset_ids": [
-      "terra1qw6sp3rjar2x7mfa0x4uj90ssemwap8p50f8kh",
-      "ukrw"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1yqnd70kvrdfazu7aplalwqdp3ksnu35fv9cv9m"
-  },
-  {
-    "id": "terra1gk2nnql0vllx34dev6l9grl425leuehckwpx3d",
-    "asset_ids": [
-      "terra14ec8v4c5dnwu2pq9plfquaffutu59tq9hld77e",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1gkrajyr342clv98p2f6dx72eyj5cx0t9pa74f3",
-    "asset_ids": [
-      "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7",
-      "ukrw"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra10q52n4yx9nn7p2arhle32kyujt65euzh3vny4l"
-  },
-  {
-    "id": "terra1gnwt6a5t5vw90q26va9fj3j0rsnjemptht0szr",
-    "asset_ids": [
-      "terra15uc875u7uu8xyqf833nxwh5x4dm2kmu29u04vl",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ewm8kaj2vvh2aknjzlv6cyqm4hjc8j0uvdnah3"
-  },
-  {
-    "id": "terra1gqqc9f89a92h75m3hqt4c4hpc8466a5a8z4xt6",
-    "asset_ids": [
-      "terra1cvsfc32dkdvmla6urrscrtfceztecj0u5tvlvz",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1dxu9d263z3rxdn3s72uswtszjewx573sh4mq9r"
-  },
-  {
-    "id": "terra1gtu7lxdl878r02s2q7fx0thzfu852c3xhxj04n",
-    "asset_ids": [
-      "terra1qsjs0a02jmyfhvaeul4zax22sayx5e8dl8527g",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ekm4u8whtpzvna0arcxjpj5mx2qfcwku70nzgz"
-  },
-  {
-    "id": "terra1gy92pyp6kwllkpqv4gmw63l50cglzqmtz2jjnf",
-    "asset_ids": [
-      "terra19qad83kr29qg89fpl4qh8m02wapmlwzpw5hvc4",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1s72ztquh9j0rj5w84kxlflkwz0kwyaflgxtstd"
-  },
-  {
-    "id": "terra1gyrp3pnw34wy0ptyjehfw6akwd9h4ed6kmxmev",
-    "asset_ids": [
-      "terra1mlhehkx4rgp357jmxhqepy0nr4tjetkje9t686",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1v29xuc4he907gkpc3zmrhqhuxcvy3jhfy50wue"
-  },
-  {
-    "id": "terra1h279dtdp2jal5z46memvs3fqa9syfcnd92whp2",
-    "asset_ids": [
-      "terra1yss9zexptelas8y4mqans2qscmw69cy2g0tycu",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1dznxnr2k77nneklkd05jmxugp2j77mtt6v6yjn"
-  },
-  {
-    "id": "terra1h4mjl52nsy6y04r9snxe23fzdx85vzvpcnu6lz",
-    "asset_ids": [
-      "terra1ckrsweg4dtg47qv55ecayntlax3j8ja956nq2l",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra16v0aunfk0tqswrldmyczz8aymwe9r279kknheq"
-  },
-  {
-    "id": "terra1h9jyaf7wttw6txdy64608wc6k998dt2ny8zjwm",
-    "asset_ids": [
-      "terra1pmf2x6gp8u979q672lkkkruuhe9zarxyu5w7t2",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1xfq07tcdep6lujx480xqs02q5tk3ka3p4l2m8d"
-  },
-  {
-    "id": "terra1h9zcqxdcl89hwvgxh2v6l3e3lfyguawxcvtasw",
-    "asset_ids": [
-      "terra1pc253zfn4zns6awk7eks779uk3m7dna7y4cmlf",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1haarsvn3uxmul3rt5vr8x0856pjj45js6fwkhz",
-    "asset_ids": [
-      "terra15fvz44vh89rj4ykamk2tadw0f7wdnccn5qp0ua",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1hakq6c49989jkgpj4qcp4akxqgesazps2ss9lp",
-    "asset_ids": [
-      "terra1gqmd09k8g3lggxxdzu9z94vqcxtr5zylvs95ke",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra19c5fhtrdaarv2cly5su7w9a2ud7nk72g2vm0gv"
-  },
-  {
-    "id": "terra1hcqrfwnjvsp6y0hyp9sgfla6k2fqx23g9j9q9s",
-    "asset_ids": [
-      "terra1ktugzem827nn5uh2ccjk8y6xr9z4szvdc7x39r",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1k9tcrhdgh2q5wpzw8j4ap3fen3ryn6ycdmn4ru"
-  },
-  {
-    "id": "terra1hfm049mt76s4kgsdrz7x0au4um4spyvyxe39m3",
-    "asset_ids": [
-      "terra13zs7w76g0u4qgagcen6vq92wxuvgfucr3dy4tm",
-      "uluna"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1rvsp3qg4k2vyd432xj9qzxx2p9hs2zzn5u43qg"
-  },
-  {
-    "id": "terra1hjpke0qekl4q7uy758c9z5ve6xwsuzz5n783ek",
-    "asset_ids": [
-      "terra14g3uqp52dwk9qts40mr2skynkqdxsqwlv0862z",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra188ff6qfccynwu3ge76ylp0k9hm9ke3fsnacmc5"
-  },
-  {
-    "id": "terra1hke7ncmglkcevsgx0txma8a02pz4npypahcc0r",
-    "asset_ids": [
-      "terra1ltcad0e9cgf2jgtzqwg82n9k54fre68wdddfll",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1xtxds95gvddytcxqu5larnuvxt5gekwfxclyu2"
-  },
-  {
-    "id": "terra1hn8m4250rgmtpx04uc75sfvqsyvcj4g9fdrmlg",
-    "asset_ids": [
-      "uusd",
-      "terra1pujanvsuhqsqf8vc7r3ky9ghr8sgeg4e3ngjun"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra140jj5n8yd52ucvntzfh02yslfuys3kxnd47lzr"
-  },
-  {
-    "id": "terra1hq3kf4353m5d858u08mymad5rvgkc4zeqhr8vs",
-    "asset_ids": [
-      "terra1kuf3mxgrcwnlh4zfk5p5c6tcv436j5kza70asm",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1j02hv8ulc5yg7hc79ycsxfhgmys7jjc0m550c0"
-  },
-  {
-    "id": "terra1hsyfna6jujxrfd86043w2tcydyvql7dks9v4zr",
-    "asset_ids": [
-      "uusd",
-      "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1gjz8xr2z92pffvzgp0khu569njf75jkhe6ta04"
-  },
-  {
-    "id": "terra1ht5zgyecp4w7s3jzgq9j4unjx44hx4se94yp62",
-    "asset_ids": [
-      "terra159tnr8a3uutvwxhgkea4f2hucm4v24evv2se2t",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1qts4ddzv4ndsv4mkccazupmfx8q978g0kr459n"
-  },
-  {
-    "id": "terra1hv6zykkt9xjhuqzumrkpvp5e9t6hrq0837c576",
-    "asset_ids": [
-      "terra1juul8ypgcs4wtuqsc7fjv76g0tq77nc44ymxph",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1mjvdm5ahr6l9yg2h6sn0khu6y2dkesfmy9dfnf"
-  },
-  {
-    "id": "terra1hxekdhzzlqrytzvf7vl7jvz8tk36eldmaygdu7",
-    "asset_ids": [
-      "terra10t0rgfryqz5ds93z5tqed740nqh4ele9lm9fhq",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1x32xraswsr08qg9dee6jkkjac4y2j3q557f8q8"
-  },
-  {
-    "id": "terra1jccp3z6efd6r4f88p7ewy2qpjtahxtz3glqu6g",
-    "asset_ids": [
-      "terra1fd0gy7f5dcgmvdl95mt3z9fh8se48gf0wxs68k",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1lk96dy8w7cq4x09q780cfg7wwpkuxrxtqjpycj"
-  },
-  {
-    "id": "terra1jftv4fh6wyxx8rnfw343vyl5ehcpn47syn8yzh",
-    "asset_ids": [
-      "terra1mt957lrc2z93f5utk509zma6pgtceaq6tqedc6",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1k597uc4rzvlgmel8xkz434xdw0tsfmt7es0pwy"
-  },
-  {
-    "id": "terra1jgrs4fnevw78q8rvutwyjzxhyy5fzqwtft6jea",
-    "asset_ids": [
-      "terra1pamyemqvkj8ws0easzq9pkl8usnjt424ddraff",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1kw6qk3wpdzj7aklge6yegqjlmnrm83248v3vwz"
-  },
-  {
-    "id": "terra1jgzc2rkgl0nlxxqgy097wtq55c7qv224ysx2dw",
-    "asset_ids": [
-      "terra1gdapfuda0dxtjc98raemhszntcxty7chyr0wpd",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1mqhv4thnf8mpwvj6ul7wrrjs2y5vua257yhxns"
-  },
-  {
-    "id": "terra1jq6ud6xdljsrpgnmuhwc8e9sxjut5el6t5z9gr",
-    "asset_ids": [
-      "terra1qn4v9nnc2a0mdnkzl73rh60264gvhu6pxusz0r",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1juyxhxne0gm7nma4vrm3pz949lj3p5wg266x55",
-    "asset_ids": [
-      "terra10aa5cyfu879fm88glc099sjg8unejcp46cv6hd",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra159je5qq2c45l4vl4j2uwpelyxvmf06nnqyyc3y"
-  },
-  {
-    "id": "terra1jvq9ufp4vvypp86hl56afvjn7jqgxxu30l5zhd",
-    "asset_ids": [
-      "terra1r3u50sue9akjnndgvxm7fe0fy5jdtnyxwuetw8",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra19yfdxaw7qexrzq8lr8mjs478uu53ptmdmgrhad"
-  },
-  {
-    "id": "terra1jwl5rzg3xe0a3f8r26l0l3d957vlxm833srtcp",
-    "asset_ids": [
-      "terra1gpwkclxwwuzd5wyjw2qn3km0r5ge4t4f4mnf0x",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1srcv0x7huzrxce3awyl4u5g9rpt4fqn5nwcw6m"
-  },
-  {
-    "id": "terra1jx3m7swaseumanezk3z6r73cptucc9dqg6hprk",
-    "asset_ids": [
-      "terra1pmcr4gjjsu62t2d9e33q6d75sydrhnpt37nayz",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1jy57s4anzh959e6cr02dwt5s3vw03ajwtfr2l9",
-    "asset_ids": [
-      "terra1hytrupk3argcrsl5x7dv55gyda0tn7f2qqlwkl",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra17tjnesmzly8gv3aj87mmtdrma77au2z6756x9d"
-  },
-  {
-    "id": "terra1k2sgkcw0z5drjcy4nl09v40xt6hgf0kpcm4rpc",
-    "asset_ids": [
-      "uusd",
-      "terra1gl3ywddjkukupa3qv86r8xy434frncmxna630k"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1k40xfmkswya285zwcsj0qlamg0f4kyrvn2cd0d",
-    "asset_ids": [
-      "terra1xxze8dty562la0d6g9q3srlddh0qemk08kpgfr",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ryc8v8srh8kwclxcay7dgqtkclty3g5n7gj0y5"
-  },
-  {
-    "id": "terra1k5gg6rjgmmut6m3klz0sz36x7lt505p977pc9a",
-    "asset_ids": [
-      "uusd",
-      "terra1t5r5ptw6ympy9npq0z7fa37nrk39n8054c6763"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1y848ua0mxnczs6hslk6gug8tmtx9cmlgf2ju7q"
-  },
-  {
-    "id": "terra1k5rnwftj26qlw6q746nv59jvg964zjr58ddsq4",
-    "asset_ids": [
-      "terra1mvgs32slrxy29qhfmd2vn7y6l8knmtw396uxde",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1za869t75aa4tjatrtc8sqxfphymmdj3k56w7fg"
-  },
-  {
-    "id": "terra1k7ugqrw3jkk5auuudpnuf52wtzerx4a7cjjhfg",
-    "asset_ids": [
-      "terra18gtpe3cu99pp2ej4mmf5hanrfwy6qcvd5x5cmz",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ch9gwujlyz6pjptuqcdpyawn5a87dtw7a360v2"
-  },
-  {
-    "id": "terra1k8fkje4xawkgtg0czxkp98qd2gu8uz4xgnuzsv",
-    "asset_ids": [
-      "terra157n30a667ethsknneaavga2txtze58eajyfv45",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1ka5d8934txtr2lhpdk40334k30t66hxyqswq37",
-    "asset_ids": [
-      "terra133q7a0uctlld9kru6put3hk99qvxm9qzmklu9f",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra13vxffk8n8a65lr9a24a7g28ls5hzkhcf3kzvtq"
-  },
-  {
-    "id": "terra1kafq6reya5v8ksdlnpyzv5gnyax3l3vp9l79wd",
-    "asset_ids": [
-      "terra1g0rda5pawz0duymd37puescqsx2hgqu9hgrp8h",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1g95dha38ht2y8qchz2zqa0kjnr372zpgsyyejx"
-  },
-  {
-    "id": "terra1kag0uhcl2e7tddmzaavqr7agkhr9ukghutryjm",
-    "asset_ids": [
-      "terra19k974ngjsml8dtmk56cdhuy6pplr94rxqdt95p",
-      "ust"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra134cyuqglj8nmz2us3y7nl7z4mqsmj2dx8f3xq6"
-  },
-  {
-    "id": "terra1kcdknzuz8q5zjeyzyy30ykfpf3xs4dzxh57vgw",
-    "asset_ids": [
-      "terra1aegvmfgdl4dclgpwtajll6382tcc7r0saa2eek",
-      "ukrw"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1t0mgl6lns0ff6wva27zjwqfpqrjdzw550ed652"
-  },
-  {
-    "id": "terra1kd38g9rmfvklwyrszpe43dddhvl8zdgeya6ms4",
-    "asset_ids": [
-      "terra10ypru3yma98ukk3anr5cjv02yq839pcvqc476k",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ek3f48k9xje7zr6ytfdm2p9xe5qkx959kgrle3"
-  },
-  {
-    "id": "terra1kedzs6p7mc73lvnw87gvp5aa5azynafthhsxpc",
-    "asset_ids": [
-      "terra1qgvd7llck3nfav7n9k2qh35zcsmjwap073x5et",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1e8nn0zsqmlnhmxfmwe5qz5p3utyx2fljemtrya"
-  },
-  {
-    "id": "terra1kgytwyu7aqah7cm97xeeurvsj3n6kxp0tc9esu",
-    "asset_ids": [
-      "terra1kd4rfff04cvw7vae0szgawj0xye90fkchljv7y",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra105wahgnrx7t2dsxfx9wer2mtcfrvfpr5hjxyt8"
-  },
-  {
-    "id": "terra1kjlt8zsdvmxaw63u38krl658zunaj9hzxwknqs",
-    "asset_ids": [
-      "uusd",
-      "terra1zqyfp259xhhct6q2alp88pke90qrxgr5u2zc7s"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1kljzhnu4edtc8f8xzxu223n03hj82k66xp6mfw",
-    "asset_ids": [
-      "terra13k5m9dmcdm8y52j95tuppuz23lvjug6hrh7vjx",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1caxrxg3n67egv4u0v6klt66nsz4y90sydlatzr"
-  },
-  {
-    "id": "terra1klucl4s6jusuvrxag9hyay90cq4h80mkjhkw9j",
-    "asset_ids": [
-      "terra1u2tj2wy6gc8gw9g507a66796ej2csewp9asznk",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1m28rcqy4fhhu9twwpuv6fdajwmfwlm02lwlzw2"
-  },
-  {
-    "id": "terra1klw8gs2ra6tvf0s86kvye26lcv3ztf885p9fwy",
-    "asset_ids": [
-      "terra1s56hsyhyvq4xxxvnz8qr0pnktm2dadsm4gkl45",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra19uvpg6ppn5jqh85c72rw8ywnyr9ecalgfe20ek"
-  },
-  {
-    "id": "terra1kneyp2t00kehpwkaxml9w7dg5p7nl703dv65vr",
-    "asset_ids": [
-      "terra1gs2pykgl27l04e6lprgqs6uwlr7rm2vjcnya8g",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1kngr9srtrzfwz0y8ckjhx7559xhdgsthu44y2k",
-    "asset_ids": [
-      "terra1q0q09duq6jsth9m0gfj7fpxlxwlj5fcxgchuza",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra12wmaguvdvjf225ua9xjwpj5k5euy6nhtu334n3"
-  },
-  {
-    "id": "terra1kngrh3kmwngq7t4kcnqdustp3qurvenrhphyxa",
-    "asset_ids": [
-      "terra1ypgjelmtp0mv5akzwmnj5xhukhd3fy9gd28wpj",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1d49ve0m99xz250uyj848yd9sgwuh5vw30kxm9h"
-  },
-  {
-    "id": "terra1kphghf722vxe0aq04n4erzflgcpp0pysrvtj0p",
-    "asset_ids": [
-      "terra1l0rnt55mf8q87q2nqfn9un3lxnmxkhqrl939x5",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ay647sah03j0zv7pn62sp46sys7gqtnawnf3u7"
-  },
-  {
-    "id": "terra1kvg5qyt25nrgkqeuanz0k7cavxg0qxe2lgjh90",
-    "asset_ids": [
-      "terra160y9666sr9ctqfzk4mu7useh6g6swet8vnl7uz",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1k093hrmpy8l930ehgtvc7hrdkja3pnudr7ue5j"
-  },
-  {
-    "id": "terra1kwhysskh35wqrsuxyv3c02cenwd05l6pm96pnk",
-    "asset_ids": [
-      "terra1edualxuj7afpm27uxvv38zr4e0zf4r4z6twfyf",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1zczk7ccfd2wfetyq8y6gkg0qghntahd5pq5qf7"
-  },
-  {
-    "id": "terra1kx5dge4hsm5ke5vuxzp06as8lxv0d5dwl54xep",
-    "asset_ids": [
-      "terra1kx73zld4tmv24r66h7jp8gaz2rrl4asxlzq2g4",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ug8jeyh65zxffe5wwj3j88fntdjdaj8xft6g95"
-  },
-  {
-    "id": "terra1ky57u0437dszysa0qchyxcvuxs6ax9f3p6anrv",
-    "asset_ids": [
-      "terra12gsrt6nmp56x0q9t9h47frgr8praqyaqdvpaan",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1nq8x3tc9gudc99pp0j58n2q50us7al8v0y9eh8"
-  },
-  {
-    "id": "terra1kyrnvh3l0natnqsapzalahmp4t29dz3ylxkp3a",
-    "asset_ids": [
-      "terra13u7ddpvnxlephv6ltswy7c7hnq77agz5078l3y",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1qwyfe8zymqtnhcrt46yhtk290h9cdpynx3gg3m"
-  },
-  {
-    "id": "terra1l0ldny298vsdln3gsd8xsfzln8yddgntuc3e4p",
-    "asset_ids": [
-      "terra138d8ek2zl48pp3el4s25jxnxn8m9nl2n4y0glm",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1g666d8h4hsqhw8s8axdrzeu6n7sul2w2zsgmn8"
-  },
-  {
-    "id": "terra1l649ch0y5nxnu5mrkefjfsgyyn5yj9pqjyfgc0",
-    "asset_ids": [
-      "terra1ddjp4wgu52cktzgzvahwkr4dcd95mxaqad2pmu",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1k43ed8sql40cxd3mgaqujachuhhdrpzvuj7tvv"
-  },
-  {
-    "id": "terra1l6s778y6gljerp0epa8wwmj7dxtlm7qfrmk8h7",
-    "asset_ids": [
-      "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
-      "usek"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1070nrsj5mf8qhess7f3vtylcmryhzpn9xqr577"
-  },
-  {
-    "id": "terra1l7l9grndgnjagmgm7e0wf0aglwrj3wtzgcdtz9",
-    "asset_ids": [
-      "terra1zrfd9hf3z6kwewxrt3rluzdj5d7ymzxnnptc6k",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra10fmk0879fn2hm6728kgc40ytkqgn6cdxfnzyty"
-  },
-  {
-    "id": "terra1l9l4slsr2tllds0r85nuem4fcmqrtjdp655pdt",
-    "asset_ids": [
-      "terra13awdw2dt45l958q274ukg0hvvmctghllv343lp",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra12ncluxlmuwkhq492dkd8y6g8p9kzt50dvdxxtc"
-  },
-  {
-    "id": "terra1la2j3fggypkv5v7rc3vdrs6f3nm5duexd7y4pj",
-    "asset_ids": [
-      "terra1n6eltvex47mta0me66ygqw0fgvjx2ul7qm9fjp",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra13wn4sj9c09638wdxn73d2hgzlzg2dp5gh4fj4c"
-  },
-  {
-    "id": "terra1lc2jzj4x8r7f6asy6vf9jlwnjpuz83vuruutkj",
-    "asset_ids": [
-      "terra1k5hx3egz7jnzqs7n2ze0d93mce80y4cndd5saj",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra15s5dsy04dkplkf7k8sggc5nwc40dhnx9eektvt"
-  },
-  {
-    "id": "terra1lku3pluvh5hgdr76d2mmz9uch55uxqkk2nzc42",
-    "asset_ids": [
-      "uusd",
-      "terra1v7q43s46ntt4p7cpxcvsxjk6srr7uxvldn6vuk"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1rxsqmtax455x5628dzhjtflcs0grpxar6hcgvl"
-  },
-  {
-    "id": "terra1lskrhzzyxtm235j69ty3y4fk7mswczq5f93ntq",
-    "asset_ids": [
-      "terra10l407saphqe2tc35ejhzg7xyulqkeqccvvc6uw",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1lw2vz28ajmdntvgfz95rdgljq4gc4qw90wc6jm",
-    "asset_ids": [
-      "terra1zucgllq5ddqkfgsyjr7qnrfhymu0y4rgqsfyet",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1y0ej8fdyvcy4736m02eu8d9ftr892de78dypwp"
-  },
-  {
-    "id": "terra1lz2uwr6jqjp08yqf6fee8n484hdxa2rzpte2h4",
-    "asset_ids": [
-      "terra197txx8gsllv9rakjs6zh7pw6hnlgvte8yf8a8t",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1je8e4j30696s3j2tv4rvscnzgsan87uqy694x3"
-  },
-  {
-    "id": "terra1m74nhtm9uj36jc3024y403h9cnh3uvthhpq6zq",
-    "asset_ids": [
-      "terra1jvsfc3aedh7cyf3wd6vs7r5fmdsf4v6veh525e",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1hfrwjf66e7ayc90p53t9h5qxcqthtg5ug4yejq"
-  },
-  {
-    "id": "terra1m7n5p8e0mkh370mfp0e93jfk7uc34gxxxqegwn",
-    "asset_ids": [
-      "terra1cu7zc3q8089cuu4z5ed5nl4c9w59qqhs2mmfyy",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1srwc8xh9d5zx700n7n7unq4eww620vw384pwvg"
-  },
-  {
-    "id": "terra1m8dlx0g0j00xlxvavh972sk0gja2xn5gxjvtu3",
-    "asset_ids": [
-      "terra16ygrvq7q2zxw7jj3f96racur50w0g7r0mj6e2y",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1ml720ts5kfg5s9hhsft74hy6clqsevsqkvu0du",
-    "asset_ids": [
-      "terra1037zmxv6f73e5mlq6hsyadlev0fj4q462llw3d",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1vkjgr2rsagh52jdcur4zgjyj7ag5xrfmyekne2"
-  },
-  {
-    "id": "terra1mmc2z9znnl92338yquuhwzh2vj7gt9ez66nnt5",
-    "asset_ids": [
-      "terra1g5unnjllx9900hjsx6x3zhhv504ssqktdc82l5",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra15hnvcwq69maqesv0497f45fez0lmunmghjqmwf"
-  },
-  {
-    "id": "terra1mp2d8zjhtenah2rgv7p4g6zaxp3s44pqx9z5ek",
-    "asset_ids": [
-      "terra1spuk4t4lxsmgx8wqq0ltqrxagnrzwvk6lmf4t4",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1zjxyrnfgf93kw5uhamvnqxdfnczqhwsgpe0evv"
-  },
-  {
-    "id": "terra1msws3xuf0ey3l0sdt0t3rw49gjcq4nya8h3lad",
-    "asset_ids": [
-      "uusd",
-      "terra1ld37cm20t8z3r0zvk7hx2qcfr2cdayteed8089"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra14jaq6qur7mafha4ky8u6ct67xav4zt054p865j"
-  },
-  {
-    "id": "terra1mtt2dpjah3mja54rg9exyexsdkw8u3pljdu34j",
-    "asset_ids": [
-      "terra13gdkkedrnd48kel0fc8sr08usdfpdce9ku6qku",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra16ledesd9tn24fte454883p577qvr24hngmfefg"
-  },
-  {
-    "id": "terra1mwsw7mzxqdv33naqg50quz9ataxfveur7u48aj",
-    "asset_ids": [
-      "terra1ep337j8q9xm7t9ypqugr4yhgnvf0jgyjga50tv",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1sdlk96gvztayg9yayxksaghrkwv5hsz3psu3xn"
-  },
-  {
-    "id": "terra1n4kt65x0mmynpfdgcwfz36dwws2v6er3eer6dw",
-    "asset_ids": [
-      "terra1qlan324u6rsdevvc6ye3m02ump7dtp3z67uhqy",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ua0ehzs2z7qq05qehnzvp44gev2w7cc7vnuyh2"
-  },
-  {
-    "id": "terra1n5nzqdktzh6j935y09244rghn6zl3ga6h8ktdk",
-    "asset_ids": [
-      "terra1mtm6l7xdmpuelf2q74sq58d2e5gwm72d42algk",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1t32vjs5l5f5452kq78wvtaest5qkhr37vymcfa"
-  },
-  {
-    "id": "terra1n5y7ym6x3ma0en8ff692406gtaagk8e7l4nyzq",
-    "asset_ids": [
-      "terra1y4yx8w0p9v247w5uv5hfqv2fccda7rmt65mwcd",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1dntanjjlturgu2zn3t07evdf6cljepaap3vmfa"
-  },
-  {
-    "id": "terra1n7kaxpxslz5aw36gx2mnc9a30n4yu0us7x2xj7",
-    "asset_ids": [
-      "terra1xs3pv5rd2xu36w9vg05shkgxcrxkvz40fhnfsv",
-      "uluna"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1237hndgalhuukzuccfvfjj538az8739td5cnaw"
-  },
-  {
-    "id": "terra1n8jq50xnupyassyc3z4apwc33av3499v45tllv",
-    "asset_ids": [
-      "terra1lxh32h38lf8xdk6lv7k5w0ewy7gu6psy4gfmnm",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1nayuuwy7mdcjtka7n9xt9gpcpldyqglt0jt5vf",
-    "asset_ids": [
-      "terra1lgx3e9f6fhqda47zdyntfs07rdm5arp745mec7",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra17nwqqwfedrq50k779ulvl8da3jncj960xjylns"
-  },
-  {
-    "id": "terra1nazuk5vy7u5nwdnlxefcevy75yyr9z4mejq0a9",
-    "asset_ids": [
-      "terra1m6myw86l5zgw3z58z6rynr8zxaexprfc3m3357",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1mw45v6n4n3r4ekcqn73t9wmed9xv45sx526ty3"
-  },
-  {
-    "id": "terra1nf6wl37jxthskggvesngsp7y50s0jchmur57v3",
-    "asset_ids": [
-      "terra1dw6yapjv8k8anef2kg43hewg3g73wle22ncaje",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1nfkhe4vy2844352ev350ldpccw06ud88qptxd6",
-    "asset_ids": [
-      "terra1av9tfs7k5gfuzm04e7p0d4ezrc53vq9mn3m08z",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra18ypccdtr2c57zd2q8l6fu0fw932ewawlx25pzk"
-  },
-  {
-    "id": "terra1ng3vjr2av7hgx9029pyc3v6y8l4zy2gf7nrk0c",
-    "asset_ids": [
-      "terra1hnsqjjzerf2leaufj7dt9j54nyjvhyppj7khaq",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1qwa26w5mdznxf52zug3qegzhq8pggutfqrdq5y"
-  },
-  {
-    "id": "terra1ng4tm5a9sru4cgwqs77tm5fh47tt4sh6glzd9l",
-    "asset_ids": [
-      "terra14yyepy06yw57f4x564xrfwxvv460vq0su5ype8",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra167c9s2r2jkze9xe989wfeek2zkc87ggjcu2u7k"
-  },
-  {
-    "id": "terra1nhsam29a0cnxv0sd7tk8s5x676wq9rar8vpqwn",
-    "asset_ids": [
-      "terra170r0wm50x5eh47zkvlrjkxhajp4g7wrmgsz523",
-      "upepe"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1xgn0ffavkylmh0rh2upgapj0sa9j9apray0eu0"
-  },
-  {
-    "id": "terra1nksjldc9ze8ql6e93fms7d2y6t79h8qzv0q4yf",
-    "asset_ids": [
-      "terra1wlhgvtult73t5vpeng4sw9qmsq5jlujfm98gg2",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1xyzz6yvtvndqx4hp78vuvnzwt82xraw8xd5y6v"
-  },
-  {
-    "id": "terra1nsdxqpe5upkvy9jegqdkzyhetravf8vl7m496h",
-    "asset_ids": [
-      "terra1xs3pv5rd2xu36w9vg05shkgxcrxkvz40fhnfsv",
-      "ukrw"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1e7d7325sjpfk02vnzqkwsnlu0xqejydleeh2h8"
-  },
-  {
-    "id": "terra1nugs0qddjw9eznndg497ukt04cq0cxurql52qk",
-    "asset_ids": [
-      "terra1a2f4pxdqd98qclaeafdqxlc3dvnt3wqedx3l77",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1fe089wx8cnm3pfk9am2rmexrwu0vkp5skzphnm"
-  },
-  {
-    "id": "terra1nurx5e8lh8pfg8hnxw35duczvsx6lhdjrxy5e6",
-    "asset_ids": [
-      "terra1zfcfvsw9m3gzk5l42cek0ukn5g4dmd8gl4lyra",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1e6kja3hn04rhc8lslkdk63ry0gspr6zwufs323"
-  },
-  {
-    "id": "terra1nvmffcs9l6qv7c9z0unkt69jk2qtadaqw7skp9",
-    "asset_ids": [
-      "terra1vl3khh0w2fydtd72ly03vjmlll4nr0ldcl9u4z",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1yek22pthmx98yn0k3jdgu5t9tevd79c9z8l60l"
-  },
-  {
-    "id": "terra1nvpfq78mfe6emt35f9fgys2vxwcdt3kx28g08a",
-    "asset_ids": [
-      "terra1gq2yya7grd359c4y0wjfdusgrh805r6ml9jyyl",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1r2ec9hu0l8d2xrl6nnawy7exmjyrlu4usyr5fh"
-  },
-  {
-    "id": "terra1p39xsp5j3e6e9703gguen049pkf4p52rmwf2vm",
-    "asset_ids": [
-      "terra1lrdzs5tgllwqgawtq2emuzn7snpxq87fzzl44y",
-      "uchf"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1p445mk3wsctep477kpzvp6a4xekyzu4fqcc456",
-    "asset_ids": [
-      "terra18m6fr3fk9xh0u9vrvyeu25w0k40dptfrhw53rh",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1zeestkmhgk2vjwq9wg396qpjvryftwqt2u0xt8"
-  },
-  {
-    "id": "terra1p6nzgyy7gq9hw54errcyrnjkf7p4expcsnmxz3",
-    "asset_ids": [
-      "terra1ctfsa4qfanzmz4my78m3u4r9k5qr9gpua9f6hj",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1wd25umnrgnfydwd7k7m364ykk79r76tclm5v4n"
-  },
-  {
-    "id": "terra1p7npd4c5f8vsr47ncvkm50qfkvddanwy4er5ls",
-    "asset_ids": [
-      "terra13kr45ssru9cqhp2kaaan88wfaa7f2h3jfvuldp",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1p7y8st3wjgs62vs3w9dw2sf603e4777v3jamhn",
-    "asset_ids": [
-      "terra1h0jk42weh0urhgdtjql93rrvgdccspnp7vyf49",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1y3c0z35uju9apsn0faewjdw630tqalhmtpgtc5"
-  },
-  {
-    "id": "terra1pcjl6ammvypn4z4srs9dgzd2pgqvsw0xy85fj5",
-    "asset_ids": [
-      "terra1r7e9a5su34ne07e6v0r7n2xp4h6tjkxc8j2lz2",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1qt6nek5pe7l0l3hwcarjd62mn24a6v7kz8zkxf"
-  },
-  {
-    "id": "terra1pcwu6flzc3srtu44cyvt8c7dn59lkyckprhqht",
-    "asset_ids": [
-      "terra1j7p2fxrzryfpzrrsfe585klnkqutg94kca9vtj",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra15ggrlf3z0j7phzunfh90rjscuvrx4hgfljxhf9"
-  },
-  {
-    "id": "terra1pdstq4vkeftz5kmvwk5dzaytpesv5f3kq5q6s5",
-    "asset_ids": [
-      "terra1ppuu0devppvm6d75sclj4vwh5ghwyx7grurlvx",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1f0tup70r7ycf682vc9h65p6g59jk8eefvy67qn"
-  },
-  {
-    "id": "terra1pfdfzk3qs55lwtd8l00da7cext07ufpn9fe2c7",
-    "asset_ids": [
-      "terra1daa3rrcq6nk9vh3ecg08x7rmkx3h6egsfex3ze",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra10skty5urn3fzfkwg3f93z2f56xm52gufh2u76l"
-  },
-  {
-    "id": "terra1pfkanl8ycczuzyj02rjr3vx3sw0us9vxhpr0mt",
-    "asset_ids": [
-      "terra1h4wq9krj88hcl0m2e2kxfn3gznga30g5rrm4qa",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1n4cydpuvk8encunn0ag2h0y0pnzjkh4y8hr0ua"
-  },
-  {
-    "id": "terra1pksem0e9s7xdjf08j9swuyr5m677660qhyhuqk",
-    "asset_ids": [
-      "terra12k6ua9et2dnpmmq2rgz0wn0ugzr9jtyps5l8vt",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1saxejc25jretqgp4z6wj9me37qx8zg4lgzrmrx"
-  },
-  {
-    "id": "terra1pkuqexqszqcxszy9fpmxdnl6gwefjd7vger0jh",
-    "asset_ids": [
-      "terra1u4gx4v0nqgzm2kcajk3xf0d35gutwcvdyyjrnc",
-      "100000000000"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1w4276v5yzxa94ess4ryyfwanssfr3psgyk4jm3"
-  },
-  {
-    "id": "terra1pm4gx7u354nlgjdz0xf4kxpx977egdt6z5naca",
-    "asset_ids": [
-      "terra1v58klw3jakaeas2dkppqdh4y4dzd52kzda2fgf",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra17tdq6g3xqmwpk3q4mgfl0qcuyz7sqaxqa3n0rm"
-  },
-  {
-    "id": "terra1pqpha5xe3fhtvyplcuwyzhls8hgdupahujpyay",
-    "asset_ids": [
-      "terra15xf5wqprgzl59ckfyjtgavh7rqtxcju7gn57rc",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1gdndzwhsua4zw90pef309ked5h6npusgcu2j2c"
-  },
-  {
-    "id": "terra1pr0nnzw0elpqk8q2shc5gjnzaz95q4j8qy65w3",
-    "asset_ids": [
-      "terra1n8awtfqa0wphx90pd2zc9v8vccc65f0gvv6rq5",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra16znt4xty0md2k7e6evq8thsumhn6lm4kavqzzy"
-  },
-  {
-    "id": "terra1pr6tmhnve5cawzauzyzw5uscz558gzmd3d6wps",
-    "asset_ids": [
-      "terra1s8gu8mx2qcxpx9y90fxvdetpwq9mpyrapphw2u",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1ps2j3kp3gwjx56fsahnnkmzv2y9e597gqkulfn",
-    "asset_ids": [
-      "terra1u02kfjra4q9272p0ckq8yjtfc5qq6584amvrnm",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1psuy4666c74vz9exfxvupsxmkgytneq7gushws",
-    "asset_ids": [
-      "terra14l9lspj9lp2rpnhp6qjpruwcqst0yvl9cm6l96",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra13084cqs5f65aal0c7m4zefh7785t3wvvw6dx44"
-  },
-  {
-    "id": "terra1pvetz858samujj0gkx7rr5n8m0gcy5gz8lcxz5",
-    "asset_ids": [
-      "terra14tc6kg4my06ckzugrukq0r903sup3a6agdmx4y",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1kxqugyrr0e4he5furrqrehr8qhzqpfxxnt3vlf"
-  },
-  {
-    "id": "terra1pxlm7mjmqc4h4ht494jvmmwq840zn77eyex8yd",
-    "asset_ids": [
-      "terra14dtgwushpvu2c8d8rtc58z9r2t4p67ug8wl4d7",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1py6jq9p9qjjsqfg3sfj3stkpggyxl0sy5a006s",
-    "asset_ids": [
-      "terra1u2k0nkenw0p25ljsr4ksh7rxm65y466vkdewwj",
-      "usek"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra186hhp3gfmqf2353pekrcmdpajfveu56j0ej7ft"
-  },
-  {
-    "id": "terra1q0vldkwqgc2y2crhrcsdw2pacdt8nnrgvzcsf6",
-    "asset_ids": [
-      "terra1exgprpvwmn9we9xfxlqzchfqd533wtnafhg0w4",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra12qz82rul3ukhgaw06n2gv32gehermzu4zd8pam"
-  },
-  {
-    "id": "terra1q4nynp5mp4yhtxkyzegdkf594h94hhycmgxdq4",
-    "asset_ids": [
-      "terra1hpz206wxjhta4x83ukmk4v9rvk9dky2h0texf3",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1s6acdmcz4dnphyw8yctl9qmkxluj8u6snankqq"
-  },
-  {
-    "id": "terra1q6h4sgkulkxl6tq8tafadl899sc88zp4dj6yd3",
-    "asset_ids": [
-      "terra1p2enl6vfmhdfj7ud32p3fkgns22sg62ls9mh2e",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1q7hat4ymhtawg8agg70u74m8eu3q7qsg9rqmr2",
-    "asset_ids": [
-      "terra15wwvprh6gddrc7yvshghc2g944ufsq79ay94da",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1m7gu655my73ulr42zhaz466mgl65au8dwvp3vj"
-  },
-  {
-    "id": "terra1q9cxc20mhr526qhrct46ucrwxywmv3daa7a36v",
-    "asset_ids": [
-      "terra1vdpk5k7203r73fgl2ppwsg30vmtu5akgk0emse",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1fst9xfe8wv8jucvnn5afnsmkzqf3hu6yy2d9y5"
-  },
-  {
-    "id": "terra1qgksgy6g76jx9732u8dpdy7epqgwtyy0rwj53n",
-    "asset_ids": [
-      "terra1aa9kg8crxjq86ts54d4un6ku5skec9e98t6tau",
-      "uluna"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1n45t7tamwtrnr48f43pcq8krul8yf4kap8xfcq"
-  },
-  {
-    "id": "terra1qhpgt8pglujysknesj6jnea5tjc47upuutmee8",
-    "asset_ids": [
-      "terra186qt4d07ghj7dm2x64tyc0muw6rl2876jlhv38",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1gzvdqgg9zrgv92948l923hjnvxgldwaqzshla3"
-  },
-  {
-    "id": "terra1qkjrvyzncs8h2w6zyctm7etv743x0vl5syrc3r",
-    "asset_ids": [
-      "terra1vlrerpu78hdezzz8zzx34adpced73lmd0ujyqa",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1uxgl9umfun75qkv4gctl3fk4cqv02crsl5y57w"
-  },
-  {
-    "id": "terra1qksw58xydjsqh9swyv764jptsdfskzx52qvalg",
-    "asset_ids": [
-      "terra1v8xzfedstujqexgz6vd902hppykuu2e7ar3pu8",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1eepaxpggqy23hefzwj57xtfukkaq240mrmlnm8"
-  },
-  {
-    "id": "terra1qm7vvqg2jh5mwkd696luhvqe4mx96e4xuk60g2",
-    "asset_ids": [
-      "uusd",
-      "terra1lj0m5346vc6da9r9ljcyx7letcl3727g7wac62"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1xxj9nsxffy6hcc6mfq84fjfwt9k9e0n4800pgy"
-  },
-  {
-    "id": "terra1qr8vxrmlsyune368pd9nmgfuqt7kdek7yy6kwx",
-    "asset_ids": [
-      "uusd",
-      "terra1sa0klf6nt77z3afqlx7nq30xrvr7hsfz5jsqmd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1trdcl3lw5ca8ta7nfm5qh7w0mudfn6fdhl2qm6"
-  },
-  {
-    "id": "terra1qrlz2dl224glxn7sqa56wpdx7dz6yn5jlxm02f",
-    "asset_ids": [
-      "terra1sqagv65dlqj3hlg4fxrljlhfg5wulsp4nm58j7",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra184waaggxgdg4nevql50lmpeyferkmal7f904eu"
-  },
-  {
-    "id": "terra1qrrr4kqfqptd7wx0f45sgem6z8ejenh3k7esnx",
-    "asset_ids": [
-      "terra19tvczk4us839rsvet9ncwg8est73nmzecdewkm",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra12j3ye47a9jjk9jtjg7k8f0rs09hsvdpp6tpl58"
-  },
-  {
-    "id": "terra1qsf2sn65fjyc5hvm2v9a65qcyc23fnylr84fsg",
-    "asset_ids": [
-      "terra18f86dw6n40r6hqzjw0qsfe09nxesqs7vx2jkcx",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1cazwgay0h75rt78q2vxr6eggfk25xf4d0fwj7c"
-  },
-  {
-    "id": "terra1qstd3t9jv9v24ew6v430c42xfx9qf7mg7sg28d",
-    "asset_ids": [
-      "terra1kh0w04u79rhwvchmjsd7q4xxlm72y5wpf6a87v",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra18zs698tsn3600gtv4egtzx34uppcahzg7qlh8x"
-  },
-  {
-    "id": "terra1quwpd8khrwhuvqqk42mfw0q56nh524gu5zm294",
-    "asset_ids": [
-      "uusd",
-      "terra12wlcu0kgdfrfutjydvvcmhlx8jrfsqhwqarc3d"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1vawsn9qcgq9dcrjwldmqtmp9pj4373eapurm0j"
-  },
-  {
-    "id": "terra1qvy5r6r3fyh6rk9j93e9w63z3qu4wlmxemd0kt",
-    "asset_ids": [
-      "terra16gnk7mpqr84f4mnmqjklpdxxe602dn0fjslwhy",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1z27p3u53z9tfagnpffqe64js9l77w38ywyvefp"
-  },
-  {
-    "id": "terra1qxvf6f92f38wznvpyjqcd8ncppffuva79rvdeu",
-    "asset_ids": [
-      "terra1kafnpwanfluj6ne5t8ayg8ykarx060a50l72sw",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1qyag7j7s5z0d02em5g09ltgcztxpdguz3pkxjk",
-    "asset_ids": [
-      "terra18y93cy77qrxx65vdz959g2ngms55v3s3yythys",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1qzlnxa9mdnxkhs6wwf0xvx0hxqday87dgxn9yq",
-    "asset_ids": [
-      "terra1ulzl6vfexrk39vaje0qryarzlq2ahy80cdl4fz",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1mfs0xeakt59wemvwyelmh80025a3m06jfylx2e"
-  },
-  {
-    "id": "terra1qzrqt3phmawkrrzm8x8hwngz26nrpdgpkw5pmd",
-    "asset_ids": [
-      "terra1p0w9hh9aea5mg26mjnx7tl695ldwxfksvw4yn4",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1r3cjla7hlktc4vfa0dmzz8489e88k67yxjndpd",
-    "asset_ids": [
-      "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap",
-      "usek"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1r66l8vkzyhduuq7dfc8nm6p9wlwtnclve4wpxl",
-    "asset_ids": [
-      "terra10yycj46tjfnfhkk5d6er49gvcn28jpqk0spthr",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra10zlafqxy3zyfx2wh35mxh8xepp6fz3f3yl9e8a"
-  },
-  {
-    "id": "terra1r6dcz9whd2dxunau0vtp3g06n0yus9gfaq76pz",
-    "asset_ids": [
-      "terra17ckx25kqhwzf3fudprs78kqgp3lhpr2w74yf7t",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1r909kfjzeuj9nhwle2d6kg5jhn2af8j59lcsqj",
-    "asset_ids": [
-      "terra1pafrxwl8ur3jzjgw5qhts9vku68xsenctgqvkq",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1tc3llqz3ckh4ahepmv4sdxc3s4dvn9vqxtax9l"
-  },
-  {
-    "id": "terra1r96mse06m03de6jkx52ku45p36htc9zx8k89l4",
-    "asset_ids": [
-      "terra1vpws4hmpmpsqwnz3gljn8zj42rv7rkpc5atgt4",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra158g4r6gglcsst7ddua65rzfvzqums08y5m5dym"
-  },
-  {
-    "id": "terra1rcdumk59pxaem9my3frynyu3jgrkj9v4han9eh",
-    "asset_ids": [
-      "terra1sdm7qux8u0qtfxa6ukuh3zgppazdxlhmmjks23",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1w3z2lk8skrdw7ar9vq2kf5jeam9ar0m257k843"
-  },
-  {
-    "id": "terra1rfdh5rephrd37ga0x5cry9lek8eutf54umkk04",
-    "asset_ids": [
-      "terra1zdpymdwpyg5gj5ye4uvr0mqmxw8c88k5vqegfr",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1wq2tmhvx2yn3zqdah26sg3xzlaaxwd3fhsnj2y"
-  },
-  {
-    "id": "terra1rg9p352hcepvclfrxptpk0ua7a0tz4gcc0f0p8",
-    "asset_ids": [
-      "terra187lnjdwluvfnzxcef4appgr4v7fwljj5d5wdhf",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1d2muut0rea9fkff6y304yn6qkr2uacau7ltggc"
-  },
-  {
-    "id": "terra1rjdh8dj7jrjwz5dul7n8m9eyne92rvzftnjueh",
-    "asset_ids": [
-      "terra15afvt8ch38n8qj4n6wvykwkl2fqvfla826qdqe",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1684j38r062hr2nlwgf4ludpt9zk5g24g85syzj"
-  },
-  {
-    "id": "terra1rjv0jjm9mzgrj3grs2p0gvyuwpuf5qt9p30wwp",
-    "asset_ids": [
-      "terra1lesh2dshyf8a7wfm9fkxfrxjxc6yuyqnvspuvw",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra184ufgqclvjkuycs82j0fp4xha8r6rryp7luj7g"
-  },
-  {
-    "id": "terra1rn8stwf23aes786t37je7v8vxe9qwyzshrl9ft",
-    "asset_ids": [
-      "terra16z32tp6cqx2f7lpr8t4scv8hj9zlljagprxfh7",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra12eruh2ggjy2q8wutzsg2ww90nrucxm4hmuzdct"
-  },
-  {
-    "id": "terra1rnenevclqn95uhszznh6v25gaqswfejsvcatu2",
-    "asset_ids": [
-      "terra1f887h6wqygswcp4arjjak6mpdhwlrv6nj8y9wt",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1gmvqnsr262yea2ltxvv6qxqgl26jsl4ah0cw2y"
-  },
-  {
-    "id": "terra1rpcz0746qj4f6nwcpap8z5knjpf4fj6wmalupy",
-    "asset_ids": [
-      "terra1kx4y3y4pn32jssqr90cj0rw89ds98dc0t5eqfp",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1rr3rf5kptdtemsmf3g3jl8sy8rtamz2y6mcyh4",
-    "asset_ids": [
-      "terra1jkrl0xap6ptp8rd5lecp2j2sx3kws8rzxljsxn",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1syzg420suxvcarx38k7vep65tdqmpnsuth8a5w"
-  },
-  {
-    "id": "terra1rvjjnmeq5a9fje6r2guaxuezd7mhghk4t9cw4p",
-    "asset_ids": [
-      "terra1vyenreh8z62r35rydtupkqnmjsalee4tl90vn6",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1l22rm7mmajqgxep8lv4nuwzvuj9xc0xahfe9lv"
-  },
-  {
-    "id": "terra1rwezyr03fs72talr7g2gjgr9jmfew834u7gl5l",
-    "asset_ids": [
-      "terra1y273xzgr58qsdkc89xa6qu5y9padxtm265am00",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra17v6ravmxwz8v9je9w9c23px3zhcvajk4tndt63"
-  },
-  {
-    "id": "terra1rwsyvg7e67rald7d45833nsw487f9mt2wk7a23",
-    "asset_ids": [
-      "terra1tewnpkjdtqq37udf5c5wjfrtkpegthfmls8lp7",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1lyldsl94d3w3jhcenqjwsp4cme9jufur8fahk2"
-  },
-  {
-    "id": "terra1rx428v0rr62qcwd0cppz0xwj9qrh8zpqkahkj2",
-    "asset_ids": [
-      "terra1ts6qq7va0msf0se3cwjsppt3vkumkh3t6n4d8a",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra12awz2khk7ccyzfhstnzzgu5um4vt5yts59z4dz"
-  },
-  {
-    "id": "terra1rxwlts8xqulfrmx66whcknczmqjh05hdhwm4zj",
-    "asset_ids": [
-      "terra1ufsyu3ddskufc7nel5p4lyrzhv8qdddg3tl550",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1vhw9kpcshkr2kfrjke3pgp5sr5vsxdu2cjrf43"
-  },
-  {
-    "id": "terra1s0tfy4juc4pj4ke6mr9u68mnmgfapplhr52fr8",
-    "asset_ids": [
-      "terra10led4w62hglspyngk0ydxjsdvelvwthftevq0f",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1aef680pzs5cm30655wdz664v8jgeqtw76ptmcg"
-  },
-  {
-    "id": "terra1s2tkg3l4h4hrlsq6dnatcfhv97lyutpmxw0uk4",
-    "asset_ids": [
-      "terra1whwxszdwu6m4pup0glpfn7qhwmnh6a49mrsv2h",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1hfad2shn4h26g75t66yjasyg3qh84xlkp5g838"
-  },
-  {
-    "id": "terra1s846ywp9gdkjfmk48cs8pd0phtsnn842zsgsa5",
-    "asset_ids": [
-      "uusd",
-      "terra1m86rdykfvtwucrd0y0gzlel7wpcdryctak5wyl"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1dkpn37uh5f5j3u9rjp6ynpekm5kzd7ysfffqwq"
-  },
-  {
-    "id": "terra1s9gquy9js5z64eehsf22w2zq7dwr9a7lavuxk7",
-    "asset_ids": [
-      "terra1hja2d2790m6hynju77t56nhmmyl0w09s5acqhc",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1sez4t0zhe9d7lxlup0j8u4cnkz0qvzr7dj2lf0",
-    "asset_ids": [
-      "terra1qrq5r95txaregxpa2c7mhf549u5jkm28rzmvt5",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1sk902qkn05mm3j94eh6qz0rmj2rq4gfj363na0",
-    "asset_ids": [
-      "terra1jwjweh50vrd2gg55y8cr50e32jwwc0vuhvdymh",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra10fh6hy5f9t8mn09qzrps889qtew2km3zs44q9x"
-  },
-  {
-    "id": "terra1sprcgsnem4yrnzjd67wunkjnvndjr45jme060w",
-    "asset_ids": [
-      "terra1tw845kgt0uq0gfmavawacfvaq5t9fa9v57g6m9",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1aa22fmunt253n4hmuerm7p2jmt08trj9l43ne2"
-  },
-  {
-    "id": "terra1sqaw3rsp5w84r5hwvcvcgweqcxlrhxl3e5a9na",
-    "asset_ids": [
-      "terra17azgr4x2gz20uquy7vdacfdgjjkgd0h9lm377v",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1su2magsez6h9xwss3czd8wj6l3c8eujed09d8v",
-    "asset_ids": [
-      "terra1745fzfxnd8wx5kdrf4uwgj7k0mkqk64pdrh56k",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1shwul2pfd5x5k8am6ffpts369s533pcspjr7m5"
-  },
-  {
-    "id": "terra1svequ729grnrj2d8x609e45axajrdjz87athfh",
-    "asset_ids": [
-      "terra1zsaswh926ey8qa5x4vj93kzzlfnef0pstuca0y",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1gm9lk22dcd36c9s86pqdql6ll0w2c8tpnwye0x"
-  },
-  {
-    "id": "terra1svqq5rsjpvsrt6g365wrrxz3xje0jnjljax42r",
-    "asset_ids": [
-      "terra138zs0y4arp48v0vpzqa7r4ehxcy7sk3dpv606e",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1sx3clxk5yhqjq5j5q87jw7qu27cn7en37zk323",
-    "asset_ids": [
-      "terra1k9ltsdc6e4ay4g8f8nt8qd7my9yyd27m7eh82d",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1hggkcl2v8wxzpy0vzxf2a5chw2h2fh7avl7j86"
-  },
-  {
-    "id": "terra1sxxn4rxuqgxn3um6ly5lf9wsjuewrr7j8tvjg0",
-    "asset_ids": [
-      "terra1lnav098k7vd006lz7d73mychha503pmw35la7l",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1t4ee4m2merzrmz5uwuacuhk773wq82g32v6zu4",
-    "asset_ids": [
-      "terra1qm5jjajyv5pmap9687sgckc0j9hurlks3xzpx2",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1fvlf5y9uh3ylxff40eda4j60h52lnkthzhrsdz"
-  },
-  {
-    "id": "terra1tetfz00c58t656cg2gtyyv23jwh34sd590ue33",
-    "asset_ids": [
-      "terra13zl9thu8cgpkvpsx8r652hvgw4p2v42sahz6t8",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ysma0f8sw7254l8nnfylfl4nded9a8wj7mn8up"
-  },
-  {
-    "id": "terra1tf360u087hzhw54yymtat9wd5p5c9a3n5jvhek",
-    "asset_ids": [
-      "terra1vg6wky3jm7qnr4w4qtw6hflhlhc0v79z9jvnxu",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1xcxlsvm6q2nk003kqnhhddfcfm7dtnze02f3yw"
-  },
-  {
-    "id": "terra1tg8yu978lhcveq9j4emc9f7agn00dvecvx4wju",
-    "asset_ids": [
-      "terra1tgv52cmga9s6ymah2efz877xlpc4v8phq7mn69",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra18c9war4ldlccnast92snzt78ty378e0ggh8a8j"
-  },
-  {
-    "id": "terra1twxv2kaeuyf3uxc6uzpgh3twe4mtagzpmn6sj4",
-    "asset_ids": [
-      "terra1ghkclqug2jhanmjsx46x0vymcglchcesg98057",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1u2g4fc0k4tq6z6lrdwhm4gry3q55dg8k9anjtw",
-    "asset_ids": [
-      "terra1qq4lemqmahjfhl68kpzx0kheuuvfyeu4ncnkaq",
-      "ukrw"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1z0z6hz96au9lr027uedxay3s09ry36md3wpm0v"
-  },
-  {
-    "id": "terra1u8dt2feqxchklzft7n0s38d7kz2wwx7zqey8z4",
-    "asset_ids": [
-      "terra1gwr8mq2ljqzwmufgm55yu58339k55wja9529sg",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1quraxjgn87qe63h53mu8ksulqywsdlas648axv"
-  },
-  {
-    "id": "terra1u9hhdcqsd25q72dqme8hp8jkq6gq67vtg3rdq7",
-    "asset_ids": [
-      "terra1zpke3t4nprnh4044a4n97hwv384v9vff688cyj",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra18wnz4a622jvlhk5xnwuetk93j5xrkrpy23kqp0"
-  },
-  {
-    "id": "terra1uf6gyusnqzluacssjjdcjt2yme6wvx23ac3hpw",
-    "asset_ids": [
-      "terra1cp02hkhu2nq7zznz04shwfvh9hdsp3y5334n6t",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1dwnm3mxgp6svmtng5shfkc52m8d0xsagdx6z37"
-  },
-  {
-    "id": "terra1ufrkf9n6nlq35e0gdjyc5s7qx63mfhkxrsxkmc",
-    "asset_ids": [
-      "terra1cqxahw3zls3x5k9sngtyjt5qm8nzmzsleyx8hh",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1wm2rpkpd3n0e6mkjxkc3fy3a2nw9mcrrl0npj6"
-  },
-  {
-    "id": "terra1ufzll076stnpmlmndlss4uezlq58gmwc83c72n",
-    "asset_ids": [
-      "terra1zfqe2kf0kh8mvyy3ksa29qqnkhc64ncffufg7g",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1slr9qj73j3gn2muf94aysdaeex6ahk5ghq7ehp"
-  },
-  {
-    "id": "terra1umst8uwnuvd42aecxzf26jyy9eutghxk4xvlkn",
-    "asset_ids": [
-      "terra1rwskqpnk03hrh8z8rrprzdluxhzc5udycdn5g4",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1unvncye5u9qeme7amjf8snd889hm9mp93w4m9z",
-    "asset_ids": [
-      "terra1l0zqxdgs5h6tfdsvhm34mvwrevyt5cuxj6ewzz",
-      "uluna"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1s9gjv7083uvz0l90hdq2mq5d9j8je6w9ttax65"
-  },
-  {
-    "id": "terra1uqju4mlp0f000atx07xd49y3dlwe50e0d8d4xe",
-    "asset_ids": [
-      "terra1j874eyvev9pm7uxm0h9l82raswe3qwcug8wxuf",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra19t9e42yxukxuuqzyekccm5jpu3gek3nttdsz8f"
-  },
-  {
-    "id": "terra1usq239ur4z4utc8s4ecdrk09hd062nrdcdc7yd",
-    "asset_ids": [
-      "terra19pz3ehx9f2thr9t9jk5y89aalxmhzuq9j8ak99",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1uukk3m4qemzdjatzh8p0m2qrg95f2yc8wrfzav",
-    "asset_ids": [
-      "uusd",
-      "terra174c2cy42fl7hags7cap8j4xtsmcc0ql2s8q5du"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra13ae05947uryk5x2us5l5dgkhmedsxudnxjwfm6"
-  },
-  {
-    "id": "terra1uxwgfuyn57xqek4jgxajhd3270khgyusncarnv",
-    "asset_ids": [
-      "terra10t5spcvn5m52fs4j5tnjerm6wzsn9vuqdsheje",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1uyd2jx409kdesatvpwrvzkuvfyhfa0es0r9s9g",
-    "asset_ids": [
-      "terra13zemc0wmem8lt0un0lya3qtg4cpf9jcdsgtvf3",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1u47cpzrevxlld30cw6veflzj569k5ayyly4c59"
-  },
-  {
-    "id": "terra1uyq0vtcmzhz754z5rpv62u4skf7s4e7fuancwn",
-    "asset_ids": [
-      "terra10vvl9llw4p7ca2zhmcdljk5el9fkpp9hg6qy53",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra17wctee086rxqzng25jsm80u2mf5wx5lnyghuhw"
-  },
-  {
-    "id": "terra1v73xl4qu05ahep8c8flf83vvrr437fftdxwn70",
-    "asset_ids": [
-      "terra1zp4xkexmng539vylktxkf45hxjg68ufx673x8p",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1p62jdngzanleq5wrwehehwl05nkwzhuuld6nae"
-  },
-  {
-    "id": "terra1v8lsm7hmkdwrgcxtlv3ltzvpup0ez6dr8nxdl6",
-    "asset_ids": [
-      "terra1aas795lj3dt6qrsp8n38fr39ypt43p6czgz3ra",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra12a5st8kc8hlypk7lhe8tquljcs4z89shah98ce"
-  },
-  {
-    "id": "terra1v8mkxsvtjjdln52ltu6u6ak87uvmvgffwvt0vx",
-    "asset_ids": [
-      "terra18lxu0868tj9pek9xn3wlgnlv0hs3s9t6473saz",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1fhzyy5jgrjl2adhk3swalzdl4hnh0rmnusk9hz"
-  },
-  {
-    "id": "terra1v9lxv5kje00972tyf67qp7gwdc7msxwr8wf0j2",
-    "asset_ids": [
-      "terra143h4n4h3j36z64t7l8ey7vny6x47ukpz8s2gvs",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ty6nleg3m2lq7rfrlsw0adulaevsk76p4mfups"
-  },
-  {
-    "id": "terra1vd20ymyajdvafp3726ft5wlndnlsqmyfr6pr20",
-    "asset_ids": [
-      "terra108fs4ahf6zzy7tqpvczg5yrfjpqw20kxc43pq5",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1hgr37dvhd2r4mz0x5c2g60z0ggfhxy0a3lq4vd"
-  },
-  {
-    "id": "terra1vfwf4vd0yp47renczuqe8n7yrraxa2j7a7q0jf",
-    "asset_ids": [
-      "terra192g6ran4vfvyxhz0q7g4yls29fk6379hza6plw",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1cps2jsd3flznjzce86qyma34a4d45v0wz0yy4j"
-  },
-  {
-    "id": "terra1vjyvxsunxs6dvu5kh08chk69zffcqcntccgpf8",
-    "asset_ids": [
-      "uusd",
-      "terra16gx5th8mk5v62xpvgf675xj2vuaf3dg4v75ml5"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1hyt7x6duee8qxhnuyjdkmf5ucg27a2fjl7tdzw"
-  },
-  {
-    "id": "terra1vm6whnkl54g5zy82533r34fhuaqp58f9kn826c",
-    "asset_ids": [
-      "terra1aa9kg8crxjq86ts54d4un6ku5skec9e98t6tau",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1g80la29wu6pnme68wj69sskcnnqg7zha69fej4"
-  },
-  {
-    "id": "terra1vn3anrcp54lep043kqwvk9433r0a60xj2tlgpu",
-    "asset_ids": [
-      "terra1u02lqdhuhdfwph8wsl9yx9r0jupfdsd22q60tc",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1h44ahd05f63yamv553rqa0qzmfyp86j56smv4p"
-  },
-  {
-    "id": "terra1vnrd37f7cjwgu9zgn7whqcjjuclhhd38qrnqlw",
-    "asset_ids": [
-      "terra1c5wn5quxclujf8n38cu0sh2r4hq697lpc9385g",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1e92r33fhkft6p8fyamwu3zp300t5l35cjxf5tf"
-  },
-  {
-    "id": "terra1vqc0pcdz97llaglpf7gfjtykhxy5r00uex0hnz",
-    "asset_ids": [
-      "uusd",
-      "terra1ezkr298e3lef6hh5pzmvrtw0qd0kc6u7dgl5rc"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra12qzdpl39xj79ra7s8d5l9tvrqmwk4924hphlvz"
-  },
-  {
-    "id": "terra1vsyw78g3jfn5kelw09tttxfklrhewgtp62tw0a",
-    "asset_ids": [
-      "terra1elt5czsf7sntku3qafxf7xrjxdx309kkkmc8up",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1xm9vcuuyduxy8cc98tuaknnhv5tjv4x5350jvh"
-  },
-  {
-    "id": "terra1vu0hrz47per5rgq3mqjw272z3wgvk2x2qudvcp",
-    "asset_ids": [
-      "terra1w5pzereyvecexd9hsmlsakgnpjnlw56fgrha4s",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1v09eme9k7zfqjm8a5yf3wrc5t66qqfvm50x2ks"
-  },
-  {
-    "id": "terra1vv088zvmzzjv5qgpu25ym9mlgcuxhksqxnrcp2",
-    "asset_ids": [
-      "terra13j3uuywz8q3tljmqxt6trcgcxy29dd5exrnhtq",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1svsdduee7kk6ghh7hz4c2rk8tkagfkzaplltx6"
-  },
-  {
-    "id": "terra1vvvpchwf7rac404q070x2d0jr20l0sxkcgv8y7",
-    "asset_ids": [
-      "terra1pxuknzmg3kup7790vjzssjjuelrq3a3ys4aml6",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1ppaywpn8kyde0c0xngdfagjyq9l3jwudmckxw2"
-  },
-  {
-    "id": "terra1vzd3vra0zfnug80gtuwlc2j5rtucr87qkh4xmf",
-    "asset_ids": [
-      "terra152qpnfe76pnkwe8msfjxf4wjq0tcjtuuunv7eg",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1cz49n0uhccm0qdyd4crhjgrvrfhtucelr3u0fs"
-  },
-  {
-    "id": "terra1vzhsu5x9f9sglyq3acm5vq7hv0deemvdneqqw7",
-    "asset_ids": [
-      "terra1ex5age9gqd5em86wg8hu0ak5wrqez9yufvlrat",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1w0hm732ejcvyp59pru5e77j6wf92rdnkknf7u3",
-    "asset_ids": [
-      "terra19qcznmhmwf88lm75nmrj3prr6cmvtnz02hvu4g",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra18nvqp4lhezyw30kwuufplp0urggd0z9uge6ucr"
-  },
-  {
-    "id": "terra1w2aryua8k5s0a27kt9v8662jpsh4wglctu9z3h",
-    "asset_ids": [
-      "terra1pshxc56zwgm6j78mhjgn2rgkj5d32aa887l7j6",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1jx0n352z9jhxsu0ung276fukdcn64vvyujyp9u"
-  },
-  {
-    "id": "terra1w7cyg38vclgtlsw5vxgxxleky2x29p3lh36yru",
-    "asset_ids": [
-      "terra19ztfg6l5k22cw8xg2h0uncpg3kwpv84ft9h6t0",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra17selfzmc4a3dlgn5ewtwkg99a4hkhgtshh4z7f"
-  },
-  {
-    "id": "terra1w94sqf77fzlv9eh3fz8j5kmcdv2x230hnz9gj4",
-    "asset_ids": [
-      "terra1p0yttugxt3h2zvs9cghysmss3um6dp0mzt9vwd",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra13tlvdmr6x6fqddezpde0d3aadk3g6ye7u6l0ud"
-  },
-  {
-    "id": "terra1wcs60r56r743ws6nxv3tn9pgz4xqv3x4lgeqkt",
-    "asset_ids": [
-      "terra1s0y8aldsy3t6wtg5tpwe8xzq3lyet5e9grwmlz",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1drs4cetuf7hxry0xrh0vz79242f8clmtjpwhft"
-  },
-  {
-    "id": "terra1wgyq7kdeqeq70uzv04effzrgndtmtmevv4p9xr",
-    "asset_ids": [
-      "terra19y395vzlylv3s3nasr7cu4yey7s22ghqd35ps8",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1wkcrktmkp3wfvwqvydlx0a3g4tywjktke4pva6",
-    "asset_ids": [
-      "terra17pv5zcuddm96m0nuanw25u4p8nkc9460hz0sy4",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1hyc2qcu25cgg2fm75zee79a8au038mevhgaaql"
-  },
-  {
-    "id": "terra1wn34gxq3jyg9qtjxjfzlj42jzjeegvgymdld2c",
-    "asset_ids": [
-      "terra1re7as700g3gels30zak6ctnjtsjhhc6vjr93ms",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1wpawa65459fzfvf244rz8c8q56ampvpkjnpe6f",
-    "asset_ids": [
-      "terra1zpp3fdnpkrhpehjxvzz3wwwujmk0zxw5h4y0rr",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1q84pz7rtnmjr02uqkpjt75r5hgcjxf0l8qpwvy"
-  },
-  {
-    "id": "terra1wt43khwmzaeyxm77jnq47hyurrehzczyzxxds8",
-    "asset_ids": [
-      "terra1wx4h5qzvgp90ez53fgqr2s9t4rqzzjc03cjxr4",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1e0dkhp72ted6rcz2ptnggnvtfea2hw4r2luc5n"
-  },
-  {
-    "id": "terra1wvhxy96s86xk4mynuqggxhm46jaq7h30k8gphu",
-    "asset_ids": [
-      "terra1zce4mxwwdyk04txa2f3aqepzsq8jy7ca50gn8w",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1uz6m6h6seck9q870hnc8g2t8rxtzn5nwg7txts"
-  },
-  {
-    "id": "terra1wvnw3nkwdx7ut3ua4wwm5u0lf7sl3fqgy8kltl",
-    "asset_ids": [
-      "terra1klz458efcl7md99vafn5sdxtluauem0q5nqjtn",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1yh6uxxmr2yhuwrswkhtvq7wq5ra8ecyucdtewh"
-  },
-  {
-    "id": "terra1wweezy8awhrmqtszun57zh2xh5yat4pndv9ejz",
-    "asset_ids": [
-      "terra1fdg5u7nttkcw2v4sepgzlwsznfffn8pnml35pu",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1fxzmf732l2mj23wq3aryww50xg7gclhelvs2k3"
-  },
-  {
-    "id": "terra1wxl8ay7srh0cuwmtaew5yh7dap54f6vrayhnwj",
-    "asset_ids": [
-      "terra18u4zkkm5ddge6decp83dk9zmkx7lvhv2xkynrr",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1tyltj0lhs59mekgw8ej2dt49adue7mwa56xa2m"
-  },
-  {
-    "id": "terra1wysjqge8zc40e5g67vlaw0n2qu865pxxxv9sn3",
-    "asset_ids": [
-      "terra13k03g6n38f4m90pchn5h3nmk55xrnzt5ksvsml",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1wzuyqt38l99tdxzttx9grktr3grllgsqe02dz8",
-    "asset_ids": [
-      "terra1mfwgs4aglpetsyy4y55k9g9hsnp5xtcykknldk",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra14936pd4ptv3hkh2280qm3fx940srjvvx6gv8sl"
-  },
-  {
-    "id": "terra1x67kglh8uxc5rq4z0dsrv4az0rkfgs6k42fu06",
-    "asset_ids": [
-      "terra1epz3d7rmltreyt6chgnuv28cy8e0d3yad75xh8",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1vz850g76xvryz4jhpf2juamv40yey0ugh0pyjf"
-  },
-  {
-    "id": "terra1x6dvc72unfrdnrkyzvm8pz6kmugdzkzu66fd9v",
-    "asset_ids": [
-      "terra1t5y4xm7xdc7csud2j2aezxs6e4uuj3lqpqk7jy",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra16ut6d3kh5tw08lu9np7s9fqlxl0z3c2gpsqn64"
-  },
-  {
-    "id": "terra1x6sxgww5nrclca4thc6f7m35fyk5mgepe63pxh",
-    "asset_ids": [
-      "terra1a95wwge5ut59aet6wx9m5ukq0alnxj0waf4sgl",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1x8em0g87c30a3s5hqp4ar3ad732q7eclftwlwm",
-    "asset_ids": [
-      "terra124zh80answg0srxqynl8syswgsjx0heh9txxw9",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra152jfl6s4fmte2pe8ct0f0wtdm2k3xu6uesdfj0"
-  },
-  {
-    "id": "terra1x8rmne82kuy2gx26r3ecxrjns97ef8ckf9exvv",
-    "asset_ids": [
-      "terra1ldrmvk4n0le7tdaxj7r8gk5kny95r6mxw3ask7",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1xe69w9cuwz4s8e6nsxsf439pr2jyuhjj24s0ch",
-    "asset_ids": [
-      "terra1677xekxjqc4f3jqut8yr6p29e8h5zfay37et58",
-      "uluna"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1dypf4pfqw8a8whlkzhgrzew68f00z50r3hcd63"
-  },
-  {
-    "id": "terra1xen8n3l5sr3z9ad7mmmgdrhy8qa36wa00s45kg",
-    "asset_ids": [
-      "terra1h56g0tp38whpxlgdwcqdtgmrkkdyqerkymyklp",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1fsvjcrmalf6n9lu72p9cv9rum6x6nhg2343ghz"
-  },
-  {
-    "id": "terra1xf5x5gyg5x4n22v9tyv3mtxzxz86hmpd3jkfju",
-    "asset_ids": [
-      "terra1rxl2tv8jhv3rkhnesashgk8dwuvfa9kdzv36rp",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1aglpvqsrgcmwy4v93uezlmaftdqu3qvg9htlcc"
-  },
-  {
-    "id": "terra1xghv9y36n9nfvqmlksj8seysd3fftfgud3zgm4",
-    "asset_ids": [
-      "terra1dgwaqnzp9yt4w4g8l2kwxemrhlwqm50j7eehns",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1cvwy6kx24fhpeq4gjuyp2ynwcsxu8gtvk3mde7"
-  },
-  {
-    "id": "terra1xk2dnaqynl297f6r2yp5xp83yd5k8kk3mv8s7r",
-    "asset_ids": [
-      "uusd",
-      "terra1atpd4n3u6tl9ttqeqdwk303lcj2j7u8tpnx53p"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1mywz0a0fzzv69fxct84jj2777t2err6sn6pyu6"
-  },
-  {
-    "id": "terra1xlgl3xvkha2y6mssy9s4qe70sq295825sdmt2q",
-    "asset_ids": [
-      "terra1q59h4hyxvfpu2hp3v39r8rpl4wykqe7axrc9rr",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra165k229vdtpng40rhdfn3tqtqphwxeyjx5wrwxw"
-  },
-  {
-    "id": "terra1xtaxvdlfjxyea7qpz37f5j3py3cyafkycgy8c5",
-    "asset_ids": [
-      "terra17n0sj0ed82upz3c38px5hl2zy7mestccskauva",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1z364vxmwx7gadv0pd8ywul8k2k68rjahxq0c5w"
-  },
-  {
-    "id": "terra1xvvrm52lglquyp62kgpcww8489v4wqy9us6skq",
-    "asset_ids": [
-      "terra1r2p90ur2zy8javfhnf7ejdvzac60ax3wcvkvxz",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1xxrx7rgpzlep532ulyyndpm7g2md3zspgepmfa",
-    "asset_ids": [
-      "terra1ydznesu47hety3am8athucgp6hl4dcxsxqpka3",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1m5gwp6ujj0frnwkgxlkmhwu5we9xaysnwa6f8s"
-  },
-  {
-    "id": "terra1xzk9vcd53j2eql8zfnds9xfxy6z9c6ran3ld7p",
-    "asset_ids": [
-      "terra1e3s670y5lns7vlq3gxdcn9rv8mdpydhd89jdwz",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1y03ldlhcscet96kflc0fefnfkvug92ly3xmgr2",
-    "asset_ids": [
-      "terra1su29mtytdsev3ty2au5xlfrqrjcy696yeqwvcy",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra19hvxtwdprvaadfldxhyc0demuyhhz26z86r54r"
-  },
-  {
-    "id": "terra1y0cfekprajjqmz9jth6veq8pe5t2qurwg9kk4m",
-    "asset_ids": [
-      "terra1z9yq8l5fn7y5msg37rx2p0up0pgkf52ml4uv0q",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra18vvfrdsxefmheygjlw2d6835p969snpvm2xlar"
-  },
-  {
-    "id": "terra1y53r7wkxtajtsmn0zjqu4keqyd2qn5hv3ykmt8",
-    "asset_ids": [
-      "terra1tn2upc52zce96qprewh0gk5thvqqtuhaz7r6qd",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1smfcvgpdggf8jp7p3yvaqs0jl25ene6rwynn80"
-  },
-  {
-    "id": "terra1y6x737xg3q0nrqfgjkzy9ggfjmanu7675vva8s",
-    "asset_ids": [
-      "terra1f85kt39ar3tkscq6w8ylxv2t9qh4ktzayw35ta",
-      "uluna"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1td4yfemjtq38lq98vqhnywfmjec979z8qxqrx2"
-  },
-  {
-    "id": "terra1ya6tdm86gequ9wc7lusx374j2flgldv33426zg",
-    "asset_ids": [
-      "terra1zpz6dfn24cnykwausjt7qwfdqf87kny0trn94k",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1pl7nft4helwl8xt3ev0lknk4rkhrceve4s8lk3"
-  },
-  {
-    "id": "terra1yag6m3d3q60wnhpd8fm2qhn4uhkzpufazwz6w9",
-    "asset_ids": [
-      "terra1g7fa8wpfp56tzdd5mgz5r5jsvqw7hm5e3tdlnq",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1nl5wp6j8tna08ymthheynq0u0eam0gad5pgxku"
-  },
-  {
-    "id": "terra1yeh80vf0yezluv2u5nc6e5n8d4phjy4c55zvg3",
-    "asset_ids": [
-      "terra12fctlld90cakzkuhd2c3h246zxrhwqd6kp546g",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1vtz8425zxtpm8sng8u3grrdq5cruq4zeeh0cn8"
-  },
-  {
-    "id": "terra1yje5awrwutgx5p4mg3e8vtpnttav5f6y9m3rgh",
-    "asset_ids": [
-      "terra1mkw8x32086w0emr0wkprrns9j0c82nnxusn7dw",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1h3a58p3haxgt95eq8fwkptwscyppq0laque0f3"
-  },
-  {
-    "id": "terra1yqrryqqnvq9wgqad89dhdxwspspqzzj2dy03yy",
-    "asset_ids": [
-      "terra1x5mhyxzmy8da89rh7dnt3v289qz988hclyl6kk",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1l7hmc3k3zlg5r6jet9tuv846h735p3xjul2dh8"
-  },
-  {
-    "id": "terra1yv9dr0suw8njr88ls6ya34y2pevq45k5yg0vl0",
-    "asset_ids": [
-      "terra1my8t2mhxxv5rzjtzc8cppj8y76hy3apvcntttw",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1w3xdh7zpllve9d72anjtr5lkxndshggdw3zdke"
-  },
-  {
-    "id": "terra1z0g2y0d3eemtcsd253qd8vpl74a089deqas2hp",
-    "asset_ids": [
-      "terra1kujvztl5p8a45k56u42fq39jxldxcvuejtpfq5",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1uu0xsadf4x7v5q9vpgp2dd9t9x2khwqlal5rl9"
-  },
-  {
-    "id": "terra1z2p2vs8q95frqntrnqwkwmj9nempl83l3m699n",
-    "asset_ids": [
-      "terra17efcrd3glln324tqke56w5wgnfkfn5emz4um8j",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1fnr2j2cfapcuxr90z83sj0qjrtzt88sutz4cpf"
-  },
-  {
-    "id": "terra1z3u6mw3s20kt67ts9txrg2mjkzcwt7tgasp7gw",
-    "asset_ids": [
-      "terra12flsr4mk5sxmu8yk7m8zc5f44tfx00yjvzj7v4",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1z50d83kx5dke2fw2wtrs4kj6ae8ga2pe5vhwl8",
-    "asset_ids": [
-      "terra1pfynaj6mslxnlekjx7f6rxgfastl46c4hg3kg7",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "TODO LP TOKEN ID"
-  },
-  {
-    "id": "terra1z7w93yyhzl0vf6cxvt0c65ta2q48akft53uj3k",
-    "asset_ids": [
-      "terra10722f40cxl8tkxjk7f88uj0ehkcw6lu2j504f0",
-      "ubluna"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1naap0c8xly4fh5aq7vhayqrrj6pmt826r0uukn"
-  },
-  {
-    "id": "terra1z96yec8dxc6ummv5kkksft3agxmsaur07zxgq6",
-    "asset_ids": [
-      "terra1v2s7gkylfrnwsdcx8s83k5475nj3jykzs9gsqm",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1fn7psza4kxrmu3vhnelg08629uapvmmr48xnew"
-  },
-  {
-    "id": "terra1z9d33epxt9jaa4d4ta6rf5fwfysfufeumz4zga",
-    "asset_ids": [
-      "terra1xp4uhylkhwgam5tc97m0xfaxarajgf6wtcqwp9",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1vemqvqr0khzdtfl9909u27v977pthardrwf9zh"
-  },
-  {
-    "id": "terra1zl89gw3t5ykhfxtut3marguhyff9fwupmnmhrl",
-    "asset_ids": [
-      "terra1dszjh6392kc6avpztu4vdx8xl0qte4ntmue07r",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1pq9m7syytshndh2sckgxyrh83wsm59w4gduvg8"
-  },
-  {
-    "id": "terra1znka2za38gsj3p8u8etlfejqz4prf3snz36tnr",
-    "asset_ids": [
-      "terra1wz8w0susqsraw2smttuymzkgr3p8tgkntqhcre",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1q7vnlkn4gqgfqucjp8hadz6nzpma759qvjttsx"
-  },
-  {
-    "id": "terra1zzqkcp3e5apwdpsnavfrdrf6q0qf4esd556xg0",
-    "asset_ids": [
-      "terra1m9w3pdjst86dmfdamq5tuu4ny99e89eaavdz06",
-      "uusd"
-    ],
-    "dex": "Terraswap",
-    "type": "TODO TYPE",
-    "lp_token_id": "terra1tk7a0hcs3yehfzrscjhw824jq52ndvsv07d7zk"
   },
   {
     "id": "terra102a44aeeq4x78pmv5kj79qxaq2ghtsk24gj6g7",
@@ -7820,6 +2930,16 @@
     "lp_token_id": "terra1x6dwnqnr890whm0wtzz9td052s7008g2tg8ffp"
   },
   {
+    "id": "terra103kw7gde0cu8v7xm5fwm54dp7uyq8d58svtf8t",
+    "asset_ids": [
+      "uusd",
+      "terra1q93ws00plywc5prwv7mf2gdf7alhuqgk5w68lq"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1q88d7swxfd36kcfeqhgdncjrht9rsh7c0a9vm3"
+  },
+  {
     "id": "terra103ttjgs24wak64epwd7pl5qmqw44jzujr8l3hd",
     "asset_ids": [
       "terra19ya4jpvjvvtggepvmmj6ftmwly3p7way0tt08r",
@@ -7828,6 +2948,26 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1wvnwpt66528vajjps7m9daux600sck8mhx5wmr"
+  },
+  {
+    "id": "terra105cnw8azykz23ec9gtm06prssq9aqxg8pchjq4",
+    "asset_ids": [
+      "terra10jyyy0ylv34lafqv2mldcuxhk4qpdmnckgfls2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra16n3xcufpvrgv5nnrjmcg3qnypuq30vutmq4l8k"
+  },
+  {
+    "id": "terra105lwyhfuw0p0q39tghg2hxnjdarg6uy6n9s24n",
+    "asset_ids": [
+      "terra1xc5ll57yu269x8ysxvdpjmvxmac3js7pst5ddr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1g0qrmushesf6l7cwmvfm4nqh8dakrk3a7daq0j"
   },
   {
     "id": "terra105yxgufwjx5gsapk0n0rkea0dxvykyujx379g0",
@@ -7850,6 +2990,16 @@
     "lp_token_id": "terra132njtndm2rjcn4x95tq5qm5h98smn8a7hnvwj7"
   },
   {
+    "id": "terra108hz9wugglvu2rjty2xaddvwtr09ukd7kwm78n",
+    "asset_ids": [
+      "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1nzlw9mny82p598ue0d4skguwlffhl5vdszjr86"
+  },
+  {
     "id": "terra108ukjf6ekezuc52t9keernlqxtmzpj4wf7rx0h",
     "asset_ids": [
       "uusd",
@@ -7868,6 +3018,26 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra18tc6j7mmqk6fwt38la3uvespuxvefkw3703xdx"
+  },
+  {
+    "id": "terra10a9jdeled7uev64ugtmc8kzjlg9xv6eeey88xh",
+    "asset_ids": [
+      "terra1ewesd6y7dswxd8qdfff7vxl8g2p0dfwpanf5fv",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra16qlxlx3h5ty2t2fmdwrh8a35yqngg6hlmv0w56"
+  },
+  {
+    "id": "terra10apggvnqewuu3zg03l8nzqemuwtnfhnsp7pup4",
+    "asset_ids": [
+      "terra1gukawnd63qd9ptuqe0ejm0vvweql45084lx4pq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1y02yk8gwl7efuv76le3lrct9fn3uzs5a7nq4xh"
   },
   {
     "id": "terra10css4arzlu5ws98tz8dmsclurck3lawgddu0nz",
@@ -7890,6 +3060,16 @@
     "lp_token_id": "terra16gqa7q433a2q7d6ankxz0qk4pwet53fakazqv9"
   },
   {
+    "id": "terra10dua387cxqwuulwwpcvk6atwe5alkh6qky7xhu",
+    "asset_ids": [
+      "terra18ys4xv4yjy6c7984mv4sz08p3rpl8cdtxxhuhw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1kdqt7wfvem3nmdsrr5pwqlnhzl6w8xklqey35v"
+  },
+  {
     "id": "terra10ex2fzy8wwwykgcdl8p3ruvvh536f4mw8fxzzh",
     "asset_ids": [
       "terra1vpws4hmpmpsqwnz3gljn8zj42rv7rkpc5atgt4",
@@ -7898,6 +3078,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1dluesh3lqcgatxpcy4c4jg6hydkcc0echunw0c"
+  },
+  {
+    "id": "terra10f9t46rjhxjdm3324kkadhsm6adqhzva3y2g4j",
+    "asset_ids": [
+      "terra1nxwnngqr0ks3j842jlr6pnrmd79kztjqyycer2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1tdhcdlugvx4wwx9metx92nqpumahw9mzn7mhrs"
   },
   {
     "id": "terra10fkdl22gefrydr762n5gah45du54ykwgxw2smx",
@@ -7920,6 +3110,16 @@
     "lp_token_id": "terra1mmjzshcvdhtalmtugqalam7l9vk507ncmpu3q2"
   },
   {
+    "id": "terra10jnrtfv5vle4gdknnu55d2p8trd6lxzwc5shp5",
+    "asset_ids": [
+      "terra1f3nc4md37vcy9l89qte2p5tej42pr8rzch8mfe",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1v7wyvflxcxchx2zxu2n7e858wlx9u72pkku3hv"
+  },
+  {
     "id": "terra10jyd2dy3ul5z2qqh9gej2zd3d46kv9dtk7c3a0",
     "asset_ids": [
       "terra1rl20t79ffsrqfa29rke48tj05gj9jxumm92vg8",
@@ -7927,7 +3127,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1s8euv39e7ydrn3qnuzd9em4zmp7l8l3w2pnp9d"
   },
   {
     "id": "terra10k7y9qw63tfwj7e3x4uuzru2u9kvtd4ureajhd",
@@ -7950,6 +3150,46 @@
     "lp_token_id": "terra1ftd4p3rfcry6sgrwjs78s0562kmut3p6cpnq77"
   },
   {
+    "id": "terra10mwe766az3rz5u84h53z6u0hxq9jp6jx54z3jh",
+    "asset_ids": [
+      "terra1j9zvn74s7v2kylvv2xcg4p0s69pvejrw5qzv7j",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1tnj6gg7ntn9wht35uqxz5dpe6nw4fd92ukmhyl"
+  },
+  {
+    "id": "terra10qeuxxj46luwqk8huh4gcp2r0ve7w5vh3hrtev",
+    "asset_ids": [
+      "terra1ft9qff9fgumdca5qluxu3e8fh8xc7d4hfek8s2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1nwrrs5nt2klcspvhtacsru03g5mzsxvdx6p8jg"
+  },
+  {
+    "id": "terra10qnu9yudvcnm7we04xj8lu3mjrgx5lc247h0y2",
+    "asset_ids": [
+      "terra17ktj9hq69ae9mj49dwqfzmj05t6eqlkyywukf8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1xra8v827ml3m6zfylvzfv5g72mj4qhdk7snchy"
+  },
+  {
+    "id": "terra10rqw6xrzq2y3whp2r9q44zxyu5f8cdk0f4qa63",
+    "asset_ids": [
+      "terra120v2mhzge3mxat8nsz8ctqgy6f0cnnfjymsgum",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra139kpcz9239c35dulyqkkyqsdhnx99vhfk6q4fe"
+  },
+  {
     "id": "terra10u8rwg2wjj4x2wyyhddjkpkkp8v40thyyg0gwj",
     "asset_ids": [
       "uusd",
@@ -7957,7 +3197,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1ujpn0k55faap5cqav45rcs4qydtyekpqm3jyxh"
+  },
+  {
+    "id": "terra10ups2qsazavszk2ml0ed52rqdstuwr2qtuxdjd",
+    "asset_ids": [
+      "terra17pc8eq0u35yslg7zulkqzc2mvxryfj3hw7nmsr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra170c9286vqw9vddvfg4pemue5nxx6vdswxyccmx"
+  },
+  {
+    "id": "terra10v3f4lprsjx7wsxnmmah99vx0xw8q5zeq8zhvc",
+    "asset_ids": [
+      "terra1n4g9jamjrxhe5yssczrlq55syhxvwqkx7jpkjl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1v0wxjtv45n0emx87mlx8y8qy5e449wcj3t3gt2"
   },
   {
     "id": "terra10vatx9jkv4lcksugsrkajstw2duh834j5psxzs",
@@ -7967,7 +3227,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1js00fmassgas3hvnurd5va8u72el0ehvjxjw2f"
   },
   {
     "id": "terra10vpqzvhmy25pjgwkqt9eq22w3t7r7hta60gxgk",
@@ -7987,7 +3247,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra104hduate30ak42e42k284v66spfjmg80584csq"
   },
   {
     "id": "terra10xf7yakydjc5q4uye6zuuux8d3hxet2wpfk4se",
@@ -7997,7 +3257,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1xm9elzdgt0m8hpvy7kj3dwh3xd5udpplw84wm5"
   },
   {
     "id": "terra10xlgqrh0uhc8tt50wwqv3peh9w5zjjq3cz00n0",
@@ -8020,6 +3280,16 @@
     "lp_token_id": "terra1m9dlyzueyqy3pdl3tzwn60lc7myhum7j0zq5p6"
   },
   {
+    "id": "terra10yg2w6s5c38shu0l6mx0gn8u8ctdp8lr9xdplp",
+    "asset_ids": [
+      "terra1j3w0tswl56yxduhen4gnela7m4we86w9xkwaee",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra163fswxeuysgmnflm2hl75elytulp9qnxu4muqk"
+  },
+  {
     "id": "terra10ypv4vq67ns54t5ur3krkx37th7j58paev0qhd",
     "asset_ids": [
       "uusd",
@@ -8037,7 +3307,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1yjqnl9em87f77x4l7cj9ush02w9t7p6rvhmrgm"
   },
   {
     "id": "terra10zaw5l7aa8hcgfml5eugkmg3dgvrxhnxnsrtdr",
@@ -8047,7 +3317,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1c6q6u65steuen92250ev86rvm25yay3lx6008z"
   },
   {
     "id": "terra10zcf3z97m34kks7ly78ydshrcqf57fttc5sdrt",
@@ -8057,7 +3327,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1uysyjwea5505rk3h6caeax3thnnpfp4vx885gp"
+  },
+  {
+    "id": "terra10zgqdcpxhj0rgvm98w2slu9z09t8rk4fs5r8da",
+    "asset_ids": [
+      "terra1r5c53q49wu2vqerecdvua2zpvy9k8vlw7cnx25",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ces0z6rlujzjw2f6axxjxaqav8v8kh8tqmhpqk"
   },
   {
     "id": "terra1228ck5ztqu455fye2yg8jwm9nr7w7yzdjqzj8n",
@@ -8067,7 +3347,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1gggcqzd4su09erq8e3g8f9qdf7dydcj7mj9qdc"
+  },
+  {
+    "id": "terra1238lf7cayjp4f4fxle5v87eat6vekqn2zfh9w2",
+    "asset_ids": [
+      "terra17qy9f5h35504jxexwprsf6gtj009d3gjcml5pp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1m6hs2jffl6w3qtetxkuaelnasg0jhwg00yz22p"
   },
   {
     "id": "terra123ttrnasfv5htzt88phmm7v0r302z0lqh7l25t",
@@ -8107,7 +3397,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1x4c3g8z9p3ae3sdc4zkts4d253ws6nsyczckzt"
   },
   {
     "id": "terra126fv7f8e3qgpc0g74vnp0gzks57r8z2ec2jh6j",
@@ -8117,7 +3407,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1tlw7qds9n5pmw659488ugteq32ve6m2mdnvc8y"
+  },
+  {
+    "id": "terra127zvfgggng7zx3taaj8myslx28rrq28ffycqxp",
+    "asset_ids": [
+      "terra1ttm7w640scqrarn0qxqz26798d84u94sg7gshw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra14un4rp20aqq7h07zpgzxrz2fcwsplj8jp0jham"
+  },
+  {
+    "id": "terra128s8lplqeqepy8vh55cr0rzdhe66v9h3n52qk3",
+    "asset_ids": [
+      "terra1lnucwh7feutx0y8dgh3lu759a6netxx4wjzm4w",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ekfxyvagzayn32m6jcqylzefdtjnhkcnwjvwre"
   },
   {
     "id": "terra129a0pp22q8m2m9lvd7n93pzx5eyjw2tj0ueunn",
@@ -8190,6 +3500,16 @@
     "lp_token_id": "terra1cahp2lp0zjcuyx25rcau04v8x7jk3qllmmhrx9"
   },
   {
+    "id": "terra12guk0mlt4jknln7mu8y7kjdaglqehu2r2kk6d3",
+    "asset_ids": [
+      "terra1fc38stp3xzjh5q8u0nrlk4n0gagxrnen35rsq8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1jcu9exrj6ejq8a4u67xf9htmrn2dup8gg9kwts"
+  },
+  {
     "id": "terra12j29ct74f4wx0vrz54c96sl4gvz5a3k7mynzrq",
     "asset_ids": [
       "terra178v546c407pdnx5rer3hu8s2c0fc924k74ymnn",
@@ -8197,7 +3517,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1u7ym5zglwd7q0ppstuzaqfelhxw9p94czrcqdy"
   },
   {
     "id": "terra12jl0hnmgrs9j0tv8u7pfqdey9nukmmk7vehgkz",
@@ -8230,6 +3550,16 @@
     "lp_token_id": "terra147g92kn88fhyjxgt4lut827smfgtjqngpg8873"
   },
   {
+    "id": "terra12lvqty3v0ncnxn3s4agekcp94akp95n7qgv289",
+    "asset_ids": [
+      "terra1kdkcxnsldqmj50ll77gmq5x26u69z8m69hdas6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1va79wsdl4zrs2f9z2eef3c76p7akhuk3n654gc"
+  },
+  {
     "id": "terra12mehtwqlcypjlp6u6mf7k39c2esjd2w4fw4ke2",
     "asset_ids": [
       "terra1dameg63csxum2hspscam9h6d33chnqa4wsn3sp",
@@ -8250,6 +3580,16 @@
     "lp_token_id": "terra1hvz34zmk4h6k896t94vd8d5qjdchhnkdndunzx"
   },
   {
+    "id": "terra12qgav8q2qa5x8me759ajhf3j64525qumznc8h7",
+    "asset_ids": [
+      "terra1572yxtl5yxa9mjyzg44gj6knemudreekplelxh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1u3m39v7vs066wazhl3manl8ztmyxpafw7ysdr2"
+  },
+  {
     "id": "terra12qjaagzpkz28ngtpg5ugelsmcmtl7x4w4nuuz0",
     "asset_ids": [
       "terra1z8ta6q6tfvp3sec0f4yftt8ew656d0x8zhgp66",
@@ -8267,7 +3607,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1yyngu9q2jc9det2lp3ffkam4cwm6jqj6ljcv0p"
+  },
+  {
+    "id": "terra12uem5pwjtllme9dnw8ccw39ewvgyetrhnlnhtx",
+    "asset_ids": [
+      "terra19245ct3nfz95j3peem0zxy0e8e0w2uq4n4ssr3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1vv7cqzr6ppgkueq4qgykfjfjsdlufvpljcxf8x"
+  },
+  {
+    "id": "terra12vqe3zqn9t7j7k7r3u22mpr3pjq9w3gnmx6pd6",
+    "asset_ids": [
+      "terra1e05lrpp2tl6sfm8p095mgn8hqu9c42f9sn0eh5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1y097nnhjger6l3ds9r96xfdpq7vcdp5yh70n6x"
   },
   {
     "id": "terra12wfnxnvzd9fjt3gyw38mhncw027n2kd3p8jf2x",
@@ -8290,6 +3650,26 @@
     "lp_token_id": "terra1dp5pt02qxmla9a88alp3ljl5m97p5ge690p50h"
   },
   {
+    "id": "terra12xwh5s8nxl2tr9lvshtv5ny02g349sdhgca4zs",
+    "asset_ids": [
+      "terra16mvysduudq3ys8vn08c5ts8yx08g5vahjaylq4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1hqz4rpdymf0vdmmg54r8fzr95uwtq7m7stsqzs"
+  },
+  {
+    "id": "terra12y07m3ra6x6qgl4jl5jt5t0qvk7smft3ye4l3h",
+    "asset_ids": [
+      "terra1nccuq0ujp4hc84kjmfwjc3002z2q7xzmdu6crm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1jv5v6cskf8atvn0hlnmuhp3vpqypk76qjw9xxn"
+  },
+  {
     "id": "terra12zwtkdu6qhs4f8jw9zvdgrwl24mwag5kuh7gus",
     "asset_ids": [
       "uusd",
@@ -8297,7 +3677,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1283mf36gl6zks6yxr50mc5cvzvg26qg50mq74s"
   },
   {
     "id": "terra1305xtjl5qtlpdlp8gg0k8u4yl05hj7qvyffvd4",
@@ -8307,7 +3687,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra14nhfccre389ypnmfr5s462gyhe05naqzwumss0"
+  },
+  {
+    "id": "terra1323sdyuhfl05jkhlk47ypmhtyx2chzv92tnsn6",
+    "asset_ids": [
+      "terra1tmar57largkrtts55q8szey2q78zc9em43ej5n",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1phcujfuv584t5mrmmxtag00pn36kscspec80gy"
+  },
+  {
+    "id": "terra132hq2uqczg2d7l4czhtcdwwlgl6cga6rs3nv6p",
+    "asset_ids": [
+      "terra18zqpuua4d8u9q9d6zsn8fqtjj5k8hk845prz9v",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1cu22t7m64dpm0fsznnq0t74etu3p0q2xh974vu"
   },
   {
     "id": "terra132qjgv0evru0em6v2rcwakgxzafjhwfz7fc7hh",
@@ -8317,7 +3717,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1495vu7s83d8kyqk4lzawajqt5d27pjfd8ym398"
   },
   {
     "id": "terra133308rh6p96pxw0cztmfln8av2jkxnjlfvfcyq",
@@ -8327,7 +3727,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1nz7ualeu7fcdayv64nmaypdd6e4hda9tgl502u"
   },
   {
     "id": "terra134ce0ucmswxcsjl0st8p36hgxk0edty06nhhv9",
@@ -8338,6 +3738,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1p5qffpcsqjk6t9v0dn3luzj2lhxnep09d8pgep"
+  },
+  {
+    "id": "terra134jare8j7annsu6fgtkpu6zp8gmfau88jrsnaz",
+    "asset_ids": [
+      "terra19fd35n93667mg020fj5lupws9rhkw59cw459wm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1yp25tl2335p6usfwtfl0qt3z7utglx9zrac4z9"
   },
   {
     "id": "terra134mvek3w6tp9rzgdklv9pndpdkc2gqvf24um3l",
@@ -8370,6 +3780,26 @@
     "lp_token_id": "terra15uzdzdpv7gfzl84yhx53uz6769krhf6krd3s7c"
   },
   {
+    "id": "terra1390zekgvzfwdvjfghh9fxmaxq4tzfzux59slpp",
+    "asset_ids": [
+      "uusd",
+      "terra1t8wkdq7kth8ngxgrpltwam0gv0h88ajh0get5c"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra14uuhfjnxewphya674fgf7t0g3cn32uryrgkm5k"
+  },
+  {
+    "id": "terra139j7k5lfre6kwy6lh2d37tkvyj07h7aafke3qj",
+    "asset_ids": [
+      "terra1z3ejshh0vwkdr35wt9eyxetsqm6mnraya8myxs",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1rcdp0wd0qww62h69kex8f9c99549902dp7huf6"
+  },
+  {
     "id": "terra13awymgywq8nth34qgjaa6rm6junfqv3nxaupnw",
     "asset_ids": [
       "uusd",
@@ -8380,6 +3810,16 @@
     "lp_token_id": "terra1aw52tgnmu3dfeguy36vm3we3ju0v6dhnvkj2cg"
   },
   {
+    "id": "terra13eclwgxxns9v0m6nxveug7m54v49fsfx9fn88d",
+    "asset_ids": [
+      "terra1wdz268njqhhpy30qcd6zxmvtu5y0xr06cnkdqq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1jmzlups5p4upfx995j824vyngnahsx5tjpk3m7"
+  },
+  {
     "id": "terra13eyn98smadfflnm0jgt04q5dqzs3dtjg6kjjrj",
     "asset_ids": [
       "terra1hfyxtste6842zulmjv9n92srv803q6rhn7t8d4",
@@ -8387,7 +3827,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra14y8k4uux6x76wjqdy9vpqqunhtmjsd5vu0jxv5"
   },
   {
     "id": "terra13h83g8cv50e98kk450pkpk76fmjeryd32zvef6",
@@ -8397,7 +3837,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1sxu9nuzung9tw2eklqf80tcm3nyct68tvn42lr"
+  },
+  {
+    "id": "terra13ha9p29fpj4cckj6jr3m743d9h9v9nv3xcmded",
+    "asset_ids": [
+      "terra1atagmw0ssv6wlgmrjjdaa22p7h4wmsy33eljgw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1mlkw7ja6gdy4nrrlv8xxtfxh8guuwzz7w38p46"
   },
   {
     "id": "terra13hmvr56ld8lhtdxkzw9q08lkzscnjlsa8jff2r",
@@ -8417,7 +3867,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1ky8la6rcvuj7ks02lj0vqsg808jj8rq6sy5lux"
   },
   {
     "id": "terra13htj4202asg8fdmyq002zm53j7h4my8q4kdddt",
@@ -8427,7 +3877,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1q4qtr2pzzqg6ukdymazqux9vj9w3t0lqet0ygd"
+  },
+  {
+    "id": "terra13kqma6mk7ylcvg8u4qmfcwyw3wfytdgwwszmqc",
+    "asset_ids": [
+      "terra1uf95uwdtg7rp734pmadujg2ukmuc88fph2925c",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1p9gjvxkdefm98aghrv98nj5g3j8vp2qq22kg6m"
   },
   {
     "id": "terra13kvcwhxa0ym2tpgcchk0rn0zrrl7r7w0mgv74q",
@@ -8437,7 +3897,47 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1n9w80dcemd9uys5fjfv6detru9vcftservvj5n"
+  },
+  {
+    "id": "terra13l4d3vq7kurmyah9fxcjv8zdqdpndm9n0zs954",
+    "asset_ids": [
+      "terra1nywvm8avu8medrj84x9dxdc4gfdqd2zg8gv049",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1nwe7rgzr8uk9w90h8trgppew6kf9x9a3jevpep"
+  },
+  {
+    "id": "terra13l96rf63hd9ysruu9ma0vpjwwnjuk4e05tj7xy",
+    "asset_ids": [
+      "terra1fd2f52tmq59mc093nrawdaey5mzgjnwyu7hwqz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1f6jappjsusascekd2uk8djncfwsh6ygp07h7mq"
+  },
+  {
+    "id": "terra13le0pfhey5ltg42z8e2cq2yt8jxu4ry3tdmwu0",
+    "asset_ids": [
+      "terra1vnkmt0cwd5k870ny0e2crt2yrkmj0cfd3sylvc",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1klgaa9lyrcgdwudd9mvu0ys2spdsxd8mk55ure"
+  },
+  {
+    "id": "terra13lnw7ytlt0cjtjtakgewfzydq3nmx7n9q60gs8",
+    "asset_ids": [
+      "terra1extnklxgx3sylp25zplvxsfarmvh3r4k6grskj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ygp3he69u96xzy09krfa5rkpyk3mjcmrl4dp4r"
   },
   {
     "id": "terra13nerldmwsc5gal4jtjr2t04vng02q5d7nthqtj",
@@ -8447,7 +3947,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1jvyqwekdywt2ggjxqqq9f8w58yft0y0zgccd45"
   },
   {
     "id": "terra13nwgt8kxyat5pt70faxnm8dje0c67hwsp53d5x",
@@ -8457,7 +3957,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra14kzy8xfmzq8pugr6fp92pcer7nuesyyeqt8d9w"
+  },
+  {
+    "id": "terra13r4plx4hme32jmzlmsyah9ulewyrq56krxh84j",
+    "asset_ids": [
+      "terra1g36mr60pqf8x4hr3ulpsptrg84w088m0eunsw0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1qje7t49vxtulwq8lw5re455hnj3r266uc7lquh"
   },
   {
     "id": "terra13rprqshf7dxn48v0aaztv5c7ytct6t6u7djtlw",
@@ -8480,6 +3990,36 @@
     "lp_token_id": "terra1egnufc5nzjch6r9nuan4ywc90nmtyr5fqq6cv6"
   },
   {
+    "id": "terra13tngwuhz27g97gue2wg36nsc73agv9axnjrmd2",
+    "asset_ids": [
+      "terra19k974ngjsml8dtmk56cdhuy6pplr94rxqdt95p",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra12zfj4sczu849y7q3kzdlxxd9x7y3wjx5xtjmau"
+  },
+  {
+    "id": "terra13vj9z3cjvtg0v7uu00m4pwd7qw5faznuvr6mhf",
+    "asset_ids": [
+      "terra158gqaxafjche7vtew0f4zk9g80224qr07kwfsk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra120vlcdqz23ssmpvdeysq75a47pjy5shlxya4zv"
+  },
+  {
+    "id": "terra13vkjx8agphchqzlntq7qn3et86ev4nga6uz9dh",
+    "asset_ids": [
+      "terra1pjnfhsvg7g52hfkdegr4apz7ax9x9xn0n2eayj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra12ms0jp4kt9r3s4g2w5dphu8vqf027x6u0t9z25"
+  },
+  {
     "id": "terra13x30y5swfdjw4hhwpur83gljsf50s4afmmfrj4",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
@@ -8497,7 +4037,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1xz2yxgnwhqrufj4ty245m7uhavn8zy3ylqq7fz"
   },
   {
     "id": "terra13yc7dcphaxpgd538msys7r75d3lwa5mu9u6d88",
@@ -8508,6 +4048,46 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra17vddhyh8zulk4yx2zapsk9z5y5r5mjaf9w6egv"
+  },
+  {
+    "id": "terra13zhrlgpz2zmw6c9vd8lgc60qfysdn97sgf2hej",
+    "asset_ids": [
+      "terra1h067erdar0vs6466jafpjsd7nahzwghtemn6y0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra10j58rxwrw5fqurt3yludmp9j7xxgxtn9k2thk2"
+  },
+  {
+    "id": "terra140dcz7t06l4llh38u62wh8rcm0gus9dd93envl",
+    "asset_ids": [
+      "uluna",
+      "ibc/EB2CED20AB0466F18BE49285E56B31306D4C60438A022EA995BA65D5E3CF7E09"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra13ynn6xnvm6pj9hgaw0ywkewr0nv33qgc0pt8dp"
+  },
+  {
+    "id": "terra1452cjwwujuejcyy2jujmw54aae96dsyg063ycl",
+    "asset_ids": [
+      "uusd",
+      "terra1y5ffh484f3jcy62zuslx3qlv0n6c4zsffjapm8"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1gzu6j09js98082arj8a0nxlz47enzp4m0sp588"
+  },
+  {
+    "id": "terra14572czl65ta5gqhpjfehk47yytdxerpntw2h5w",
+    "asset_ids": [
+      "terra1efu7hut9pywcgwj74klay9mlzswp542s6fa0zq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1tpxyhuyfwqe5a44crzf35pvjv66v0eu2j20kpr"
   },
   {
     "id": "terra146c06de7zllrc3r960dmxq4m5q076fvw95529p",
@@ -8547,7 +4127,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1kyxge285zakkmet7fyam99f39xyhkh8ntw5gf7"
+  },
+  {
+    "id": "terra14cqsw04rl6lu5dghdzqz5984rjd3rryc2psu2d",
+    "asset_ids": [
+      "terra1jw43a4x2jdftvk9ylfyuqhy9asam4ymjufme44",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1s9rf42yddzzxqr60l0a3dtf0qqkhq7cukql3p0"
   },
   {
     "id": "terra14czsfcd6j4z8ffyekkgsr4zkpw8tdnec0v9jz5",
@@ -8557,7 +4147,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1aukvhzg6q7357zzh5ydyzjc6y3ye6meg9qn2yt"
   },
   {
     "id": "terra14dvkhl6xzg7dj2e60vasr6vcvh3354wwnfpv0d",
@@ -8577,7 +4167,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1z6detujgnxu24gv8htetq3r6qhy63tmtk4ff2h"
+  },
+  {
+    "id": "terra14fgsnt4y6x7npwnnpq7nepk85fzz59vqn562v2",
+    "asset_ids": [
+      "terra1c5p65p6q6ekfav0k72h5ez23mpntve5am07mpr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1q03qkg493g267tyympe6qx5l5v4de20uwupnn4"
+  },
+  {
+    "id": "terra14fkcayxsf0xg4dwvn7xgtsyhzff97zckpzlzhv",
+    "asset_ids": [
+      "terra1udknntc8sjm4ntxezhlqe6p9atct00r296aw95",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ce4u5ecla5klh9a68mjugq2aj2zqffrar4vzwh"
   },
   {
     "id": "terra14fyt2g3umeatsr4j4g2rs8ca0jceu3k0mcs7ry",
@@ -8588,6 +4198,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra16auz7uhnuxrj2dzrynz2elthx5zpps5gs6tyln"
+  },
+  {
+    "id": "terra14gsl8tl6pwe4xmtuc4c78w356n66klmh8xn26w",
+    "asset_ids": [
+      "terra1ra0ljqpyt59k7z4xrx93ef5jvpy67f56lhudf9",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1uasdrlm92p47mvgtawcjmn24ut2a44mykyfz6j"
   },
   {
     "id": "terra14h9hukadz5qwm4jtxjrvnpnj52ynrnrcq6wjfq",
@@ -8617,7 +4237,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1nvhkaq2r992j83gnxgjwd6u00a86zdmje93jvc"
+  },
+  {
+    "id": "terra14j82htz2rhn47jasltna6tnqy4gy2097zf2pat",
+    "asset_ids": [
+      "terra153u8c40h2mm8nvs0daqxsnwgvpw43muxj3c28h",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1sa4y2x977nn4a9rlvpajx3mucyq2qhwhyq6gct"
   },
   {
     "id": "terra14lg4pfn3s5p4zcmujnppvpr09n5a7583cz4czd",
@@ -8627,7 +4257,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra15m3ffdydxu4jz2d45q2jwhfmwc9vuk85syqsqa"
   },
   {
     "id": "terra14m7prknmsyxjey7mkafl6340ckvnn6ve0uuxlr",
@@ -8638,6 +4268,26 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1e4uxrgeezzcw33cfek64u7kq55jyn5dsartakt"
+  },
+  {
+    "id": "terra14m9xq2tvculdx22kunc40te7gfhylx0v44qj3r",
+    "asset_ids": [
+      "terra1elkjjsg4vm5u4tnesqcj3dzgvhanzld48lkqv2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra14t4pe3avwql7s3d7euz3jrpsjzrgrl50x4asv0"
+  },
+  {
+    "id": "terra14ma9cyp3xt9rj3jz6nmz8zteujuphuyssv7vvj",
+    "asset_ids": [
+      "terra1smeev4u44zhv94cn4pyy9dtsshup53n9xefayx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra14nszv45yz78hm2n69rq69g5xa2l4cznak4aa4z"
   },
   {
     "id": "terra14n525nzgnsqpy5ne28ffj6e2ul3c3n7hkv5ql9",
@@ -8660,6 +4310,16 @@
     "lp_token_id": "terra17cfp93qzf62qyds74jpcyxvs04cvrmf7dd4hau"
   },
   {
+    "id": "terra14pq5tphkfpd2wphq47g7mrwmvt7x63nskmkkrc",
+    "asset_ids": [
+      "terra1m2ar36pnymh6h4n0p7l2w4uxswc70e9auyvxh6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1rxft4gfmy7s5suhmn7jpu65qmct8nps09ur8ds"
+  },
+  {
     "id": "terra14q2h9nce4spj8n74g6kppj3yf86qx8hsrqngfh",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
@@ -8667,7 +4327,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1h5egnh0uu4qcjx359fgr5jfytjsazsynhm7lw7"
+  },
+  {
+    "id": "terra14qtsl0gqwnlz5z72cl9yc52lt8q464zhsx08tq",
+    "asset_ids": [
+      "terra1atcayac92cwn9x6fcpxnjzycvmkkhwsk53tg29",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1fpaehunc4mdk0vmkn4g32epcf7yl523nujrjsw"
   },
   {
     "id": "terra14rmvvzfs88axcrk0farsdswylj55umpj6kqh79",
@@ -8677,7 +4347,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra184dw47xvmz29g7aem7evwe55pqhy96xq8fy8rv"
   },
   {
     "id": "terra14t6yzxt5vhx4dyjknzj78tge6j8385awnczxpg",
@@ -8687,7 +4357,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra13hf5j4de47zx42ak2sleh4wkyvt0hsz2dfl2zl"
+  },
+  {
+    "id": "terra14t9rgrx4t53un932r8jtcsgtrqqvvucndte4cg",
+    "asset_ids": [
+      "terra145nmjpjhergp4uw02hp079phtnedslmxv4v3n5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ga4yfg9uclqmaeg8trv8yaydm9ufh82cdqea40"
   },
   {
     "id": "terra14tqq6d7n79sfjmeeqgkmewyhq65dvczgym5rhq",
@@ -8700,6 +4380,46 @@
     "lp_token_id": "terra1z6x7xnsgye3gzs2mlj5v2gmyw8c35amrgu5327"
   },
   {
+    "id": "terra14tzfka0vjjw8sttpkg0nqlrs5a078ngmqxjv5h",
+    "asset_ids": [
+      "terra1dd2qt59v86gwgzl2e6u3xexefvrkjmgd8mu638",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra12nl2t220t5504dgaxl7yj68vfs39xky7zux2pa"
+  },
+  {
+    "id": "terra14u4v5ms29m94jvu2nn37jep35frmg5u6a2qw8h",
+    "asset_ids": [
+      "terra1fhsljj6qc8f7cnu62e8uxqt82czflztge05dwk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1fwx3235vfpcwkv68nu2vv0cm2sda3dxtdtnpuh"
+  },
+  {
+    "id": "terra14u72dnthxnct8gqx8zxjpqza8dkr8nlc7w2dk8",
+    "asset_ids": [
+      "terra1rwph273axfefh8gh57scw3jfm7kn4s7t5hlu03",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1zrlt4v8jzrsst0zq4ug98xaz0rmerpajff63yf"
+  },
+  {
+    "id": "terra14v7q4ujj95wx0leltqsxdxy97gzgw4g4q9656s",
+    "asset_ids": [
+      "terra1uv3298xevlfdcjthfv4me7tn7gjxd3drv6ejvt",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1fj8zwe73graryv3jlmgtt8a74agw849jrl3tfg"
+  },
+  {
     "id": "terra14wt2rhghhtuyl07h4ls78hjuh5gk4nxj66u2tp",
     "asset_ids": [
       "terra1vlqeghv5mt5udh96kt5zxlh2wkh8q4kewkr0dd",
@@ -8707,7 +4427,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1vc96k8egcj6wejqjd9k2ng52qlnk4ncucaa2dh"
   },
   {
     "id": "terra14xpe4dx4xt3cxmyhlnnm4rhpn3umhw0peyva5u",
@@ -8740,6 +4460,16 @@
     "lp_token_id": "terra1y8kxhfg22px5er32ctsgjvayaj8q36tr590qtp"
   },
   {
+    "id": "terra150cw99qkvwafxw95vyef7d9upswsmr2wf7xyh7",
+    "asset_ids": [
+      "terra1z49dpvu5g4st7t4j5lsaxaq7v9u6f390m28ap9",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1nu25e6fzs456lh27gpzyq4gn3vpedf7cut5020"
+  },
+  {
     "id": "terra150jz4237l3dfhhpppdrnz78hp0kw2ujqczf2e0",
     "asset_ids": [
       "uusd",
@@ -8748,6 +4478,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1vheyufspfcfh3ka9nafmxec0lwzls80cuf3sd7"
+  },
+  {
+    "id": "terra150scqwurj3m6d5n0yt82zer4w8vsdf6hzl6fcc",
+    "asset_ids": [
+      "terra1hwcnalcf35p48lvj3wt7tztkzh5szmpnxwyvdc",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra12ndzg4g6k6q48hasdrrk7rul428npl88ljugtf"
   },
   {
     "id": "terra153xclqwcvxch99mclac5fxuu4cmeu7w7mamghu",
@@ -8770,6 +4510,16 @@
     "lp_token_id": "terra1tpx744z60ysm4ntrpk84whqp9tunmrgzm6utcf"
   },
   {
+    "id": "terra1558wqfc8ffq37qj3cjfkgfj6r5xflh7gnfytw9",
+    "asset_ids": [
+      "terra1tdvvjf700gerwvkwncjc7nzythdewstk47ah93",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra17ntlqfva06ga9jdmz0t6mhqsmvr5lqrekrxnug"
+  },
+  {
     "id": "terra155rgjn955ppq9vz5gapcfgwaf6vg9294xp2kcj",
     "asset_ids": [
       "uusd",
@@ -8777,7 +4527,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra15hre72m5u6fyfm8r0yq2m8n2u7xz8edu5eg9r9"
+  },
+  {
+    "id": "terra156h9adaua27vcqtguttxk6pg3st07nrypcmy6f",
+    "asset_ids": [
+      "terra1zfvr6uszt8khnf4damxrujfkhgl0mep0khcs7w",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra17a0zdmq6xf9jgac89y2nyqcytkcchnneefu8nc"
+  },
+  {
+    "id": "terra156wnmhqelwxwcmkfcn0j5fehj59ktjv6w4xca8",
+    "asset_ids": [
+      "terra109vclyh90fkj77ruk299pkk460sjm54vs9x6et",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra153pf6eyne720ev2nv7c3atxgrde9uu8l7h9e44"
   },
   {
     "id": "terra1580sp4lade7khxntaq8856we6480p4gg6xrzw7",
@@ -8797,7 +4567,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1cvnn7tz7fuxx8u8ym8gdfa7dp2jwv6e3le9ame"
   },
   {
     "id": "terra15asyerx0su2j3urlsn2xea0klrr5dpd75jamwj",
@@ -8808,6 +4578,26 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1g5pe82m6hv90h2ed8esz5ldw8jpcw6y209k788"
+  },
+  {
+    "id": "terra15c30300aaa2gt43svqy40jedyh7mqgn02tyukg",
+    "asset_ids": [
+      "terra14qs03ha38aya45vac8q9wn8pjy92knwta2exdx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra10xqkk0p4nmgmpkh7faudc0ftmkcx6lhd23vc3g"
+  },
+  {
+    "id": "terra15czn3ttmcsn9xl72hfx6muyr23u8h3nhgc5e2y",
+    "asset_ids": [
+      "terra1qgt75fpc097an2vtqufx52anfcsu33n57wjkac",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1gp5dpf7lqmx46ravzh64a6azarewy3n8tff6a9"
   },
   {
     "id": "terra15ge8z5l33w4u2lnq6udk8dpywglcpgxyl0h0dc",
@@ -8830,6 +4620,16 @@
     "lp_token_id": "terra1ndlx5ndkknvmgj6s5ggmdlhjjsz0w6wrnwn5cf"
   },
   {
+    "id": "terra15ledqp3plgp9gqkalkf9p2skdg3kg7l7zd7uhc",
+    "asset_ids": [
+      "terra1pmc29k34jrv96wde08znhmjq4v2rmzy78y6dhg",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1peq4pvfc0jzpgdnutdkpu5ad420zyr9lyrqr2n"
+  },
+  {
     "id": "terra15n30h56p9zva8gfp7ejd0smw2zf5xlxwelgg95",
     "asset_ids": [
       "terra1tt9jmf58nvaj8l0lckwfekfl43verjdpywcdwa",
@@ -8837,7 +4637,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1grmmss2wq0e52uz77wudxfqdgwt6gxqmdrvajc"
   },
   {
     "id": "terra15n7vemjsxv7w4wgnwqtzufp6tddmycqsklgqe3",
@@ -8860,6 +4660,16 @@
     "lp_token_id": "terra1d9myqs75njsaymp9yhrnzkkwhg0rsv9gpwcx60"
   },
   {
+    "id": "terra15p4lwjtk9jkkvkz33pf5xelnrnqahac5ksj8cj",
+    "asset_ids": [
+      "terra10jgqgc3vt34w79t4puharnzjxxv7s3fq8tmnkp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1wvglhgmnfyw0z8h9ucjyyye2cqds9trjws9u6t"
+  },
+  {
     "id": "terra15qa20t4hrq27ugcyut363mum72hdlgcqnannm2",
     "asset_ids": [
       "terra14z56l0fp2lsf86zy3hty2z47ezkhnthtr9yq76",
@@ -8867,7 +4677,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1lyzxxc0jppvtnptlcssy32mkwrj40tnjz5r7d3"
   },
   {
     "id": "terra15rl2agmgqjwlx3qqqe9rfjcvs3lxl2e3srzwda",
@@ -8877,7 +4687,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1yat0hf40dwwery3p060tvdh8glf7a8mza2rrmp"
   },
   {
     "id": "terra15sut89ms4lts4dd5yrcuwcpctlep3hdgeu729f",
@@ -8887,7 +4697,37 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra175xghpferetqhnx0hlp3e0um0wyfknxzv8h42q"
+  },
+  {
+    "id": "terra15vy6lhftmg8jnhnsnyazxl44fkutx9yawemeq4",
+    "asset_ids": [
+      "terra1ez8x6k2rru42w3z8lnfkzjs778rllmq6xhgf7a",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1u9nnlnvlqfgz04hvu7w2nqah034m0qjukfvrx2"
+  },
+  {
+    "id": "terra15waumwnpjw488cgchv3x5j7g7qlca73sd4zmp6",
+    "asset_ids": [
+      "terra1hvv3qzmzmmr9qkf2xj928hhy2yxuledwzn2v5u",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra12cwf2ge7mxjsaylmvpnpcy0q8t65fhevhasuxs"
+  },
+  {
+    "id": "terra15ytncdwh7yqttvvxjmw7cd2phj9a7cyldv8547",
+    "asset_ids": [
+      "terra1kp8vne240370hn722ec5sacsdluyt2j0gc5nph",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1wl74zp9lyhznusz7p3xcag9jur58njc7fqa0nz"
   },
   {
     "id": "terra15yyefja9as60nfn5dmyqt8tm3flddyvn3apf3s",
@@ -8900,6 +4740,26 @@
     "lp_token_id": "terra1y4z7u7psjqyxu4uw5rwz8wmhwrpweay4t0le42"
   },
   {
+    "id": "terra15z794we063zfzxtvlxzetnq9cv7ftymglqh0g6",
+    "asset_ids": [
+      "terra10722f40cxl8tkxjk7f88uj0ehkcw6lu2j504f0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra14jd23js53c4kk8rqxy6v6h7ju6cc8f9kf70v86"
+  },
+  {
+    "id": "terra15zfs6kf7c0f8u4layzwnwkzpqnkj8lrm86q8un",
+    "asset_ids": [
+      "terra1gjuhc34ccr6ajq7dm5266xyedu96sgkv4qnley",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1pl38m9mkneuu6z9swzhvfl7gd50jf7a88meemt"
+  },
+  {
     "id": "terra15zv6wcyqkw9ye86qku2yesqdgpr9qsz2xus4yx",
     "asset_ids": [
       "terra1u553zk43jd4rwzc53qrdrq4jc2p8rextyq09dj",
@@ -8910,6 +4770,56 @@
     "lp_token_id": "terra1ylqfv4ykp65gxxx5e39qe5ahzm52f20u8equxd"
   },
   {
+    "id": "terra160vz23qwte45w6dcgkkae05fqpap8l4s4alaax",
+    "asset_ids": [
+      "terra12jhul3zlafuvl4fd54pvaax4ls872z8p06p8qv",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1dun3ne9rhwz3u7m4q2ddsnwmkaqkf0cf65zd9f"
+  },
+  {
+    "id": "terra162ccsqcru4zy55r4u52rlm46plwzvzc2x67meg",
+    "asset_ids": [
+      "terra1krtfgcavw64dc8nhnz89eafpqm5pdz95l9a89f",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra14x387d844rddafa4v2swz89tljm2ux59qz954z"
+  },
+  {
+    "id": "terra162cf20c6hrag6fhy9aqwaq9cvrp5lq5ffpvuez",
+    "asset_ids": [
+      "terra1qup6c3w83xjrfdtzujqkh5j8pcar96up8f0pdy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1smzc7k9u3mnkynjvqclnz9qn7qfldj6waweh38"
+  },
+  {
+    "id": "terra1632r5htxk5ctf4srh7v2teguz47aen7ygkvphr",
+    "asset_ids": [
+      "terra1veke25wgg7xk34c3gxsweuxsdqajemr307e8df",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1uz9zfvrltmy3gawmsedg790xjl25jpgdm6fl3y"
+  },
+  {
+    "id": "terra163ddeunmzqr90qw4j2nxxmk0fmz56mhly4g07e",
+    "asset_ids": [
+      "terra19j57fzwjahvf52wxffgrajd0jjm9m8akfsl0qw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1cw640zur4svu6942kq9eu6ruxupryjmz5sd9yh"
+  },
+  {
     "id": "terra163pkeeuwxzr0yhndf8xd2jprm9hrtk59xf7nqf",
     "asset_ids": [
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
@@ -8917,7 +4827,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1q6r8hfdl203htfvpsmyh8x689lp2g0m7856fwd"
   },
   {
     "id": "terra1650mr52prhczyyjz9rec0ye38q5j55v7gq6wc7",
@@ -8930,6 +4840,26 @@
     "lp_token_id": "terra1srmemhy8etjaam7ksnl2062x9emwg7ykrfvnz2"
   },
   {
+    "id": "terra166j8s9pehm35egpmdfkrvlqj9a4248wqcg5s08",
+    "asset_ids": [
+      "terra1yx2z4j3wr55k7jns06qhn2hsw6agskvcke6zu6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1q7pc75pf453crpdkhh8eqkg77chuvvnqxuxnmu"
+  },
+  {
+    "id": "terra166lp9jpsca40cqhh78f9ve8t4nx446yxp6ra2s",
+    "asset_ids": [
+      "terra19ur0s3h72v7t2qmy58z60e0cl0epkal3mle4mu",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1zqnywcumfdnueyccgzp9qjzcaf7zuzc8hu2fts"
+  },
+  {
     "id": "terra1670lwuaqtzw43q402anw4aj44ud9nqd87d639f",
     "asset_ids": [
       "terra172hwjglf7rsgrnwet52zqnzjhg7vjgcpm7nctn",
@@ -8940,6 +4870,16 @@
     "lp_token_id": "terra1u6ua0t8url95p2dh7tp6kvqp04h48dxx5njclp"
   },
   {
+    "id": "terra167d8as4vjhgn3m04x3jzl80re5sytn89lr8s2j",
+    "asset_ids": [
+      "terra1tj9zrn3myxvkct20ehzje5whu5j75c94s8r666",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1em445q3t0ckevthda8enkd7v8v0wlncqyls06t"
+  },
+  {
     "id": "terra167gwjhv4mrs0fqj0q5tejyl6cz6qc2cl95z530",
     "asset_ids": [
       "terra1zsaswh926ey8qa5x4vj93kzzlfnef0pstuca0y",
@@ -8947,7 +4887,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1t4uuc09t4ld560vg2k9w2f5m9e5trftnym50zj"
   },
   {
     "id": "terra169l808rtk42ukexh3wqyx2cgxp4gvn5fqmn5zq",
@@ -8957,7 +4897,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1nks5yffczcxcfrrahmv8kdg9yn3z9pmd3388ka"
   },
   {
     "id": "terra16aunxdkl5pu0ftz8q7sgapmwtlls078lj56r9e",
@@ -8970,6 +4910,36 @@
     "lp_token_id": "terra1myejqyh8u3q5prx6h8p9hplswdhwtuxuk5stc4"
   },
   {
+    "id": "terra16c42gghky97m3g5nj80h3528m3l7m099xjlh0h",
+    "asset_ids": [
+      "terra1uwsnmc4fpalrv3xgvf0aedx8tfn22xcyrx4467",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra19unte8ca7uu34q5e0lktrd6esm7wq9j3cmfl4r"
+  },
+  {
+    "id": "terra16d99plysndjucurqz87d8p0my7z3kffuhehl30",
+    "asset_ids": [
+      "terra1j8nxezl70lfekdzaeanzyzn75htf4sz9vmwhu7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra10rnu02fhw7lg7eka8f2yw2wn9j7kn3mgqs860s"
+  },
+  {
+    "id": "terra16edju746kt6k44meljuql30scd6ml0ey0qwj8v",
+    "asset_ids": [
+      "terra13l9e6lelggxjzm7dxhgkfgqwutwr67y5qvc7mr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra18kq50rff38rr6xt6etkkjvhv59msdst23pf9dv"
+  },
+  {
     "id": "terra16eecm8exp3p82ld5eh5feweup0qvfv8468np6j",
     "asset_ids": [
       "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
@@ -8978,6 +4948,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1yrthzcrf6p0l568rk2uumzfg0355zedywmaf8z"
+  },
+  {
+    "id": "terra16g8fsnjsmys6dl25s7wvl4r7y68drvfjc7pszl",
+    "asset_ids": [
+      "terra18vl2cypy8pdys2qdqlg7pzmcmpqmur8lmrnk2c",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1n347g69jtaez50mva3unn9npyd0jfkkzge9p2t"
   },
   {
     "id": "terra16jv42g5t95zj2rvddzqvvd5sjvpvtz5fz5sksz",
@@ -8990,6 +4970,16 @@
     "lp_token_id": "terra1z038v5j6mlwluahjjy6z73q6ckq6rwkllj5xue"
   },
   {
+    "id": "terra16k9sv0425t8prauxk680sj8aecgh4t948v8ktf",
+    "asset_ids": [
+      "terra1534wdj9s0c3c64pmgqk8544usm0jvfysn9zq2k",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1d4x2hk2gqua29fn5mq5nqq9nm9vn7qu0fvnfzs"
+  },
+  {
     "id": "terra16kgssn83sz92u22mmqtgmd795edtttu7apjsm9",
     "asset_ids": [
       "terra17zucl25842g99vytr9yzw0eqmql3wwpql357cx",
@@ -9000,6 +4990,26 @@
     "lp_token_id": "terra1gk602sa0jwk73xlr8tpkd3fpukhfa8hjety68r"
   },
   {
+    "id": "terra16l746rd5nspcav63emsj9uem7v7s7jflrf4mv7",
+    "asset_ids": [
+      "terra1vyusa796w86yh99l67dpd5g3hfva759vyuhn5z",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1emk8xeed780j8extpdd5q42h0grdj0ad4ce849"
+  },
+  {
+    "id": "terra16ll0n5lm5j4vp94mjr0xa4tqxfpvvgx57mdtg3",
+    "asset_ids": [
+      "terra17rwgygp5y7tx83xyclwuxu654vjt2whpwxx688",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1tqgkra60jq5jzear9e3zm6knwwzdxvwl2hn5vd"
+  },
+  {
     "id": "terra16pwrn7frj4d8r4dfc3l8y3xkt5uk2505ad7nvm",
     "asset_ids": [
       "umnt",
@@ -9007,7 +5017,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1rckmyh59j6lg29432yhy088q3umcd3ssc0pkwf"
+  },
+  {
+    "id": "terra16qj6hfx9t2st567eg0hzfd0vq3dtvvc8y0knxj",
+    "asset_ids": [
+      "terra1wlwkuyv9g7d320dm5cqg6wsygplmt8tjjglc6w",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra179nsfzyw6gpd4aqjxk644y662geq0rdyt90cay"
+  },
+  {
+    "id": "terra16qjw56mjdzurqualderrjh4p0gprm66yd02dar",
+    "asset_ids": [
+      "terra14ldz32u9l0s9lh07zqqqxgmnzwyww04hmvs923",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ks60j2lj62jrpcn69eejtzvg0gatjmz44x0l6y"
   },
   {
     "id": "terra16r4zqs04jzyrert9udg2s8g4qnrqy9syw4kxhp",
@@ -9027,7 +5057,37 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1y798nnrh3qkhyswfl82m9emg5lffxhj82vxyfd"
+  },
+  {
+    "id": "terra16s7w70jm98htj2v6mkhcx8uy03l7d4w5mjfnf7",
+    "asset_ids": [
+      "terra1vjgnhlv9h0nlta2v7s5hts75h2mc065c6ap3j5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra13pnaneaclmvtd52pl7crf74dwvau9r9r430uk6"
+  },
+  {
+    "id": "terra16u0mmxkx0tm7ll5674dqazj0rznft6jfeku0ve",
+    "asset_ids": [
+      "terra1ufxgdde0fkmmc7mvmkuaxps9raua78r7f0vm3x",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1cxefedc77znngtrw5lfrf87kk6u7wus6mrf4ly"
+  },
+  {
+    "id": "terra16v3cxjng86zd4hmahglj89k9gejh04nghnyavx",
+    "asset_ids": [
+      "terra1s44vplvv5fphrrv4g68gx46xwrmvnqm9e0hazl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra12sv6yvas2w2wrtjzly647h074tq8g48lxlqpaz"
   },
   {
     "id": "terra16w76qmlwdevxvt9xnfafmczrjyar6rh5rtsyhw",
@@ -9047,7 +5107,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1aws0wttvv6lzm8zmwqe2ppwkzexcc8wv4hph97"
   },
   {
     "id": "terra16x00f2haetp736xgj8v0t2p3ju6tgnc4f8pzd8",
@@ -9057,7 +5117,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1xvur9y9z8m5c7cq9rpfh6lxwr047wreuqp043a"
+  },
+  {
+    "id": "terra16yrzqhe84x86jzgaav5hszfsu4mhxjk0aqlk2g",
+    "asset_ids": [
+      "terra19m0xqgdaltwkesdt6m383jkqh3m9xyxwtp0f6f",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1shgduktaen6fx7zp637d4ndp99j59jttdp5wnw"
   },
   {
     "id": "terra170athjxhauwzdn3tejfcv49pej3atyv4qwffrm",
@@ -9068,6 +5138,46 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1xhjavlxlfwqw2w5hj4395m7stl4ut5zus6mn4x"
+  },
+  {
+    "id": "terra170hht9lwe50ugfhnruzjaezpj29l7nvw3l6725",
+    "asset_ids": [
+      "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1wdfhtdvsvjazrjnd37uyfzg45j2e0v32vz3ez7"
+  },
+  {
+    "id": "terra170lzdyflaamashcqkst23k9ew773dtg67tfu5m",
+    "asset_ids": [
+      "terra1p8y9f7dpmyzy85ldv3k8xccuw0u87lsn9fl86l",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1t8qmg9p583jcp2f7uuhga73yh7ze0u4ny7kmzy"
+  },
+  {
+    "id": "terra170uexnuckv87q2fl392269m6nt847fczs0yzuy",
+    "asset_ids": [
+      "terra1znvnhtdxxsy9vkvmqv85nscujeqmmtjlp2a3wj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra10klhxjnafqnt5mu6jugrcqs0kaepprmf425c8q"
+  },
+  {
+    "id": "terra172nqk47g4vc3zfde06nkq0em69lcwf6dp9uj92",
+    "asset_ids": [
+      "terra18lk5y974rsknqmcqlruj636mvg57yln93ay0h8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra14e8sutnxhzgfzt4gdq84dqjymz422k75nglnp7"
   },
   {
     "id": "terra1774f8rwx76k7ruy0gqnzq25wh7lmd72eg6eqp5",
@@ -9090,6 +5200,16 @@
     "lp_token_id": "terra1rqkyau9hanxtn63mjrdfhpnkpddztv3qav0tq2"
   },
   {
+    "id": "terra17cfpltkk9ja3rcv3x9rwqzxdeqs9r67ga607lw",
+    "asset_ids": [
+      "terra1jz9plajrq6knks3vgv9px4ezwshzaxsr2xz7jn",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1udh2534z6lu609dtvlfp8y42w6tswvs5e9034d"
+  },
+  {
     "id": "terra17dh7ekvz3qeghj50rqphx9es33qr5z5c5dhgdz",
     "asset_ids": [
       "terra1tlgelulz9pdkhls6uglfn5lmxarx7f2gxtdzh2",
@@ -9097,7 +5217,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1zn6ke73eyqvr4s5zsfkm2jx3ll0uk9aw8yd7pd"
+  },
+  {
+    "id": "terra17ds00wg6xtgy9f7apfl59f4978svh626f00238",
+    "asset_ids": [
+      "terra192dse96aslp5cduzvjqly4j7jaka6dlv2xx7f8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1knn3f89x8tnf6h9aglz5rhz96wa2cgwfsx3mwy"
   },
   {
     "id": "terra17eakdtane6d2y7y6v0s79drq7gnhzqan48kxw7",
@@ -9117,7 +5247,37 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1zq56xrvegmuwlvcmmhatt37gsx6df2n3j759t7"
+  },
+  {
+    "id": "terra17fwqk93kurqedvdyrly3a0c9g2v8eax3j7l5ek",
+    "asset_ids": [
+      "terra1gdze0yyar2y6vs3un79my828cery0jea8mzn07",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1k6mgu6smngvqhq63stjgj2vq9e49umxvr0e6cn"
+  },
+  {
+    "id": "terra17g2lqz62y4p40hp6f0caup374m7v0uptw38vev",
+    "asset_ids": [
+      "terra1a54dqqqh4qlz70m43n3a0vqeu2dv5tkz6t2zan",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1chlp9faqplsyc5y886trcffyzxhnsvuvj9qv5k"
+  },
+  {
+    "id": "terra17gh85ddky3gqyzg5lh8xry0d4ee497wju497m3",
+    "asset_ids": [
+      "terra1ayxfyasd2ursa5gt5zgzgfywsw999dz4yykjn7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra15q4ypjhljlfkfmz86xddkd6y0vnwyh03mj6q6p"
   },
   {
     "id": "terra17gtlmwdasc0p8rzms7wzhts4nshu47f5xud05w",
@@ -9130,6 +5290,36 @@
     "lp_token_id": "terra17mwkhsau43y602yev5nmgzjhel5jsen433wf22"
   },
   {
+    "id": "terra17hfwmsfq7xmecrlzaqgqqsymzr6jz4urcvd9sq",
+    "asset_ids": [
+      "terra10ewuq49hkk438jhd7q79hfetqpkkt04tfm7rzc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1enjwdma23v5f7rm5xc7zqq8rra00ggmr464nkf"
+  },
+  {
+    "id": "terra17j0yumlretpyprsxh3qk5zwyzfrdydgnpt0zh7",
+    "asset_ids": [
+      "terra185fgz0v2wm79ujn58tm3qeucnvlnfuffa4wpjp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1c063gh7d06rdwem37tqvmqhfvwce7m2aypyrhf"
+  },
+  {
+    "id": "terra17jaq2p66s2n40wad52mfudk0z6u5tmyanhkc2g",
+    "asset_ids": [
+      "terra12a39fn0k0duteqefme6zgr5efg0g5ya7eglvyu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1rkewqq6kkvpp787ltvpeccvz4qsqh4w7fv57xj"
+  },
+  {
     "id": "terra17lrhh6zh99g2u2d92y77xn8sg3j4sp9frkga3d",
     "asset_ids": [
       "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
@@ -9138,6 +5328,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1fwj38qsjpj7huatrms3ptp5spgnmz03ghmdhtw"
+  },
+  {
+    "id": "terra17lvnk2k34us38zflqz4zze6zkn7vrktpeuszcy",
+    "asset_ids": [
+      "terra10aey3n8rwxup6l2x68fa7fwdurxnu9hwxf0k7f",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra16m0mus8nn6ye0j2qze5ffpl25z8mw0tjtk2dy7"
   },
   {
     "id": "terra17mu25k7a2lj7pn8vjgtc5vjvah6gkt6njgh4q5",
@@ -9160,6 +5360,16 @@
     "lp_token_id": "terra1z9xh489wp8wksdqh43wsmmyvm9qepdltq87aqy"
   },
   {
+    "id": "terra17nht56uc42wj73z8u0gs5n2x9d74ur7z76vmz6",
+    "asset_ids": [
+      "terra1je4ll79zmy03zpl4wdhgmadvznqr08tzrncpqw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1q5a6apsurh9hkvql2mj2l688dxgm7hpyuvp5cr"
+  },
+  {
     "id": "terra17nntay5n5c7za2yzgrgfcl9jaytyq37qzrwg6z",
     "asset_ids": [
       "terra1tm2jhnfh6hmnpvzsyfteqhcn6h5uw2qafr48yh",
@@ -9180,6 +5390,26 @@
     "lp_token_id": "terra1757aqwhfgdjdadpwvy9hv324g4ss73nn43eqp4"
   },
   {
+    "id": "terra17qag5rxkfraheygnsq0xy6y4a8ay0vrmm5cftm",
+    "asset_ids": [
+      "terra1dxt75lk0m5g0wpucg0mz905akta99fjhuhafqa",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1l58a2w22pv0fgukypvqt9fdmkn3ktd0jznexyl"
+  },
+  {
+    "id": "terra17rduyemsyel8jl5pvyh7j33ee78606zqzkzh8l",
+    "asset_ids": [
+      "terra133chr09wu8sakfte5v7vd8qzq9vghtkv4tn0ur",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1m7q2pxeq8fkw6xjsx7msj0gvnukrr35fthwhyh"
+  },
+  {
     "id": "terra17rmhzak7ymvwlwr275neppvxkrr3xl6vj0dczr",
     "asset_ids": [
       "terra1e6lfxnuyqg3wxvczuz0zkmvr40ldvqx26eqk5g",
@@ -9187,7 +5417,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1004n2l4z26cuvchplkkrkxamx3un7lk702f0xy"
+  },
+  {
+    "id": "terra17rt5kvtt7vgdnxyelqhctaa4p0wwszjqx4etr3",
+    "asset_ids": [
+      "terra15pv3xxp2d5f65qeu2v27vqf9zpqjx0fuztfwcu",
+      "100000000000"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1q2xj2w477fd8vx4n4psa449hj03m8py8la423q"
   },
   {
     "id": "terra17rvtq0mjagh37kcmm4lmpz95ukxwhcrrltgnvc",
@@ -9200,6 +5440,36 @@
     "lp_token_id": "terra1p60datmmf25wgssguv65ltds3z6ea3me74nm2e"
   },
   {
+    "id": "terra17sh5yr9tcfl2qsltrm2tulnlpzz0c6ufk683dc",
+    "asset_ids": [
+      "terra17t0uuy2cg7apfsqj4xqn6w5scxkd2ajgns9xvz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra153k57e8cka9mutkp5g6f0elje02qtmh75nshny"
+  },
+  {
+    "id": "terra17supgps4aqq7nfkcqt97y0jxzh5u6mrzqlg936",
+    "asset_ids": [
+      "terra1hn8mghxm4qm2g654m3h4rmqccgs2wcdsvsex82",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1jz8tpf2pnpmw5ek8yvc8gnm86ef67k8a4r6lfr"
+  },
+  {
+    "id": "terra17v05w2qmmxy864ltjtts0nzqlzw32gp6uynh0y",
+    "asset_ids": [
+      "terra1d9ec4gm0c03p74d3qd95qvny2ptf0ge5twqpdk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1wdmkqdhqmyv9csgwfdh8739fu65qpay7jj5vvh"
+  },
+  {
     "id": "terra17vk5j4mhxnpl74xmndmyjfma3ynpef6kj7jhuj",
     "asset_ids": [
       "terra1zawrkv57eh7rne45zjta7s876jqc59slrev9xy",
@@ -9207,7 +5477,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra16t34llthsfwdjazglwamhv4f20f4ux4wmm9zzy"
   },
   {
     "id": "terra17y0ujwl2far0rtm5qqjlx6ghtndcpyzqulur3e",
@@ -9220,6 +5490,16 @@
     "lp_token_id": "terra14r3jnk537uwkgvuwg227jj3z50xcetwtjcj7sh"
   },
   {
+    "id": "terra17y80pnvqu3kd3g5jwn5kpkfp6hh2stzxmvazjw",
+    "asset_ids": [
+      "terra18we4g8y6u55x7atttzu5xgx46zzss0tpmktf9s",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1h8qvlt5tvwwpykkfly4gatmxdkfddx0te8p265"
+  },
+  {
     "id": "terra17zp4dqu3d2sj9kq8uqnsvwy4ll66g7380uh03s",
     "asset_ids": [
       "terra1dwyd6vds479kv54f7kucevny97lge20c3s9w2k",
@@ -9227,7 +5507,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1kslvxkarlrneqddynteuwhd4uqy2w3a36h0ce5"
   },
   {
     "id": "terra180jp452au9sfwq4kuxtsd9q2wzjfu6v9ghrkax",
@@ -9237,7 +5517,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1je3y5wnfm5v884j3vdegcc8045kje39g6aflce"
+  },
+  {
+    "id": "terra182n2psy6gl9u90gltznv2r0h6t5sz7ajgu4dl2",
+    "asset_ids": [
+      "terra18m523525ntva277qramnc6x2hh56a28w0vndjf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1xp7l5hahtcl23ghx5u6sw5fa7cds4anmarj5nn"
   },
   {
     "id": "terra1830q85e520kyhh5e0a254gvt88z8ngxa05tj6q",
@@ -9247,7 +5537,47 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1u2f86x2fagtz3fghdc4ymc6dat3arepfu3rtum"
+  },
+  {
+    "id": "terra183kl26dv4ymz55cytumj77z5u6m383wgfvsrvd",
+    "asset_ids": [
+      "terra1vn8rmcu3yywfndh2ze43v5h2wg28rycdekdr6u",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra10uz6jgxmj3ywj9xndsnreula337h05jpkzppnx"
+  },
+  {
+    "id": "terra1854dxe6nw9pktdd5j5ulesv74k3ztqgdx6mcxe",
+    "asset_ids": [
+      "terra17etsw9uywcmw79st5yp4saar97z22l3np0m3zz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1x3ymanpm2v945c78zmhn3slw2890a6t039tt57"
+  },
+  {
+    "id": "terra18573lxn0gjcs3fh2dc6qfv7l3afrws2k2dk2zz",
+    "asset_ids": [
+      "terra1epzqhvam83e7lfqtdmgzatlvlzwu23x8kd4t4v",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1asqt56e65cw3dmszq47ru7vzrkua6spg9au4mt"
+  },
+  {
+    "id": "terra1867v6pwuaachav723ukq9sajaxgtpe7w3aefm7",
+    "asset_ids": [
+      "terra1ry60wuc8a7a4ujt3tmrp3upxzf6a4awj88eys3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1jmap9tuf59k5mmr5shgmywqfxmcmlzxusn49vl"
   },
   {
     "id": "terra187406r5f8nl09xskt0p6zeq54hs86m6j04q35f",
@@ -9257,7 +5587,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1tdlrn8mg034rm0sts6ej5k4mxwfgdgd97wgrqq"
   },
   {
     "id": "terra187pxc9su35stqfdd02xy2r778qd83lruaey3fq",
@@ -9300,6 +5630,26 @@
     "lp_token_id": "terra1x3musrr03tl3dy9xhagm6r5nthwwxgx0hezc79"
   },
   {
+    "id": "terra18atry8rvvpu35pp2tm87exk7y56jm2yhza4fgp",
+    "asset_ids": [
+      "terra1tvs43r9ry6s6g6j5mnmruw97s3fjhqxpc540hu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ynzjmya27v8f2clle2dl5vw909ffxqlkxgcyfw"
+  },
+  {
+    "id": "terra18cwjyccu8snhk2tknk962h2vdvnmerwhrn57cn",
+    "asset_ids": [
+      "terra1tesjetjz6q7s2etc0pa93ep6fwhzqqtcvreccl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1xdgsm8apwxuxgql7ll5uc34h4w3y0tnywvsg25"
+  },
+  {
     "id": "terra18cxcwv0theanknfztzww8ft9pzfgkmf2xrqy23",
     "asset_ids": [
       "uusd",
@@ -9340,6 +5690,26 @@
     "lp_token_id": "terra1kr5twwkkdr38wa3t2477cmmrwwpjuggxl962y9"
   },
   {
+    "id": "terra18f5npedpgufd4zyq8gae05c3htnkex7sld2rkf",
+    "asset_ids": [
+      "terra1xzk97nrq0ma7dzgy6aj5tm04sg92q720lq2yum",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra148se8h985hfw3s3jl86vf95qgfz7hztdj0u7qp"
+  },
+  {
+    "id": "terra18g4d309jykk54l43k58fjqq8h2qdpzgdctxfwf",
+    "asset_ids": [
+      "terra18neulu99zm7kj040tndhavjskjm7aaxsk240rx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1mzpxqr5vwnzl822sjd3yskaekz2lyvfpavush6"
+  },
+  {
     "id": "terra18gdjzd5p76dwywsqn7kgxsadfllw6csghl37vv",
     "asset_ids": [
       "terra1twcwynuvhs778m8x46n7e6gyvu7srtkjcaufxd",
@@ -9358,6 +5728,66 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra19rc9ttpt80k7mgmy8e0t9e3r6q4m5mwvwyjwul"
+  },
+  {
+    "id": "terra18jkyaayc7s3an3gn6xhz9ue75pdy46zrvzwle2",
+    "asset_ids": [
+      "terra1l4uygw365sgdgvasmckkd7lcawyemzn9k83lrh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ldy8tjaqa9zjq6h2290ac2k40ta94e4hky8caa"
+  },
+  {
+    "id": "terra18k700765d9kyglezc07n64wnkdcfzf9d6juccz",
+    "asset_ids": [
+      "terra10rv8jte682eec8s3fyd522hhq577cl75zghx83",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1l6nvej775vwnlmf84gzv5utyjw6rh0unyyc2y0"
+  },
+  {
+    "id": "terra18kf909r8usm8l29t6krwtexyzd8wr3vrqqd9vm",
+    "asset_ids": [
+      "terra1hxcsd8ttymrqzp5uh5f5885j0ms0tnzux9jzsc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1cu947swy2q3re6er4f8stuxlxdeljx0umlq9my"
+  },
+  {
+    "id": "terra18kwhhu4fxcc2x7lwtct8jatwv9843n6de33g6r",
+    "asset_ids": [
+      "terra1rkn2d2yc0946a0gx0w0hwf3l2j32ve39egsjkd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1f32d5xv494x2sy7mugu6k0hy3jvqu7dut7zk2s"
+  },
+  {
+    "id": "terra18nz2gztwduce3u40wuuafl8xj8e4s63nty75ym",
+    "asset_ids": [
+      "terra13zs7w76g0u4qgagcen6vq92wxuvgfucr3dy4tm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra10n0uq2w37h8q3fjmdyxml2z54scv9695ljhdth"
+  },
+  {
+    "id": "terra18paw08s6xkw23swl76w6njga2rq6kh80zch24h",
+    "asset_ids": [
+      "terra1duggxa56m97yfcat99ew27z3q4rnax4w4u8waw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1vwa9j8y76ew90v7ukh5slz9euj50dq22cs0qvs"
   },
   {
     "id": "terra18pykmlsv9llayy0j252h365vkh9h787jla9vg8",
@@ -9417,7 +5847,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1na4sgkt5ft37s72l9hd6wsa7hdql0j75er0u7l"
   },
   {
     "id": "terra18z9fg8nd7dvccqnmyhy2p5t4pdak9c8j9qkr4y",
@@ -9440,6 +5870,16 @@
     "lp_token_id": "terra1k67ut87c2up66tury4qc4n96d85t43u20v24sy"
   },
   {
+    "id": "terra190r2p96klarzvdssdg77r6sd4nfutjra7wwz8d",
+    "asset_ids": [
+      "terra1ma4frxgvc974je0xsxrzpa52j34h9swlww2yed",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1hl09j27s27407wkct646lqnxg3qskpl2ehuvn9"
+  },
+  {
     "id": "terra1935xkvhhrv8aeq7sl5hqez5uxlwvld3098mjmp",
     "asset_ids": [
       "uusd",
@@ -9448,6 +5888,26 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1l0yxvzzszzfcrfcle55wdf2xxmalc9eg5c28ej"
+  },
+  {
+    "id": "terra1947q02rc7dcynzgywduaudwjmr9nucjzkd7l6e",
+    "asset_ids": [
+      "terra1aszsg6mzlzkydqtm46u42mf8zxur9m4ydh9vrr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1sedpm809sp8spmk7svhnxqdqyu0tzxn6h0zltn"
+  },
+  {
+    "id": "terra194d6fn47g5lztfxl42fq37mwlnd4lqwestky0x",
+    "asset_ids": [
+      "terra152mtjjndwpwvtszd4cxnhvjm8nzxv6kdwtdugg",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra16wlnwhhd0x0jp9lxqnms2ssmsdhg4v206uwysv"
   },
   {
     "id": "terra194j4rhezku4dmfz2vsnpzqv0actlg3xepg7l3t",
@@ -9470,6 +5930,26 @@
     "lp_token_id": "terra1zck3zn662n00tvfhmwaf4ujltr885qt5v2n4sn"
   },
   {
+    "id": "terra1970uk99ys24x9xsck497709n4tzeaa5lgkw0ye",
+    "asset_ids": [
+      "terra1sf5tt6p6wnlhm0jqlflan8lw7pmv3f82sffsja",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1d83udzk95gnk2np5wklqj3hxdq59r0ely8tdea"
+  },
+  {
+    "id": "terra19825apq06ve8ae5mhdtljcssm77xrtdkvm55gk",
+    "asset_ids": [
+      "terra1yg4qw00d3cpdvs9zyhyh32jkfcl8un8nxc3f08",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1lm3mk44nft4mn74hajn0p8x4enp6e38yyf4ey9"
+  },
+  {
     "id": "terra198q4sqvt4yczlxxs9cjtktqdy7tzthz8vhz6xq",
     "asset_ids": [
       "terra1aaqzva7adgwtzfkt9nmrmuvkg9s6lmsgtkg3jd",
@@ -9477,7 +5957,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1ngyawdzf02gktxmat3m5gletfq65c9twkeyf73"
+  },
+  {
+    "id": "terra199cwj22qrsuqnuv4slrmhc3dfydxjh3894tajt",
+    "asset_ids": [
+      "terra1mq6sw9dt57hlpe7ffjm2z3pytr98l4a00lnxp6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1yjvdd73lsjq49v7x80rhe3kyltg27gew5nrls8"
   },
   {
     "id": "terra199dwfkrv44n52nrtyf4fsj0tp9s60vl0xuaaaw",
@@ -9488,6 +5978,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1y6frqkq3ghvypja2t9uqxkfulpaqeuhfzm69vp"
+  },
+  {
+    "id": "terra19ak9slt8fmlv5p09j0y9edswgpvmk07p8nplrl",
+    "asset_ids": [
+      "terra1thrmc4qul2e02y2rskm7583g6guvtrvc8pnlmx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra102pj92vh6cem9hyzyep465k0dw3ng4hqaaqsj4"
   },
   {
     "id": "terra19crn3jxwjspu29kc8ftn27lw5vr3vzk42qar86",
@@ -9510,6 +6010,16 @@
     "lp_token_id": "terra1h69kvcmg8jnq7ph2r45k6md4afkl96ugg73amc"
   },
   {
+    "id": "terra19hmp39k3dlwtywtqcs4nrr4lal66kzwc7ea42r",
+    "asset_ids": [
+      "terra18jv5j86hjhc0zx280wu3kjggd9dvfyl9v4t04k",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra17jrxg9srhvhu2rcf5umt2lnrvahtgxwate8gej"
+  },
+  {
     "id": "terra19jjgf89q82d84fag9qqr5lyhcmctljjygt2yac",
     "asset_ids": [
       "uusd",
@@ -9528,6 +6038,36 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1w34xlv8euhjfffp3mu98qtc9umcwy79jw7pfxe"
+  },
+  {
+    "id": "terra19luytfs7wt8l2e5fgg7del39m93sm64qsmufsy",
+    "asset_ids": [
+      "terra17w68lnnp47k4zkfkpcyzu2xeu6qw576ksfpp4r",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1jfrngqdwqkfs25sgcmuxrlk6a7y8058purc4hx"
+  },
+  {
+    "id": "terra19mzvauzmythgn8d8vl944vczh5egrlnqfqygke",
+    "asset_ids": [
+      "terra1ruz2e26humerfnd9uhurc9766a4at8x8e3m2e4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1gsrzxzh5err6vsc8e5qseam2x3gx5kuavwuuzq"
+  },
+  {
+    "id": "terra19nhjua64eq04ulurrdayj3u0f6yw5qw6t4mc8g",
+    "asset_ids": [
+      "terra1n3l6xg66m9t342qcvgdqk6md5cqvtatgg8tw39",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1h30mmqyw6gu5dnresfzdcwsr2ahec5usf0vst2"
   },
   {
     "id": "terra19pg6d7rrndg4z4t0jhcd7z9nhl3p5ygqttxjll",
@@ -9557,7 +6097,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1jed2nwcyz0xx8qutczeze08axeetcagawf32lc"
+  },
+  {
+    "id": "terra19rsnccnawx00kzynaxexxh4540qp5y6atfrkjj",
+    "asset_ids": [
+      "terra18ky9ln4g6x3n9f9s8a5ttshynv6lgzfppmrmyg",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra19pztt2p6wuy63dehanjeuyf7vx399ptwdq93zj"
   },
   {
     "id": "terra19slzdkvt3kekyq4ydp3ky4pjuus5lmedafkkzs",
@@ -9567,7 +6117,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1nrn8m6laft49628jr4t9ajfj4um8r7nzedw5wx"
+  },
+  {
+    "id": "terra19ujj2teuw6m45v9c2wk33wzl4mjr22jlw3nqrs",
+    "asset_ids": [
+      "terra1rctv4sdztvscdxw890us4ewcuvh77t8wydxkxr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1exs7v9pvkl90zjyd5h7lu26hzszwczfsedc3hj"
   },
   {
     "id": "terra19vrx0crmjpkahyhmmtlsgcnzgss32nwgnqudfq",
@@ -9590,6 +6150,16 @@
     "lp_token_id": "terra1xtrwsa7dh7jz0whaa5fsy0pu9x83z93r7lhmy4"
   },
   {
+    "id": "terra19ypukqk0v8l2f04qjsc9pwullq7r24eufm6led",
+    "asset_ids": [
+      "terra1tdc7hmydg3es6lmn2asfwfgs8ykq7xa0nz9rkh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1yhlgg0kkm7vngmj68suf0jmx5fj7v7hpxy4udn"
+  },
+  {
     "id": "terra19z6n7l67rkg6y7vggwr3jh889t9vg6yn2jdl9n",
     "asset_ids": [
       "uusd",
@@ -9597,7 +6167,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1p7zqell9644a5dn5347dz4gy7uzlfckp3l9jru"
   },
   {
     "id": "terra19zmlnmj5pqpwvtzzgyzqurlul972myjzntsmn8",
@@ -9617,7 +6187,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1z373t5nj0jnh0tjr7ljpdwgh046gq3ym9vk775"
   },
   {
     "id": "terra1a4cjrs86m97rk0g5yuds8yjd7f0en5drqnynwk",
@@ -9627,7 +6197,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1mvdalcuxntt9jrzye3chf9xv6apr3dh9h2z5kw"
   },
   {
     "id": "terra1a5cc08jt5knh0yx64pg6dtym4c4l8t63rhlag3",
@@ -9640,6 +6210,26 @@
     "lp_token_id": "terra1veqh8yc55mhw0ttjr5h6g9a6r9nylmrc0nzhr7"
   },
   {
+    "id": "terra1a5pqgv432f3u25zu5q5r0t6e00pwd6xa8unwp3",
+    "asset_ids": [
+      "terra172qlk30wwyux37m45w5c7mkypn7ks0t0s3d0ms",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra13hcayvzgxur5f43qwauz3jsnf4j353ee9s7qq3"
+  },
+  {
+    "id": "terra1a5s9cgdzw4pz4nf8rxyqp77q0wuegahs78tpfd",
+    "asset_ids": [
+      "terra12qgpr0fw773gc8lrkys3knnw6nkgdlc8ggaty9",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1pgyxxsnn08vgaav3a8yc77jh3sl0st8typpylc"
+  },
+  {
     "id": "terra1a6uk8kz25l59krr2m683ph8l6waky0nphm5l66",
     "asset_ids": [
       "terra1g0pm8xm5c2dq4qtv8j9a80hg4mhe5ndy8qad07",
@@ -9647,7 +6237,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1yxqlflppw6ldewgu6z0w5x4rmm588cjckvj20s"
   },
   {
     "id": "terra1a852hrcu4rsafrf9wftvqstl2vqn2argplnnmp",
@@ -9670,6 +6260,16 @@
     "lp_token_id": "terra1dchs757cqkjarjyl3cwk37kcd9tkvhkuypfr2f"
   },
   {
+    "id": "terra1a8t3w4ts39fu5su3dg60p9akhr8uf85fzccuxq",
+    "asset_ids": [
+      "uusd",
+      "terra19hnegq0ed5w0gds64765uakh5huw7jepvjakh5"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1w507ax3yxh7cme3fdk9wamurgnakt4ej7syq7s"
+  },
+  {
     "id": "terra1ad4crwtu2vpc0qcmw4xmypcy3asp54w3kg95cv",
     "asset_ids": [
       "terra1hj8de24c3yqvcsv9r8chr03fzwsak3hgd8gv3m",
@@ -9687,7 +6287,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra125am36fdtwds7elfm8yc8l3sg4qe3m0gv24snl"
   },
   {
     "id": "terra1ae0jhhxlwx46xp9uf9cwlca6pm5wa79wf8ppgj",
@@ -9710,6 +6310,16 @@
     "lp_token_id": "terra1stfeev27wdf7er2uja34gsmrv58yv397dlxmyn"
   },
   {
+    "id": "terra1afgh029jj9nxglezr3jxmr0heujj55pgspvx4m",
+    "asset_ids": [
+      "uusd",
+      "terra1cq4lkf7dlygdp23yql8a4daunnxr4xd5tymszl"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra12sjz9t2pnjxvytczwl6ynk2ptw6g3c9q0xy6zf"
+  },
+  {
     "id": "terra1afslx9uqz7gw348kae05drt39uu2nxnrhlgupu",
     "asset_ids": [
       "terra1dk3g53js3034x4v5c3vavhj2738une880yu6kx",
@@ -9717,7 +6327,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra16nsgdnjwx6m48sua57ahh50a0vkf8hj4vpark6"
   },
   {
     "id": "terra1ag6fqvxz33nqg78830k5c27n32mmqlcrcgqejl",
@@ -9737,7 +6347,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1j2cgnnz83zsr953jfsdc46mpkka28j2yluua08"
+  },
+  {
+    "id": "terra1ahygklrmejad3mmeugsd0m5lczv9jl8hjepp6r",
+    "asset_ids": [
+      "terra1478yfcsa6ycykstdfh2mclwdy3d6zpemkyfu4j",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra16k9tt8q30dswt9ksp00wrfdmdlze9s2en5y7ts"
   },
   {
     "id": "terra1ahzjyx9l523fs5s7xe6luqy9auc5tdwzgqz0k9",
@@ -9747,7 +6367,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1n029wutk47xq27tueyc9gn8rptsws678p7c2qg"
   },
   {
     "id": "terra1ajj4klvt3gpf5mmkmlsaz7t23paaanm68xn9dj",
@@ -9757,7 +6377,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1pg9ukye32aga2z8kqxdkdmyeyx8un6lhdvszrc"
+  },
+  {
+    "id": "terra1ak3u2e0303wvnfsese2z382pn4sxl9etz9rrkj",
+    "asset_ids": [
+      "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
+      "luna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1uc9r5fcjzrnl65agh3eajkmle494msx7nynsv6"
   },
   {
     "id": "terra1alaaant5ykususyuv0x6k298sh8kl8qkpkuu8e",
@@ -9777,7 +6407,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra158wdmf0zs6eeec9fda8v2mxajv9kh9730lmmll"
   },
   {
     "id": "terra1amv303y8kzxuegvurh0gug2xe9wkgj65enq2ux",
@@ -9790,6 +6420,16 @@
     "lp_token_id": "terra17gjf2zehfvnyjtdgua9p9ygquk6gukxe7ucgwh"
   },
   {
+    "id": "terra1aqd837959wjcpzssqqr56rhh7dcq2nrqpgqrdm",
+    "asset_ids": [
+      "terra1tc7tcg8u54p3t2r5yfufgf4z340ggwpvlc2rwt",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra16c2lh2lr0xe92ayf558rgzw47gf8cmqh58v06n"
+  },
+  {
     "id": "terra1atzg5zp4p9sy7k9urun8q703upffm2maffm8tz",
     "asset_ids": [
       "terra19cxwwhtkpp4qvf4tvjmhh8lnh8lle7uw7ndqjw",
@@ -9797,7 +6437,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1seymtr0r73sahrl2y8ul7afjp87ldrct8vtksh"
   },
   {
     "id": "terra1au85utmuaskgd0uhgmhus35hpaca2munlzuhrd",
@@ -9827,7 +6467,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1gtkh07x4puthw7tufyn4lnwyp625djczf4rvvq"
   },
   {
     "id": "terra1axd3wejrvzx27sn54yjlxlhrrr49zphqw9fpn5",
@@ -9837,7 +6477,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1d0zt56yn4lx24ewxy3n40ry6jg7e7xvrp2uhpq"
   },
   {
     "id": "terra1ayqus392c2fzs4mgrsnlkzjaqfd5efla72el85",
@@ -9847,7 +6487,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1e5ydr2utqs4skdetw377ndqmgn07hzrdwc0t0m"
   },
   {
     "id": "terra1c0afrdc5253tkp5wt7rxhuj42xwyf2lcre0s7c",
@@ -9860,6 +6500,36 @@
     "lp_token_id": "terra1jvewsf7922dm47wr872crumps7ktxd7srwcgte"
   },
   {
+    "id": "terra1c0g493amwrzx47zxa0qcvrks7wyhmqkpsf8u2y",
+    "asset_ids": [
+      "terra1pkfzenexjj6ne68xv2g9t8387s7d6z39c60ghr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra13mehc6ldhs2sryy388tuqn5cxq573gdhrq0cjg"
+  },
+  {
+    "id": "terra1c0hc7ncedxaps2hxl0qazxlh79g4zdre5geq4m",
+    "asset_ids": [
+      "terra1pmmdfnmhrjnywsgkd6xplgp8nx03fxm6ygma09",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra10fh39v2p59x7pcu0659r7pq7zdhkwp7hr96cca"
+  },
+  {
+    "id": "terra1c3zsqpvlev8x70cmekqxmqjjamvwdw93gzqjlc",
+    "asset_ids": [
+      "terra12zzantsa5trfm0ssrgsnhvlram502ats35qtc3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra17xhypskf3f0cqf0knvyqw844vm54fg2j4fxng4"
+  },
+  {
     "id": "terra1c4ddm3ds2zwun37r7ldek908ypkxxpkvkcat5f",
     "asset_ids": [
       "terra100yeqvww74h4yaejj6h733thgcafdaukjtw397",
@@ -9867,7 +6537,67 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1ce3ac6jqm396r4qtsgu5m37qxrk44q6n3ht25g"
+  },
+  {
+    "id": "terra1c4r7vdd7f3cjts6kzjuv0sx4apesxr9p55kqc6",
+    "asset_ids": [
+      "terra19v4cg3w698qprsjwzw52cns6245vkxug74q9lc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1hndks78y9k49jq35x4kwjsvpp8g9hn26e5n7d3"
+  },
+  {
+    "id": "terra1c535v3f7fz8a94wu2cev2p9wvzfv7x35uv7tk6",
+    "asset_ids": [
+      "terra1wzxpydn6z4z0us0wpx3n96gcs5p9qqavhw5sqs",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1xup47v2ypdhk4lpmjw68k8hlt9s2ejjg4pv83j"
+  },
+  {
+    "id": "terra1c586ncze76sv75zlg3cqusqdmn6zluukdhc9cx",
+    "asset_ids": [
+      "terra1vsr6l45yyqn58at6nymdx99kph9sw7zql70akr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra10qpu5aajfmkucfft53hs6hzn96ckaqa0cdmhje"
+  },
+  {
+    "id": "terra1c59fgnldauz68wpxzawxy7w650r0yvhq34g6ng",
+    "asset_ids": [
+      "terra158ut7lycly6ep0v334rpjtcjs8hlvwjzf5tfrk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1fgnzu8mwnmg6utjqslrw5fr08yqxeaat88gfc2"
+  },
+  {
+    "id": "terra1c5j97vq48wjln03wgtalfhlmlg6uyczmpj74vj",
+    "asset_ids": [
+      "terra14rq6etqgza9qqpgz9yjfmsclgnzhk9jsafdtyc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1we6ygtflu43kjgzj8ug6d43f4zkd3fmssax5sx"
+  },
+  {
+    "id": "terra1c5khrjsj0q9l2pyt75cw7hrwst7xyr9vegutkv",
+    "asset_ids": [
+      "terra17zeqmepm87d9g4dujjsctqjrfhz4xjkup26t03",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1hd9hnlwtqm5s5mkngqdqytdc0a6elquh6n70nk"
   },
   {
     "id": "terra1c5swgtnuunpf75klq5uztynurazuwqf0mmmcyy",
@@ -9878,6 +6608,26 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1l8jgxd9uv430rdt2u58h4h7kdfxsle4w6w2ecq"
+  },
+  {
+    "id": "terra1c74x8j9caymapwg30z3gse2jlxvgkm56uhv6zq",
+    "asset_ids": [
+      "uusd",
+      "terra1my0tlq45u0vlpyt2n4qchxkzhzwnxrd2playfq"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1cgfghgpw8u832e9xlrya7pqpj0pyyfpyptwdte"
+  },
+  {
+    "id": "terra1c78mey84ygre2ym4aznw28796qfuytcl32p83j",
+    "asset_ids": [
+      "terra15plvf4hfgsrev5athn7wmnqgt6f0lddmduzp90",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra15gpwuqw3uezt69vxa5ftd2dt7yc8ap2fydqhat"
   },
   {
     "id": "terra1c7uxt89gap5gcclvhtqvx3wpd0ee2dpjhf0ct6",
@@ -9900,6 +6650,26 @@
     "lp_token_id": "terra13698ymrlv2xpy8l28r6qx5fx420w744zg24qzp"
   },
   {
+    "id": "terra1c9t0gzff3z4mh62ky9cj9hkunlj8zqz58kqa87",
+    "asset_ids": [
+      "terra15q3lzrnfstr3rqgh55cqmp95z4xr3we5tfyqm9",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1gmuytg024c2edzq3hdkk3quqzcttpnax0cq6el"
+  },
+  {
+    "id": "terra1cc2w6lgzxarvawywfr7v4q7nq30tfvnfs62u54",
+    "asset_ids": [
+      "terra1wdc6xjyng08qwssthzvd5u8a4z58r8jxxn3j5t",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1zy5sjsw4aswykccwtvkaq27s2eedspvakut7gw"
+  },
+  {
     "id": "terra1cc660x0c7w8ln0rvqftrjt09sjs0wg4xaxtx6s",
     "asset_ids": [
       "ibc/73A56F04D27FC4CCF6F75C7516A9698B7411E1CE763E240C8A29A50404F86B53",
@@ -9910,6 +6680,26 @@
     "lp_token_id": "terra1mr7mh33nyf86vzutwr6ypcv3ceeecfvfdwz0l6"
   },
   {
+    "id": "terra1cdj55x2gj369g50g3w2uqjm6p2fchgy2ehjd0p",
+    "asset_ids": [
+      "terra1fkwfm2w8kffl3ged3zulknz849rnfdxnwjgdnk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra10z27h35npl969tp9d05qfs49k925rxm3w5sd96"
+  },
+  {
+    "id": "terra1cds3ru8n9s6cpuqszd6kupxjghj8r8rqk8jvmq",
+    "asset_ids": [
+      "terra1fpfn2kkr8mv390wx4dtpfk3vkjx9ch3thvykl3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra12vugedn4wdhxztzaycucs4cn9l2wrqnq4xr4f5"
+  },
+  {
     "id": "terra1ce7rky5mjrjhyadp976r25r05jhslyn0q3rl86",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
@@ -9917,7 +6707,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1avac7r4n0jvaqgj6tnmkscujhmh2924jt9k2v8"
+  },
+  {
+    "id": "terra1cf38v8qumxruarhxfsgnylkymz6935c6qhcrkv",
+    "asset_ids": [
+      "terra16pem7c3h7renxuxa4jvw8efv4nhrdc3leguzyn",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1kxddqksg8x8gmdu5l5ceqqyva9ypnzujldkj03"
   },
   {
     "id": "terra1cgsuvt2nyxxqc6gfg39q2h99s3877mhyhd29uf",
@@ -9927,7 +6727,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1qzf6d0jp4seajurxtp6gfvr4gc3qe42mj5mzem"
+  },
+  {
+    "id": "terra1cj2du5dmwr86u56u3xp6kx5u9ww7z2vcz2vrrr",
+    "asset_ids": [
+      "terra10c4zqj4f7ze4keuwvm6hk2wrdj9p8h07sp4fg5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1hffx97vzfuj5ysxtpzjpatf5utpaqces0dvm3y"
+  },
+  {
+    "id": "terra1ck5vwpsz9nf95c7t84jjwfgpxtcnpj23aka3ml",
+    "asset_ids": [
+      "terra1pduqn0tpqce36ndwcv6z6xjlnujdddl6pedz9y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1l46txnnqf0j4l7g6630dhf0vxqhpxyzzadchfj"
   },
   {
     "id": "terra1cmehvqwvglg08clmqn66zfuv5cuxgxwrt3jz2u",
@@ -9940,6 +6760,26 @@
     "lp_token_id": "terra1z0vaks4wkehncztu2a3j2z4fj2gjsnyk2ng9xu"
   },
   {
+    "id": "terra1cmvp86pqrt2r986v63mm5257ctplnf737rktl7",
+    "asset_ids": [
+      "terra1y6mgy2ha0fwhtkd06jdca7hpep7z8hz9n2jz8t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1wqa24s7qzqess0pwrx3q70lh0uj04vajx6uf58"
+  },
+  {
+    "id": "terra1cpmqngse0kw0rkgv5pewgg8dvg9ep240xelxc4",
+    "asset_ids": [
+      "terra1f659ez3nysf06765jjjqnl7m65urrqaxx2t40h",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1uzzyyxp6kj87q2ygm0d9se0pthnrjh7jy75jxd"
+  },
+  {
     "id": "terra1cpnemrjze8904e4ggujp86y0vs737uapqqfmjz",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
@@ -9947,7 +6787,57 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1e5twxxjms8pks8sjd9lentkcwqv9prgxj674wd"
+  },
+  {
+    "id": "terra1cr5uef9rrl74xcw9vjsqklud2dstdfr4xj7hqm",
+    "asset_ids": [
+      "terra1ce0z2295uajnvxltll75zuvh5mvecczy3fmlzj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1my49papxtmataag9arh9wdrqyyuqyjfw7cc44v"
+  },
+  {
+    "id": "terra1cr8m0mpdj5e7m34ekdrqgw59az5v98pgckha4y",
+    "asset_ids": [
+      "terra15tqztw9vjcuc9znkvmxn7rh30ffdnahhnw4vym",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1dsj8lxhuvtz8k8vt9v7zjm85cca4qjhsqgvced"
+  },
+  {
+    "id": "terra1crkwlasutngkqdlfskk7rcgasehpq6aaerarqd",
+    "asset_ids": [
+      "terra142yp486a6jjelr87c0kx6vxv22nw6dsvkcnhma",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra196f5vd4s9zn6deqv9shjktk348nk7k4kcl4apd"
+  },
+  {
+    "id": "terra1ct767uq6h75duwd0jl6t9lxt3zn3wvvnec3snh",
+    "asset_ids": [
+      "terra1ygrhf4zv86jp7hnyl358uj42llm75gt7w8e9s4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1lkcazx0hn69qsw62tyhj6u0svsnepg73vj553h"
+  },
+  {
+    "id": "terra1ctdwhvfkhrp8z8l78l85h0da6ywlmp2yjtws2e",
+    "asset_ids": [
+      "terra1s9jnada32ld74gmng8ng5l3zfy9vk8kfds5828",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1edy63xnmphdr47p97hw3h6fu72md3u952ra0hk"
   },
   {
     "id": "terra1ctt2k8euhqny20vqynjpxqv32nlr0r95gr2eeq",
@@ -9960,6 +6850,26 @@
     "lp_token_id": "terra16r76trzhj48rj8tmq82f8set2mm6v7qrje3rn3"
   },
   {
+    "id": "terra1cuxd5x9vs0m604pze90c0xgccraucv2kqcwlz2",
+    "asset_ids": [
+      "terra187zprsu04wnfs64pznf69mkls6vefhtmtwt8w6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1pgjfhamw0dv2t9a5d9q9eu7fm9etj4zcewyak0"
+  },
+  {
+    "id": "terra1cvg3jjepvcxzkv5elvr3x5khk83wllvg4qygfc",
+    "asset_ids": [
+      "terra1lxpjyl6k60rsyp0x7fa40s8jsl5l0d27ycmwfh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1rkzg0jw55t78www72zu9tzqvzhzzexe86tryv2"
+  },
+  {
     "id": "terra1cvur5qlnaqulwt987f2crk8ccttlvztuq9w66a",
     "asset_ids": [
       "terra1zey5xuv48yfjf9y0v6zkyfdtv2du5kau2kdrna",
@@ -9970,6 +6880,16 @@
     "lp_token_id": "terra1wrwxmmea6nxktx09hf2f2m5m0473wnq9lxhn66"
   },
   {
+    "id": "terra1cxcxfa5hd60t8t8rphzgpwunwh3dxplzm0xpwj",
+    "asset_ids": [
+      "terra1m97d9028kdz002wkq23kp329w68yun7p0x6vlh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1r099m6j4unzjxv77vxnt05hrszphpm69f5x2rs"
+  },
+  {
     "id": "terra1cyu32h09k6djqt3a0pgljgan2vass3etl6vcng",
     "asset_ids": [
       "terra1lnrphdxwfre5w7rwazzfnp0k9d4glm63t7gg70",
@@ -9977,7 +6897,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1adrqsdqtnhsvadl9gzuqcrh63vyye2zdzsj64g"
   },
   {
     "id": "terra1d3jylrg6w94akvu0dky0y6l62sktrfzd4zfkq8",
@@ -10007,7 +6927,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra14ldgmqnhpf80attmgjcu6am76zzn8cd2ntkvpf"
   },
   {
     "id": "terra1d76u99glatdeep6qjkhg48u2a9fvuejcwnasut",
@@ -10020,6 +6940,26 @@
     "lp_token_id": "terra10etw4xh7ymehx3ngpknfa0p9nq2w7c97vhjzw8"
   },
   {
+    "id": "terra1dagf0h7ux63pqak79m7rqsnm5yujga48sg37pv",
+    "asset_ids": [
+      "terra13yf7ukapmeznh2uamd0342g0hy872my8shc74j",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1mf2f35qq37pkmq6e657ha0asc6tzxm8zwaxg6r"
+  },
+  {
+    "id": "terra1dc84dhqyqrrzpt3tjnkrzsyky2yyzxr5tszzxw",
+    "asset_ids": [
+      "terra1tknq3prjtkzttvx2u48hn4r7xfwh7gz9cxzgqf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1dj5q78dmy35a27dq97sl28ta78yw2qaz275xaj"
+  },
+  {
     "id": "terra1dcq5sd3y34q4fjwgcja7uhw26xn5ylq33tk3gn",
     "asset_ids": [
       "terra1d633fx8wlpgqnns9j4xw66cq6ypdy4u8r0rr7j",
@@ -10028,6 +6968,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1ade4g64fk6jx3udjxrxz0lppqne3y2turx7cc7"
+  },
+  {
+    "id": "terra1dcqj2agjxrc7gz3zsfqxux8js3r2rz0wumch6t",
+    "asset_ids": [
+      "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
+      "terra16gx5th8mk5v62xpvgf675xj2vuaf3dg4v75ml5"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1h0vyhc8ttqe2swxkvwl8v75wpfpp5c3vxwdxxv"
   },
   {
     "id": "terra1dcs9ja40rmdax9g4ffc756w4cf6yvrf4auxye5",
@@ -10047,7 +6997,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1q94p9qjlykvzd2m0uv22r6uaj2k7gde0grzjcu"
+  },
+  {
+    "id": "terra1ddu6j495ephpxm8at7jzg55n6u0zc2yadvuz26",
+    "asset_ids": [
+      "terra1v6p9v6dqaql0600hmdl78h592ax5rxmheefgd2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1cs0u86hcfau5shkdzx6ynyrhar7r0vlsua609d"
   },
   {
     "id": "terra1de8xa55xm83s3ke0s20fc5pxy7p3cpndmmm7zk",
@@ -10060,6 +7020,16 @@
     "lp_token_id": "terra1cksuxx4ryfyhkk2c6lw3mpnn4hahkxlkml82rp"
   },
   {
+    "id": "terra1dfv0ww0tqu432aa9z6r0npucjyslu356602ayr",
+    "asset_ids": [
+      "terra1gkfv34wapjun9w0qpg8f245greudfguzlhp87f",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1n0hxydmnc55rzs8kyvefpj0xkp0524wc39euwv"
+  },
+  {
     "id": "terra1dgqs3aa66l24natsgslvwwkj3henn4c9uesfz9",
     "asset_ids": [
       "terra1w8kvd6cqpsthupsk4l0clwnmek4l3zr7c84kwq",
@@ -10067,7 +7037,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra147g65flk0wtqej7k87ggc53ftwu74w3l9vj6ln"
   },
   {
     "id": "terra1dh2kva6kd99fnq0xa0rn3yjp4dqaw7h806klyt",
@@ -10077,7 +7047,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1wlh8acne68zmuyp4n2rmsnpc9atay9s5xn3s0a"
   },
   {
     "id": "terra1dhs8euwxt0hu2vj0cne7v8qnxycsmwef36cshd",
@@ -10090,6 +7060,26 @@
     "lp_token_id": "terra1u9s0hj3sw840xkygjhemt4rxazv7gv2dgnu45c"
   },
   {
+    "id": "terra1dj35t0w5w5knw7cq6dj3s68ry724nctq069w5s",
+    "asset_ids": [
+      "terra1xmd43yrfxm4xy3lnptc7kr4rr93pzh5u0z0wgt",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ksymk0cy2lvhqljsa97c0t7098843289k6pneu"
+  },
+  {
+    "id": "terra1djzkg6ghcwmlkcdxpqq7lw42e695ulzljrvavr",
+    "asset_ids": [
+      "terra1r8ak49p50g76zamn25h3u7lkmn9n4maq2k2le2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1u5qgpemcltd5y0mzwqsz44wws5z00zyusa8w7z"
+  },
+  {
     "id": "terra1dkc8075nv34k2fu6xn6wcgrqlewup2qtkr4ymu",
     "asset_ids": [
       "uusd",
@@ -10098,6 +7088,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra16j09nh806vaql0wujw8ktmvdj7ph8h09ltjs2r"
+  },
+  {
+    "id": "terra1dkhyzytlc99rf43n4jrxttwxcvg0hvmaa477cq",
+    "asset_ids": [
+      "terra1yj7vlx4uj39u8x4ptvvpxhpfnmphypmlhfhq42",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1mvht6zch65z2jstqfz6dye5wlazhhmc4eky6gz"
   },
   {
     "id": "terra1dl6h9np5xhtwe520ksjawy5q9lh4cznmhmzkw2",
@@ -10117,7 +7117,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra19jfkgnpz6gr67vrp52ya9wx9fg9mkr4kffs3p7"
   },
   {
     "id": "terra1dnzskpmnl0s9la8g4jczfgpzfq62kh766cg3pg",
@@ -10137,7 +7137,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra16e6c93s2ye74hnrw3h406zadl8r0sdayw05vxt"
+  },
+  {
+    "id": "terra1dq27eeasl3rtlc8j3ls5yz8wurnksahj240tsr",
+    "asset_ids": [
+      "terra1zva2uegkvwr03p98mdaam4dtrkfxxvu330zwaq",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1prswk9yyayfkkq99fpaz5zs7h0lhcpsqa4swj9"
   },
   {
     "id": "terra1dqjt2jm908qaayw5hdl36w50sshmgem37suawr",
@@ -10150,6 +7160,46 @@
     "lp_token_id": "terra1lzacmnuaceg2578lpxemnx5mts5es8fnf2d6u2"
   },
   {
+    "id": "terra1dqz4zx0uecwjqafzyej7pzyhhqse2agq767al2",
+    "asset_ids": [
+      "terra17qfuwapug8scgw5satxs4n95u3taw6fe8hdgty",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra15pqvt8z4vd3kn3y7d7pjla76a3hh7c9xxhjkwy"
+  },
+  {
+    "id": "terra1ds7gy9gyf9e7rl8zmmtfjt2e2dm4d6p9szu8tq",
+    "asset_ids": [
+      "terra1ss460ny4hl5zew0tlvywnw38rsy2ql3n420lv2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1mqm4zudg8hyg3lyjh46vuqd77qf9lr2wznrgpe"
+  },
+  {
+    "id": "terra1ds8u8qrqv87e5mud77up62rl34rtltg3v4w3tc",
+    "asset_ids": [
+      "terra1qv98rklgrdv89gvf47rrzx2lzehd43uwz2rus4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1maal7qmyn8vv4435wc3nx7nryu7swnj0n2v4dp"
+  },
+  {
+    "id": "terra1dsmz3dfejj47wcxes66gktwqhsvyxe9n2pld0e",
+    "asset_ids": [
+      "uusd",
+      "terra162k5t3hl204lrwe8xvalh4pv4gdrjvdrjlgxst"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1cnryfady5636utnsvv9uj429mhnwfqmtr4als0"
+  },
+  {
     "id": "terra1dtsjzg6g5zkqsfwrw0uxlyl6e6u4kna0xzk0q7",
     "asset_ids": [
       "terra1kc87mu460fwkqte29rquh4hc20m54fxwtsx7gp",
@@ -10157,7 +7207,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1vmheszf3h84h4s08ru6s9p9f5t692s08vwvppr"
+  },
+  {
+    "id": "terra1duyea9eyua7uftths0n0kn5uzrdsguj7mmv666",
+    "asset_ids": [
+      "terra1ykq4e3ca2e5qgeetk8k8m3w6tk9tclr0xj2st7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra14janxct88y74znp68z4jh5j6hq3nfd6shr3sjl"
   },
   {
     "id": "terra1dv8tp8nustr58z0mlg8v4jpxjd62s2g2dflwhr",
@@ -10170,6 +7230,26 @@
     "lp_token_id": "terra1yxlq4zezzvkha2e8wmck0nzx9e26xrjylk2dax"
   },
   {
+    "id": "terra1dvwewun965qpex2k8hrpfpzt8t7qtq3ptwu6j3",
+    "asset_ids": [
+      "terra133j6tpq7gcrjjgvgj4r3fjwda0hegmmrazmwt0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1j7q92vh3nvm0srpm86lhte566guh64myzw007q"
+  },
+  {
+    "id": "terra1dwsngznkraae33wufcz8qu4rd83elrzn9g03el",
+    "asset_ids": [
+      "terra1ptmrg9j7tcjphzejzlygehaxwtzrr6ywsu72qq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1zky7u7ynn6m67zequu5cgh7jefadg6ux46a22z"
+  },
+  {
     "id": "terra1dy4dpuxev7y4tqa0rhwjrc6e4yz3w9gqr6szz3",
     "asset_ids": [
       "terra18zqcnl83z98tf6lly37gghm7238k7lh79u4z9a",
@@ -10177,7 +7257,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1g7ze40w256lkrma0km7p5v0yk200mvw97ygw6h"
   },
   {
     "id": "terra1e3d9xx54vc4fhepvgqhrwt7m97zftaxet2zayz",
@@ -10217,7 +7297,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1sfu56eqhepfk6snvc64srx24s5gecyejag486r"
   },
   {
     "id": "terra1e9zck0ak5ufz94csu83p90xu37q22dhk22trh7",
@@ -10250,6 +7330,26 @@
     "lp_token_id": "terra1fwwxakw6ue3jt398uneyf8agnwyf2pys8dcjcz"
   },
   {
+    "id": "terra1edmq655dxqjk4dh52z6e0h9uajs5g0yl5lk7y7",
+    "asset_ids": [
+      "terra1nh6theuhf4pv67pcyqnz58czljr382mxrp2rdh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1dt5n5tf9afjzms493nfkt3telqtvp5mmmftu0e"
+  },
+  {
+    "id": "terra1edrk0fflh8ve8d0dn8hna46ftvu9mrruhzeunv",
+    "asset_ids": [
+      "terra1d3pmqshpe6n5cs7d6mnffdun4tg0k05zfy99zh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1xajvgkhmt8lqkna2f5t28jegsywwkgxvncl988"
+  },
+  {
     "id": "terra1efwf7jw3tgyy7uqx3u8j9p0kpl9ts39avgnzec",
     "asset_ids": [
       "terra1z3e2e4jpk4n0xzzwlkgcfvc95pc5ldq0xcny58",
@@ -10257,7 +7357,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1kyyakqzf92xsg0cu8j5xwcjnzmuxy42nygdgpf"
+  },
+  {
+    "id": "terra1ehdk7m3p7fwpmzhfh8pdnqueqy6ymmccsnjpsd",
+    "asset_ids": [
+      "terra1f8m2ylcpzfeg3675yk7htw90d72jltgk4mkr9t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1lxx00gux7zl549dj98cd0rws0xv48ns4qdf2zf"
+  },
+  {
+    "id": "terra1ejql0hjel8s7ywxansv3svrrv4hv8t7h0803em",
+    "asset_ids": [
+      "terra1zzfhavsjlhhx42rnjfvwk6u7taplh4qxqmhgfa",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra16dv8v3v52s7ktxdgltxz6yje67xs8c3azaa9g9"
   },
   {
     "id": "terra1ejyqwcemr5kda5pxwz27t2ja784j3d0nj0v6lh",
@@ -10267,7 +7387,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra18cul84v9tt4nmxmmyxm2z74vpgjmrj6py73pus"
+  },
+  {
+    "id": "terra1ek0rr6pj76mtrukw9l90wd8xwcuknw8aqp48sj",
+    "asset_ids": [
+      "terra1247nlrmskhfu9qpg66zt5w6f8cw250878enl9g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1hucpvv7d9nqydwg86nyk2xrz4x44nf839zjyf2"
   },
   {
     "id": "terra1ek3g47rves5tmulz3h7twl04fawldwhdr7pyxf",
@@ -10280,6 +7410,16 @@
     "lp_token_id": "terra1gj5azdr9y80d3reegwumpz48ww09sqqym68vrz"
   },
   {
+    "id": "terra1eky5etgq3jwhtyz2tqyuykkxpj6rep7jd7v7rq",
+    "asset_ids": [
+      "terra14zj58ljhlyrgshe0n99un3k5ll2s0eucp332nu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1054t5v3fszukf4hajqvf4zsndcn2rdx4yz8crq"
+  },
+  {
     "id": "terra1elte83u4a6yrw90qmaeee58w94sy6yq7mrf8k0",
     "asset_ids": [
       "terra1d8h5yckrkgzneng72c8yskgdfd2s9870fuxnfy",
@@ -10287,7 +7427,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1cdhk0p72gn7fyhkgj229ynzt5j8n6xlkuteeha"
+  },
+  {
+    "id": "terra1emetwzv9g6pc0gp5ghj7h9wyvwm902wtxj76d4",
+    "asset_ids": [
+      "terra1mfek3m9s0sazd40kjraw5qv3963t5n3gwk408u",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra19kadah8p79e4m766e3q869jv5f67s60qfxznmp"
+  },
+  {
+    "id": "terra1emg7lr0fxyqxkytdk7seupa4lvgda2frxjluz6",
+    "asset_ids": [
+      "terra1a8k3jyv3wf6k3zngza5h6srrxcckdf7zv90p6u",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1drarcarn8y5hzw0hkjcpa9nhefpq8gqdfeq3rr"
   },
   {
     "id": "terra1enhh46s0ry3mnj6zx0rd2jjr0pyuspmueywaxl",
@@ -10310,6 +7470,16 @@
     "lp_token_id": "terra10dlmpyedw742sjg99kkh3sfyy4e0tqkjfd3qyh"
   },
   {
+    "id": "terra1enwvvus429s4yxr0d5umud3k6eyhln6vn57v8z",
+    "asset_ids": [
+      "terra1d8uw3zddfrexn06f80nz6hx2cd3f32a7p45agf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1hp9saxd4mjfrmmzlzmkt9x9jk69vpu7vsh6lwf"
+  },
+  {
     "id": "terra1eqclhzm2d9r7kecf2v87lja6ghgc4s6fmh9prt",
     "asset_ids": [
       "uusd",
@@ -10327,7 +7497,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1ngxra5n0awmaujstndfkg4sgczfvnplvw3ewx2"
   },
   {
     "id": "terra1erfdlgdtt9e05z0j92wkndwav4t75xzyapntkv",
@@ -10337,7 +7507,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1mdujhgx37fjg7wrwqj98mkuu6knks7ap934987"
+  },
+  {
+    "id": "terra1eryc869znes7ujk8usxrrhy2zru8f77478mn0e",
+    "asset_ids": [
+      "terra1lrqv79tw447kk4ham08suw7vak3a7pf9de2qx0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra16pj9ycwu7yvfwtkrew87ss2tqvr537fl2rl800"
   },
   {
     "id": "terra1esaxnyzts8256a8afsgqsghvm263ngzr32c9km",
@@ -10348,6 +7528,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra143v5xc8zll66xq8zljxulacqylsdhlzwaraz02"
+  },
+  {
+    "id": "terra1et3se39fd2nmnuygcvls2amujzmv4v6k4xwv69",
+    "asset_ids": [
+      "terra1mz858mn7jeglmzj0ay8z5zy6v78fvv7em9tljz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1r52sh4ksk35t4zt6qvpp33l0fu8l4fp0k7j5dj"
   },
   {
     "id": "terra1et63aq9nclyehc6j05uv5j3nvm8sqfey99u9g2",
@@ -10367,7 +7557,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra14xvjk7nq8ee6ks4nzgaeexwmc2jgv9dxv73d4s"
   },
   {
     "id": "terra1etdkg9p0fkl8zal6ecp98kypd32q8k3ryced9d",
@@ -10378,6 +7568,26 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1c9wr85y8p8989tr58flz5gjkqp8q2r6murwpm9"
+  },
+  {
+    "id": "terra1eu62yulj5zjhs8wa9uvlj5l92a809a2hcp83uv",
+    "asset_ids": [
+      "terra18glhvftntrqg00hv96qkpx3r37g34qh8qytnps",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1zaqqruu0ch0qgq2s2djkelywfn9x9yfg7wjet7"
+  },
+  {
+    "id": "terra1evfprrp4l8kratzm3hs2yxnly2t3ps2r5x7jh2",
+    "asset_ids": [
+      "terra143dkyw98s3ksxu97zln8z5s220ytatygd5rqdx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra16kvs9y46p4lkj0dnyef6ly4fzs7883ztl2l9dk"
   },
   {
     "id": "terra1evjf2hq2w6y9t53d2fmxrfddauz8manutpykp4",
@@ -10397,7 +7607,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1h0lllt9mecr69e4r7qs8jtnupz6vnk30l87egc"
+  },
+  {
+    "id": "terra1ex4tn8m3g2c8xv3q9q5mlm0d8aa6684g40y3cx",
+    "asset_ids": [
+      "terra12mvfnsk4r2chx7n032aztme7zcypyla5pllhzm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1cckk499jtsquglucsygqj5gxy9k7fu0vgwxgrs"
+  },
+  {
+    "id": "terra1eyyqh5a5w6sx36q0dgdewmnvxkud8yap2u2xp3",
+    "asset_ids": [
+      "terra1agkfm4zumwkkudpj0882xaex7fne3rume0775y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1fl4qcp5a3vs5unz3f3kgjwr7rxvq3g393jrk5v"
   },
   {
     "id": "terra1f22zcf6m4600eajay6wnzw03lmjdy0f8mjxphe",
@@ -10407,7 +7637,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1ungyyyachxaszce53zstctel0mpzactmtz8hdp"
+  },
+  {
+    "id": "terra1f27dfgcgx5zpa2f3zd9s79jrjmklwq0l8fa6el",
+    "asset_ids": [
+      "terra1e60jlze35lh05dlqrh2yjv3r8z3gktwchykrq0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1r3hc388xqf83u86ruvhfe3p7pnggz3stf694qc"
   },
   {
     "id": "terra1f2d4qd9wdwrwkksezst20u0dgk867vuf438pah",
@@ -10420,6 +7660,16 @@
     "lp_token_id": "terra1g7a4hl64r0pmjmdrd3cwsy2cdg2st5x7xlc6m0"
   },
   {
+    "id": "terra1f3tdduzpsdrg33x6w8cqmzmyytnmhzcvwnharl",
+    "asset_ids": [
+      "terra1y8q4jk5xwag3sschctduxa43eesupjkk6kr452",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1wl8puq7gyxdu2nwqc5xym2gs5836mx4980gpmq"
+  },
+  {
     "id": "terra1f562s8g3y45cqxqn4qftvwcwxh2rc3v68ug2cx",
     "asset_ids": [
       "terra1u3cykdenv7z3hveg6vfc0w23gfhwkdktftka9a",
@@ -10427,7 +7677,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1uyar5ylq5r4ctw490jsypuu9gufyc702638kn8"
   },
   {
     "id": "terra1f6d9mhrsl5t6yxqnr4rgfusjlt3gfwxdveeyuy",
@@ -10447,7 +7697,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra18fafa8k888gyu3zza7dhcc77xvfzwplnqe909y"
   },
   {
     "id": "terra1f9l20gvf6vd7wtkga89n2vu69jmpqg0qyzapa5",
@@ -10457,7 +7707,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra13tz3rplgkhj3yav5h388hac4a23p5w0cptzffr"
   },
   {
     "id": "terra1faaael2u6jp9wscfvwqu0376djt8t4rnjmn9p6",
@@ -10478,6 +7728,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1hq2t2lgg6frwpr9sycwc5cyqqdlv7pam5qehe7"
+  },
+  {
+    "id": "terra1fcgvdqe2dcgr7x2a9w3nfc0nhjh07zggzdlnfm",
+    "asset_ids": [
+      "terra1paulfn369vuz6s6ty65y56wj8gnamzpdzwk9x3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1de0x05wwqt9yn8lpd5phd4r0pgu2zawcc4pd28"
   },
   {
     "id": "terra1fcr6s373mxsw000z5xv9zftmpz2uvc4u0x3dxk",
@@ -10507,7 +7767,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra19tn6v77xf2v5tkd0g3dl5wqvjdh8d0u4g3p2j7"
   },
   {
     "id": "terra1fehg72ukrnmt56evclq023rpefzjmrwre9k6vl",
@@ -10517,7 +7777,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1mrs4cvfg8s8anlyvyf9ttfv4uf49p4q0qc44ws"
+  },
+  {
+    "id": "terra1feuaajpy0yyag7zsz2w2yxst6faeemn82mlnrf",
+    "asset_ids": [
+      "terra1rumme3vcguv9ly60p53j6wg5qanacfa9nl5uyw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1gpavmsf3snhltxnf7n6nyz2ehyswtflhsqk7de"
   },
   {
     "id": "terra1fg8f9s8ltyw59crjde6vrv2chvcprndayk9gt4",
@@ -10527,7 +7797,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1w5etcaqzhwe6huwytkwuxzkvlvqx98vgu6z96u"
   },
   {
     "id": "terra1fggg5s5eayyqm46p6m27xh3manl6c4pt8kfvn2",
@@ -10540,6 +7810,26 @@
     "lp_token_id": "terra1jaw7xw5904fsarqgugk0h4tl32w385zv5zaax9"
   },
   {
+    "id": "terra1fgn8re8qf9am8ymkmaawgspym43en9f8w50f8c",
+    "asset_ids": [
+      "terra1m9fuqymdz03umd88guyc79083hd7vppzu74vck",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra10evwunz82kc0wucnwyxnzq35yjygl9huglrlgu"
+  },
+  {
+    "id": "terra1fgwk7tjfzcul8mc8xwdkf3ejswgcxkh7d087ku",
+    "asset_ids": [
+      "terra1yanmc0xxg9dl387qkudnysjkymgytj3cdhgeek",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1c7lwa0k2uu0xxgsqjlk4yaycxj3wwp4ft7lxsd"
+  },
+  {
     "id": "terra1fh2j8kr484725ra3hwc9q3j52h2qdnnwargzhp",
     "asset_ids": [
       "terra1k8fakrhcg5h87zux06hlds3eswej8389l8fdlc",
@@ -10550,6 +7840,36 @@
     "lp_token_id": "terra1a3n5ryr8ud3mw0cdu6gm8yqdcjjmelu5d79g7q"
   },
   {
+    "id": "terra1fhgksqjyawsym7myq04ddvm0sgxwzqqlw4pp5j",
+    "asset_ids": [
+      "terra1elveensfjwt270xzt8rcpvwmnhawrrqfx5atj4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1xsv563k2wyuqkwza0mrz6ye8exx4a9r0hdvxs6"
+  },
+  {
+    "id": "terra1fhs5njpe2sy6acf7r3s8qh62mvs0dgs5wntdtu",
+    "asset_ids": [
+      "terra10hr9gx9m9tq44xcxk2c5mzzlk7p22zd7x6esr7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1xapjctwprfuqpcte2h4mnpxtf7nh3jhurgv6sf"
+  },
+  {
+    "id": "terra1fjrjynsdxvgqsahquuun46w440d59020vxva9d",
+    "asset_ids": [
+      "terra1fcq75y4ezhsws0vudna3cddk20d3k0eg9nznyh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1qmkvvy88csy36tdqcknlw27h0vyqg9s0jph4zp"
+  },
+  {
     "id": "terra1fl3x3plfat8y82c9wpu6uv97wkqap7lp04a4jr",
     "asset_ids": [
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
@@ -10557,7 +7877,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1punuh0ts2fdqmp2zlzw6cutr9vfnpxvu56ehel"
+  },
+  {
+    "id": "terra1fmp455y0fgee5dv68fxwfnylnpux6fv3th4m2f",
+    "asset_ids": [
+      "terra10vwyclaux26l47hj2dgnjw2pcsrt4y0ukfgp9u",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra156yh2j8krf0a6kjz2gkf9skkhefg9cdmvc2fpx"
   },
   {
     "id": "terra1fmv3g96s4xc9nrnlkdn87vxyaydd22xsxzel5r",
@@ -10580,6 +7910,16 @@
     "lp_token_id": "terra1luejncg2je82xgts7sg3f3g4ytq2473ge5z3px"
   },
   {
+    "id": "terra1fpnmpty0r6fmyxnfzere7xd62cnjaumslzz7d9",
+    "asset_ids": [
+      "terra1spe82hmc9j2y2vjl6urue78zhrn9r9xyydkyx4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1fwcdnx8flnyy4skav4fvurtmrh86ef9mkumgt6"
+  },
+  {
     "id": "terra1fqf55gk7a2znglw3kh8j5gu0zgfj6sxv4q9ng4",
     "asset_ids": [
       "uusd",
@@ -10587,7 +7927,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1fn984w8kr48yh222rxusel7sk94z60m0krfl8h"
   },
   {
     "id": "terra1fqhyxfrvlhguw97nuhxm34uvzar8vfr63ft7km",
@@ -10597,7 +7937,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra12m9t48jgj9hmja98p003y796x7zffxj6c55npl"
+  },
+  {
+    "id": "terra1fqr0y0djympq8zfgztev9dj7fpp248pff7860f",
+    "asset_ids": [
+      "terra16q2hhuva6u0zakfav0pmrdw2fhjsanvqq9y56t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra16800h94m9r3n8alhu2rsxxpxyesh9sylu3jgen"
   },
   {
     "id": "terra1fts4e488k0u9xc6etggjdqrcnxvmj48vmd23ly",
@@ -10607,7 +7957,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1tfxtdv9x39m4gecmdg4mpkvxf5tfrslte7ea3s"
+  },
+  {
+    "id": "terra1fvzjp7p8qy0l332qy8rpljcufmsqdxjyvckney",
+    "asset_ids": [
+      "terra1ua6saapgern9jpmklkvxxq4l06nal2cwd0003t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1dvkjth7zak3f5kvn7l8vfp9n0cu8dtjnjhdql6"
+  },
+  {
+    "id": "terra1fx82cs3ttpcnd9wg32a70ajkfturmedrgup2vv",
+    "asset_ids": [
+      "terra1cxusd4uhgpgk2sp99rexrcknpn08anak3v9tz7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra15q2dvy9ex5k3nl7dsay83sf76t2ug8zend39em"
   },
   {
     "id": "terra1fxn30f9j9a2slvlxxxk6gyjlqnznhprh0wu0mv",
@@ -10620,6 +7990,16 @@
     "lp_token_id": "terra1wy2cweqqxf0w23g3c9t8e8n5wukcf24fujfhpt"
   },
   {
+    "id": "terra1fydslvtnl4d4dujz5kapslwty6were2aeerd95",
+    "asset_ids": [
+      "terra1ejmg85y0vgsxv5r3cd4024j732pqnwudl0v2d2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1q3q8lrucdvs93walj4edxqlaj0lqqyrs2sgk7e"
+  },
+  {
     "id": "terra1fykaggpacrhy6rjh2u7vs3ec8p9u3l7ynf6gy8",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
@@ -10628,6 +8008,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra12apekfpt3pzjrcwz7rqjswqr0nsrezjkvlzvzm"
+  },
+  {
+    "id": "terra1fyrvx3m5njh265wu3xycty3ynf04x8wqhpm2lh",
+    "asset_ids": [
+      "terra1897wmaycufjr9hu894mt0g33ddcgm9vfsfcyyd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1hqpfh2g457fuzrm8e0skagwwh79pffr3zzqwek"
   },
   {
     "id": "terra1fzjflxpv8e0d8ue7hu7faap6mnd0ckamwje5zp",
@@ -10647,7 +8037,37 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1uvlukgsje5cp6pnczg3y4etkctrh7yjps5tewj"
+  },
+  {
+    "id": "terra1g39kq9n6qmjzpls9kfxu86yvcz3p9ajy8fqjp2",
+    "asset_ids": [
+      "uusd",
+      "terra12y2uzvrn3j4y5390kfljtpq6z3wqflyg0wls2z"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1da3m78cejl8l396gahuqnllwl4qyxeeysm5vrq"
+  },
+  {
+    "id": "terra1g6jmfxv2rangz50u335rfum2fxxqmk4cnl43kw",
+    "asset_ids": [
+      "terra1866wzpwzmrnmh0s267twyhr8c4tc47tqj5aths",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra109kmkve0p4ksffjdfkry75d44hy038mk7x6ygc"
+  },
+  {
+    "id": "terra1g7an9lfz22gkv74238dhc2j6ymfp4jy0k55yxk",
+    "asset_ids": [
+      "terra1qw6sp3rjar2x7mfa0x4uj90ssemwap8p50f8kh",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1yqnd70kvrdfazu7aplalwqdp3ksnu35fv9cv9m"
   },
   {
     "id": "terra1g8kjs70d5r68j9507s3gwymzc30yaur5j2ccfr",
@@ -10667,7 +8087,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1a24wnwx8c3yg0jwu8hsp0qwrvuv0pz7ed09gwj"
   },
   {
     "id": "terra1gal8pckrn8w0mxk3q5lkwa0grw2qmdfpkwgex4",
@@ -10687,7 +8107,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1cx9shhtqmxcacs8jhcdgxce8hqum2u6u68d0sv"
   },
   {
     "id": "terra1gg00qrm9l7ghqs2c2ey55uwtc7cvu39c799lr9",
@@ -10697,7 +8117,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1esgjh8xnmnrndcctdjz6ux5khdylcmgenyyq9r"
   },
   {
     "id": "terra1gg0snqxxxhjcma4095nn7lduwtv3k5xw34lzks",
@@ -10707,7 +8127,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1f7jzky244gwy220xp7cdd0vzhu6l5ncafderaf"
   },
   {
     "id": "terra1ggqhles03a4zcxp470s0nwctm9n57ggae0vmfj",
@@ -10730,6 +8150,16 @@
     "lp_token_id": "terra1zaj3vee3qrperz3djkmjzhvsdnt80vy2a9szgw"
   },
   {
+    "id": "terra1gk2nnql0vllx34dev6l9grl425leuehckwpx3d",
+    "asset_ids": [
+      "terra14ec8v4c5dnwu2pq9plfquaffutu59tq9hld77e",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1zg9vp5w4xtasrua7kx3rn4smm3e2nrda4u3432"
+  },
+  {
     "id": "terra1gkdudgg2a5wt70cneyx5rtehjls4dvhhcmlptv",
     "asset_ids": [
       "terra1w0p5zre38ecdy3ez8efd5h9fvgum5s206xknrg",
@@ -10737,7 +8167,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra14d33ndaanjc802ural7uq8ck3n6smsy2e4r0rt"
+  },
+  {
+    "id": "terra1gkrajyr342clv98p2f6dx72eyj5cx0t9pa74f3",
+    "asset_ids": [
+      "terra1fy4yf7n076wqmcfhsfh543xu35024lw2wlcxq7",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra10q52n4yx9nn7p2arhle32kyujt65euzh3vny4l"
   },
   {
     "id": "terra1gkx2ft0568avqalllpj0d29gxkfq6spk967vzu",
@@ -10747,7 +8187,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1zppeatj9dmjecgl2dqkqw8fjwrcmdzdf0kh7tc"
   },
   {
     "id": "terra1gm5p3ner9x9xpwugn9sp6gvhd0lwrtkyrecdn3",
@@ -10758,6 +8198,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1gecs98vcuktyfkrve9czrpgtg0m3aq586x6gzm"
+  },
+  {
+    "id": "terra1gnwt6a5t5vw90q26va9fj3j0rsnjemptht0szr",
+    "asset_ids": [
+      "terra15uc875u7uu8xyqf833nxwh5x4dm2kmu29u04vl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ewm8kaj2vvh2aknjzlv6cyqm4hjc8j0uvdnah3"
   },
   {
     "id": "terra1gpc8f9t9fhehjqlhxlq7aug4vgpw0rfrzsgwd0",
@@ -10790,6 +8240,16 @@
     "lp_token_id": "terra1jmauv302lfvpdfau5nhzy06q0j2f9te4hy2d07"
   },
   {
+    "id": "terra1gqqc9f89a92h75m3hqt4c4hpc8466a5a8z4xt6",
+    "asset_ids": [
+      "terra1cvsfc32dkdvmla6urrscrtfceztecj0u5tvlvz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1dxu9d263z3rxdn3s72uswtszjewx573sh4mq9r"
+  },
+  {
     "id": "terra1gs8pm90pllcz5t7hsqs2fnxjv6pxzf47gg3eua",
     "asset_ids": [
       "uusd",
@@ -10798,6 +8258,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1hrrdpncsr6z978kekdamdaw9jrxjr5r5qtsdas"
+  },
+  {
+    "id": "terra1gtu7lxdl878r02s2q7fx0thzfu852c3xhxj04n",
+    "asset_ids": [
+      "terra1qsjs0a02jmyfhvaeul4zax22sayx5e8dl8527g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ekm4u8whtpzvna0arcxjpj5mx2qfcwku70nzgz"
   },
   {
     "id": "terra1gv6t0xkxdr096gkad4kksxr0kjl4rxuf583rgr",
@@ -10817,7 +8287,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1hx9erauuaalwsexsg8jn7fmyd3n4g744dj59p3"
   },
   {
     "id": "terra1gxyn0lewraduax9lgcqekpcxf0yx2cqtl9pq99",
@@ -10827,7 +8297,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra12zl9vnd4rt0xrgt4zylztjcm40u7fmfcf33vn0"
+  },
+  {
+    "id": "terra1gy92pyp6kwllkpqv4gmw63l50cglzqmtz2jjnf",
+    "asset_ids": [
+      "terra19qad83kr29qg89fpl4qh8m02wapmlwzpw5hvc4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1s72ztquh9j0rj5w84kxlflkwz0kwyaflgxtstd"
+  },
+  {
+    "id": "terra1gyrp3pnw34wy0ptyjehfw6akwd9h4ed6kmxmev",
+    "asset_ids": [
+      "terra1mlhehkx4rgp357jmxhqepy0nr4tjetkje9t686",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1v29xuc4he907gkpc3zmrhqhuxcvy3jhfy50wue"
   },
   {
     "id": "terra1h205tvn624npz49snyha3l4cv60d9kccvdr3cn",
@@ -10840,6 +8330,16 @@
     "lp_token_id": "terra1klc5n2zy79ttxur0mdvhqldyzhkmcehaqm877w"
   },
   {
+    "id": "terra1h279dtdp2jal5z46memvs3fqa9syfcnd92whp2",
+    "asset_ids": [
+      "terra1yss9zexptelas8y4mqans2qscmw69cy2g0tycu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1dznxnr2k77nneklkd05jmxugp2j77mtt6v6yjn"
+  },
+  {
     "id": "terra1h2mpd99j8mcuyjcxh2wa5xsdkhwtrhyucsyrzr",
     "asset_ids": [
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
@@ -10847,7 +8347,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1ec352y2dlwe75kx8px3ncxpgc6j46cmlsvn42f"
+  },
+  {
+    "id": "terra1h4mjl52nsy6y04r9snxe23fzdx85vzvpcnu6lz",
+    "asset_ids": [
+      "terra1ckrsweg4dtg47qv55ecayntlax3j8ja956nq2l",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra16v0aunfk0tqswrldmyczz8aymwe9r279kknheq"
   },
   {
     "id": "terra1h7t2yq00rxs8a78nyrnhlvp0ewu8vnfnx5efsl",
@@ -10870,6 +8380,36 @@
     "lp_token_id": "terra126pa5vgw2ca80yd8gnk4fs08ef94g6j2f4kjcu"
   },
   {
+    "id": "terra1h9jyaf7wttw6txdy64608wc6k998dt2ny8zjwm",
+    "asset_ids": [
+      "terra1pmf2x6gp8u979q672lkkkruuhe9zarxyu5w7t2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1xfq07tcdep6lujx480xqs02q5tk3ka3p4l2m8d"
+  },
+  {
+    "id": "terra1h9zcqxdcl89hwvgxh2v6l3e3lfyguawxcvtasw",
+    "asset_ids": [
+      "terra1pc253zfn4zns6awk7eks779uk3m7dna7y4cmlf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1x9qq5yerv3wpq5f0hlhj84lq7ulpmd88taxvnd"
+  },
+  {
+    "id": "terra1haarsvn3uxmul3rt5vr8x0856pjj45js6fwkhz",
+    "asset_ids": [
+      "terra15fvz44vh89rj4ykamk2tadw0f7wdnccn5qp0ua",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra10pkxzyxsxxrpumks8v6txn8ym0z339nrjf6fje"
+  },
+  {
     "id": "terra1haay9t8vvpvdrtd6t9c6pzl2cpr8m4xeadhykv",
     "asset_ids": [
       "uusd",
@@ -10877,7 +8417,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1k5z9y8h9jr4ex63cmmlazn3kjc7mncn66xrrk4"
+  },
+  {
+    "id": "terra1hakq6c49989jkgpj4qcp4akxqgesazps2ss9lp",
+    "asset_ids": [
+      "terra1gqmd09k8g3lggxxdzu9z94vqcxtr5zylvs95ke",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra19c5fhtrdaarv2cly5su7w9a2ud7nk72g2vm0gv"
+  },
+  {
+    "id": "terra1hcqrfwnjvsp6y0hyp9sgfla6k2fqx23g9j9q9s",
+    "asset_ids": [
+      "terra1ktugzem827nn5uh2ccjk8y6xr9z4szvdc7x39r",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1k9tcrhdgh2q5wpzw8j4ap3fen3ryn6ycdmn4ru"
   },
   {
     "id": "terra1he8as5az55glkg7rye69ujsgl8f8gs3khjxwm2",
@@ -10887,7 +8447,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1xxracarga8mf8yadf8s25hekr4kd92l3wr35vm"
+  },
+  {
+    "id": "terra1hfm049mt76s4kgsdrz7x0au4um4spyvyxe39m3",
+    "asset_ids": [
+      "terra13zs7w76g0u4qgagcen6vq92wxuvgfucr3dy4tm",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1rvsp3qg4k2vyd432xj9qzxx2p9hs2zzn5u43qg"
   },
   {
     "id": "terra1hgzc444yxhgrdj4g9js9j87uarvsk3ze0uv4mn",
@@ -10897,7 +8467,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra15rsfzmyk0vfch3dg3wve6l2cggppmuuyfxjawx"
   },
   {
     "id": "terra1hh5c3yuq9q2rnvndkdqp0nxr3yh7hwkfsnuwwl",
@@ -10920,6 +8490,26 @@
     "lp_token_id": "terra1wjw2f93ntqtahv9unlwhx3jjzmmy0npnkjh6f2"
   },
   {
+    "id": "terra1hjpke0qekl4q7uy758c9z5ve6xwsuzz5n783ek",
+    "asset_ids": [
+      "terra14g3uqp52dwk9qts40mr2skynkqdxsqwlv0862z",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra188ff6qfccynwu3ge76ylp0k9hm9ke3fsnacmc5"
+  },
+  {
+    "id": "terra1hke7ncmglkcevsgx0txma8a02pz4npypahcc0r",
+    "asset_ids": [
+      "terra1ltcad0e9cgf2jgtzqwg82n9k54fre68wdddfll",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1xtxds95gvddytcxqu5larnuvxt5gekwfxclyu2"
+  },
+  {
     "id": "terra1hkp4hulmttwzagzphr6vczvjm46e6ryxv99nan",
     "asset_ids": [
       "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy",
@@ -10927,7 +8517,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1mm72fhs0t0sxnvvdu34srcqfk4c8zgcaf2xzd3"
   },
   {
     "id": "terra1hl4624c6pkza6jyxnzpyxf07vyhuwt34c67ujf",
@@ -10947,7 +8537,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra10n7l0rxnmwjehufywtvd3lj952rxdt7n8e9skp"
   },
   {
     "id": "terra1hmcd4kwafyydd4mjv2rzhcuuwnfuqc2prkmlhj",
@@ -10958,6 +8548,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1qq6g0kds9zn97lvrukf2qxf6w4sjt0k9jhcdty"
+  },
+  {
+    "id": "terra1hn8m4250rgmtpx04uc75sfvqsyvcj4g9fdrmlg",
+    "asset_ids": [
+      "uusd",
+      "terra1pujanvsuhqsqf8vc7r3ky9ghr8sgeg4e3ngjun"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra140jj5n8yd52ucvntzfh02yslfuys3kxnd47lzr"
   },
   {
     "id": "terra1hngzkju6egu78eyzzw2fn8el9dnjk3rr704z2f",
@@ -10990,6 +8590,16 @@
     "lp_token_id": "terra1j0j79nurur9fhqf5hrl8uav75pqmrt0t06a4ap"
   },
   {
+    "id": "terra1hq3kf4353m5d858u08mymad5rvgkc4zeqhr8vs",
+    "asset_ids": [
+      "terra1kuf3mxgrcwnlh4zfk5p5c6tcv436j5kza70asm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1j02hv8ulc5yg7hc79ycsxfhgmys7jjc0m550c0"
+  },
+  {
     "id": "terra1hqnk9expq3k4la2ruzdnyapgndntec4fztdyln",
     "asset_ids": [
       "terra14vz4v8adanzph278xyeggll4tfww7teh0xtw2y",
@@ -11020,6 +8630,26 @@
     "lp_token_id": "terra1gm0vm4fpr9xe93tw3nc2vdp9ju3g9knwd75afn"
   },
   {
+    "id": "terra1hsyfna6jujxrfd86043w2tcydyvql7dks9v4zr",
+    "asset_ids": [
+      "uusd",
+      "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1gjz8xr2z92pffvzgp0khu569njf75jkhe6ta04"
+  },
+  {
+    "id": "terra1ht5zgyecp4w7s3jzgq9j4unjx44hx4se94yp62",
+    "asset_ids": [
+      "terra159tnr8a3uutvwxhgkea4f2hucm4v24evv2se2t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1qts4ddzv4ndsv4mkccazupmfx8q978g0kr459n"
+  },
+  {
     "id": "terra1ht8f0pnym9tcnt5srxmlnyndsfl84nntphqfsl",
     "asset_ids": [
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
@@ -11037,7 +8667,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1uwedwfrkjnxzf7q8t5wjj5fcymp3kjdsssjzjg"
   },
   {
     "id": "terra1htymlk5xlkzezmd6sy3rmucvhgdcglv5e8jzay",
@@ -11060,6 +8690,16 @@
     "lp_token_id": "terra1kksfhstvdl9ht4pxzx900279s7fdaqp3un6l40"
   },
   {
+    "id": "terra1hv6zykkt9xjhuqzumrkpvp5e9t6hrq0837c576",
+    "asset_ids": [
+      "terra1juul8ypgcs4wtuqsc7fjv76g0tq77nc44ymxph",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1mjvdm5ahr6l9yg2h6sn0khu6y2dkesfmy9dfnf"
+  },
+  {
     "id": "terra1hwaaf5sj0039qf80q3e5cce37rw6kgdce44q0f",
     "asset_ids": [
       "terra12897djskt9rge8dtmm86w654g7kzckkd698608",
@@ -11067,7 +8707,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra18kvjp6xw2epma0vlfpktg6l7kuztzexl3nc0me"
+  },
+  {
+    "id": "terra1hxekdhzzlqrytzvf7vl7jvz8tk36eldmaygdu7",
+    "asset_ids": [
+      "terra10t0rgfryqz5ds93z5tqed740nqh4ele9lm9fhq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1x32xraswsr08qg9dee6jkkjac4y2j3q557f8q8"
   },
   {
     "id": "terra1j0927vf9tuawu3k85q73jjrp58mn26psmmyw75",
@@ -11087,7 +8737,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra14ex4azzmx6dez32tf5xm2432ua577krfz37c8v"
   },
   {
     "id": "terra1j3dc7eh7tus3jn476zwz9waf37w6hy5qgtjhc3",
@@ -11117,7 +8767,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1fcfl5xa6kwgtmymwgjr2rgq3j2h8q00vy39gs8"
   },
   {
     "id": "terra1j5rqw5vtxsx7el0mptyjqhtfaqnxgg6yu90ek7",
@@ -11127,7 +8777,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1kngl26kllhsmhkjjh20dz3du2fd35t75rran60"
   },
   {
     "id": "terra1j6dx9d05sdpynkxexvp4jqdlgqv2adp7uls4we",
@@ -11137,7 +8787,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1da9qfgpar8v427x9me632qpk3jna4q37z2asn8"
   },
   {
     "id": "terra1j8cg2ncvtkfm00lvhsaa80rckq7cerhlvs9r5s",
@@ -11148,6 +8798,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1q6ktjyy3mpk4edjz5lq3wphu860sqp2rkhchkt"
+  },
+  {
+    "id": "terra1jccp3z6efd6r4f88p7ewy2qpjtahxtz3glqu6g",
+    "asset_ids": [
+      "terra1fd0gy7f5dcgmvdl95mt3z9fh8se48gf0wxs68k",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1lk96dy8w7cq4x09q780cfg7wwpkuxrxtqjpycj"
   },
   {
     "id": "terra1jdzll6cwkmeeqjjkm4vfljmjx7aats8fyqmvda",
@@ -11170,6 +8830,26 @@
     "lp_token_id": "terra1lzqkq68yfgtuu5hkmd38f3tsnw9khgaj7362t6"
   },
   {
+    "id": "terra1jftv4fh6wyxx8rnfw343vyl5ehcpn47syn8yzh",
+    "asset_ids": [
+      "terra1mt957lrc2z93f5utk509zma6pgtceaq6tqedc6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1k597uc4rzvlgmel8xkz434xdw0tsfmt7es0pwy"
+  },
+  {
+    "id": "terra1jgrs4fnevw78q8rvutwyjzxhyy5fzqwtft6jea",
+    "asset_ids": [
+      "terra1pamyemqvkj8ws0easzq9pkl8usnjt424ddraff",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1kw6qk3wpdzj7aklge6yegqjlmnrm83248v3vwz"
+  },
+  {
     "id": "terra1jgvh68gc0zedgrs0fne2y8r0zvc2z7u4sdemwh",
     "asset_ids": [
       "terra15a9dr3a2a2lj5fclrw35xxg9yuxg0d908wpf2y",
@@ -11178,6 +8858,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra122pv8ln4s5kled99288gn8sfk4ep5pw05yynez"
+  },
+  {
+    "id": "terra1jgzc2rkgl0nlxxqgy097wtq55c7qv224ysx2dw",
+    "asset_ids": [
+      "terra1gdapfuda0dxtjc98raemhszntcxty7chyr0wpd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1mqhv4thnf8mpwvj6ul7wrrjs2y5vua257yhxns"
   },
   {
     "id": "terra1jhvqagr7mqf0nn749et3qz9nc9rfehq6n8xgv2",
@@ -11200,6 +8890,26 @@
     "lp_token_id": "terra12pltplchslx9wmsc2mey5hvramycnmnra974f2"
   },
   {
+    "id": "terra1jq6ud6xdljsrpgnmuhwc8e9sxjut5el6t5z9gr",
+    "asset_ids": [
+      "terra1qn4v9nnc2a0mdnkzl73rh60264gvhu6pxusz0r",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1lfrpc9npxgz9enqcdswmealzvt96aae2qe20jg"
+  },
+  {
+    "id": "terra1juyxhxne0gm7nma4vrm3pz949lj3p5wg266x55",
+    "asset_ids": [
+      "terra10aa5cyfu879fm88glc099sjg8unejcp46cv6hd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra159je5qq2c45l4vl4j2uwpelyxvmf06nnqyyc3y"
+  },
+  {
     "id": "terra1jvhqxjzezxvss9d0rfpttvz4hv6lp7urvwmx0j",
     "asset_ids": [
       "uusd",
@@ -11207,7 +8917,37 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1whdv289y72n38x8sevz5erze8zys493ha2fd0a"
+  },
+  {
+    "id": "terra1jvq9ufp4vvypp86hl56afvjn7jqgxxu30l5zhd",
+    "asset_ids": [
+      "terra1r3u50sue9akjnndgvxm7fe0fy5jdtnyxwuetw8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra19yfdxaw7qexrzq8lr8mjs478uu53ptmdmgrhad"
+  },
+  {
+    "id": "terra1jwl5rzg3xe0a3f8r26l0l3d957vlxm833srtcp",
+    "asset_ids": [
+      "terra1gpwkclxwwuzd5wyjw2qn3km0r5ge4t4f4mnf0x",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1srcv0x7huzrxce3awyl4u5g9rpt4fqn5nwcw6m"
+  },
+  {
+    "id": "terra1jx3m7swaseumanezk3z6r73cptucc9dqg6hprk",
+    "asset_ids": [
+      "terra1pmcr4gjjsu62t2d9e33q6d75sydrhnpt37nayz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1lqedtculy8lxdpdyy7pagztkf2aj3kggaf530s"
   },
   {
     "id": "terra1jxazgm67et0ce260kvrpfv50acuushpjsz2y0p",
@@ -11228,6 +8968,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1qjlakmnnswdzmssfzurpdg48ygu5cnw4lg9h80"
+  },
+  {
+    "id": "terra1jy57s4anzh959e6cr02dwt5s3vw03ajwtfr2l9",
+    "asset_ids": [
+      "terra1hytrupk3argcrsl5x7dv55gyda0tn7f2qqlwkl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra17tjnesmzly8gv3aj87mmtdrma77au2z6756x9d"
   },
   {
     "id": "terra1jyqk0rg9wty4nvvxej9qhnsg3ef3agcc5nmkqp",
@@ -11267,7 +9017,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1znt9ness8ayxvpmldqser8ess07engetmrxwfd"
   },
   {
     "id": "terra1k2ez4u7fnmwv30gysa2rhj4gs4pkngatnl6vxw",
@@ -11280,6 +9030,16 @@
     "lp_token_id": "terra1ka9qplck0h0kj2jxmnagt8vh64c5qczwkwp0hx"
   },
   {
+    "id": "terra1k2sgkcw0z5drjcy4nl09v40xt6hgf0kpcm4rpc",
+    "asset_ids": [
+      "uusd",
+      "terra1gl3ywddjkukupa3qv86r8xy434frncmxna630k"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1v8qcdlqarhhwtqm5fl9wxfrg58xmtjnka0dnvl"
+  },
+  {
     "id": "terra1k30c303e059kqhz705a77kgdhr2ndldfdxjvsr",
     "asset_ids": [
       "uusd",
@@ -11287,7 +9047,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra17m0ujjyw0na6jmjspl7ykzzuu675c67rl7m9gl"
   },
   {
     "id": "terra1k3nh2pqgxm0clwm8c4d3stggytn824kejht7v8",
@@ -11300,6 +9060,36 @@
     "lp_token_id": "terra1mxup2qhrk0d5pd57erhxa9h4uwl9ugh2yn32ef"
   },
   {
+    "id": "terra1k40xfmkswya285zwcsj0qlamg0f4kyrvn2cd0d",
+    "asset_ids": [
+      "terra1xxze8dty562la0d6g9q3srlddh0qemk08kpgfr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ryc8v8srh8kwclxcay7dgqtkclty3g5n7gj0y5"
+  },
+  {
+    "id": "terra1k5gg6rjgmmut6m3klz0sz36x7lt505p977pc9a",
+    "asset_ids": [
+      "uusd",
+      "terra1t5r5ptw6ympy9npq0z7fa37nrk39n8054c6763"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1y848ua0mxnczs6hslk6gug8tmtx9cmlgf2ju7q"
+  },
+  {
+    "id": "terra1k5rnwftj26qlw6q746nv59jvg964zjr58ddsq4",
+    "asset_ids": [
+      "terra1mvgs32slrxy29qhfmd2vn7y6l8knmtw396uxde",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1za869t75aa4tjatrtc8sqxfphymmdj3k56w7fg"
+  },
+  {
     "id": "terra1k6na35qccghzvdcrmp8djyw9vxklrkxx3vd49p",
     "asset_ids": [
       "terra16pj0sful7hl87j8h5qwnv6j4vv76mxj6a6026v",
@@ -11308,6 +9098,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1k0zuu3ljmwqmvaufz0d22d37evsrzju3cz4xru"
+  },
+  {
+    "id": "terra1k7ugqrw3jkk5auuudpnuf52wtzerx4a7cjjhfg",
+    "asset_ids": [
+      "terra18gtpe3cu99pp2ej4mmf5hanrfwy6qcvd5x5cmz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ch9gwujlyz6pjptuqcdpyawn5a87dtw7a360v2"
   },
   {
     "id": "terra1k8dax754ampumzvrkq9770p7x40tnvamglg8kd",
@@ -11320,6 +9120,16 @@
     "lp_token_id": "terra1njsea05lp96jt50f7nc0euc8sjmak6drz8ajdf"
   },
   {
+    "id": "terra1k8fkje4xawkgtg0czxkp98qd2gu8uz4xgnuzsv",
+    "asset_ids": [
+      "terra157n30a667ethsknneaavga2txtze58eajyfv45",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1pk0vx4t0aum2jlyv6v0hanq3unvkhl4lxp6zl3"
+  },
+  {
     "id": "terra1k9ndjyjxmyqe3kk7sq92p42kz8ptrtz9wuyq6n",
     "asset_ids": [
       "terra1nzvqd5mr0jn58cvam9j06k9kry4myu0vp7a9ug",
@@ -11330,6 +9140,16 @@
     "lp_token_id": "terra10jmlz5uwz6w5hks8y9tretjjk4f8ad2me44lve"
   },
   {
+    "id": "terra1ka5d8934txtr2lhpdk40334k30t66hxyqswq37",
+    "asset_ids": [
+      "terra133q7a0uctlld9kru6put3hk99qvxm9qzmklu9f",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra13vxffk8n8a65lr9a24a7g28ls5hzkhcf3kzvtq"
+  },
+  {
     "id": "terra1kaed40250kxfhy60sy2zf6g665l50m2ms3zjw4",
     "asset_ids": [
       "terra13zaagrrrxj47qjwczsczujlvnnntde7fdt0mau",
@@ -11337,7 +9157,57 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra14v3je4ndyds5uqur9xun0ds4nv53q2yp4eh266"
+  },
+  {
+    "id": "terra1kafq6reya5v8ksdlnpyzv5gnyax3l3vp9l79wd",
+    "asset_ids": [
+      "terra1g0rda5pawz0duymd37puescqsx2hgqu9hgrp8h",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1g95dha38ht2y8qchz2zqa0kjnr372zpgsyyejx"
+  },
+  {
+    "id": "terra1kag0uhcl2e7tddmzaavqr7agkhr9ukghutryjm",
+    "asset_ids": [
+      "terra19k974ngjsml8dtmk56cdhuy6pplr94rxqdt95p",
+      "ust"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra134cyuqglj8nmz2us3y7nl7z4mqsmj2dx8f3xq6"
+  },
+  {
+    "id": "terra1kcdknzuz8q5zjeyzyy30ykfpf3xs4dzxh57vgw",
+    "asset_ids": [
+      "terra1aegvmfgdl4dclgpwtajll6382tcc7r0saa2eek",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1t0mgl6lns0ff6wva27zjwqfpqrjdzw550ed652"
+  },
+  {
+    "id": "terra1kd38g9rmfvklwyrszpe43dddhvl8zdgeya6ms4",
+    "asset_ids": [
+      "terra10ypru3yma98ukk3anr5cjv02yq839pcvqc476k",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ek3f48k9xje7zr6ytfdm2p9xe5qkx959kgrle3"
+  },
+  {
+    "id": "terra1kedzs6p7mc73lvnw87gvp5aa5azynafthhsxpc",
+    "asset_ids": [
+      "terra1qgvd7llck3nfav7n9k2qh35zcsmjwap073x5et",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1e8nn0zsqmlnhmxfmwe5qz5p3utyx2fljemtrya"
   },
   {
     "id": "terra1kf6ctpmz72mta3h2y68jyg2mlnxktaudsjcxdm",
@@ -11347,7 +9217,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1cpttgtdegngfq5euh3nzcacplukxv3vr08u6t2"
   },
   {
     "id": "terra1kg3ngv5j7jmef9vkrtdgaglrkxs9csruur822y",
@@ -11377,7 +9247,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1s0pcf407f6ljn2hprezdaep0wfgz53qyyhcxy6"
   },
   {
     "id": "terra1kgcv6dq7ajlh98t34puyexhy08ltnnx2tycrtu",
@@ -11387,7 +9257,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra12vd39hfjd5gtn0a3t6jy0xsy99k2kcvlcw6gcf"
+  },
+  {
+    "id": "terra1kgytwyu7aqah7cm97xeeurvsj3n6kxp0tc9esu",
+    "asset_ids": [
+      "terra1kd4rfff04cvw7vae0szgawj0xye90fkchljv7y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra105wahgnrx7t2dsxfx9wer2mtcfrvfpr5hjxyt8"
   },
   {
     "id": "terra1kh2g4fnhvqtnwwpqa84eywn72ve9vdkp5chhlx",
@@ -11417,7 +9297,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1gqfhyqlqmh09whk47y03a56azp76v5nl2qc3wc"
   },
   {
     "id": "terra1kj8zfkf3nsc2wcad7gkjjza45qnd5lgslpz4pr",
@@ -11430,6 +9310,36 @@
     "lp_token_id": "terra1lsx5sjly4yc8szw6w04cwhp7tzmlrssh2g7trr"
   },
   {
+    "id": "terra1kjlt8zsdvmxaw63u38krl658zunaj9hzxwknqs",
+    "asset_ids": [
+      "uusd",
+      "terra1zqyfp259xhhct6q2alp88pke90qrxgr5u2zc7s"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1jz8zydxlar694nqhdfjc592c9lddvxyqtn0arz"
+  },
+  {
+    "id": "terra1kljzhnu4edtc8f8xzxu223n03hj82k66xp6mfw",
+    "asset_ids": [
+      "terra13k5m9dmcdm8y52j95tuppuz23lvjug6hrh7vjx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1caxrxg3n67egv4u0v6klt66nsz4y90sydlatzr"
+  },
+  {
+    "id": "terra1klucl4s6jusuvrxag9hyay90cq4h80mkjhkw9j",
+    "asset_ids": [
+      "terra1u2tj2wy6gc8gw9g507a66796ej2csewp9asznk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1m28rcqy4fhhu9twwpuv6fdajwmfwlm02lwlzw2"
+  },
+  {
     "id": "terra1kluzznl8srzx3ssxqw5las5ym9rwqtnrgcl5wu",
     "asset_ids": [
       "terra1cyaj8agnyzqtw2k5095ysxxgjpgqptyam283dj",
@@ -11438,6 +9348,56 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1u7v3aqt6uv2y60kwur5zk3sxpcjn609s4xyzx6"
+  },
+  {
+    "id": "terra1klw8gs2ra6tvf0s86kvye26lcv3ztf885p9fwy",
+    "asset_ids": [
+      "terra1s56hsyhyvq4xxxvnz8qr0pnktm2dadsm4gkl45",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra19uvpg6ppn5jqh85c72rw8ywnyr9ecalgfe20ek"
+  },
+  {
+    "id": "terra1kneyp2t00kehpwkaxml9w7dg5p7nl703dv65vr",
+    "asset_ids": [
+      "terra1gs2pykgl27l04e6lprgqs6uwlr7rm2vjcnya8g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra18p6hxmks8pcvpvju8hlke3mkrsfwjm5v8l3x0l"
+  },
+  {
+    "id": "terra1kngr9srtrzfwz0y8ckjhx7559xhdgsthu44y2k",
+    "asset_ids": [
+      "terra1q0q09duq6jsth9m0gfj7fpxlxwlj5fcxgchuza",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra12wmaguvdvjf225ua9xjwpj5k5euy6nhtu334n3"
+  },
+  {
+    "id": "terra1kngrh3kmwngq7t4kcnqdustp3qurvenrhphyxa",
+    "asset_ids": [
+      "terra1ypgjelmtp0mv5akzwmnj5xhukhd3fy9gd28wpj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1d49ve0m99xz250uyj848yd9sgwuh5vw30kxm9h"
+  },
+  {
+    "id": "terra1kphghf722vxe0aq04n4erzflgcpp0pysrvtj0p",
+    "asset_ids": [
+      "terra1l0rnt55mf8q87q2nqfn9un3lxnmxkhqrl939x5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ay647sah03j0zv7pn62sp46sys7gqtnawnf3u7"
   },
   {
     "id": "terra1krny2jc0tpkzeqfmswm7ss8smtddxqm3mxxsjm",
@@ -11457,7 +9417,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1xwup7jk3su3mnj5hjj6unsa2hrpc6uwr6t8anr"
   },
   {
     "id": "terra1ktsswe96kkjwvcx8md8dt4k8szt2wkr5fh7px7",
@@ -11470,6 +9430,36 @@
     "lp_token_id": "terra1npak6kyfz07etkg7hk027yge7h83pp2h5u0t26"
   },
   {
+    "id": "terra1kvg5qyt25nrgkqeuanz0k7cavxg0qxe2lgjh90",
+    "asset_ids": [
+      "terra160y9666sr9ctqfzk4mu7useh6g6swet8vnl7uz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1k093hrmpy8l930ehgtvc7hrdkja3pnudr7ue5j"
+  },
+  {
+    "id": "terra1kwhysskh35wqrsuxyv3c02cenwd05l6pm96pnk",
+    "asset_ids": [
+      "terra1edualxuj7afpm27uxvv38zr4e0zf4r4z6twfyf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1zczk7ccfd2wfetyq8y6gkg0qghntahd5pq5qf7"
+  },
+  {
+    "id": "terra1kx5dge4hsm5ke5vuxzp06as8lxv0d5dwl54xep",
+    "asset_ids": [
+      "terra1kx73zld4tmv24r66h7jp8gaz2rrl4asxlzq2g4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ug8jeyh65zxffe5wwj3j88fntdjdaj8xft6g95"
+  },
+  {
     "id": "terra1kxvdprmwjxpfl4e87vazwmzdu3pphxgkmt7j2v",
     "asset_ids": [
       "terra14pwhc79alqnxdhtzm0rrxt64uh4s568u8mluhu",
@@ -11478,6 +9468,26 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1v5e88rv3easl8630pf8g2ylzlg73nv5hx0km4k"
+  },
+  {
+    "id": "terra1ky57u0437dszysa0qchyxcvuxs6ax9f3p6anrv",
+    "asset_ids": [
+      "terra12gsrt6nmp56x0q9t9h47frgr8praqyaqdvpaan",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1nq8x3tc9gudc99pp0j58n2q50us7al8v0y9eh8"
+  },
+  {
+    "id": "terra1kyrnvh3l0natnqsapzalahmp4t29dz3ylxkp3a",
+    "asset_ids": [
+      "terra13u7ddpvnxlephv6ltswy7c7hnq77agz5078l3y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1qwyfe8zymqtnhcrt46yhtk290h9cdpynx3gg3m"
   },
   {
     "id": "terra1kytqskj07g0d5qwk3jr3l3z8fdvzjytyntda9v",
@@ -11490,6 +9500,16 @@
     "lp_token_id": "terra15mewh6pgu8lvwjvyp692ez0yfu386mtydw3vp7"
   },
   {
+    "id": "terra1l0ldny298vsdln3gsd8xsfzln8yddgntuc3e4p",
+    "asset_ids": [
+      "terra138d8ek2zl48pp3el4s25jxnxn8m9nl2n4y0glm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1g666d8h4hsqhw8s8axdrzeu6n7sul2w2zsgmn8"
+  },
+  {
     "id": "terra1l3gn79zdchj977p5cg9etzv97cnmcp2yze4ulz",
     "asset_ids": [
       "terra1kqf8ua7al5tdnkz95ue4zkuv4gcu52pt63ya54",
@@ -11497,7 +9517,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra16997r7lh6nwq4v86t8awxnszvsuk8usxlur9ez"
   },
   {
     "id": "terra1l5lxw4uucaserz6f9g7av9ejyfyac5jpw94fh3",
@@ -11517,7 +9537,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra19yxmfrdhdgz5xhpcyz0sje40tnxlq2psfpr4gd"
+  },
+  {
+    "id": "terra1l649ch0y5nxnu5mrkefjfsgyyn5yj9pqjyfgc0",
+    "asset_ids": [
+      "terra1ddjp4wgu52cktzgzvahwkr4dcd95mxaqad2pmu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1k43ed8sql40cxd3mgaqujachuhhdrpzvuj7tvv"
+  },
+  {
+    "id": "terra1l6s778y6gljerp0epa8wwmj7dxtlm7qfrmk8h7",
+    "asset_ids": [
+      "terra14tl83xcwqjy0ken9peu4pjjuu755lrry2uy25r",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1070nrsj5mf8qhess7f3vtylcmryhzpn9xqr577"
   },
   {
     "id": "terra1l774jntnhr80wsj758fr9hlj49t8j5qf0dxhsg",
@@ -11530,6 +9570,16 @@
     "lp_token_id": "terra1knrlem7cg0ywg5hldmghlj8eqh0f8lw2fhc599"
   },
   {
+    "id": "terra1l7l9grndgnjagmgm7e0wf0aglwrj3wtzgcdtz9",
+    "asset_ids": [
+      "terra1zrfd9hf3z6kwewxrt3rluzdj5d7ymzxnnptc6k",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra10fmk0879fn2hm6728kgc40ytkqgn6cdxfnzyty"
+  },
+  {
     "id": "terra1l7urxwu5txjsy56xcuaxac4et42ll3jnjnjrsk",
     "asset_ids": [
       "terra1g2dz304juraseqdqq6ufnktqgeqen67sct3p7d",
@@ -11537,7 +9587,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra14cukkjnldflzke4x5xq5fgf3txkfq99zw5l35q"
   },
   {
     "id": "terra1l7vy20x940je7lskm6x9s839vjsmekz9k9mv7g",
@@ -11547,7 +9597,37 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1urt477n29estvze3nuqp06y3me8u0tfehjc8e6"
+  },
+  {
+    "id": "terra1l9l4slsr2tllds0r85nuem4fcmqrtjdp655pdt",
+    "asset_ids": [
+      "terra13awdw2dt45l958q274ukg0hvvmctghllv343lp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra12ncluxlmuwkhq492dkd8y6g8p9kzt50dvdxxtc"
+  },
+  {
+    "id": "terra1la2j3fggypkv5v7rc3vdrs6f3nm5duexd7y4pj",
+    "asset_ids": [
+      "terra1n6eltvex47mta0me66ygqw0fgvjx2ul7qm9fjp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra13wn4sj9c09638wdxn73d2hgzlzg2dp5gh4fj4c"
+  },
+  {
+    "id": "terra1lc2jzj4x8r7f6asy6vf9jlwnjpuz83vuruutkj",
+    "asset_ids": [
+      "terra1k5hx3egz7jnzqs7n2ze0d93mce80y4cndd5saj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra15s5dsy04dkplkf7k8sggc5nwc40dhnx9eektvt"
   },
   {
     "id": "terra1ldpgn35p9m2ksumh8dksp3edvv4nz9tdj2pwv2",
@@ -11557,7 +9637,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra18qgqfp2pay886vakll5duudytylazyy9eh89yq"
   },
   {
     "id": "terra1le9jy02n73ghxkus40dldgrpeez24pa0t0yl65",
@@ -11577,7 +9657,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1sukupmhftyy0d32s75atnu4fcp0hcmeq6j7u39"
+  },
+  {
+    "id": "terra1lku3pluvh5hgdr76d2mmz9uch55uxqkk2nzc42",
+    "asset_ids": [
+      "uusd",
+      "terra1v7q43s46ntt4p7cpxcvsxjk6srr7uxvldn6vuk"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1rxsqmtax455x5628dzhjtflcs0grpxar6hcgvl"
   },
   {
     "id": "terra1llf5gsmqnql3rvztx6zv0ej3fdes7nqmhrwvfw",
@@ -11607,7 +9697,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1uqlv6yqf3qqnftrlz4xak33hlfhkc80eucz4fz"
   },
   {
     "id": "terra1lr6rglgd50xxzqe6l5axaqp9d5ae3xf69z3qna",
@@ -11618,6 +9708,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1s0dgcsdy9kgunnf3gnwl40uwy9rxtmc39mhy2m"
+  },
+  {
+    "id": "terra1lskrhzzyxtm235j69ty3y4fk7mswczq5f93ntq",
+    "asset_ids": [
+      "terra10l407saphqe2tc35ejhzg7xyulqkeqccvvc6uw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1tmfam6rhnv0r3u6ejrc7fdn5m25kulx9xsnzzj"
   },
   {
     "id": "terra1ltjtvt27ra3vrhyfmv4x4wymez7kwal5tzx3mq",
@@ -11637,7 +9737,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1tdsuw7ruwahf9hffnzudvppz23ak2e3m9qm8ef"
   },
   {
     "id": "terra1lvkkwhzgchq9n9xafag9u4q96q057vge0q87zd",
@@ -11650,6 +9750,16 @@
     "lp_token_id": "terra1snem5zhmzj3q4wzm59tf98f0czsf6hcfpf703z"
   },
   {
+    "id": "terra1lw2vz28ajmdntvgfz95rdgljq4gc4qw90wc6jm",
+    "asset_ids": [
+      "terra1zucgllq5ddqkfgsyjr7qnrfhymu0y4rgqsfyet",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1y0ej8fdyvcy4736m02eu8d9ftr892de78dypwp"
+  },
+  {
     "id": "terra1lxug53rtdtv5c8k7alxum9pfnayzhq5mu4y880",
     "asset_ids": [
       "terra1l6nqyv78m3kj8v4wa7r5fr3vhp0qzrauwkx5av",
@@ -11657,7 +9767,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1a9z6wmutvfnl7va3e85mmfu90uph0lx3jtq9m4"
+  },
+  {
+    "id": "terra1lz2uwr6jqjp08yqf6fee8n484hdxa2rzpte2h4",
+    "asset_ids": [
+      "terra197txx8gsllv9rakjs6zh7pw6hnlgvte8yf8a8t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1je8e4j30696s3j2tv4rvscnzgsan87uqy694x3"
   },
   {
     "id": "terra1m68xcezywdvdwr7tfe9lauygx99h7wyx64ss7m",
@@ -11677,7 +9797,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1293yfuq5y40exg47kutfaelhknaegq6rk02djj"
   },
   {
     "id": "terra1m70c962mz88gesrp2ascej5pr2027vs324vynh",
@@ -11687,7 +9807,37 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra10m40dna4wht424lwngv8e7jnawu579jth2m2pm"
+  },
+  {
+    "id": "terra1m74nhtm9uj36jc3024y403h9cnh3uvthhpq6zq",
+    "asset_ids": [
+      "terra1jvsfc3aedh7cyf3wd6vs7r5fmdsf4v6veh525e",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1hfrwjf66e7ayc90p53t9h5qxcqthtg5ug4yejq"
+  },
+  {
+    "id": "terra1m7n5p8e0mkh370mfp0e93jfk7uc34gxxxqegwn",
+    "asset_ids": [
+      "terra1cu7zc3q8089cuu4z5ed5nl4c9w59qqhs2mmfyy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1srwc8xh9d5zx700n7n7unq4eww620vw384pwvg"
+  },
+  {
+    "id": "terra1m8dlx0g0j00xlxvavh972sk0gja2xn5gxjvtu3",
+    "asset_ids": [
+      "terra16ygrvq7q2zxw7jj3f96racur50w0g7r0mj6e2y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra10yxksgtaluqt4mdley4umd3fqsgj49wfe5knvg"
   },
   {
     "id": "terra1m97h5kfh9gf8d42vuvhsq7es4t8y6s6dte8kz5",
@@ -11707,7 +9857,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1d26gruswnl36rvlny8sltdzjvpew4nf2vnj38u"
   },
   {
     "id": "terra1m9wn7rpc570tsgfuk973m4c8u52k8gmks4f3ej",
@@ -11740,6 +9890,16 @@
     "lp_token_id": "terra1jyy5a49r77le4l566m4wfun3pkpm0ed7n0luk8"
   },
   {
+    "id": "terra1ml720ts5kfg5s9hhsft74hy6clqsevsqkvu0du",
+    "asset_ids": [
+      "terra1037zmxv6f73e5mlq6hsyadlev0fj4q462llw3d",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1vkjgr2rsagh52jdcur4zgjyj7ag5xrfmyekne2"
+  },
+  {
     "id": "terra1mlz0yv4j8rw6saz5v7fq35m0qtacag8qj4hr83",
     "asset_ids": [
       "terra1lladdxhn49jz0hrvwgalu4a548txh94mcec595",
@@ -11747,7 +9907,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1shgxcgjrr8wvnjzryzmkyvkc5rptsyc0thd75u"
+  },
+  {
+    "id": "terra1mmc2z9znnl92338yquuhwzh2vj7gt9ez66nnt5",
+    "asset_ids": [
+      "terra1g5unnjllx9900hjsx6x3zhhv504ssqktdc82l5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra15hnvcwq69maqesv0497f45fez0lmunmghjqmwf"
+  },
+  {
+    "id": "terra1mp2d8zjhtenah2rgv7p4g6zaxp3s44pqx9z5ek",
+    "asset_ids": [
+      "terra1spuk4t4lxsmgx8wqq0ltqrxagnrzwvk6lmf4t4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1zjxyrnfgf93kw5uhamvnqxdfnczqhwsgpe0evv"
   },
   {
     "id": "terra1mp40g7sneygtnxdm2ncxmjq45pgut2hryxck3a",
@@ -11757,7 +9937,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1q7n7hzd9dsmakmzjql2mdg5gfrnx42a9hj8665"
   },
   {
     "id": "terra1mp8mm0m43s926dqmwv3mgfaagvtpx8e4w84ur6",
@@ -11787,7 +9967,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra10jcr5y0geuyxl350jlcvc0gauvdzzlr7csk7j4"
+  },
+  {
+    "id": "terra1msws3xuf0ey3l0sdt0t3rw49gjcq4nya8h3lad",
+    "asset_ids": [
+      "uusd",
+      "terra1ld37cm20t8z3r0zvk7hx2qcfr2cdayteed8089"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra14jaq6qur7mafha4ky8u6ct67xav4zt054p865j"
+  },
+  {
+    "id": "terra1mtt2dpjah3mja54rg9exyexsdkw8u3pljdu34j",
+    "asset_ids": [
+      "terra13gdkkedrnd48kel0fc8sr08usdfpdce9ku6qku",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra16ledesd9tn24fte454883p577qvr24hngmfefg"
   },
   {
     "id": "terra1mv3tksqwfextmnejw8s7ada9qu3pwav098qfxu",
@@ -11797,7 +9997,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1xgkkmc6luamzndndxtpg0520ajsnzzplcavq76"
   },
   {
     "id": "terra1mveechnw84gnylqjs7v5wrk9ky9jyly6lsfmfr",
@@ -11807,7 +10007,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1j0mx27zxqne7e7c4558eksje8n8368v89mjc7k"
   },
   {
     "id": "terra1mvjm8g5zmwutqmqsjaq6q4rtv96c825v3lpep3",
@@ -11820,6 +10020,16 @@
     "lp_token_id": "terra13dvh4d653c6tyu7f30hwcpjnrz8xhx87yduphr"
   },
   {
+    "id": "terra1mwsw7mzxqdv33naqg50quz9ataxfveur7u48aj",
+    "asset_ids": [
+      "terra1ep337j8q9xm7t9ypqugr4yhgnvf0jgyjga50tv",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1sdlk96gvztayg9yayxksaghrkwv5hsz3psu3xn"
+  },
+  {
     "id": "terra1myn9wsgv02jny8jwhnxdf8lrfy6gvdnv2c3wk3",
     "asset_ids": [
       "uusd",
@@ -11827,7 +10037,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra17tlyml4tq2hw922aq2dq4dhnjcu296mlkgrx6n"
   },
   {
     "id": "terra1mz0p4wzz5tmethu7rca2jjrw077hv2ypj7h06z",
@@ -11857,7 +10067,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra10zkfrqvgqvsh026ljcswe59lwh88yc5v43yc9q"
   },
   {
     "id": "terra1n4cqpg6yrgrjy3znfyx0pka5gyh6hysv5vqudj",
@@ -11868,6 +10078,36 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1dp54cd4mq449w0x6gnxlw6v0yg9dtpjpm4urv3"
+  },
+  {
+    "id": "terra1n4kt65x0mmynpfdgcwfz36dwws2v6er3eer6dw",
+    "asset_ids": [
+      "terra1qlan324u6rsdevvc6ye3m02ump7dtp3z67uhqy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ua0ehzs2z7qq05qehnzvp44gev2w7cc7vnuyh2"
+  },
+  {
+    "id": "terra1n5nzqdktzh6j935y09244rghn6zl3ga6h8ktdk",
+    "asset_ids": [
+      "terra1mtm6l7xdmpuelf2q74sq58d2e5gwm72d42algk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1t32vjs5l5f5452kq78wvtaest5qkhr37vymcfa"
+  },
+  {
+    "id": "terra1n5y7ym6x3ma0en8ff692406gtaagk8e7l4nyzq",
+    "asset_ids": [
+      "terra1y4yx8w0p9v247w5uv5hfqv2fccda7rmt65mwcd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1dntanjjlturgu2zn3t07evdf6cljepaap3vmfa"
   },
   {
     "id": "terra1n66fcrg3hh2q36jrk8j900jx6xf72zw0thf3h7",
@@ -11887,7 +10127,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1u9ytts0kz3lsfg2z9804u8pdyz79283n5jevum"
+  },
+  {
+    "id": "terra1n7kaxpxslz5aw36gx2mnc9a30n4yu0us7x2xj7",
+    "asset_ids": [
+      "terra1xs3pv5rd2xu36w9vg05shkgxcrxkvz40fhnfsv",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1237hndgalhuukzuccfvfjj538az8739td5cnaw"
+  },
+  {
+    "id": "terra1n8jq50xnupyassyc3z4apwc33av3499v45tllv",
+    "asset_ids": [
+      "terra1lxh32h38lf8xdk6lv7k5w0ewy7gu6psy4gfmnm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1xvqs6trs4d2vca2us0f8uyc75jpf5d76d9d5dy"
   },
   {
     "id": "terra1n9dgrp7e8fxds75ffflaqfk9f7edeswnd7x2pc",
@@ -11910,6 +10170,26 @@
     "lp_token_id": "terra1hv0xq2uyav58w57dckcvcg3fu39gvrjca737sg"
   },
   {
+    "id": "terra1nayuuwy7mdcjtka7n9xt9gpcpldyqglt0jt5vf",
+    "asset_ids": [
+      "terra1lgx3e9f6fhqda47zdyntfs07rdm5arp745mec7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra17nwqqwfedrq50k779ulvl8da3jncj960xjylns"
+  },
+  {
+    "id": "terra1nazuk5vy7u5nwdnlxefcevy75yyr9z4mejq0a9",
+    "asset_ids": [
+      "terra1m6myw86l5zgw3z58z6rynr8zxaexprfc3m3357",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1mw45v6n4n3r4ekcqn73t9wmed9xv45sx526ty3"
+  },
+  {
     "id": "terra1ndvg44ygupqwq8xqzvtyqjq7agl50wwfpm0jfq",
     "asset_ids": [
       "terra1nl9dx4pkat90gzw2j99n338n984e4cw7nxq65w",
@@ -11918,6 +10198,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1fepqumj8lea8w0au7mqluuthv0jly22tx0rcls"
+  },
+  {
+    "id": "terra1nf6wl37jxthskggvesngsp7y50s0jchmur57v3",
+    "asset_ids": [
+      "terra1dw6yapjv8k8anef2kg43hewg3g73wle22ncaje",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1um0scxtlme7nrtdk4dmccwxvaggpr43qc84vfr"
   },
   {
     "id": "terra1nfe80fnw2d0wax64ag7j95evqglqelhkh78l6t",
@@ -11930,6 +10220,46 @@
     "lp_token_id": "terra105j7u0yn7gjx6sdnahd35a6n6f2hm6y6saqz07"
   },
   {
+    "id": "terra1nfkhe4vy2844352ev350ldpccw06ud88qptxd6",
+    "asset_ids": [
+      "terra1av9tfs7k5gfuzm04e7p0d4ezrc53vq9mn3m08z",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra18ypccdtr2c57zd2q8l6fu0fw932ewawlx25pzk"
+  },
+  {
+    "id": "terra1ng3vjr2av7hgx9029pyc3v6y8l4zy2gf7nrk0c",
+    "asset_ids": [
+      "terra1hnsqjjzerf2leaufj7dt9j54nyjvhyppj7khaq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1qwa26w5mdznxf52zug3qegzhq8pggutfqrdq5y"
+  },
+  {
+    "id": "terra1ng4tm5a9sru4cgwqs77tm5fh47tt4sh6glzd9l",
+    "asset_ids": [
+      "terra14yyepy06yw57f4x564xrfwxvv460vq0su5ype8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra167c9s2r2jkze9xe989wfeek2zkc87ggjcu2u7k"
+  },
+  {
+    "id": "terra1nhsam29a0cnxv0sd7tk8s5x676wq9rar8vpqwn",
+    "asset_ids": [
+      "terra170r0wm50x5eh47zkvlrjkxhajp4g7wrmgsz523",
+      "upepe"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1xgn0ffavkylmh0rh2upgapj0sa9j9apray0eu0"
+  },
+  {
     "id": "terra1njhvhtgvteu08dpgnhve9gpa0wmcrzyf80s76t",
     "asset_ids": [
       "terra17yjdhu7pk865t0jeswtpecukg0uw8xelzvfmdq",
@@ -11938,6 +10268,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1mlkgz49lqndlgjfe3m5m4et7kz258fx89re28p"
+  },
+  {
+    "id": "terra1nksjldc9ze8ql6e93fms7d2y6t79h8qzv0q4yf",
+    "asset_ids": [
+      "terra1wlhgvtult73t5vpeng4sw9qmsq5jlujfm98gg2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1xyzz6yvtvndqx4hp78vuvnzwt82xraw8xd5y6v"
   },
   {
     "id": "terra1nlk3qg58gu88kfm2j34qydaxaxu9rw3yf2scvf",
@@ -11957,7 +10297,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra16ejgdv4scnaedcjrser8lc73w2gerggx2cqv5c"
   },
   {
     "id": "terra1nr2hvucfvtnzxm39022jal53wker54thdkll4r",
@@ -11967,7 +10307,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1e6dy7amgryx5xycq67wv2dxn6072kc9d90uyc9"
+  },
+  {
+    "id": "terra1nsdxqpe5upkvy9jegqdkzyhetravf8vl7m496h",
+    "asset_ids": [
+      "terra1xs3pv5rd2xu36w9vg05shkgxcrxkvz40fhnfsv",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1e7d7325sjpfk02vnzqkwsnlu0xqejydleeh2h8"
   },
   {
     "id": "terra1nsmppls52m3fmphznag3f7lue5wp6ffrp9e4s5",
@@ -11987,7 +10337,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1k4gswh2lyasmggzedw8y23v6gpxvgp0kva03xg"
   },
   {
     "id": "terra1ntdceldg23ymqljh94wcp78dl6qmzndq8u2hwa",
@@ -12000,6 +10350,46 @@
     "lp_token_id": "terra1swpfg0q9uz0ct4tqfdunrumnxx8zxxzdlnlfkw"
   },
   {
+    "id": "terra1nugs0qddjw9eznndg497ukt04cq0cxurql52qk",
+    "asset_ids": [
+      "terra1a2f4pxdqd98qclaeafdqxlc3dvnt3wqedx3l77",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1fe089wx8cnm3pfk9am2rmexrwu0vkp5skzphnm"
+  },
+  {
+    "id": "terra1nurx5e8lh8pfg8hnxw35duczvsx6lhdjrxy5e6",
+    "asset_ids": [
+      "terra1zfcfvsw9m3gzk5l42cek0ukn5g4dmd8gl4lyra",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1e6kja3hn04rhc8lslkdk63ry0gspr6zwufs323"
+  },
+  {
+    "id": "terra1nvmffcs9l6qv7c9z0unkt69jk2qtadaqw7skp9",
+    "asset_ids": [
+      "terra1vl3khh0w2fydtd72ly03vjmlll4nr0ldcl9u4z",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1yek22pthmx98yn0k3jdgu5t9tevd79c9z8l60l"
+  },
+  {
+    "id": "terra1nvpfq78mfe6emt35f9fgys2vxwcdt3kx28g08a",
+    "asset_ids": [
+      "terra1gq2yya7grd359c4y0wjfdusgrh805r6ml9jyyl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1r2ec9hu0l8d2xrl6nnawy7exmjyrlu4usyr5fh"
+  },
+  {
     "id": "terra1nx3rggxrpv0yekes85kg3fa7v73qgphst6v5gj",
     "asset_ids": [
       "terra1aydw57mpa6jg5n3xnrau9g7mftd3ch6fh7qzal",
@@ -12007,7 +10397,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra15hus6hg88440lypz37a8u90t8twdjmwnp92yfn"
   },
   {
     "id": "terra1nytaqyhspr05thllfkl9lgnvmfwxdxmcy42k3s",
@@ -12037,7 +10427,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1t5wjlrfzl4nc9v8nh40xla3ketfaw94ycxg7ln"
   },
   {
     "id": "terra1p2462m98je6pk3n03fwrnmngkm05mcr9pn6cmt",
@@ -12048,6 +10438,26 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra198pmh4mhd42ltqlcntja99fzg4psw7en4w3z7l"
+  },
+  {
+    "id": "terra1p39xsp5j3e6e9703gguen049pkf4p52rmwf2vm",
+    "asset_ids": [
+      "terra1lrdzs5tgllwqgawtq2emuzn7snpxq87fzzl44y",
+      "uchf"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1w8m7qm67t90mzykvgtn72ug7lm9cac8kaggmga"
+  },
+  {
+    "id": "terra1p445mk3wsctep477kpzvp6a4xekyzu4fqcc456",
+    "asset_ids": [
+      "terra18m6fr3fk9xh0u9vrvyeu25w0k40dptfrhw53rh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1zeestkmhgk2vjwq9wg396qpjvryftwqt2u0xt8"
   },
   {
     "id": "terra1p44kn7l233p7gcj0v3mzury8k7cwf4zt6gsxs5",
@@ -12080,6 +10490,36 @@
     "lp_token_id": "terra126evm399rxsvzw06qe9kxcmv3ly5lwarycq5nw"
   },
   {
+    "id": "terra1p6nzgyy7gq9hw54errcyrnjkf7p4expcsnmxz3",
+    "asset_ids": [
+      "terra1ctfsa4qfanzmz4my78m3u4r9k5qr9gpua9f6hj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1wd25umnrgnfydwd7k7m364ykk79r76tclm5v4n"
+  },
+  {
+    "id": "terra1p7npd4c5f8vsr47ncvkm50qfkvddanwy4er5ls",
+    "asset_ids": [
+      "terra13kr45ssru9cqhp2kaaan88wfaa7f2h3jfvuldp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1csfthprdmt6yw0n9kz3yuds5f36ng6zhwnzp3d"
+  },
+  {
+    "id": "terra1p7y8st3wjgs62vs3w9dw2sf603e4777v3jamhn",
+    "asset_ids": [
+      "terra1h0jk42weh0urhgdtjql93rrvgdccspnp7vyf49",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1y3c0z35uju9apsn0faewjdw630tqalhmtpgtc5"
+  },
+  {
     "id": "terra1pc0r79hmaznqh7tnsmzmh9zsl5y87t02zz2fmr",
     "asset_ids": [
       "uusd",
@@ -12087,7 +10527,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1y6x3mh07l8xdpxap7xw2u5pclrenjaulpcfh36"
   },
   {
     "id": "terra1pc7pufyc4z5lcwm0fhrsveu3fxly97htyh2hnu",
@@ -12110,6 +10550,26 @@
     "lp_token_id": "terra12jcvk4ltvdygacp2k56vnre42cjwr60jmv77py"
   },
   {
+    "id": "terra1pcjl6ammvypn4z4srs9dgzd2pgqvsw0xy85fj5",
+    "asset_ids": [
+      "terra1r7e9a5su34ne07e6v0r7n2xp4h6tjkxc8j2lz2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1qt6nek5pe7l0l3hwcarjd62mn24a6v7kz8zkxf"
+  },
+  {
+    "id": "terra1pcwu6flzc3srtu44cyvt8c7dn59lkyckprhqht",
+    "asset_ids": [
+      "terra1j7p2fxrzryfpzrrsfe585klnkqutg94kca9vtj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra15ggrlf3z0j7phzunfh90rjscuvrx4hgfljxhf9"
+  },
+  {
     "id": "terra1pd3sdj23u85w3vlrtmrpadud4qmxhppyy6dsyq",
     "asset_ids": [
       "terra1mqug8fps3zqsywzrukz5m6shcnj4j4rqna3kzf",
@@ -12118,6 +10578,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1rdjzzqdcqasnu4kgk796e3rr9nvrhx5y9xdg7e"
+  },
+  {
+    "id": "terra1pdstq4vkeftz5kmvwk5dzaytpesv5f3kq5q6s5",
+    "asset_ids": [
+      "terra1ppuu0devppvm6d75sclj4vwh5ghwyx7grurlvx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1f0tup70r7ycf682vc9h65p6g59jk8eefvy67qn"
   },
   {
     "id": "terra1pdxyk2gkykaraynmrgjfq2uu7r9pf5v8x7k4xk",
@@ -12147,7 +10617,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1r3zg43ftsjsgtm8kwyjletc3u57ut2ee6t08jh"
+  },
+  {
+    "id": "terra1pfdfzk3qs55lwtd8l00da7cext07ufpn9fe2c7",
+    "asset_ids": [
+      "terra1daa3rrcq6nk9vh3ecg08x7rmkx3h6egsfex3ze",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra10skty5urn3fzfkwg3f93z2f56xm52gufh2u76l"
+  },
+  {
+    "id": "terra1pfkanl8ycczuzyj02rjr3vx3sw0us9vxhpr0mt",
+    "asset_ids": [
+      "terra1h4wq9krj88hcl0m2e2kxfn3gznga30g5rrm4qa",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1n4cydpuvk8encunn0ag2h0y0pnzjkh4y8hr0ua"
   },
   {
     "id": "terra1pgf2ntzk2gh2lar6zh0yjwchmrtym8zfzp296y",
@@ -12157,7 +10647,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra12xvfjxzqw22n55ck4x2vqegev2qgf32vu3j9vc"
   },
   {
     "id": "terra1pgla9506h2ed9p93y6ryvxgj5admukssrcedwx",
@@ -12177,7 +10667,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra18zea6jvea9t204dp50wsd8cw52vgjum04p84pp"
   },
   {
     "id": "terra1pk77hewqerplsemc7wu9h78zwxs7cktfejdq5s",
@@ -12190,6 +10680,26 @@
     "lp_token_id": "terra1ukk0exsl5cejgnsn4jrdju83wrpdcwg0thfzpm"
   },
   {
+    "id": "terra1pksem0e9s7xdjf08j9swuyr5m677660qhyhuqk",
+    "asset_ids": [
+      "terra12k6ua9et2dnpmmq2rgz0wn0ugzr9jtyps5l8vt",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1saxejc25jretqgp4z6wj9me37qx8zg4lgzrmrx"
+  },
+  {
+    "id": "terra1pkuqexqszqcxszy9fpmxdnl6gwefjd7vger0jh",
+    "asset_ids": [
+      "terra1u4gx4v0nqgzm2kcajk3xf0d35gutwcvdyyjrnc",
+      "100000000000"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1w4276v5yzxa94ess4ryyfwanssfr3psgyk4jm3"
+  },
+  {
     "id": "terra1plf355sg3tntq72wa35qlrv99tduhhjax0vxjr",
     "asset_ids": [
       "terra1rhhvx8nzfrx5fufkuft06q5marfkucdqwq5sjw",
@@ -12198,6 +10708,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1ufumstplfqt5c9qs6zjzr5vp3dew7s29u7e7jd"
+  },
+  {
+    "id": "terra1pm4gx7u354nlgjdz0xf4kxpx977egdt6z5naca",
+    "asset_ids": [
+      "terra1v58klw3jakaeas2dkppqdh4y4dzd52kzda2fgf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra17tdq6g3xqmwpk3q4mgfl0qcuyz7sqaxqa3n0rm"
   },
   {
     "id": "terra1pn20mcwnmeyxf68vpt3cyel3n57qm9mp289jta",
@@ -12210,6 +10730,36 @@
     "lp_token_id": "terra1t4xype7nzjxrzttuwuyh9sglwaaeszr8l78u6e"
   },
   {
+    "id": "terra1pqpha5xe3fhtvyplcuwyzhls8hgdupahujpyay",
+    "asset_ids": [
+      "terra15xf5wqprgzl59ckfyjtgavh7rqtxcju7gn57rc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1gdndzwhsua4zw90pef309ked5h6npusgcu2j2c"
+  },
+  {
+    "id": "terra1pr0nnzw0elpqk8q2shc5gjnzaz95q4j8qy65w3",
+    "asset_ids": [
+      "terra1n8awtfqa0wphx90pd2zc9v8vccc65f0gvv6rq5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra16znt4xty0md2k7e6evq8thsumhn6lm4kavqzzy"
+  },
+  {
+    "id": "terra1pr6tmhnve5cawzauzyzw5uscz558gzmd3d6wps",
+    "asset_ids": [
+      "terra1s8gu8mx2qcxpx9y90fxvdetpwq9mpyrapphw2u",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1t4m40patyzxcm65fp2sz2p0f8yzkcdejrlz4wu"
+  },
+  {
     "id": "terra1prfcyujt9nsn5kfj5n925sfd737r2n8tk5lmpv",
     "asset_ids": [
       "uusd",
@@ -12218,6 +10768,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1d34edutzwcz6jgecgk26mpyynqh74j3emdsnq5"
+  },
+  {
+    "id": "terra1ps2j3kp3gwjx56fsahnnkmzv2y9e597gqkulfn",
+    "asset_ids": [
+      "terra1u02kfjra4q9272p0ckq8yjtfc5qq6584amvrnm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra19e0lhr0645336tuhdv5adj4cqgsphrp6p9mjya"
   },
   {
     "id": "terra1ps8wcwxt783qq07gfza0f67xf3kuaguq0r0e4y",
@@ -12230,6 +10790,16 @@
     "lp_token_id": "terra15qmh9jl388v2hr2yn75v8psdj0q9ghfwwxzckg"
   },
   {
+    "id": "terra1psuy4666c74vz9exfxvupsxmkgytneq7gushws",
+    "asset_ids": [
+      "terra14l9lspj9lp2rpnhp6qjpruwcqst0yvl9cm6l96",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra13084cqs5f65aal0c7m4zefh7785t3wvvw6dx44"
+  },
+  {
     "id": "terra1pufczag48fwqhsmekfullmyu02f93flvfc9a25",
     "asset_ids": [
       "terra1xj49zyqrwpv5k928jwfpfy2ha668nwdgkwlrg3",
@@ -12238,6 +10808,36 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1xwyhu8geetx2mv8429a3z5dyzr0ajqnmmn4rtr"
+  },
+  {
+    "id": "terra1pvetz858samujj0gkx7rr5n8m0gcy5gz8lcxz5",
+    "asset_ids": [
+      "terra14tc6kg4my06ckzugrukq0r903sup3a6agdmx4y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1kxqugyrr0e4he5furrqrehr8qhzqpfxxnt3vlf"
+  },
+  {
+    "id": "terra1pxlm7mjmqc4h4ht494jvmmwq840zn77eyex8yd",
+    "asset_ids": [
+      "terra14dtgwushpvu2c8d8rtc58z9r2t4p67ug8wl4d7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra13e46ch6vkx5yyaftp69f66lplm4uxhdze958ze"
+  },
+  {
+    "id": "terra1py6jq9p9qjjsqfg3sfj3stkpggyxl0sy5a006s",
+    "asset_ids": [
+      "terra1u2k0nkenw0p25ljsr4ksh7rxm65y466vkdewwj",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra186hhp3gfmqf2353pekrcmdpajfveu56j0ej7ft"
   },
   {
     "id": "terra1pyc4z680nrvd00xnqh24dtvap2840w0a44x7ns",
@@ -12257,7 +10857,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1zl55zufg86ruky5fh6yk70h333rgj3yftyksp6"
   },
   {
     "id": "terra1pzhcs3l028l8dzvj9hvxgt93ez4uq203askad3",
@@ -12277,7 +10877,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1f70a00zl3uas3m6sjvw72aezslznedhuy46dfs"
+  },
+  {
+    "id": "terra1q0vldkwqgc2y2crhrcsdw2pacdt8nnrgvzcsf6",
+    "asset_ids": [
+      "terra1exgprpvwmn9we9xfxlqzchfqd533wtnafhg0w4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra12qz82rul3ukhgaw06n2gv32gehermzu4zd8pam"
   },
   {
     "id": "terra1q2cg4sauyedt8syvarc8hcajw6u94ah40yp342",
@@ -12297,7 +10907,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1xxv4fyflcxly4pt0ve0xwztnsm5l0ty4vu3j06"
+  },
+  {
+    "id": "terra1q4nynp5mp4yhtxkyzegdkf594h94hhycmgxdq4",
+    "asset_ids": [
+      "terra1hpz206wxjhta4x83ukmk4v9rvk9dky2h0texf3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1s6acdmcz4dnphyw8yctl9qmkxluj8u6snankqq"
   },
   {
     "id": "terra1q4xywudqrgsuvdc0n9w0mhmrpzqj9lrl5wcf6j",
@@ -12320,6 +10940,16 @@
     "lp_token_id": "terra13wgcwjzgcphqgcay6k06th604rdggjf2plcyjz"
   },
   {
+    "id": "terra1q6h4sgkulkxl6tq8tafadl899sc88zp4dj6yd3",
+    "asset_ids": [
+      "terra1p2enl6vfmhdfj7ud32p3fkgns22sg62ls9mh2e",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1xwq5m8nkjkcfm2thpr0vesl4g9frqzdqwf8l6h"
+  },
+  {
     "id": "terra1q772ps7jxy57kgfhhpmg8gxsgn9fr7npwsn4kw",
     "asset_ids": [
       "uusd",
@@ -12328,6 +10958,26 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1jm8tx0aump43epcd8u0fspqp47agykvmmfrzh6"
+  },
+  {
+    "id": "terra1q7hat4ymhtawg8agg70u74m8eu3q7qsg9rqmr2",
+    "asset_ids": [
+      "terra15wwvprh6gddrc7yvshghc2g944ufsq79ay94da",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1m7gu655my73ulr42zhaz466mgl65au8dwvp3vj"
+  },
+  {
+    "id": "terra1q9cxc20mhr526qhrct46ucrwxywmv3daa7a36v",
+    "asset_ids": [
+      "terra1vdpk5k7203r73fgl2ppwsg30vmtu5akgk0emse",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1fst9xfe8wv8jucvnn5afnsmkzqf3hu6yy2d9y5"
   },
   {
     "id": "terra1q9lnctytu3c4p5ekv3xpmyxnegxe83adeufemv",
@@ -12370,6 +11020,16 @@
     "lp_token_id": "terra15rsfe8x9w3p7hl9n4ptawzw40x29t4w4h0hhnq"
   },
   {
+    "id": "terra1qgksgy6g76jx9732u8dpdy7epqgwtyy0rwj53n",
+    "asset_ids": [
+      "terra1aa9kg8crxjq86ts54d4un6ku5skec9e98t6tau",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1n45t7tamwtrnr48f43pcq8krul8yf4kap8xfcq"
+  },
+  {
     "id": "terra1qhnylhd7vdu87sdyjs908ndxc4ck0pgzpr7ky0",
     "asset_ids": [
       "terra1948uvsah8aw40dhsa9mhl3htq8lraj0smlh77g",
@@ -12377,7 +11037,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1knt7mzm6ndw35tc3upfgxwzdzpn398ftmdsxhk"
+  },
+  {
+    "id": "terra1qhpgt8pglujysknesj6jnea5tjc47upuutmee8",
+    "asset_ids": [
+      "terra186qt4d07ghj7dm2x64tyc0muw6rl2876jlhv38",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1gzvdqgg9zrgv92948l923hjnvxgldwaqzshla3"
   },
   {
     "id": "terra1qjus04wsfvxgg0k5k4hjdr20ttlcxewq2lu7vk",
@@ -12400,6 +11070,26 @@
     "lp_token_id": "terra1mspnuehp4h68f03t35lr0dzz8ajhzdq9jazjk8"
   },
   {
+    "id": "terra1qkjrvyzncs8h2w6zyctm7etv743x0vl5syrc3r",
+    "asset_ids": [
+      "terra1vlrerpu78hdezzz8zzx34adpced73lmd0ujyqa",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1uxgl9umfun75qkv4gctl3fk4cqv02crsl5y57w"
+  },
+  {
+    "id": "terra1qksw58xydjsqh9swyv764jptsdfskzx52qvalg",
+    "asset_ids": [
+      "terra1v8xzfedstujqexgz6vd902hppykuu2e7ar3pu8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1eepaxpggqy23hefzwj57xtfukkaq240mrmlnm8"
+  },
+  {
     "id": "terra1qll0dwhllspv30xnekl2csr6k3ykygtqdzuxl8",
     "asset_ids": [
       "terra10famrcyze8z9c84x5726aplefwuf4k2zqf3rxr",
@@ -12408,6 +11098,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1fgc9vy7hhzjgv90chemxgs0p5j5dfhkzsfexlt"
+  },
+  {
+    "id": "terra1qm7vvqg2jh5mwkd696luhvqe4mx96e4xuk60g2",
+    "asset_ids": [
+      "uusd",
+      "terra1lj0m5346vc6da9r9ljcyx7letcl3727g7wac62"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1xxj9nsxffy6hcc6mfq84fjfwt9k9e0n4800pgy"
   },
   {
     "id": "terra1qp6jp2sfsv8gmdh2tu33w904qqym394fzkxnxd",
@@ -12427,7 +11127,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1qmr8j3m9x53dhws0yxhymzsvnkjq886yk8k93m"
   },
   {
     "id": "terra1qr3jrdwrkqhntnkpvx39efrmayx45ysuhpg9qk",
@@ -12437,7 +11137,37 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra10fad8fupsy82nwdpddc2yqce2pmzfy6xy5ee8t"
+  },
+  {
+    "id": "terra1qr8vxrmlsyune368pd9nmgfuqt7kdek7yy6kwx",
+    "asset_ids": [
+      "uusd",
+      "terra1sa0klf6nt77z3afqlx7nq30xrvr7hsfz5jsqmd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1trdcl3lw5ca8ta7nfm5qh7w0mudfn6fdhl2qm6"
+  },
+  {
+    "id": "terra1qrlz2dl224glxn7sqa56wpdx7dz6yn5jlxm02f",
+    "asset_ids": [
+      "terra1sqagv65dlqj3hlg4fxrljlhfg5wulsp4nm58j7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra184waaggxgdg4nevql50lmpeyferkmal7f904eu"
+  },
+  {
+    "id": "terra1qrrr4kqfqptd7wx0f45sgem6z8ejenh3k7esnx",
+    "asset_ids": [
+      "terra19tvczk4us839rsvet9ncwg8est73nmzecdewkm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra12j3ye47a9jjk9jtjg7k8f0rs09hsvdpp6tpl58"
   },
   {
     "id": "terra1qs0zjzd6j0kwrwwf2qj5kmqqhav5ygq3q7p8s7",
@@ -12447,7 +11177,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra18je0chakhsnp8wyur0tyvuygz3c05kna06sdd7"
+  },
+  {
+    "id": "terra1qsf2sn65fjyc5hvm2v9a65qcyc23fnylr84fsg",
+    "asset_ids": [
+      "terra18f86dw6n40r6hqzjw0qsfe09nxesqs7vx2jkcx",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1cazwgay0h75rt78q2vxr6eggfk25xf4d0fwj7c"
+  },
+  {
+    "id": "terra1qstd3t9jv9v24ew6v430c42xfx9qf7mg7sg28d",
+    "asset_ids": [
+      "terra1kh0w04u79rhwvchmjsd7q4xxlm72y5wpf6a87v",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra18zs698tsn3600gtv4egtzx34uppcahzg7qlh8x"
   },
   {
     "id": "terra1qthlsaqccp8mxr2z4vvkhf5ynqjl86ccxg0pqn",
@@ -12457,7 +11207,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1e90arspgwmd27x9tt6hp7hwpfjl9y5he4sc8ed"
   },
   {
     "id": "terra1quf8yfhqkt38fa2j3zhgfv93ra6tvj9t0q6sgn",
@@ -12467,7 +11217,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1zp5vensepv6xkls426fp4dr44usvnlc4td2r6q"
+  },
+  {
+    "id": "terra1quwpd8khrwhuvqqk42mfw0q56nh524gu5zm294",
+    "asset_ids": [
+      "uusd",
+      "terra12wlcu0kgdfrfutjydvvcmhlx8jrfsqhwqarc3d"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1vawsn9qcgq9dcrjwldmqtmp9pj4373eapurm0j"
   },
   {
     "id": "terra1quz6cfd40l6qsfjyrmu0xe5xsnufg6g4rr00a4",
@@ -12480,6 +11240,16 @@
     "lp_token_id": "terra1fd34ray6t095g3rnj9yskjum0kglrym44qnmra"
   },
   {
+    "id": "terra1qvy5r6r3fyh6rk9j93e9w63z3qu4wlmxemd0kt",
+    "asset_ids": [
+      "terra16gnk7mpqr84f4mnmqjklpdxxe602dn0fjslwhy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1z27p3u53z9tfagnpffqe64js9l77w38ywyvefp"
+  },
+  {
     "id": "terra1qwk53cmt2j50ge2vkmt5sgcnmua5va5gx2s6yr",
     "asset_ids": [
       "terra14zeffuryjlzw566k7cfrnzf9dy94qeat2xvcda",
@@ -12490,6 +11260,26 @@
     "lp_token_id": "terra1nazd47xg74dg4a2eld2qxaynarv67d2l24z3y4"
   },
   {
+    "id": "terra1qxvf6f92f38wznvpyjqcd8ncppffuva79rvdeu",
+    "asset_ids": [
+      "terra1kafnpwanfluj6ne5t8ayg8ykarx060a50l72sw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra17ctyhfrdw3ppnddgyqkx72fqxsc677whtggejr"
+  },
+  {
+    "id": "terra1qyag7j7s5z0d02em5g09ltgcztxpdguz3pkxjk",
+    "asset_ids": [
+      "terra18y93cy77qrxx65vdz959g2ngms55v3s3yythys",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1fg8z4tvpm2qdq7wqvpdyj8ez9wvs2ntfr8mqag"
+  },
+  {
     "id": "terra1qyynd88qccpjrdn4yghhf8n9dm9msayrtqwwva",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
@@ -12497,7 +11287,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra14qrt27zl7w2eyu2uz25ddlp849lfqeat5jy7cd"
+  },
+  {
+    "id": "terra1qzlnxa9mdnxkhs6wwf0xvx0hxqday87dgxn9yq",
+    "asset_ids": [
+      "terra1ulzl6vfexrk39vaje0qryarzlq2ahy80cdl4fz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1mfs0xeakt59wemvwyelmh80025a3m06jfylx2e"
+  },
+  {
+    "id": "terra1qzrqt3phmawkrrzm8x8hwngz26nrpdgpkw5pmd",
+    "asset_ids": [
+      "terra1p0w9hh9aea5mg26mjnx7tl695ldwxfksvw4yn4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1mejc99wk4nnz4wfxdrak7rgm0wn2t9vx2ty6qx"
   },
   {
     "id": "terra1r0288hx3mjgx0zrpmpc8rulm6ca8jheqtwhwq5",
@@ -12520,6 +11330,16 @@
     "lp_token_id": "terra1j33rxfgdpuv3dpxaexhsuc64n6ltlascr5te2j"
   },
   {
+    "id": "terra1r3cjla7hlktc4vfa0dmzz8489e88k67yxjndpd",
+    "asset_ids": [
+      "terra1t9ul45l7m6jw6sxgvnp8e5hj8xzkjsg82g84ap",
+      "usek"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1w9pj93rwhtdmf37rgfqntpn77h2trulr9tlc5f"
+  },
+  {
     "id": "terra1r3djf4znn0vknjhdmlyg89hd8955v3vhr7jj5h",
     "asset_ids": [
       "terra1mddcdx0ujx89f38gu7zspk2r2ffdl5enyz2u03",
@@ -12527,7 +11347,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1jc72rjdtrlrj60my50skekxufrqlj6m2w754qt"
+  },
+  {
+    "id": "terra1r66l8vkzyhduuq7dfc8nm6p9wlwtnclve4wpxl",
+    "asset_ids": [
+      "terra10yycj46tjfnfhkk5d6er49gvcn28jpqk0spthr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra10zlafqxy3zyfx2wh35mxh8xepp6fz3f3yl9e8a"
+  },
+  {
+    "id": "terra1r6dcz9whd2dxunau0vtp3g06n0yus9gfaq76pz",
+    "asset_ids": [
+      "terra17ckx25kqhwzf3fudprs78kqgp3lhpr2w74yf7t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra16rc4cgt4a70jfzlylyqu534m3c64tvklch2p0m"
   },
   {
     "id": "terra1r6pp7pp0pgvp06nh80qmu697qfjsegddqnsg8t",
@@ -12537,7 +11377,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1ceg8925w6y833wsn5lv7srpf64uw9rf3fsgwxf"
   },
   {
     "id": "terra1r786pmp9z6edc0qufxgxxaheh5ag735avkfm30",
@@ -12557,7 +11397,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1c64zl49ukr62zdzdggn36luym9edyys63xkywn"
+  },
+  {
+    "id": "terra1r909kfjzeuj9nhwle2d6kg5jhn2af8j59lcsqj",
+    "asset_ids": [
+      "terra1pafrxwl8ur3jzjgw5qhts9vku68xsenctgqvkq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1tc3llqz3ckh4ahepmv4sdxc3s4dvn9vqxtax9l"
+  },
+  {
+    "id": "terra1r96mse06m03de6jkx52ku45p36htc9zx8k89l4",
+    "asset_ids": [
+      "terra1vpws4hmpmpsqwnz3gljn8zj42rv7rkpc5atgt4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra158g4r6gglcsst7ddua65rzfvzqums08y5m5dym"
   },
   {
     "id": "terra1r9e7efml7zk8fd5x5atk39e8jua9kdt7n7lp5r",
@@ -12580,6 +11440,16 @@
     "lp_token_id": "terra1gvakrl38c6ygrvzv2srnp738z43xy5prpmy78v"
   },
   {
+    "id": "terra1rcdumk59pxaem9my3frynyu3jgrkj9v4han9eh",
+    "asset_ids": [
+      "terra1sdm7qux8u0qtfxa6ukuh3zgppazdxlhmmjks23",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1w3z2lk8skrdw7ar9vq2kf5jeam9ar0m257k843"
+  },
+  {
     "id": "terra1rds4mfy90pxtn64px8dq9d68d2vwkcplpt6sl5",
     "asset_ids": [
       "terra1xjxegty6mmdr5jwqwde9rqhz758sy8c73vxzea",
@@ -12590,6 +11460,26 @@
     "lp_token_id": "terra19uca4zxqr8e9t9l6lcz3rztzaygnawwlex8g8l"
   },
   {
+    "id": "terra1rfdh5rephrd37ga0x5cry9lek8eutf54umkk04",
+    "asset_ids": [
+      "terra1zdpymdwpyg5gj5ye4uvr0mqmxw8c88k5vqegfr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1wq2tmhvx2yn3zqdah26sg3xzlaaxwd3fhsnj2y"
+  },
+  {
+    "id": "terra1rg9p352hcepvclfrxptpk0ua7a0tz4gcc0f0p8",
+    "asset_ids": [
+      "terra187lnjdwluvfnzxcef4appgr4v7fwljj5d5wdhf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1d2muut0rea9fkff6y304yn6qkr2uacau7ltggc"
+  },
+  {
     "id": "terra1rh6rwrekv3r7ep89lmkysxugsvuaqljmmepx5s",
     "asset_ids": [
       "terra16qsk2zwv5fsqd944p28f2dkddr7eq9uzuxeh8h",
@@ -12597,7 +11487,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1gwkdwvljnj0pud5qk87e0vnuu0a5j3qh30v6g8"
   },
   {
     "id": "terra1rhsh5xxl52xkuj7qq9240hwmcyzq2gpyj9hl0x",
@@ -12610,6 +11500,36 @@
     "lp_token_id": "terra1s6e449z6xz0vm0tx2h5p6drxwz9r2jvrcvcc62"
   },
   {
+    "id": "terra1rjdh8dj7jrjwz5dul7n8m9eyne92rvzftnjueh",
+    "asset_ids": [
+      "terra15afvt8ch38n8qj4n6wvykwkl2fqvfla826qdqe",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1684j38r062hr2nlwgf4ludpt9zk5g24g85syzj"
+  },
+  {
+    "id": "terra1rjv0jjm9mzgrj3grs2p0gvyuwpuf5qt9p30wwp",
+    "asset_ids": [
+      "terra1lesh2dshyf8a7wfm9fkxfrxjxc6yuyqnvspuvw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra184ufgqclvjkuycs82j0fp4xha8r6rryp7luj7g"
+  },
+  {
+    "id": "terra1rn8stwf23aes786t37je7v8vxe9qwyzshrl9ft",
+    "asset_ids": [
+      "terra16z32tp6cqx2f7lpr8t4scv8hj9zlljagprxfh7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra12eruh2ggjy2q8wutzsg2ww90nrucxm4hmuzdct"
+  },
+  {
     "id": "terra1rnc5cp7r9nxrskhup9uqs9v0e43hmm6u9xydec",
     "asset_ids": [
       "uusd",
@@ -12620,6 +11540,26 @@
     "lp_token_id": "terra13p6glny4ltdtrlptq2g9gs3e8m35t55uwgs9ea"
   },
   {
+    "id": "terra1rnenevclqn95uhszznh6v25gaqswfejsvcatu2",
+    "asset_ids": [
+      "terra1f887h6wqygswcp4arjjak6mpdhwlrv6nj8y9wt",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1gmvqnsr262yea2ltxvv6qxqgl26jsl4ah0cw2y"
+  },
+  {
+    "id": "terra1rpcz0746qj4f6nwcpap8z5knjpf4fj6wmalupy",
+    "asset_ids": [
+      "terra1kx4y3y4pn32jssqr90cj0rw89ds98dc0t5eqfp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1wspgkqtkul0m2qc7rnxsuz0t0k0q597ahelv29"
+  },
+  {
     "id": "terra1rq55zs9w6s24wmlmd540j2q2p6whanurfj26eh",
     "asset_ids": [
       "terra1yg3j2s986nyp5z7r2lvt0hx3r0lnd7kwvwwtsc",
@@ -12627,7 +11567,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra12r2ux466d9r3v44dq6zvj8mrutpslz9xrqv9vu"
+  },
+  {
+    "id": "terra1rr3rf5kptdtemsmf3g3jl8sy8rtamz2y6mcyh4",
+    "asset_ids": [
+      "terra1jkrl0xap6ptp8rd5lecp2j2sx3kws8rzxljsxn",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1syzg420suxvcarx38k7vep65tdqmpnsuth8a5w"
   },
   {
     "id": "terra1rre03e5p2w39uuvgxpxygnmtalj7cu7sp540zk",
@@ -12647,7 +11597,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra107tg7rwfd3mjxzzev305r6qg52z0xl7yxq7s2z"
   },
   {
     "id": "terra1rsuhf9cfvrfcj5h2h28ad72hhqgxxqyg2pf74y",
@@ -12680,6 +11630,16 @@
     "lp_token_id": "terra1zn5ycnftj4lplwwtjrt6jtvqtqwc2xl0ypyegs"
   },
   {
+    "id": "terra1rvjjnmeq5a9fje6r2guaxuezd7mhghk4t9cw4p",
+    "asset_ids": [
+      "terra1vyenreh8z62r35rydtupkqnmjsalee4tl90vn6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1l22rm7mmajqgxep8lv4nuwzvuj9xc0xahfe9lv"
+  },
+  {
     "id": "terra1rvnzun0xww86xnhu88prga8qt2n2trkjm72s4m",
     "asset_ids": [
       "terra15k5r9r8dl8r7xlr29pry8a9w7sghehcnv5mgp6",
@@ -12687,7 +11647,37 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra140u2w6fe5fdvlf24rrmxw54pevvc5spdmkept4"
+  },
+  {
+    "id": "terra1rwezyr03fs72talr7g2gjgr9jmfew834u7gl5l",
+    "asset_ids": [
+      "terra1y273xzgr58qsdkc89xa6qu5y9padxtm265am00",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra17v6ravmxwz8v9je9w9c23px3zhcvajk4tndt63"
+  },
+  {
+    "id": "terra1rwsyvg7e67rald7d45833nsw487f9mt2wk7a23",
+    "asset_ids": [
+      "terra1tewnpkjdtqq37udf5c5wjfrtkpegthfmls8lp7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1lyldsl94d3w3jhcenqjwsp4cme9jufur8fahk2"
+  },
+  {
+    "id": "terra1rx428v0rr62qcwd0cppz0xwj9qrh8zpqkahkj2",
+    "asset_ids": [
+      "terra1ts6qq7va0msf0se3cwjsppt3vkumkh3t6n4d8a",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra12awz2khk7ccyzfhstnzzgu5um4vt5yts59z4dz"
   },
   {
     "id": "terra1rxn03zjqscvv770h0ede4v4649y62zlr0lxlx8",
@@ -12700,6 +11690,16 @@
     "lp_token_id": "terra1etsh6y54ew6jcud4yhuu8awfdcz4j6jev6ej3u"
   },
   {
+    "id": "terra1rxwlts8xqulfrmx66whcknczmqjh05hdhwm4zj",
+    "asset_ids": [
+      "terra1ufsyu3ddskufc7nel5p4lyrzhv8qdddg3tl550",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1vhw9kpcshkr2kfrjke3pgp5sr5vsxdu2cjrf43"
+  },
+  {
     "id": "terra1rxzs4rs28rx89dt57nnph6xz8zmycf5js2d4ey",
     "asset_ids": [
       "terra1srp2u95kxps35nvan88gn96nfqhukqya2d0ffc",
@@ -12707,7 +11707,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1rmd0dm804l69m27fzcgue3v38ckhfg6n04gw8a"
   },
   {
     "id": "terra1ryajnmy7npuzq3de9yt9c7x8ac2awdtf8ekaw8",
@@ -12718,6 +11718,26 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra149zg8aesny2xasfkc4wd6z8agewjfq5uve3pfe"
+  },
+  {
+    "id": "terra1s0tfy4juc4pj4ke6mr9u68mnmgfapplhr52fr8",
+    "asset_ids": [
+      "terra10led4w62hglspyngk0ydxjsdvelvwthftevq0f",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1aef680pzs5cm30655wdz664v8jgeqtw76ptmcg"
+  },
+  {
+    "id": "terra1s2tkg3l4h4hrlsq6dnatcfhv97lyutpmxw0uk4",
+    "asset_ids": [
+      "terra1whwxszdwu6m4pup0glpfn7qhwmnh6a49mrsv2h",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1hfad2shn4h26g75t66yjasyg3qh84xlkp5g838"
   },
   {
     "id": "terra1s47rsyk3q7h8ketsuw2swdtgqr4lqfvt9jfdx3",
@@ -12740,6 +11760,26 @@
     "lp_token_id": "terra1svwqdq0gcuw2q2vzmy76qjvl2pnwaz65d4xvs0"
   },
   {
+    "id": "terra1s846ywp9gdkjfmk48cs8pd0phtsnn842zsgsa5",
+    "asset_ids": [
+      "uusd",
+      "terra1m86rdykfvtwucrd0y0gzlel7wpcdryctak5wyl"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1dkpn37uh5f5j3u9rjp6ynpekm5kzd7ysfffqwq"
+  },
+  {
+    "id": "terra1s9gquy9js5z64eehsf22w2zq7dwr9a7lavuxk7",
+    "asset_ids": [
+      "terra1hja2d2790m6hynju77t56nhmmyl0w09s5acqhc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra18at36s7ysqaefq929u008hct0amdn4hgfapk3u"
+  },
+  {
     "id": "terra1sa70wy0857fzu2gjcrg4mm7n5767k7lhj3yrct",
     "asset_ids": [
       "terra183x8jduwtdgcqkwtqxdzjlq2mq0rlnj6hm22j7",
@@ -12757,7 +11797,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1u3zraaq8n0t7550mzlq9jv68pzu0nphx0rrxau"
   },
   {
     "id": "terra1sdmk3k5ajmnk5zdfujmr8q3yfvlp067h8syq5l",
@@ -12767,7 +11807,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1nd7mj26z7wxpatnsy7qxms2lzpswv8y79zkyr7"
   },
   {
     "id": "terra1sdu63qdzkndpavvl5ephzwl7jj2slvcy89qu9s",
@@ -12777,7 +11817,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1xl5rv3h6uw5g26halsl9lyz4p9pa4hgdle4pru"
   },
   {
     "id": "terra1seh55ualnngk9jau3qsw7xrl4q7vqhc8y64w5q",
@@ -12788,6 +11828,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1jnn5xpmeythug88hu66pwl3x9fz2s0ms034aw6"
+  },
+  {
+    "id": "terra1sez4t0zhe9d7lxlup0j8u4cnkz0qvzr7dj2lf0",
+    "asset_ids": [
+      "terra1qrq5r95txaregxpa2c7mhf549u5jkm28rzmvt5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1gpwfs62dyazxxu8szap927f5vyakyhaw9uqmcn"
   },
   {
     "id": "terra1sg6tzmqegqhacd6nkrkrxn6hy4lx59ex7tt6mv",
@@ -12807,7 +11857,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra18vqxp8zhpxclchwxwwr8ze2ey8qsljm3fwkhnr"
+  },
+  {
+    "id": "terra1sk902qkn05mm3j94eh6qz0rmj2rq4gfj363na0",
+    "asset_ids": [
+      "terra1jwjweh50vrd2gg55y8cr50e32jwwc0vuhvdymh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra10fh6hy5f9t8mn09qzrps889qtew2km3zs44q9x"
   },
   {
     "id": "terra1smwa4uj94ecy8qtenezzew0z8mur9vy443pqc5",
@@ -12817,7 +11877,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1mhr8snhqv5328j4hz9gwhvz77rf2efgtv8xpyh"
   },
   {
     "id": "terra1sndgzq62wp23mv20ndr4sxg6k8xcsudsy87uph",
@@ -12830,6 +11890,16 @@
     "lp_token_id": "terra1xqeym28j9xgv0p93pwwt6qcxf9tdvf9ztfxf0w"
   },
   {
+    "id": "terra1sprcgsnem4yrnzjd67wunkjnvndjr45jme060w",
+    "asset_ids": [
+      "terra1tw845kgt0uq0gfmavawacfvaq5t9fa9v57g6m9",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1aa22fmunt253n4hmuerm7p2jmt08trj9l43ne2"
+  },
+  {
     "id": "terra1sprg4sv9dwnk78ahxdw78asslj8upyv9lerjhm",
     "asset_ids": [
       "terra1f62tqesptvmhtzr8sudru00gsdtdz24srgm7wp",
@@ -12840,6 +11910,16 @@
     "lp_token_id": "terra19ryu7a586s75ncw3ddc8julkszjht4ahwd7zja"
   },
   {
+    "id": "terra1sqaw3rsp5w84r5hwvcvcgweqcxlrhxl3e5a9na",
+    "asset_ids": [
+      "terra17azgr4x2gz20uquy7vdacfdgjjkgd0h9lm377v",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1mn2na4umsz3e3p2ulutzy6vgy4f4rua33cyrmk"
+  },
+  {
     "id": "terra1squzmwcpr5486f0zp759d5zyt0q3yykaf6e4zx",
     "asset_ids": [
       "terra15gwkyepfc6xgca5t5zefzwy42uts8l2m4g40k6",
@@ -12847,7 +11927,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1ect4kjuvn3sxh7fwmsj2fsmy802j4c2pnt8j7a"
   },
   {
     "id": "terra1st3tr5ppd3cs8zfl7ygqtc50y5thn5h6chdpmr",
@@ -12867,7 +11947,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra13cvk06h0e64y3x8c3ds3lts8pwfq955ypw08v5"
+  },
+  {
+    "id": "terra1su2magsez6h9xwss3czd8wj6l3c8eujed09d8v",
+    "asset_ids": [
+      "terra1745fzfxnd8wx5kdrf4uwgj7k0mkqk64pdrh56k",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1shwul2pfd5x5k8am6ffpts369s533pcspjr7m5"
   },
   {
     "id": "terra1su90khngc8fe80dwu0xgwt49262ytaye6zsv4l",
@@ -12877,7 +11967,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra14rsf7c75zlmcg0z7kuucs6v4pwn06hl09376vw"
+  },
+  {
+    "id": "terra1svequ729grnrj2d8x609e45axajrdjz87athfh",
+    "asset_ids": [
+      "terra1zsaswh926ey8qa5x4vj93kzzlfnef0pstuca0y",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1gm9lk22dcd36c9s86pqdql6ll0w2c8tpnwye0x"
+  },
+  {
+    "id": "terra1svqq5rsjpvsrt6g365wrrxz3xje0jnjljax42r",
+    "asset_ids": [
+      "terra138zs0y4arp48v0vpzqa7r4ehxcy7sk3dpv606e",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1pkgrrs3m3l8twfr76qpe4k0tccfeajkcrfhnpz"
   },
   {
     "id": "terra1swdaspvv9w0wtf9sylmkdmfnzjx7eu5734n64q",
@@ -12887,7 +11997,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1c9jc8r4ddulrgl5d9elt7np0gavlcjxwy2228s"
+  },
+  {
+    "id": "terra1sx3clxk5yhqjq5j5q87jw7qu27cn7en37zk323",
+    "asset_ids": [
+      "terra1k9ltsdc6e4ay4g8f8nt8qd7my9yyd27m7eh82d",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1hggkcl2v8wxzpy0vzxf2a5chw2h2fh7avl7j86"
+  },
+  {
+    "id": "terra1sxxn4rxuqgxn3um6ly5lf9wsjuewrr7j8tvjg0",
+    "asset_ids": [
+      "terra1lnav098k7vd006lz7d73mychha503pmw35la7l",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1hqj0eln43y4k4h036kddtll63lw7yvc3gz226a"
   },
   {
     "id": "terra1syp7rzmgtp9r6m4qlhu9x6luh4ltqyglkd22u3",
@@ -12937,7 +12067,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1njdw0fc5m52ucg777vc83ckvh2kpy6hwlucsxc"
+  },
+  {
+    "id": "terra1t4ee4m2merzrmz5uwuacuhk773wq82g32v6zu4",
+    "asset_ids": [
+      "terra1qm5jjajyv5pmap9687sgckc0j9hurlks3xzpx2",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1fvlf5y9uh3ylxff40eda4j60h52lnkthzhrsdz"
   },
   {
     "id": "terra1t4z4tdtn8ka6q5g7x3mx4h5w8ufh07c3s6eca4",
@@ -12977,7 +12117,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra16ejsp5mhav3kppkj7w438spp0eawknsj0afhvx"
   },
   {
     "id": "terra1t82m784qavjuawu2n6m47u6gch9wvfne38pftf",
@@ -12987,7 +12127,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1dmqluc4f2gk8yyss95sx8zmqemqndpw20yt8g2"
   },
   {
     "id": "terra1ta3lth8wu992m20qjeucg59rlxeez6qeygsxtm",
@@ -12997,7 +12137,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1wtaq3g7zzdshtn8w4mzllxs7mfjh8m8ewtdh3l"
   },
   {
     "id": "terra1tcrpkhxurjj2qcl5sksxs4cqc8mgz8dp0kfvhm",
@@ -13008,6 +12148,36 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1v0qd7s259lr83t7qp8aknmn6jeq679u4xnnhpz"
+  },
+  {
+    "id": "terra1tetfz00c58t656cg2gtyyv23jwh34sd590ue33",
+    "asset_ids": [
+      "terra13zl9thu8cgpkvpsx8r652hvgw4p2v42sahz6t8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ysma0f8sw7254l8nnfylfl4nded9a8wj7mn8up"
+  },
+  {
+    "id": "terra1tf360u087hzhw54yymtat9wd5p5c9a3n5jvhek",
+    "asset_ids": [
+      "terra1vg6wky3jm7qnr4w4qtw6hflhlhc0v79z9jvnxu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1xcxlsvm6q2nk003kqnhhddfcfm7dtnze02f3yw"
+  },
+  {
+    "id": "terra1tg8yu978lhcveq9j4emc9f7agn00dvecvx4wju",
+    "asset_ids": [
+      "terra1tgv52cmga9s6ymah2efz877xlpc4v8phq7mn69",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra18c9war4ldlccnast92snzt78ty378e0ggh8a8j"
   },
   {
     "id": "terra1tn8ejzw8kpuc87nu42f6qeyen4c7qy35tl8t20",
@@ -13047,7 +12217,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1umkmpnwdtdgujusgz7x8qvshs23mgkz0vg8dhq"
   },
   {
     "id": "terra1tq4mammgkqrxrmcfhwdz59mwvwf4qgy6rdrt46",
@@ -13087,7 +12257,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1reu7caz9ydaq2qy6p9l698edfl8x8lx3fg4jah"
   },
   {
     "id": "terra1twvmq2yfahhdpelavz94d9xhcmrfyazrn08lrz",
@@ -13098,6 +12268,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1wdjsxymg424mw4sv6zmw4luqajwxa5e7qfvfxw"
+  },
+  {
+    "id": "terra1twxv2kaeuyf3uxc6uzpgh3twe4mtagzpmn6sj4",
+    "asset_ids": [
+      "terra1ghkclqug2jhanmjsx46x0vymcglchcesg98057",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1mdxxn3jy7d7h9sv4plk7qs5lk3l9fuyv2m7yu8"
   },
   {
     "id": "terra1tz76786rwwnfra68jx3rhfnst3p6d3dscvuduj",
@@ -13117,7 +12297,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1ywx5h3cz6w4h3z9q9vg874y5f58gnkkuajfejj"
+  },
+  {
+    "id": "terra1u2g4fc0k4tq6z6lrdwhm4gry3q55dg8k9anjtw",
+    "asset_ids": [
+      "terra1qq4lemqmahjfhl68kpzx0kheuuvfyeu4ncnkaq",
+      "ukrw"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1z0z6hz96au9lr027uedxay3s09ry36md3wpm0v"
   },
   {
     "id": "terra1u3pknaazmmudfwxsclcfg3zy74s3zd3anc5m52",
@@ -13137,7 +12327,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1mnj6zstfk2ne0htcre9cvjv9ut0zd5t95wyagy"
   },
   {
     "id": "terra1u4je05rr7galjya4pn2c6s4gutg4evmt9qlxl5",
@@ -13187,7 +12377,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1q4c0u5wkfagqhrg54huxjxywhf7l8nkdy0zg3e"
   },
   {
     "id": "terra1u79vnslyaxprhmeqla6lj7dkcecg800ssclhu6",
@@ -13200,6 +12390,16 @@
     "lp_token_id": "terra13sjghs2r7seamgr4g9c4p2eeacknggetsrhcar"
   },
   {
+    "id": "terra1u8dt2feqxchklzft7n0s38d7kz2wwx7zqey8z4",
+    "asset_ids": [
+      "terra1gwr8mq2ljqzwmufgm55yu58339k55wja9529sg",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1quraxjgn87qe63h53mu8ksulqywsdlas648axv"
+  },
+  {
     "id": "terra1u993cu7zuzsgt4el5f6qu235xw2shezrde393r",
     "asset_ids": [
       "terra1v60qvtprpwt65w5tfamt4l4wpp3jk5mfeh64rt",
@@ -13208,6 +12408,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra143szxpzsamn9x6z2uwjm58369n9dmzt2rr77sk"
+  },
+  {
+    "id": "terra1u9hhdcqsd25q72dqme8hp8jkq6gq67vtg3rdq7",
+    "asset_ids": [
+      "terra1zpke3t4nprnh4044a4n97hwv384v9vff688cyj",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra18wnz4a622jvlhk5xnwuetk93j5xrkrpy23kqp0"
   },
   {
     "id": "terra1u9jgz9t8huvxcfc3u4w78u3fdxftcmzv297nc2",
@@ -13240,6 +12450,16 @@
     "lp_token_id": "terra1mtvslkm2tgsmh908dsfksnqu7r7lulh24a6knv"
   },
   {
+    "id": "terra1uf6gyusnqzluacssjjdcjt2yme6wvx23ac3hpw",
+    "asset_ids": [
+      "terra1cp02hkhu2nq7zznz04shwfvh9hdsp3y5334n6t",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1dwnm3mxgp6svmtng5shfkc52m8d0xsagdx6z37"
+  },
+  {
     "id": "terra1ufl3mnqqkucdgp68zrqxwmth9yy3ja5hnjv2c0",
     "asset_ids": [
       "terra1kp8vne240370hn722ec5sacsdluyt2j0gc5nph",
@@ -13247,7 +12467,47 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra16kw4vsl0wm3lt55cn4a47cz2y7d7ydsjwwfu08"
+  },
+  {
+    "id": "terra1ufrkf9n6nlq35e0gdjyc5s7qx63mfhkxrsxkmc",
+    "asset_ids": [
+      "terra1cqxahw3zls3x5k9sngtyjt5qm8nzmzsleyx8hh",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1wm2rpkpd3n0e6mkjxkc3fy3a2nw9mcrrl0npj6"
+  },
+  {
+    "id": "terra1ufzll076stnpmlmndlss4uezlq58gmwc83c72n",
+    "asset_ids": [
+      "terra1zfqe2kf0kh8mvyy3ksa29qqnkhc64ncffufg7g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1slr9qj73j3gn2muf94aysdaeex6ahk5ghq7ehp"
+  },
+  {
+    "id": "terra1umst8uwnuvd42aecxzf26jyy9eutghxk4xvlkn",
+    "asset_ids": [
+      "terra1rwskqpnk03hrh8z8rrprzdluxhzc5udycdn5g4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1xuqzklvz6chcpjjmy3tfgsrmytv8wtf207tyc6"
+  },
+  {
+    "id": "terra1unvncye5u9qeme7amjf8snd889hm9mp93w4m9z",
+    "asset_ids": [
+      "terra1l0zqxdgs5h6tfdsvhm34mvwrevyt5cuxj6ewzz",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1s9gjv7083uvz0l90hdq2mq5d9j8je6w9ttax65"
   },
   {
     "id": "terra1upmgq76cn9fcyftawd5a03nm88y8c82gnwhkhp",
@@ -13267,7 +12527,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra13m7t5z9zvx2phtpa0k6lxht3qtjjhj68u0t0jz"
+  },
+  {
+    "id": "terra1uqju4mlp0f000atx07xd49y3dlwe50e0d8d4xe",
+    "asset_ids": [
+      "terra1j874eyvev9pm7uxm0h9l82raswe3qwcug8wxuf",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra19t9e42yxukxuuqzyekccm5jpu3gek3nttdsz8f"
   },
   {
     "id": "terra1urmuf440vzkj48uh7x89vgmsp3w4tyzs0dln02",
@@ -13300,6 +12570,16 @@
     "lp_token_id": "terra1pc6fvx7vzk220uj840kmkrnyjhjwxcrneuffnk"
   },
   {
+    "id": "terra1usq239ur4z4utc8s4ecdrk09hd062nrdcdc7yd",
+    "asset_ids": [
+      "terra19pz3ehx9f2thr9t9jk5y89aalxmhzuq9j8ak99",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1sqd56ss9kw6fzx25y8krl8k703z4el9ttpknnr"
+  },
+  {
     "id": "terra1ut8zf8q03vcutkqgfhd8vep4xzkstt4jhap4cc",
     "asset_ids": [
       "uusd",
@@ -13310,6 +12590,16 @@
     "lp_token_id": "terra14y8396cv7trzufwknxy0jd545jdagx5d0n82ce"
   },
   {
+    "id": "terra1uukk3m4qemzdjatzh8p0m2qrg95f2yc8wrfzav",
+    "asset_ids": [
+      "uusd",
+      "terra174c2cy42fl7hags7cap8j4xtsmcc0ql2s8q5du"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra13ae05947uryk5x2us5l5dgkhmedsxudnxjwfm6"
+  },
+  {
     "id": "terra1uvchkwq4kv0vhy23c78hyy72zks2hqtpctklh2",
     "asset_ids": [
       "terra1kvjscdgwuvwc6uzm4rqfjl6nlmuhj28tequlnc",
@@ -13317,7 +12607,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1pndz6cy4t42qae4m7avkjjyu6vlcrlrx3hep0k"
   },
   {
     "id": "terra1uxduyw72vlrh8t0hvmrwn270l7z650ykeevx03",
@@ -13337,7 +12627,37 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1mt0k2prm85vp937uevm9p2390j9f58plvk2m59"
+  },
+  {
+    "id": "terra1uxwgfuyn57xqek4jgxajhd3270khgyusncarnv",
+    "asset_ids": [
+      "terra10t5spcvn5m52fs4j5tnjerm6wzsn9vuqdsheje",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1t28ggklvxuhvfgd78em98rhnddeu46vxjjgl82"
+  },
+  {
+    "id": "terra1uyd2jx409kdesatvpwrvzkuvfyhfa0es0r9s9g",
+    "asset_ids": [
+      "terra13zemc0wmem8lt0un0lya3qtg4cpf9jcdsgtvf3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1u47cpzrevxlld30cw6veflzj569k5ayyly4c59"
+  },
+  {
+    "id": "terra1uyq0vtcmzhz754z5rpv62u4skf7s4e7fuancwn",
+    "asset_ids": [
+      "terra10vvl9llw4p7ca2zhmcdljk5el9fkpp9hg6qy53",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra17wctee086rxqzng25jsm80u2mf5wx5lnyghuhw"
   },
   {
     "id": "terra1uytrvr6hqkptkkyesmf78qgwz9rhhcsxul9zsf",
@@ -13347,7 +12667,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1eqxhcr0phgthnjyn2dseewfg28pqp97lv7ryym"
   },
   {
     "id": "terra1uyvksaz9xpgxpqnq8vz9vzg59up8mlhx3463tf",
@@ -13417,7 +12737,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1gcutnc7f30xz22v3652twfvmfmj6utqsfn8wlc"
   },
   {
     "id": "terra1v4kpj65uq63m4x0mqzntzm27ecpactt42nyp5c",
@@ -13440,6 +12760,16 @@
     "lp_token_id": "terra1s89gf74pdhen0lgugethgf2jv3y2kc44xtyake"
   },
   {
+    "id": "terra1v73xl4qu05ahep8c8flf83vvrr437fftdxwn70",
+    "asset_ids": [
+      "terra1zp4xkexmng539vylktxkf45hxjg68ufx673x8p",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1p62jdngzanleq5wrwehehwl05nkwzhuuld6nae"
+  },
+  {
     "id": "terra1v846hwep6tr3wfwe2phu3z5ht9ufm9kwqzn7w3",
     "asset_ids": [
       "terra16hwgds2089kktskluq8dh5ntw7eu5e4q4z6ud4",
@@ -13450,6 +12780,26 @@
     "lp_token_id": "terra1hz2xxt4saxl79k4p3c9pqutldyqcugwuh8fzpl"
   },
   {
+    "id": "terra1v8lsm7hmkdwrgcxtlv3ltzvpup0ez6dr8nxdl6",
+    "asset_ids": [
+      "terra1aas795lj3dt6qrsp8n38fr39ypt43p6czgz3ra",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra12a5st8kc8hlypk7lhe8tquljcs4z89shah98ce"
+  },
+  {
+    "id": "terra1v8mkxsvtjjdln52ltu6u6ak87uvmvgffwvt0vx",
+    "asset_ids": [
+      "terra18lxu0868tj9pek9xn3wlgnlv0hs3s9t6473saz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1fhzyy5jgrjl2adhk3swalzdl4hnh0rmnusk9hz"
+  },
+  {
     "id": "terra1v97030v5lhr3f65qen0pc5k0723qhs5uplxnxp",
     "asset_ids": [
       "terra14s3g6jmytjjg2jcxmmaj6k837vcr6h98muxc07",
@@ -13458,6 +12808,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra166y3h6l4k42lrrj83y4lp9cdyqyxhv4cnkrjs7"
+  },
+  {
+    "id": "terra1v9lxv5kje00972tyf67qp7gwdc7msxwr8wf0j2",
+    "asset_ids": [
+      "terra143h4n4h3j36z64t7l8ey7vny6x47ukpz8s2gvs",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ty6nleg3m2lq7rfrlsw0adulaevsk76p4mfups"
   },
   {
     "id": "terra1vau3jl4x6206qx9acy6pya4vk8utv5gex0sm9l",
@@ -13480,6 +12840,16 @@
     "lp_token_id": "terra1p4pfnpsv8ly4mgzsmegz52kgjq8gp64almryky"
   },
   {
+    "id": "terra1vd20ymyajdvafp3726ft5wlndnlsqmyfr6pr20",
+    "asset_ids": [
+      "terra108fs4ahf6zzy7tqpvczg5yrfjpqw20kxc43pq5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1hgr37dvhd2r4mz0x5c2g60z0ggfhxy0a3lq4vd"
+  },
+  {
     "id": "terra1vfk7qfdchgjadv2l2rgmkfnswe5n277kwcjafk",
     "asset_ids": [
       "uusd",
@@ -13487,7 +12857,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra12awas0yfsn4r4ppzp4agqu8rp8gyw8weglpuca"
+  },
+  {
+    "id": "terra1vfwf4vd0yp47renczuqe8n7yrraxa2j7a7q0jf",
+    "asset_ids": [
+      "terra192g6ran4vfvyxhz0q7g4yls29fk6379hza6plw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1cps2jsd3flznjzce86qyma34a4d45v0wz0yy4j"
   },
   {
     "id": "terra1vjn47wdahfwxe0qm68e6k2c9uhcy4mltjdjup7",
@@ -13500,6 +12880,16 @@
     "lp_token_id": "terra1ucfttyyfm48fepyrstxlkjpp0qa9ygvln6jez0"
   },
   {
+    "id": "terra1vjyvxsunxs6dvu5kh08chk69zffcqcntccgpf8",
+    "asset_ids": [
+      "uusd",
+      "terra16gx5th8mk5v62xpvgf675xj2vuaf3dg4v75ml5"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1hyt7x6duee8qxhnuyjdkmf5ucg27a2fjl7tdzw"
+  },
+  {
     "id": "terra1vkvmvnmex90wanque26mjvay2mdtf0rz57fm6d",
     "asset_ids": [
       "uusd",
@@ -13508,6 +12898,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1q7m2qsj3nzlz5ng25z5q5w5qcqldclfe3ljup9"
+  },
+  {
+    "id": "terra1vm6whnkl54g5zy82533r34fhuaqp58f9kn826c",
+    "asset_ids": [
+      "terra1aa9kg8crxjq86ts54d4un6ku5skec9e98t6tau",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1g80la29wu6pnme68wj69sskcnnqg7zha69fej4"
   },
   {
     "id": "terra1vmvsdr04xdhh7mure2v9lgwy7l6js6s3689qyg",
@@ -13520,6 +12920,16 @@
     "lp_token_id": "terra1a05a50wz2n8mlr5nzwlsftzrdf9gvy5sypxdg9"
   },
   {
+    "id": "terra1vn3anrcp54lep043kqwvk9433r0a60xj2tlgpu",
+    "asset_ids": [
+      "terra1u02lqdhuhdfwph8wsl9yx9r0jupfdsd22q60tc",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1h44ahd05f63yamv553rqa0qzmfyp86j56smv4p"
+  },
+  {
     "id": "terra1vnpmtslwxr76ar3wmjy8jlp6c5y0sckvh96esl",
     "asset_ids": [
       "terra1p9wk5tns7jagwch6cdasgd753nzfj544v75qxr",
@@ -13528,6 +12938,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1hmuhs99qw938edq07c4sguhnpmwaulxjmufm9u"
+  },
+  {
+    "id": "terra1vnrd37f7cjwgu9zgn7whqcjjuclhhd38qrnqlw",
+    "asset_ids": [
+      "terra1c5wn5quxclujf8n38cu0sh2r4hq697lpc9385g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1e92r33fhkft6p8fyamwu3zp300t5l35cjxf5tf"
   },
   {
     "id": "terra1vq8ygvc47qn277pke8k3jvuyslh3ljtqkxka3m",
@@ -13540,6 +12960,16 @@
     "lp_token_id": "terra1mc4tyswf0msvm2358x7eyrlswn54n6x973v60a"
   },
   {
+    "id": "terra1vqc0pcdz97llaglpf7gfjtykhxy5r00uex0hnz",
+    "asset_ids": [
+      "uusd",
+      "terra1ezkr298e3lef6hh5pzmvrtw0qd0kc6u7dgl5rc"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra12qzdpl39xj79ra7s8d5l9tvrqmwk4924hphlvz"
+  },
+  {
     "id": "terra1vs2vuks65rq7xj78mwtvn7vvnm2gn7adjlr002",
     "asset_ids": [
       "usdr",
@@ -13550,6 +12980,46 @@
     "lp_token_id": "terra1mljg7dvzknqh3gc62emagf7hwxxg8efemennp8"
   },
   {
+    "id": "terra1vsyw78g3jfn5kelw09tttxfklrhewgtp62tw0a",
+    "asset_ids": [
+      "terra1elt5czsf7sntku3qafxf7xrjxdx309kkkmc8up",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1xm9vcuuyduxy8cc98tuaknnhv5tjv4x5350jvh"
+  },
+  {
+    "id": "terra1vu0hrz47per5rgq3mqjw272z3wgvk2x2qudvcp",
+    "asset_ids": [
+      "terra1w5pzereyvecexd9hsmlsakgnpjnlw56fgrha4s",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1v09eme9k7zfqjm8a5yf3wrc5t66qqfvm50x2ks"
+  },
+  {
+    "id": "terra1vv088zvmzzjv5qgpu25ym9mlgcuxhksqxnrcp2",
+    "asset_ids": [
+      "terra13j3uuywz8q3tljmqxt6trcgcxy29dd5exrnhtq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1svsdduee7kk6ghh7hz4c2rk8tkagfkzaplltx6"
+  },
+  {
+    "id": "terra1vvvpchwf7rac404q070x2d0jr20l0sxkcgv8y7",
+    "asset_ids": [
+      "terra1pxuknzmg3kup7790vjzssjjuelrq3a3ys4aml6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1ppaywpn8kyde0c0xngdfagjyq9l3jwudmckxw2"
+  },
+  {
     "id": "terra1vwk0dhr5lha56ssddl58ntxlcunfru36d0jfuf",
     "asset_ids": [
       "uusd",
@@ -13557,7 +13027,47 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1vzqxu4d5rm68mgtjcfhe6xpydy0axwjhleny2x"
+  },
+  {
+    "id": "terra1vzd3vra0zfnug80gtuwlc2j5rtucr87qkh4xmf",
+    "asset_ids": [
+      "terra152qpnfe76pnkwe8msfjxf4wjq0tcjtuuunv7eg",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1cz49n0uhccm0qdyd4crhjgrvrfhtucelr3u0fs"
+  },
+  {
+    "id": "terra1vzhsu5x9f9sglyq3acm5vq7hv0deemvdneqqw7",
+    "asset_ids": [
+      "terra1ex5age9gqd5em86wg8hu0ak5wrqez9yufvlrat",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra19q5tcdpmqna8ffvr8tmh9yn9cl8u6v66ewpk0h"
+  },
+  {
+    "id": "terra1w0hm732ejcvyp59pru5e77j6wf92rdnkknf7u3",
+    "asset_ids": [
+      "terra19qcznmhmwf88lm75nmrj3prr6cmvtnz02hvu4g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra18nvqp4lhezyw30kwuufplp0urggd0z9uge6ucr"
+  },
+  {
+    "id": "terra1w2aryua8k5s0a27kt9v8662jpsh4wglctu9z3h",
+    "asset_ids": [
+      "terra1pshxc56zwgm6j78mhjgn2rgkj5d32aa887l7j6",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1jx0n352z9jhxsu0ung276fukdcn64vvyujyp9u"
   },
   {
     "id": "terra1w3uwnguslkntkm3wsq86zan0a6jgtgwk0wr8z8",
@@ -13567,7 +13077,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1wc3c8lv6krlz2dvprvp8e3k4t330dvsn4n80p3"
+  },
+  {
+    "id": "terra1w7cyg38vclgtlsw5vxgxxleky2x29p3lh36yru",
+    "asset_ids": [
+      "terra19ztfg6l5k22cw8xg2h0uncpg3kwpv84ft9h6t0",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra17selfzmc4a3dlgn5ewtwkg99a4hkhgtshh4z7f"
   },
   {
     "id": "terra1w8symfluw393l0f83wv7rv64jklhegcjk2yv0p",
@@ -13580,6 +13100,16 @@
     "lp_token_id": "terra1p9hy2wvdgzdngexhtqfhllme89gvjpsj4uqe9w"
   },
   {
+    "id": "terra1w94sqf77fzlv9eh3fz8j5kmcdv2x230hnz9gj4",
+    "asset_ids": [
+      "terra1p0yttugxt3h2zvs9cghysmss3um6dp0mzt9vwd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra13tlvdmr6x6fqddezpde0d3aadk3g6ye7u6l0ud"
+  },
+  {
     "id": "terra1wcpqg4pr62dku9cry6r6xp7pagarvtzjtpql3n",
     "asset_ids": [
       "terra14vw4sfqwe7jw8ppcc7u44vq7hy9qa2nlstnxmu",
@@ -13587,7 +13117,37 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1ufhwwlu0yj4cprnqu0nzrr8us65whv0pmprvfe"
+  },
+  {
+    "id": "terra1wcs60r56r743ws6nxv3tn9pgz4xqv3x4lgeqkt",
+    "asset_ids": [
+      "terra1s0y8aldsy3t6wtg5tpwe8xzq3lyet5e9grwmlz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1drs4cetuf7hxry0xrh0vz79242f8clmtjpwhft"
+  },
+  {
+    "id": "terra1wgyq7kdeqeq70uzv04effzrgndtmtmevv4p9xr",
+    "asset_ids": [
+      "terra19y395vzlylv3s3nasr7cu4yey7s22ghqd35ps8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1vw5m4wklc5fg66hhlg3sulk9sjwz30dnudf259"
+  },
+  {
+    "id": "terra1wkcrktmkp3wfvwqvydlx0a3g4tywjktke4pva6",
+    "asset_ids": [
+      "terra17pv5zcuddm96m0nuanw25u4p8nkc9460hz0sy4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1hyc2qcu25cgg2fm75zee79a8au038mevhgaaql"
   },
   {
     "id": "terra1wl3ravhhyqmtslfrwvpap0xda2pwq4epxd0adu",
@@ -13618,6 +13178,26 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra16x0yfryw50tr8a4mhkh2jv2fccdtm8nyavcfxe"
+  },
+  {
+    "id": "terra1wn34gxq3jyg9qtjxjfzlj42jzjeegvgymdld2c",
+    "asset_ids": [
+      "terra1re7as700g3gels30zak6ctnjtsjhhc6vjr93ms",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1wv36wfhmlkxvgczn0c3ta4djx7u5fkvcz8fpgn"
+  },
+  {
+    "id": "terra1wpawa65459fzfvf244rz8c8q56ampvpkjnpe6f",
+    "asset_ids": [
+      "terra1zpp3fdnpkrhpehjxvzz3wwwujmk0zxw5h4y0rr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1q84pz7rtnmjr02uqkpjt75r5hgcjxf0l8qpwvy"
   },
   {
     "id": "terra1wqvhrrzkcn7dv2rkd5gdq2prawm64g7lnasy47",
@@ -13657,7 +13237,47 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1dy3ylyzykr7ykl0kyruuf5edmvqm4lm5y73n9k"
+  },
+  {
+    "id": "terra1wt43khwmzaeyxm77jnq47hyurrehzczyzxxds8",
+    "asset_ids": [
+      "terra1wx4h5qzvgp90ez53fgqr2s9t4rqzzjc03cjxr4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1e0dkhp72ted6rcz2ptnggnvtfea2hw4r2luc5n"
+  },
+  {
+    "id": "terra1wvhxy96s86xk4mynuqggxhm46jaq7h30k8gphu",
+    "asset_ids": [
+      "terra1zce4mxwwdyk04txa2f3aqepzsq8jy7ca50gn8w",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1uz6m6h6seck9q870hnc8g2t8rxtzn5nwg7txts"
+  },
+  {
+    "id": "terra1wvnw3nkwdx7ut3ua4wwm5u0lf7sl3fqgy8kltl",
+    "asset_ids": [
+      "terra1klz458efcl7md99vafn5sdxtluauem0q5nqjtn",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1yh6uxxmr2yhuwrswkhtvq7wq5ra8ecyucdtewh"
+  },
+  {
+    "id": "terra1wweezy8awhrmqtszun57zh2xh5yat4pndv9ejz",
+    "asset_ids": [
+      "terra1fdg5u7nttkcw2v4sepgzlwsznfffn8pnml35pu",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1fxzmf732l2mj23wq3aryww50xg7gclhelvs2k3"
   },
   {
     "id": "terra1wwtdsvlakd9dxstp85vyawrh5t6ftjuuqern0n",
@@ -13677,7 +13297,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra10erqkxp8nvhn3uv0lfpwyhpjh8872a2exudqkw"
+  },
+  {
+    "id": "terra1wxl8ay7srh0cuwmtaew5yh7dap54f6vrayhnwj",
+    "asset_ids": [
+      "terra18u4zkkm5ddge6decp83dk9zmkx7lvhv2xkynrr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1tyltj0lhs59mekgw8ej2dt49adue7mwa56xa2m"
   },
   {
     "id": "terra1wye679e2zq7pu55yzs9g9ptq054waaang0frfn",
@@ -13687,7 +13317,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1vz8wztxauw8tnlr6qxd7zdwrn37qulqgjymj5c"
+  },
+  {
+    "id": "terra1wysjqge8zc40e5g67vlaw0n2qu865pxxxv9sn3",
+    "asset_ids": [
+      "terra13k03g6n38f4m90pchn5h3nmk55xrnzt5ksvsml",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1hlnp0hz3hg37la6s6ppwex3dudaawvn3e7tydg"
+  },
+  {
+    "id": "terra1wzuyqt38l99tdxzttx9grktr3grllgsqe02dz8",
+    "asset_ids": [
+      "terra1mfwgs4aglpetsyy4y55k9g9hsnp5xtcykknldk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra14936pd4ptv3hkh2280qm3fx940srjvvx6gv8sl"
   },
   {
     "id": "terra1x2jjzqv55f3gvrh8ytejkt998p8vnhn0gcg26w",
@@ -13717,7 +13367,37 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1crkatrwuxvp3348vjl42r3v8n59lqjpullpm77"
+  },
+  {
+    "id": "terra1x67kglh8uxc5rq4z0dsrv4az0rkfgs6k42fu06",
+    "asset_ids": [
+      "terra1epz3d7rmltreyt6chgnuv28cy8e0d3yad75xh8",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1vz850g76xvryz4jhpf2juamv40yey0ugh0pyjf"
+  },
+  {
+    "id": "terra1x6dvc72unfrdnrkyzvm8pz6kmugdzkzu66fd9v",
+    "asset_ids": [
+      "terra1t5y4xm7xdc7csud2j2aezxs6e4uuj3lqpqk7jy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra16ut6d3kh5tw08lu9np7s9fqlxl0z3c2gpsqn64"
+  },
+  {
+    "id": "terra1x6sxgww5nrclca4thc6f7m35fyk5mgepe63pxh",
+    "asset_ids": [
+      "terra1a95wwge5ut59aet6wx9m5ukq0alnxj0waf4sgl",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1vx6h7nmljrcxfrd4n87vvlfjx37qyexzccenm5"
   },
   {
     "id": "terra1x6umr9xk86l37gxsayt4fz26cku4dya7qr2gtn",
@@ -13730,6 +13410,16 @@
     "lp_token_id": "terra1t46rhfcgqpz9xkx33qpzk55yudp7wdaygj7yfw"
   },
   {
+    "id": "terra1x8em0g87c30a3s5hqp4ar3ad732q7eclftwlwm",
+    "asset_ids": [
+      "terra124zh80answg0srxqynl8syswgsjx0heh9txxw9",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra152jfl6s4fmte2pe8ct0f0wtdm2k3xu6uesdfj0"
+  },
+  {
     "id": "terra1x8h5gan6vey5cz2xfyst74mtqsj7746fqj2hze",
     "asset_ids": [
       "terra17y9qkl8dfkeg4py7n0g5407emqnemc3yqk5rup",
@@ -13738,6 +13428,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1spagsh9rgcpdgl5pj6lfyftmhtz9elugurfl92"
+  },
+  {
+    "id": "terra1x8rmne82kuy2gx26r3ecxrjns97ef8ckf9exvv",
+    "asset_ids": [
+      "terra1ldrmvk4n0le7tdaxj7r8gk5kny95r6mxw3ask7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1wnqp45zle5yq65dvevda927ver36sgvgvfu5gg"
   },
   {
     "id": "terra1x9jv7vjcpy46k7eadp9ldx0jkkx3f8n2yvwtxe",
@@ -13750,6 +13450,26 @@
     "lp_token_id": "terra1tctqptkl50uxqt3wgpt02cmk8vxye3a3fvcm7f"
   },
   {
+    "id": "terra1xe69w9cuwz4s8e6nsxsf439pr2jyuhjj24s0ch",
+    "asset_ids": [
+      "terra1677xekxjqc4f3jqut8yr6p29e8h5zfay37et58",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1dypf4pfqw8a8whlkzhgrzew68f00z50r3hcd63"
+  },
+  {
+    "id": "terra1xen8n3l5sr3z9ad7mmmgdrhy8qa36wa00s45kg",
+    "asset_ids": [
+      "terra1h56g0tp38whpxlgdwcqdtgmrkkdyqerkymyklp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1fsvjcrmalf6n9lu72p9cv9rum6x6nhg2343ghz"
+  },
+  {
     "id": "terra1xf3u2ka5tvtq23wqy9dk94zx3kyaqvttzfetvv",
     "asset_ids": [
       "terra1d6vy3aueuucu3sf5qkrccnq7v58uwegh9m9x74",
@@ -13760,6 +13480,16 @@
     "lp_token_id": "terra17a995wgrz7ch4qvk3s748tzs9u89a274yk8qh0"
   },
   {
+    "id": "terra1xf5x5gyg5x4n22v9tyv3mtxzxz86hmpd3jkfju",
+    "asset_ids": [
+      "terra1rxl2tv8jhv3rkhnesashgk8dwuvfa9kdzv36rp",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1aglpvqsrgcmwy4v93uezlmaftdqu3qvg9htlcc"
+  },
+  {
     "id": "terra1xg660nndl83z5n7j4jd0cnrygs5dndcj30sazn",
     "asset_ids": [
       "terra1ehcjwxwf96c278n2ks84zes3ece5fqy78fa749",
@@ -13767,7 +13497,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1skhn7p85uyqle4yyxvdvr92d0lj70hvctdu9dw"
+  },
+  {
+    "id": "terra1xghv9y36n9nfvqmlksj8seysd3fftfgud3zgm4",
+    "asset_ids": [
+      "terra1dgwaqnzp9yt4w4g8l2kwxemrhlwqm50j7eehns",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1cvwy6kx24fhpeq4gjuyp2ynwcsxu8gtvk3mde7"
   },
   {
     "id": "terra1xj2w7w8mx6m2nueczgsxy2gnmujwejjeu2xf78",
@@ -13780,6 +13520,16 @@
     "lp_token_id": "terra1n3gt4k3vth0uppk0urche6m3geu9eqcyujt88q"
   },
   {
+    "id": "terra1xk2dnaqynl297f6r2yp5xp83yd5k8kk3mv8s7r",
+    "asset_ids": [
+      "uusd",
+      "terra1atpd4n3u6tl9ttqeqdwk303lcj2j7u8tpnx53p"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1mywz0a0fzzv69fxct84jj2777t2err6sn6pyu6"
+  },
+  {
     "id": "terra1xk2tjgs43pv3pkfv4cmwauvnjd09wxsaedshg4",
     "asset_ids": [
       "uusd",
@@ -13787,7 +13537,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra14k7e3kn9zr7vqgzgrxpmtfceag5l5zz65wd7d4"
   },
   {
     "id": "terra1xk72vswca7jkjg8cpl9dz0qvfadam3ms365lp7",
@@ -13797,7 +13547,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1mxfnjfa0aj0prf4se7rwa45xlwcg8px97enu6u"
+  },
+  {
+    "id": "terra1xlgl3xvkha2y6mssy9s4qe70sq295825sdmt2q",
+    "asset_ids": [
+      "terra1q59h4hyxvfpu2hp3v39r8rpl4wykqe7axrc9rr",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra165k229vdtpng40rhdfn3tqtqphwxeyjx5wrwxw"
   },
   {
     "id": "terra1xljkuseertrcrguycjwvqhht22u75epe6hdcxr",
@@ -13817,7 +13577,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra16xmae0686wrzmqvrcf4clsy8yyv6r40ddhrd30"
   },
   {
     "id": "terra1xqsumj7ydu0dwnsf66hf4aye8l0gyaawz87rrk",
@@ -13827,7 +13587,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1z0vnwxd8lzuqjzah6wnh0u4zlesl9wzvha2mgh"
   },
   {
     "id": "terra1xskmucgxkzf3quwry3dazerw74q4aqplu0vgg4",
@@ -13837,7 +13597,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra17rm53s5vhjpfrjkhappmswczcmhl8zqdwlfwtm"
+  },
+  {
+    "id": "terra1xtaxvdlfjxyea7qpz37f5j3py3cyafkycgy8c5",
+    "asset_ids": [
+      "terra17n0sj0ed82upz3c38px5hl2zy7mestccskauva",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1z364vxmwx7gadv0pd8ywul8k2k68rjahxq0c5w"
   },
   {
     "id": "terra1xtm4yzrd3a7k6pzqjnk0kag0gea7w0rkkzmqg3",
@@ -13847,7 +13617,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1wd57pf6alluruy72ctklzsl822eey2hvdsma8l"
+  },
+  {
+    "id": "terra1xvvrm52lglquyp62kgpcww8489v4wqy9us6skq",
+    "asset_ids": [
+      "terra1r2p90ur2zy8javfhnf7ejdvzac60ax3wcvkvxz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra15ctvv29qxq5h2dmqt60er08smq9547pg49j0rl"
   },
   {
     "id": "terra1xw6yl2vhnlusw5gnj7l2mk0em80c2mw03n9ny0",
@@ -13858,6 +13638,46 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1muk54uc0pqjwe6w26tpwun0x55ncttnadxrr6l"
+  },
+  {
+    "id": "terra1xxrx7rgpzlep532ulyyndpm7g2md3zspgepmfa",
+    "asset_ids": [
+      "terra1ydznesu47hety3am8athucgp6hl4dcxsxqpka3",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1m5gwp6ujj0frnwkgxlkmhwu5we9xaysnwa6f8s"
+  },
+  {
+    "id": "terra1xzk9vcd53j2eql8zfnds9xfxy6z9c6ran3ld7p",
+    "asset_ids": [
+      "terra1e3s670y5lns7vlq3gxdcn9rv8mdpydhd89jdwz",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1t6c2y90qmphcct2q94m4lscnfxvcyu7hrpnamv"
+  },
+  {
+    "id": "terra1y03ldlhcscet96kflc0fefnfkvug92ly3xmgr2",
+    "asset_ids": [
+      "terra1su29mtytdsev3ty2au5xlfrqrjcy696yeqwvcy",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra19hvxtwdprvaadfldxhyc0demuyhhz26z86r54r"
+  },
+  {
+    "id": "terra1y0cfekprajjqmz9jth6veq8pe5t2qurwg9kk4m",
+    "asset_ids": [
+      "terra1z9yq8l5fn7y5msg37rx2p0up0pgkf52ml4uv0q",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra18vvfrdsxefmheygjlw2d6835p969snpvm2xlar"
   },
   {
     "id": "terra1y0z6ulatz6puwdrjk3lnyltc2vg9rvgwyztrg3",
@@ -13880,6 +13700,26 @@
     "lp_token_id": "terra1ll78pl5a256d7lgqk49mc0r4cj9fnn544pwr0e"
   },
   {
+    "id": "terra1y53r7wkxtajtsmn0zjqu4keqyd2qn5hv3ykmt8",
+    "asset_ids": [
+      "terra1tn2upc52zce96qprewh0gk5thvqqtuhaz7r6qd",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1smfcvgpdggf8jp7p3yvaqs0jl25ene6rwynn80"
+  },
+  {
+    "id": "terra1y6x737xg3q0nrqfgjkzy9ggfjmanu7675vva8s",
+    "asset_ids": [
+      "terra1f85kt39ar3tkscq6w8ylxv2t9qh4ktzayw35ta",
+      "uluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1td4yfemjtq38lq98vqhnywfmjec979z8qxqrx2"
+  },
+  {
     "id": "terra1y7vdguewgus669kcxjlwughyxtdt3kheys05q0",
     "asset_ids": [
       "uusd",
@@ -13897,7 +13737,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1j7d46fh3p3pka4rkfc6mnwwntqur2sq05ddyx6"
   },
   {
     "id": "terra1y8uendv07j259m26dmw0mtcy4mvc5wc2qhptyr",
@@ -13908,6 +13748,26 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1kmf20rwahh3e22af9u6vq2h5s7kh89fhd9g5ds"
+  },
+  {
+    "id": "terra1ya6tdm86gequ9wc7lusx374j2flgldv33426zg",
+    "asset_ids": [
+      "terra1zpz6dfn24cnykwausjt7qwfdqf87kny0trn94k",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1pl7nft4helwl8xt3ev0lknk4rkhrceve4s8lk3"
+  },
+  {
+    "id": "terra1yag6m3d3q60wnhpd8fm2qhn4uhkzpufazwz6w9",
+    "asset_ids": [
+      "terra1g7fa8wpfp56tzdd5mgz5r5jsvqw7hm5e3tdlnq",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1nl5wp6j8tna08ymthheynq0u0eam0gad5pgxku"
   },
   {
     "id": "terra1ycp5lnn0qu4sq4wq7k63zax9f05852xt9nu3yc",
@@ -13930,6 +13790,16 @@
     "lp_token_id": "terra1rfrwm60zydsdsr9hy4smp7sckuq57nt56s3tp9"
   },
   {
+    "id": "terra1yeh80vf0yezluv2u5nc6e5n8d4phjy4c55zvg3",
+    "asset_ids": [
+      "terra12fctlld90cakzkuhd2c3h246zxrhwqd6kp546g",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1vtz8425zxtpm8sng8u3grrdq5cruq4zeeh0cn8"
+  },
+  {
     "id": "terra1yfpksrlypf5c3xc9ktsup9mtxw24r6sshck3g0",
     "asset_ids": [
       "terra1a07n2cp4wd49ezxdgm9xgtfrnpmxfcdp4yrdnv",
@@ -13937,7 +13807,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra16cdhrjh90ptzsdfajklfa9gcf4tlqkrgnqmsej"
   },
   {
     "id": "terra1yg74xslj94r7cjweu8gg6s5c497vs2sdd6zwgy",
@@ -13948,6 +13818,16 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1z36hglaqjgv867xr7e4jsz32pr7mcstjg2xm6u"
+  },
+  {
+    "id": "terra1yje5awrwutgx5p4mg3e8vtpnttav5f6y9m3rgh",
+    "asset_ids": [
+      "terra1mkw8x32086w0emr0wkprrns9j0c82nnxusn7dw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1h3a58p3haxgt95eq8fwkptwscyppq0laque0f3"
   },
   {
     "id": "terra1ykfz4hrq8en2f098j8a4ppaq8u8hangpw9tnqu",
@@ -14040,6 +13920,16 @@
     "lp_token_id": "terra1mwu3cqzvhygqg7vrsa6kfstgg9d6yzkgs6yy3t"
   },
   {
+    "id": "terra1yqrryqqnvq9wgqad89dhdxwspspqzzj2dy03yy",
+    "asset_ids": [
+      "terra1x5mhyxzmy8da89rh7dnt3v289qz988hclyl6kk",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1l7hmc3k3zlg5r6jet9tuv846h735p3xjul2dh8"
+  },
+  {
     "id": "terra1ysac4wfu87qgu0qkkz8yrh57wwgx2upytva3fx",
     "asset_ids": [
       "terra1dh9478k2qvqhqeajhn75a2a7dsnf74y5ukregw",
@@ -14047,7 +13937,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra197utwawuscdxxt6j38smj3cs8knzvlj9c4grr7"
   },
   {
     "id": "terra1yusz6qz86wuhd7vlkkc89e0y6j8au6w93f24fm",
@@ -14057,7 +13947,17 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1ferw3qu4d4980kqemf6r3rstwpzw7egdkekprd"
+  },
+  {
+    "id": "terra1yv9dr0suw8njr88ls6ya34y2pevq45k5yg0vl0",
+    "asset_ids": [
+      "terra1my8t2mhxxv5rzjtzc8cppj8y76hy3apvcntttw",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1w3xdh7zpllve9d72anjtr5lkxndshggdw3zdke"
   },
   {
     "id": "terra1yvfnqxcksy6007sp6rfu776chtugm2u7qfhved",
@@ -14067,7 +13967,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra145t3m07uxx2xr063pq8l6hh6wysp2d27np86pn"
   },
   {
     "id": "terra1yx5487aewxagnrg8s0s5aar7kzzjyhtr52gtyr",
@@ -14087,7 +13987,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1mkmwqqzdhy6lvlxy3xel7m9uxsaq7n22rvs7t5"
   },
   {
     "id": "terra1yypalnanxp26u5uypunlj7mwx0mrkrfw3juqtf",
@@ -14097,7 +13997,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1dletuefu2w56d4nptmtptrglnxm0vf4snm8l32"
   },
   {
     "id": "terra1yz9qsxe70p6j4vdhrmsg45gs858lhqzxq3dgh7",
@@ -14110,6 +14010,36 @@
     "lp_token_id": "terra1peprsfuh0kt3xz8zgjmy9rfgx40jpf36cp24sa"
   },
   {
+    "id": "terra1z0g2y0d3eemtcsd253qd8vpl74a089deqas2hp",
+    "asset_ids": [
+      "terra1kujvztl5p8a45k56u42fq39jxldxcvuejtpfq5",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1uu0xsadf4x7v5q9vpgp2dd9t9x2khwqlal5rl9"
+  },
+  {
+    "id": "terra1z2p2vs8q95frqntrnqwkwmj9nempl83l3m699n",
+    "asset_ids": [
+      "terra17efcrd3glln324tqke56w5wgnfkfn5emz4um8j",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1fnr2j2cfapcuxr90z83sj0qjrtzt88sutz4cpf"
+  },
+  {
+    "id": "terra1z3u6mw3s20kt67ts9txrg2mjkzcwt7tgasp7gw",
+    "asset_ids": [
+      "terra12flsr4mk5sxmu8yk7m8zc5f44tfx00yjvzj7v4",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra13wlheafzjwwgctnxh9t9jr0pnqejuu63ykr36w"
+  },
+  {
     "id": "terra1z4pwt3nqrwkvw26vl5tr0pm595t5qf7a2s20kk",
     "asset_ids": [
       "terra19djkaepjjswucys4npd5ltaxgsntl7jf0xz7w6",
@@ -14120,6 +14050,16 @@
     "lp_token_id": "terra1y7rnxw089cv0a5t5jlaa6wuh5uaa78rnm5k7n6"
   },
   {
+    "id": "terra1z50d83kx5dke2fw2wtrs4kj6ae8ga2pe5vhwl8",
+    "asset_ids": [
+      "terra1pfynaj6mslxnlekjx7f6rxgfastl46c4hg3kg7",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1pce629yhpm8n8rxe2va4a89akcl8826fgg7wnr"
+  },
+  {
     "id": "terra1z50zu7j39s2dls8k9xqyxc89305up0w7f7ec3n",
     "asset_ids": [
       "terra1hzh9vpxhsk8253se0vv5jj6etdvxu3nv8z07zu",
@@ -14127,7 +14067,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1umup8qvslkayek0af8u7x2r3r5ndhk2fwhdxz5"
   },
   {
     "id": "terra1z6tp0ruxvynsx5r9mmcc2wcezz9ey9pmrw5r8g",
@@ -14140,6 +14080,16 @@
     "lp_token_id": "terra14ffp0waxcck733a9jfd58d86h9rac2chf5xhev"
   },
   {
+    "id": "terra1z7w93yyhzl0vf6cxvt0c65ta2q48akft53uj3k",
+    "asset_ids": [
+      "terra10722f40cxl8tkxjk7f88uj0ehkcw6lu2j504f0",
+      "ubluna"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1naap0c8xly4fh5aq7vhayqrrj6pmt826r0uukn"
+  },
+  {
     "id": "terra1z8masgnagfxvjwdqc43mltrzpa3t4x5u873vz6",
     "asset_ids": [
       "terra1drsjzvzej4h4qlehcfwclxg4w5l3h5tuvd3jd8",
@@ -14148,6 +14098,26 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1yxaczswtwnlqqyn9x9ccsa495lm2tlrte5aa9g"
+  },
+  {
+    "id": "terra1z96yec8dxc6ummv5kkksft3agxmsaur07zxgq6",
+    "asset_ids": [
+      "terra1v2s7gkylfrnwsdcx8s83k5475nj3jykzs9gsqm",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1fn7psza4kxrmu3vhnelg08629uapvmmr48xnew"
+  },
+  {
+    "id": "terra1z9d33epxt9jaa4d4ta6rf5fwfysfufeumz4zga",
+    "asset_ids": [
+      "terra1xp4uhylkhwgam5tc97m0xfaxarajgf6wtcqwp9",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1vemqvqr0khzdtfl9909u27v977pthardrwf9zh"
   },
   {
     "id": "terra1ze5f2lm5clq2cdd9y2ve3lglfrq6ap8cqncld8",
@@ -14177,7 +14147,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1da5mtfzkz6cseukw2fc9th8n2vee7p0vpn9rvk"
   },
   {
     "id": "terra1zh33l9e6pj385jpum6uyngwhhe62p9gfaph2gl",
@@ -14187,7 +14157,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1p3twrxme27qrh9sf7day9v9qpn345vvt0p8trk"
   },
   {
     "id": "terra1zhffgf949uvq8sxgynmxa3n477sgvd4gf64w49",
@@ -14217,7 +14187,27 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1cmqv3sjew8kcm3j907x2026e4n0ejl2jackxlx"
+  },
+  {
+    "id": "terra1zl89gw3t5ykhfxtut3marguhyff9fwupmnmhrl",
+    "asset_ids": [
+      "terra1dszjh6392kc6avpztu4vdx8xl0qte4ntmue07r",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1pq9m7syytshndh2sckgxyrh83wsm59w4gduvg8"
+  },
+  {
+    "id": "terra1znka2za38gsj3p8u8etlfejqz4prf3snz36tnr",
+    "asset_ids": [
+      "terra1wz8w0susqsraw2smttuymzkgr3p8tgkntqhcre",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1q7vnlkn4gqgfqucjp8hadz6nzpma759qvjttsx"
   },
   {
     "id": "terra1zpets4h5zyvhln3muemyvk7cwvmwmam4tp8c5w",
@@ -14227,7 +14217,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra109fa5jzs7vvkey8mhuacpns8lczrrucpv30j80"
   },
   {
     "id": "terra1zpu7lgsfw3l4q782wdjskn8t6nn6rwlpq3d6j6",
@@ -14267,7 +14257,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra1qt8fh9k45hjk8n93fxa2lc6wxfpcmgve38507s"
   },
   {
     "id": "terra1zrx57z4qhsejk3r0ug6pt3xvz2efpee39rle5n",
@@ -14277,7 +14267,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra13gq946x6dddjzfa2dwpr2pq6uknqnafspzkzr0"
   },
   {
     "id": "terra1zrzy688j8g6446jzd88vzjzqtywh6xavww92hy",
@@ -14297,7 +14287,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra143lm2z3y0atfzwqzgknse2t4wf7majdtrw4vps"
   },
   {
     "id": "terra1zvn8z6y8u2ndwvsjhtpsjsghk6pa6ugwzxp6vx",
@@ -14327,7 +14317,7 @@
     ],
     "dex": "Terraswap",
     "type": "xyk",
-    "lp_token_id": "TODO LP TOKEN ID"
+    "lp_token_id": "terra198ngkjucgje5xrrup6hwuslh7jm2ks6r35gs9q"
   },
   {
     "id": "terra1zz39wfyyqt4tjz7dz6p7s9c8pwmcw2xzde3xl8",
@@ -14338,5 +14328,15 @@
     "dex": "Terraswap",
     "type": "xyk",
     "lp_token_id": "terra1k5kumxd24cyvhf52r5u4ywlr3ztktj657wnf7a"
+  },
+  {
+    "id": "terra1zzqkcp3e5apwdpsnavfrdrf6q0qf4esd556xg0",
+    "asset_ids": [
+      "terra1m9w3pdjst86dmfdamq5tuu4ny99e89eaavdz06",
+      "uusd"
+    ],
+    "dex": "Terraswap",
+    "type": "xyk",
+    "lp_token_id": "terra1tk7a0hcs3yehfzrscjhw824jq52ndvsv07d7zk"
   }
 ]


### PR DESCRIPTION
added back the cmc and gecko info into `terra/asset.json`, initialised some base files for the other cosmos chains as well (asset, pool, entity)

- `kujira`: unable to find an "lp_token_id" equivalent so I just filled it with "Orderbook" for the time being.
- `osmosis`: similar to kujira, filled it with the respective pool Id
- `terraclassic`: wasnt able to resolve some of the pool types or get their LP token ID, might be getting rate-limited

- `entity.json` for all chains except for `terra` is quite sparse for now