### PR TITLE
Add LUNC Warriors NFT as Entity

### DIFF
--- a/terraclassic/entity.json
+++ b/terraclassic/entity.json
@@ -321,5 +321,11 @@
     "website": "https://www.xdefi.io/",
     "telegram": "https://t.me/xdefi_io",
     "twitter": "https://twitter.com/xdefi_wallet"
+  },
+  {
+    "name": "LUNC Warriors NFT",
+    "website": "https://miata.io/creators/10/collection/40/",
+    "telegram": "https://t.me/LUNCWarriors",
+    "twitter": "https://twitter.com/LUNCWarriorsNFT"
   }
 ]


### PR DESCRIPTION
Added Twitter, Telegram, Website for LUNC Warriors NFT to `entity.json` on Terra Classic. I humbly ask you to merge and publish. Thank you.