### PR TITLE
Decimal fix for supply amounts

### DIFF
--- a/injective/asset.json
+++ b/injective/asset.json
@@ -672,8 +672,8 @@
     "symbol": "BABY NINJA",
     "decimals": "6",
     "type": "tokenfactory",
-    "circ_supply": "1000000000000000",
-    "total_supply": "1000000000000000",
+    "circ_supply": "1000000000",
+    "total_supply": "1000000000",
     "icon": "https://ipfs.io/ipfs/bafkreibfnrr364if2kl6qxapht7qczq2e6td6ptfv6ev6bu2tgs6obydxy"
   },
   {

--- a/injective/asset.json
+++ b/injective/asset.json
@@ -664,6 +664,8 @@
     "symbol": "BABY NINJA",
     "decimals": "6",
     "type": "tokenfactory",
+    "circ_supply": "1000000000000000",
+    "total_supply": "1000000000000000",
     "icon": "https://ipfs.io/ipfs/bafkreibfnrr364if2kl6qxapht7qczq2e6td6ptfv6ev6bu2tgs6obydxy"
   },
   {


### PR DESCRIPTION
Due to an overlooked detail, an update was made regarding the token decimal information. A correction has been applied again on this matter, updating it by removing the zeros related to the decimal, so that only the supply figure will be entered.