### PR TITLE
Added missing https:// to the GUPPY logo url

### DIFF
--- a/migaloo/asset.json
+++ b/migaloo/asset.json
@@ -51,7 +51,8 @@
     "decimals": "6",
     "type": "tokenfactory",
     "circ_supply": "1000000000000",
-    "total_supply": "1000000000000"
+    "total_supply": "1000000000000",
+    "icon": "i.imgur.com/XsUMwsw.png"
   },
   {
     "id": "factory/migaloo1ey4sn2mkmhew4pdrzk90l9acluvas25qlhuvsfgssw42ugz8yjlqx92j9l/arbWHALE",

--- a/migaloo/asset.json
+++ b/migaloo/asset.json
@@ -52,7 +52,7 @@
     "type": "tokenfactory",
     "circ_supply": "1000000000000",
     "total_supply": "1000000000000",
-    "icon": "i.imgur.com/XsUMwsw.png"
+    "icon": "https://i.imgur.com/XsUMwsw.png"
   },
   {
     "id": "factory/migaloo1ey4sn2mkmhew4pdrzk90l9acluvas25qlhuvsfgssw42ugz8yjlqx92j9l/arbWHALE",


### PR DESCRIPTION
First PR missed https:// for the GUPPY icon url. Now added https:// to the url.