### PR TITLE
remove old terra farming assets

### DIFF
--- a/terraclassic/asset.json
+++ b/terraclassic/asset.json
@@ -2180,6 +2180,7 @@
   },
   {
     "id": "terra15gjgmln8xj72rf69tx2zlrtcjzzvkcrdvrvfnmxja6kacz07pg0ssflecz",
+    "entity": "Terra Farming",
     "name": "FOOD Token",
     "symbol": "FOOD",
     "decimals": "6",
@@ -10757,17 +10758,6 @@
     "symbol": "FIN",
     "decimals": "6",
     "type": "cw20"
-  },
-  {
-    "id": "terra1s47hpp330wwff9wutu0ks87ldaueatc64497va3jxrlz2mgrjrzskx46a5",
-    "entity": "FOOD TOKEN",
-    "name": "Terra farming token",
-    "symbol": "FOOD",
-    "decimals": "6",
-    "type": "cw20",
-    "circ_supply": "70000000000",
-    "total_supply_api": "https://terra-classic-lcd.publicnode.com/cosmwasm/wasm/v1/contract/terra1s47hpp330wwff9wutu0ks87ldaueatc64497va3jxrlz2mgrjrzskx46a5/smart/eyJ0b2tlbl9pbmZvIjoge319",
-    "icon": "https://i.ibb.co/3v7ZZmZ/IMG-20240228-192129-947.jpg"
   },
   {
     "id": "terra1s4p8h244t7qgr6jyx4uzcfe69j6smma9tfk75y",

--- a/terraclassic/entity.json
+++ b/terraclassic/entity.json
@@ -94,11 +94,6 @@
     "twitter": "https://twitter.com/Elon_meme_token?t=d55ElwEGQx7jOmg7p95fYg&s=09"
   },
   {
-    "name": "FOOD TOKEN",
-    "website": "https://foodtoken.tech",
-    "twitter": "https://twitter.com/LUNCFOOD"
-  },
-  {
     "name": "FRG",
     "website": "https://lunaclassicinfo.wixsite.com/frgcoin",
     "telegram": "https://t.me/frgcoins",
@@ -331,6 +326,11 @@
     "name": "Team Local Money",
     "website": "https://localmoney.io/",
     "twitter": "https://twitter.com/TeamLocalMoney"
+  },
+  {
+    "name": "Terra Farming",
+    "website": "https://foodtoken.tech",
+    "twitter": "https://twitter.com/LUNCFOOD"
   },
   {
     "name": "Terra Money",

--- a/terraclassic/pool.json
+++ b/terraclassic/pool.json
@@ -5350,16 +5350,6 @@
     "lp_token_id": "terra1gmy3x763ku8332l97m7twf7uavn7csprlrkg9td5uzhulp90dn2sud7jsu"
   },
   {
-    "id": "terra1ejp0aa3725ktpqeaxr2msn0saq3lz00u3mppj8kug4h6aw37rfcsu6xvd9",
-    "asset_ids": [
-      "terra1s47hpp330wwff9wutu0ks87ldaueatc64497va3jxrlz2mgrjrzskx46a5",
-      "uluna"
-    ],
-    "dex": "Terraport",
-    "type": "xyk",
-    "lp_token_id": "terra1zxwkhlpt3q2m5qqwsh7z8pnnsa03p4rs55fr7xygcwc4u2h48kaspqyju4"
-  },
-  {
     "id": "terra1em84um5ljw553s7prc9ngq8jyljypxm5qs7lgx87ekks93f4rmpsh6q6he",
     "asset_ids": [
       "terra19fufgpaec6c85nrw9j2a40rshdgcm9rhn6hlj2zmx03utpqkh2ls8jnxkz",


### PR DESCRIPTION
Please let me know what to do in order to verify that the removal/replacement is legit intent of the Terra Farming owner. The old pool had no liquidity and was never launched with initial liquidity. The corresponding token is dead and was never distributed. The new token with liquidity will be launched soon.